### PR TITLE
fix: address 38 system audit findings

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,9 @@
+import { timingSafeEqual } from "node:crypto";
+
+export function timingSafeCompare(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(Buffer.from(a), Buffer.from(b));
+}
+
+export const VIEWER_CSP =
+  "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; connect-src 'self' ws://localhost:* wss://localhost:*; img-src 'self'; font-src 'self'";

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,8 +1,10 @@
 import { timingSafeEqual } from "node:crypto";
 
 export function timingSafeCompare(a: string, b: string): boolean {
-  if (a.length !== b.length) return false;
-  return timingSafeEqual(Buffer.from(a), Buffer.from(b));
+  const bufA = Buffer.from(a, "utf8");
+  const bufB = Buffer.from(b, "utf8");
+  if (bufA.length !== bufB.length) return false;
+  return timingSafeEqual(bufA, bufB);
 }
 
 export const VIEWER_CSP =

--- a/src/eval/schemas.ts
+++ b/src/eval/schemas.ts
@@ -112,7 +112,7 @@ export const EvolveInputSchema = z.object({
 
 export const ExportImportInputSchema = z.object({
   exportData: z.object({
-    version: z.literal("0.3.0"),
+    version: z.union([z.literal("0.3.0"), z.literal("0.4.0")]),
     exportedAt: z.string(),
     sessions: z.array(z.unknown()),
     observations: z.record(z.string(), z.array(z.unknown())),

--- a/src/functions/export-import.ts
+++ b/src/functions/export-import.ts
@@ -59,7 +59,7 @@ export function registerExportImportFunction(sdk: ISdk, kv: StateKV): void {
         .catch(() => []);
 
       const exportData: ExportData = {
-        version: VERSION as ExportData["version"],
+        version: VERSION,
         exportedAt: new Date().toISOString(),
         sessions,
         observations,

--- a/src/functions/export-import.ts
+++ b/src/functions/export-import.ts
@@ -14,6 +14,7 @@ import type {
 } from "../types.js";
 import { KV } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
+import { VERSION } from "../version.js";
 
 export function registerExportImportFunction(sdk: ISdk, kv: StateKV): void {
   sdk.registerFunction(
@@ -58,7 +59,7 @@ export function registerExportImportFunction(sdk: ISdk, kv: StateKV): void {
         .catch(() => []);
 
       const exportData: ExportData = {
-        version: "0.4.0",
+        version: VERSION as ExportData["version"],
         exportedAt: new Date().toISOString(),
         sessions,
         observations,

--- a/src/functions/governance.ts
+++ b/src/functions/governance.ts
@@ -50,6 +50,19 @@ export function registerGovernanceFunction(sdk: ISdk, kv: StateKV): void {
     { id: "mem::governance-bulk" },
     async (data: GovernanceFilter & { dryRun?: boolean }) => {
       const ctx = getContext();
+
+      const hasFilter =
+        (data.type && data.type.length > 0) ||
+        data.dateFrom ||
+        data.dateTo ||
+        data.qualityBelow !== undefined;
+      if (!hasFilter && !data.dryRun) {
+        return {
+          success: false,
+          error: "At least one filter is required for non-dryRun bulk delete",
+        };
+      }
+
       const memories = await kv.list<Memory>(KV.memories);
       let candidates = memories;
 

--- a/src/functions/graph.ts
+++ b/src/functions/graph.ts
@@ -190,8 +190,8 @@ export function registerGraphFunction(
         const matchingNodes = allNodes.filter(
           (n) =>
             n.name.toLowerCase().includes(lower) ||
-            Object.values(n.properties).some((v) =>
-              v.toLowerCase().includes(lower),
+            Object.values(n.properties).some(
+              (v) => typeof v === "string" && v.toLowerCase().includes(lower),
             ),
         );
         const nodeIds = new Set(matchingNodes.map((n) => n.id));

--- a/src/functions/observe.ts
+++ b/src/functions/observe.ts
@@ -5,6 +5,7 @@ import { KV, STREAM, generateId } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
 import { stripPrivateData } from "./privacy.js";
 import { DedupMap } from "./dedup.js";
+import { withKeyedLock } from "../state/keyed-mutex.js";
 
 export function registerObserveFunction(
   sdk: ISdk,
@@ -54,16 +55,6 @@ export function registerObserveFunction(
         dedupMap.record(hash);
       }
 
-      if (maxObservationsPerSession && maxObservationsPerSession > 0) {
-        const existing = await kv.list(KV.observations(payload.sessionId));
-        if (existing.length >= maxObservationsPerSession) {
-          return {
-            success: false,
-            error: `Session observation limit reached (${maxObservationsPerSession})`,
-          };
-        }
-      }
-
       let sanitizedRaw: unknown = payload.data;
       try {
         const jsonStr = JSON.stringify(payload.data);
@@ -96,35 +87,47 @@ export function registerObserveFunction(
         }
       }
 
-      await kv.set(KV.observations(payload.sessionId), obsId, raw);
+      return withKeyedLock(`obs:${payload.sessionId}`, async () => {
+        if (maxObservationsPerSession && maxObservationsPerSession > 0) {
+          const existing = await kv.list(KV.observations(payload.sessionId));
+          if (existing.length >= maxObservationsPerSession) {
+            return {
+              success: false,
+              error: `Session observation limit reached (${maxObservationsPerSession})`,
+            };
+          }
+        }
 
-      await sdk.trigger("stream::set", {
-        stream_name: STREAM.name,
-        group_id: STREAM.group(payload.sessionId),
-        item_id: obsId,
-        data: { type: "raw", observation: raw },
-      });
+        await kv.set(KV.observations(payload.sessionId), obsId, raw);
 
-      const session = await kv.get<Session>(KV.sessions, payload.sessionId);
-      if (session) {
-        await kv.set(KV.sessions, payload.sessionId, {
-          ...session,
-          observationCount: (session.observationCount || 0) + 1,
+        await sdk.trigger("stream::set", {
+          stream_name: STREAM.name,
+          group_id: STREAM.group(payload.sessionId),
+          item_id: obsId,
+          data: { type: "raw", observation: raw },
         });
-      }
 
-      sdk.triggerVoid("mem::compress", {
-        observationId: obsId,
-        sessionId: payload.sessionId,
-        raw,
-      });
+        const session = await kv.get<Session>(KV.sessions, payload.sessionId);
+        if (session) {
+          await kv.set(KV.sessions, payload.sessionId, {
+            ...session,
+            observationCount: (session.observationCount || 0) + 1,
+          });
+        }
 
-      ctx.logger.info("Observation captured", {
-        obsId,
-        sessionId: payload.sessionId,
-        hook: payload.hookType,
+        sdk.triggerVoid("mem::compress", {
+          observationId: obsId,
+          sessionId: payload.sessionId,
+          raw,
+        });
+
+        ctx.logger.info("Observation captured", {
+          obsId,
+          sessionId: payload.sessionId,
+          hook: payload.hookType,
+        });
+        return { observationId: obsId };
       });
-      return { observationId: obsId };
     },
   );
 }

--- a/src/functions/observe.ts
+++ b/src/functions/observe.ts
@@ -10,6 +10,7 @@ export function registerObserveFunction(
   sdk: ISdk,
   kv: StateKV,
   dedupMap?: DedupMap,
+  maxObservationsPerSession?: number,
 ): void {
   sdk.registerFunction(
     {
@@ -51,6 +52,16 @@ export function registerObserveFunction(
           return { deduplicated: true, sessionId: payload.sessionId };
         }
         dedupMap.record(hash);
+      }
+
+      if (maxObservationsPerSession && maxObservationsPerSession > 0) {
+        const existing = await kv.list(KV.observations(payload.sessionId));
+        if (existing.length >= maxObservationsPerSession) {
+          return {
+            success: false,
+            error: `Session observation limit reached (${maxObservationsPerSession})`,
+          };
+        }
       }
 
       let sanitizedRaw: unknown = payload.data;

--- a/src/functions/privacy.ts
+++ b/src/functions/privacy.ts
@@ -12,6 +12,9 @@ const SECRET_PATTERN_SOURCES = [
   /AKIA[0-9A-Z]{16}/g,
   /AIza[A-Za-z0-9\-_]{35}/g,
   /eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}/g,
+  /npm_[A-Za-z0-9]{36}/g,
+  /glpat-[A-Za-z0-9\-_]{20,}/g,
+  /dop_v1_[A-Za-z0-9]{64}/g,
 ];
 
 export function stripPrivateData(input: string): string {

--- a/src/functions/relations.ts
+++ b/src/functions/relations.ts
@@ -4,6 +4,18 @@ import type { Memory, MemoryRelation } from "../types.js";
 import { KV, generateId } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
 
+function createMutex() {
+  let chain = Promise.resolve();
+  return function withLock<T>(fn: () => Promise<T>): Promise<T> {
+    const next = chain.then(fn, fn);
+    chain = next.then(
+      () => {},
+      () => {},
+    );
+    return next;
+  };
+}
+
 function computeConfidence(
   source: Memory,
   target: Memory,
@@ -34,6 +46,8 @@ function computeConfidence(
 }
 
 export function registerRelationsFunction(sdk: ISdk, kv: StateKV): void {
+  const withLock = createMutex();
+
   sdk.registerFunction(
     {
       id: "mem::relate",
@@ -47,47 +61,49 @@ export function registerRelationsFunction(sdk: ISdk, kv: StateKV): void {
     }) => {
       const ctx = getContext();
 
-      const source = await kv.get<Memory>(KV.memories, data.sourceId);
-      const target = await kv.get<Memory>(KV.memories, data.targetId);
-      if (!source || !target) {
-        return { success: false, error: "source or target memory not found" };
-      }
+      return withLock(async () => {
+        const source = await kv.get<Memory>(KV.memories, data.sourceId);
+        const target = await kv.get<Memory>(KV.memories, data.targetId);
+        if (!source || !target) {
+          return { success: false, error: "source or target memory not found" };
+        }
 
-      const confidence =
-        data.confidence !== undefined
-          ? Math.max(0, Math.min(1, data.confidence))
-          : computeConfidence(source, target, data.type);
+        const confidence =
+          data.confidence !== undefined
+            ? Math.max(0, Math.min(1, data.confidence))
+            : computeConfidence(source, target, data.type);
 
-      const relation: MemoryRelation = {
-        type: data.type,
-        sourceId: data.sourceId,
-        targetId: data.targetId,
-        createdAt: new Date().toISOString(),
-        confidence,
-      };
+        const relation: MemoryRelation = {
+          type: data.type,
+          sourceId: data.sourceId,
+          targetId: data.targetId,
+          createdAt: new Date().toISOString(),
+          confidence,
+        };
 
-      const relationId = generateId("rel");
-      await kv.set(KV.relations, relationId, relation);
+        const relationId = generateId("rel");
+        await kv.set(KV.relations, relationId, relation);
 
-      if (!source.relatedIds) source.relatedIds = [];
-      if (!source.relatedIds.includes(data.targetId)) {
-        source.relatedIds.push(data.targetId);
-        await kv.set(KV.memories, data.sourceId, source);
-      }
+        if (!source.relatedIds) source.relatedIds = [];
+        if (!source.relatedIds.includes(data.targetId)) {
+          source.relatedIds.push(data.targetId);
+          await kv.set(KV.memories, data.sourceId, source);
+        }
 
-      if (!target.relatedIds) target.relatedIds = [];
-      if (!target.relatedIds.includes(data.sourceId)) {
-        target.relatedIds.push(data.sourceId);
-        await kv.set(KV.memories, data.targetId, target);
-      }
+        if (!target.relatedIds) target.relatedIds = [];
+        if (!target.relatedIds.includes(data.sourceId)) {
+          target.relatedIds.push(data.sourceId);
+          await kv.set(KV.memories, data.targetId, target);
+        }
 
-      ctx.logger.info("Memory relation created", {
-        relationId,
-        type: data.type,
-        source: data.sourceId,
-        target: data.targetId,
+        ctx.logger.info("Memory relation created", {
+          relationId,
+          type: data.type,
+          source: data.sourceId,
+          target: data.targetId,
+        });
+        return { success: true, relationId, relation };
       });
-      return { success: true, relationId, relation };
     },
   );
 

--- a/src/functions/relations.ts
+++ b/src/functions/relations.ts
@@ -3,18 +3,7 @@ import { getContext } from "iii-sdk";
 import type { Memory, MemoryRelation } from "../types.js";
 import { KV, generateId } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
-
-function createMutex() {
-  let chain = Promise.resolve();
-  return function withLock<T>(fn: () => Promise<T>): Promise<T> {
-    const next = chain.then(fn, fn);
-    chain = next.then(
-      () => {},
-      () => {},
-    );
-    return next;
-  };
-}
+import { withKeyedLock } from "../state/keyed-mutex.js";
 
 function computeConfidence(
   source: Memory,
@@ -46,8 +35,6 @@ function computeConfidence(
 }
 
 export function registerRelationsFunction(sdk: ISdk, kv: StateKV): void {
-  const withLock = createMutex();
-
   sdk.registerFunction(
     {
       id: "mem::relate",
@@ -60,8 +47,9 @@ export function registerRelationsFunction(sdk: ISdk, kv: StateKV): void {
       confidence?: number;
     }) => {
       const ctx = getContext();
+      const lockKey = [data.sourceId, data.targetId].sort().join(":");
 
-      return withLock(async () => {
+      return withKeyedLock(lockKey, async () => {
         const source = await kv.get<Memory>(KV.memories, data.sourceId);
         const target = await kv.get<Memory>(KV.memories, data.targetId);
         if (!source || !target) {

--- a/src/functions/remember.ts
+++ b/src/functions/remember.ts
@@ -4,7 +4,20 @@ import type { Memory } from "../types.js";
 import { KV, generateId, jaccardSimilarity } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
 
+function createMutex() {
+  let chain = Promise.resolve();
+  return function withLock<T>(fn: () => Promise<T>): Promise<T> {
+    const next = chain.then(fn, fn);
+    chain = next.then(
+      () => {},
+      () => {},
+    );
+    return next;
+  };
+}
+
 export function registerRememberFunction(sdk: ISdk, kv: StateKV): void {
+  const withLock = createMutex();
   sdk.registerFunction(
     { id: "mem::remember" },
     async (data: {
@@ -41,53 +54,55 @@ export function registerRememberFunction(sdk: ISdk, kv: StateKV): void {
 
       const now = new Date().toISOString();
 
-      const existingMemories = await kv.list<Memory>(KV.memories);
-      let supersededId: string | undefined;
-      let supersededVersion = 1;
-      let supersededMemory: Memory | undefined;
-      const lowerContent = data.content.toLowerCase();
-      for (const existing of existingMemories) {
-        if (existing.isLatest === false) continue;
-        const similarity = jaccardSimilarity(
-          lowerContent,
-          existing.content.toLowerCase(),
-        );
-        if (similarity > 0.7) {
-          supersededId = existing.id;
-          supersededVersion = existing.version ?? 1;
-          supersededMemory = existing;
-          break;
+      return withLock(async () => {
+        const existingMemories = await kv.list<Memory>(KV.memories);
+        let supersededId: string | undefined;
+        let supersededVersion = 1;
+        let supersededMemory: Memory | undefined;
+        const lowerContent = data.content.toLowerCase();
+        for (const existing of existingMemories) {
+          if (existing.isLatest === false) continue;
+          const similarity = jaccardSimilarity(
+            lowerContent,
+            existing.content.toLowerCase(),
+          );
+          if (similarity > 0.7) {
+            supersededId = existing.id;
+            supersededVersion = existing.version ?? 1;
+            supersededMemory = existing;
+            break;
+          }
         }
-      }
 
-      const memory: Memory = {
-        id: generateId("mem"),
-        createdAt: now,
-        updatedAt: now,
-        type: memType,
-        title: data.content.slice(0, 80),
-        content: data.content,
-        concepts: data.concepts || [],
-        files: data.files || [],
-        sessionIds: [],
-        strength: 7,
-        version: supersededId ? supersededVersion + 1 : 1,
-        parentId: supersededId,
-        supersedes: supersededId ? [supersededId] : [],
-        isLatest: true,
-      };
+        const memory: Memory = {
+          id: generateId("mem"),
+          createdAt: now,
+          updatedAt: now,
+          type: memType,
+          title: data.content.slice(0, 80),
+          content: data.content,
+          concepts: data.concepts || [],
+          files: data.files || [],
+          sessionIds: [],
+          strength: 7,
+          version: supersededId ? supersededVersion + 1 : 1,
+          parentId: supersededId,
+          supersedes: supersededId ? [supersededId] : [],
+          isLatest: true,
+        };
 
-      await kv.set(KV.memories, memory.id, memory);
-      if (supersededMemory) {
-        supersededMemory.isLatest = false;
-        await kv.set(KV.memories, supersededMemory.id, supersededMemory);
-      }
+        await kv.set(KV.memories, memory.id, memory);
+        if (supersededMemory) {
+          supersededMemory.isLatest = false;
+          await kv.set(KV.memories, supersededMemory.id, supersededMemory);
+        }
 
-      ctx.logger.info("Memory saved", {
-        memId: memory.id,
-        type: memory.type,
+        ctx.logger.info("Memory saved", {
+          memId: memory.id,
+          type: memory.type,
+        });
+        return { success: true, memory };
       });
-      return { success: true, memory };
     },
   );
 

--- a/src/functions/remember.ts
+++ b/src/functions/remember.ts
@@ -3,21 +3,9 @@ import { getContext } from "iii-sdk";
 import type { Memory } from "../types.js";
 import { KV, generateId, jaccardSimilarity } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
-
-function createMutex() {
-  let chain = Promise.resolve();
-  return function withLock<T>(fn: () => Promise<T>): Promise<T> {
-    const next = chain.then(fn, fn);
-    chain = next.then(
-      () => {},
-      () => {},
-    );
-    return next;
-  };
-}
+import { withKeyedLock } from "../state/keyed-mutex.js";
 
 export function registerRememberFunction(sdk: ISdk, kv: StateKV): void {
-  const withLock = createMutex();
   sdk.registerFunction(
     { id: "mem::remember" },
     async (data: {
@@ -54,7 +42,7 @@ export function registerRememberFunction(sdk: ISdk, kv: StateKV): void {
 
       const now = new Date().toISOString();
 
-      return withLock(async () => {
+      return withKeyedLock("mem:remember", async () => {
         const existingMemories = await kv.list<Memory>(KV.memories);
         let supersededId: string | undefined;
         let supersededVersion = 1;

--- a/src/functions/snapshot.ts
+++ b/src/functions/snapshot.ts
@@ -8,6 +8,9 @@ import type { SnapshotMeta, Session, Memory, GraphNode } from "../types.js";
 import { KV, generateId } from "../state/schema.js";
 import type { StateKV } from "../state/kv.js";
 import { recordAudit } from "./audit.js";
+import { VERSION } from "../version.js";
+
+const COMMIT_HASH_RE = /^[0-9a-f]{7,40}$/i;
 
 const execFileAsync = promisify(execFile);
 
@@ -55,7 +58,7 @@ export function registerSnapshotFunction(
         }
 
         const state = {
-          version: "0.4.0",
+          version: VERSION,
           timestamp: new Date().toISOString(),
           sessions,
           memories,
@@ -147,6 +150,9 @@ export function registerSnapshotFunction(
       const ctx = getContext();
       if (!data.commitHash) {
         return { success: false, error: "commitHash is required" };
+      }
+      if (!COMMIT_HASH_RE.test(data.commitHash)) {
+        return { success: false, error: "Invalid commitHash format" };
       }
 
       try {

--- a/src/functions/team.ts
+++ b/src/functions/team.ts
@@ -23,8 +23,12 @@ export function registerTeamFunction(
       project?: string;
     }) => {
       const ctx = getContext();
+      const VALID_ITEM_TYPES = new Set(["memory", "pattern"]);
       if (!data.itemId || !data.itemType) {
         return { success: false, error: "itemId and itemType are required" };
+      }
+      if (!VALID_ITEM_TYPES.has(data.itemType)) {
+        return { success: false, error: `Invalid itemType: ${data.itemType}` };
       }
 
       let content: unknown = null;

--- a/src/functions/team.ts
+++ b/src/functions/team.ts
@@ -31,11 +31,7 @@ export function registerTeamFunction(
         return { success: false, error: `Invalid itemType: ${data.itemType}` };
       }
 
-      let content: unknown = null;
-      if (data.itemType === "memory" || data.itemType === "pattern") {
-        content = await kv.get<Memory>(KV.memories, data.itemId);
-      }
-
+      const content = await kv.get<Memory>(KV.memories, data.itemId);
       if (!content) {
         return { success: false, error: "Item not found" };
       }

--- a/src/health/monitor.ts
+++ b/src/health/monitor.ts
@@ -77,6 +77,7 @@ export function registerHealthMonitor(
   const interval = setInterval(() => {
     collectHealth().catch(() => {});
   }, 30_000);
+  interval.unref();
 
   return {
     stop: () => clearInterval(interval),

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ import { MetricsStore } from "./eval/metrics-store.js";
 import { DedupMap } from "./functions/dedup.js";
 import { registerHealthMonitor } from "./health/monitor.js";
 import { initMetrics, OTEL_CONFIG } from "./telemetry/setup.js";
+import { VERSION } from "./version.js";
 
 async function main() {
   const config = loadConfig();
@@ -68,7 +69,7 @@ async function main() {
 
   const embeddingProvider = createEmbeddingProvider();
 
-  console.log(`[agentmemory] Starting worker v0.4.0...`);
+  console.log(`[agentmemory] Starting worker v${VERSION}...`);
   console.log(`[agentmemory] Engine: ${config.engineUrl}`);
   console.log(
     `[agentmemory] Provider: ${config.provider.provider} (${config.provider.model})`,
@@ -108,7 +109,7 @@ async function main() {
   );
 
   registerPrivacyFunction(sdk);
-  registerObserveFunction(sdk, kv, dedupMap);
+  registerObserveFunction(sdk, kv, dedupMap, config.maxObservationsPerSession);
   registerCompressFunction(sdk, kv, provider, metricsStore);
   registerSearchFunction(sdk, kv);
   registerContextFunction(sdk, kv, config.tokenBudget);

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -9,6 +9,7 @@ import type {
   GraphEdge,
 } from "../types.js";
 import { getAllTools } from "./tools-registry.js";
+import { timingSafeCompare } from "../auth.js";
 
 type McpResponse = {
   status_code: number;
@@ -28,7 +29,7 @@ export function registerMcpEndpoints(
     if (!sec) return null;
     const auth =
       req.headers?.["authorization"] || req.headers?.["Authorization"];
-    if (auth !== `Bearer ${sec}`) {
+    if (typeof auth !== "string" || !timingSafeCompare(auth, `Bearer ${sec}`)) {
       return { status_code: 401, body: { error: "unauthorized" } };
     }
     return null;

--- a/src/mcp/standalone.ts
+++ b/src/mcp/standalone.ts
@@ -4,10 +4,19 @@ import { InMemoryKV } from "./in-memory-kv.js";
 import { createStdioTransport } from "./transport.js";
 import { getAllTools } from "./tools-registry.js";
 import { getStandalonePersistPath } from "../config.js";
+import { VERSION } from "../version.js";
+
+const IMPLEMENTED_TOOLS = new Set([
+  "memory_save",
+  "memory_recall",
+  "memory_sessions",
+  "memory_export",
+  "memory_audit",
+]);
 
 const SERVER_INFO = {
   name: "agentmemory",
-  version: "0.4.0",
+  version: VERSION,
   protocolVersion: "2024-11-05",
 };
 
@@ -77,7 +86,7 @@ async function handleToolCall(
           {
             type: "text",
             text: JSON.stringify(
-              { version: "0.4.0", memories, sessions },
+              { version: VERSION, memories, sessions },
               null,
               2,
             ),
@@ -126,7 +135,9 @@ const transport = createStdioTransport(async (method, params) => {
       return {};
 
     case "tools/list":
-      return { tools: getAllTools() };
+      return {
+        tools: getAllTools().filter((t) => IMPLEMENTED_TOOLS.has(t.name)),
+      };
 
     case "tools/call": {
       const toolName = params.name as string;

--- a/src/providers/circuit-breaker.ts
+++ b/src/providers/circuit-breaker.ts
@@ -1,8 +1,10 @@
 import type { CircuitBreakerState } from "../types.js";
 
-const FAILURE_THRESHOLD = 3;
-const FAILURE_WINDOW_MS = 60_000;
-const RECOVERY_TIMEOUT_MS = 30_000;
+interface CircuitBreakerOptions {
+  failureThreshold?: number;
+  failureWindowMs?: number;
+  recoveryTimeoutMs?: number;
+}
 
 export class CircuitBreaker {
   private state: "closed" | "open" | "half-open" = "closed";
@@ -10,10 +12,20 @@ export class CircuitBreaker {
   private lastFailureAt: number | null = null;
   private openedAt: number | null = null;
 
+  private readonly failureThreshold: number;
+  private readonly failureWindowMs: number;
+  private readonly recoveryTimeoutMs: number;
+
+  constructor(opts?: CircuitBreakerOptions) {
+    this.failureThreshold = opts?.failureThreshold ?? 3;
+    this.failureWindowMs = opts?.failureWindowMs ?? 60_000;
+    this.recoveryTimeoutMs = opts?.recoveryTimeoutMs ?? 30_000;
+  }
+
   get isAllowed(): boolean {
     if (this.state === "closed") return true;
     if (this.state === "open") {
-      if (this.openedAt && Date.now() - this.openedAt >= RECOVERY_TIMEOUT_MS) {
+      if (this.openedAt && Date.now() - this.openedAt >= this.recoveryTimeoutMs) {
         this.state = "half-open";
         return true;
       }
@@ -38,12 +50,12 @@ export class CircuitBreaker {
       this.openedAt = now;
       return;
     }
-    if (this.lastFailureAt && now - this.lastFailureAt > FAILURE_WINDOW_MS) {
+    if (this.lastFailureAt && now - this.lastFailureAt > this.failureWindowMs) {
       this.failures = 0;
     }
     this.failures += 1;
     this.lastFailureAt = now;
-    if (this.failures >= FAILURE_THRESHOLD) {
+    if (this.failures >= this.failureThreshold) {
       this.state = "open";
       this.openedAt = now;
     }

--- a/src/providers/circuit-breaker.ts
+++ b/src/providers/circuit-breaker.ts
@@ -17,15 +17,24 @@ export class CircuitBreaker {
   private readonly recoveryTimeoutMs: number;
 
   constructor(opts?: CircuitBreakerOptions) {
-    this.failureThreshold = opts?.failureThreshold ?? 3;
-    this.failureWindowMs = opts?.failureWindowMs ?? 60_000;
-    this.recoveryTimeoutMs = opts?.recoveryTimeoutMs ?? 30_000;
+    const ft = opts?.failureThreshold;
+    this.failureThreshold =
+      Number.isFinite(ft) && ft! > 0 ? Math.max(1, Math.floor(ft!)) : 3;
+
+    const fw = opts?.failureWindowMs;
+    this.failureWindowMs = Number.isFinite(fw) && fw! > 0 ? fw! : 60_000;
+
+    const rt = opts?.recoveryTimeoutMs;
+    this.recoveryTimeoutMs = Number.isFinite(rt) && rt! > 0 ? rt! : 30_000;
   }
 
   get isAllowed(): boolean {
     if (this.state === "closed") return true;
     if (this.state === "open") {
-      if (this.openedAt && Date.now() - this.openedAt >= this.recoveryTimeoutMs) {
+      if (
+        this.openedAt &&
+        Date.now() - this.openedAt >= this.recoveryTimeoutMs
+      ) {
         this.state = "half-open";
         return true;
       }

--- a/src/state/keyed-mutex.ts
+++ b/src/state/keyed-mutex.ts
@@ -1,0 +1,18 @@
+const locks = new Map<string, Promise<void>>();
+
+export function withKeyedLock<T>(
+  key: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const prev = locks.get(key) ?? Promise.resolve();
+  const next = prev.then(fn, fn);
+  const cleanup = next.then(
+    () => {},
+    () => {},
+  );
+  locks.set(key, cleanup);
+  cleanup.then(() => {
+    if (locks.get(key) === cleanup) locks.delete(key);
+  });
+  return next;
+}

--- a/src/telemetry/setup.ts
+++ b/src/telemetry/setup.ts
@@ -1,3 +1,5 @@
+import { VERSION } from "../version.js";
+
 interface OtelConfig {
   serviceName: string;
   serviceVersion: string;
@@ -6,7 +8,7 @@ interface OtelConfig {
 
 export const OTEL_CONFIG: OtelConfig = {
   serviceName: "agentmemory",
-  serviceVersion: "0.4.0",
+  serviceVersion: VERSION,
   metricsExportIntervalMs: 30_000,
 };
 
@@ -111,14 +113,4 @@ export function initMetrics(getMeter?: (name: string) => Meter): {
   ) as unknown as Histograms;
 
   return { counters, histograms };
-}
-
-export function getCounters(): Counters {
-  if (!counters) initMetrics();
-  return counters!;
-}
-
-export function getHistograms(): Histograms {
-  if (!histograms) initMetrics();
-  return histograms!;
 }

--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -8,6 +8,8 @@ import { fileURLToPath } from "node:url";
 import { getLatestHealth } from "../health/monitor.js";
 import type { MetricsStore } from "../eval/metrics-store.js";
 import type { ResilientProvider } from "../providers/resilient.js";
+import { VERSION } from "../version.js";
+import { timingSafeCompare, VIEWER_CSP } from "../auth.js";
 
 type Response = {
   status_code: number;
@@ -15,16 +17,16 @@ type Response = {
   body: unknown;
 };
 
-const VIEWER_CSP =
-  "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; connect-src 'self' ws://localhost:* wss://localhost:*; img-src 'self'; font-src 'self'";
-
 function checkAuth(
   req: ApiRequest,
   secret: string | undefined,
 ): Response | null {
   if (!secret) return null;
   const auth = req.headers?.["authorization"] || req.headers?.["Authorization"];
-  if (auth !== `Bearer ${secret}`) {
+  if (
+    typeof auth !== "string" ||
+    !timingSafeCompare(auth, `Bearer ${secret}`)
+  ) {
     return { status_code: 401, body: { error: "unauthorized" } };
   }
   return null;

--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -71,7 +71,7 @@ export function registerApiTriggers(
         body: {
           status,
           service: "agentmemory",
-          version: "0.4.0",
+          version: VERSION,
           health: health || null,
           functionMetrics,
           circuitBreaker,

--- a/src/types.ts
+++ b/src/types.ts
@@ -285,7 +285,7 @@ export interface GraphNode {
     | "library"
     | "person";
   name: string;
-  properties: Record<string, string>;
+  properties: Record<string, unknown>;
   sourceObservationIds: string[];
   createdAt: string;
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,1 @@
+export const VERSION = "0.4.0";

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.4.0";
+export const VERSION: "0.3.0" | "0.4.0" = "0.4.0";

--- a/test/snapshot.test.ts
+++ b/test/snapshot.test.ts
@@ -8,13 +8,8 @@ vi.mock("iii-sdk", () => ({
 
 vi.mock("node:child_process", () => ({
   execFile: vi.fn(
-    (
-      _cmd: string,
-      _args: string[],
-      _opts: unknown,
-      cb: Function,
-    ) => {
-      cb(null, { stdout: "abc123\n", stderr: "" });
+    (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
+      cb(null, { stdout: "abc1234\n", stderr: "" });
     },
   ),
 }));
@@ -26,7 +21,7 @@ vi.mock("node:util", async () => {
   >;
   return {
     ...actual,
-    promisify: () => async () => ({ stdout: "abc123\n", stderr: "" }),
+    promisify: () => async () => ({ stdout: "abc1234\n", stderr: "" }),
   };
 });
 
@@ -36,9 +31,7 @@ vi.mock("node:fs", () => ({
   writeFileSync: vi.fn(),
   readFileSync: vi
     .fn()
-    .mockReturnValue(
-      '{"version":"0.4.0","sessions":[],"memories":[]}',
-    ),
+    .mockReturnValue('{"version":"0.4.0","sessions":[],"memories":[]}'),
 }));
 
 import { registerSnapshotFunction } from "../src/functions/snapshot.js";
@@ -125,7 +118,7 @@ describe("Snapshot Functions", () => {
 
     expect(result.success).toBe(true);
     expect(result.snapshot).toBeDefined();
-    expect(result.snapshot.commitHash).toBe("abc123");
+    expect(result.snapshot.commitHash).toBe("abc1234");
     expect(result.snapshot.message).toBe("Test snapshot");
     expect(result.snapshot.stats.sessions).toBe(1);
     expect(result.snapshot.stats.memories).toBe(1);
@@ -133,7 +126,11 @@ describe("Snapshot Functions", () => {
 
   it("snapshot-list returns snapshots from git log", async () => {
     const result = (await sdk.trigger("mem::snapshot-list", {})) as {
-      snapshots: Array<{ commitHash: string; createdAt: string; message: string }>;
+      snapshots: Array<{
+        commitHash: string;
+        createdAt: string;
+        message: string;
+      }>;
     };
 
     expect(result.snapshots).toBeDefined();
@@ -152,11 +149,11 @@ describe("Snapshot Functions", () => {
 
   it("snapshot-restore loads state from commit", async () => {
     const result = (await sdk.trigger("mem::snapshot-restore", {
-      commitHash: "abc123",
+      commitHash: "abc1234",
     })) as { success: boolean; commitHash: string };
 
     expect(result.success).toBe(true);
-    expect(result.commitHash).toBe("abc123");
+    expect(result.commitHash).toBe("abc1234");
   });
 
   it("snapshot-create records an audit entry", async () => {


### PR DESCRIPTION
## Summary

Fixes 38 findings from the system audit (1 critical, 12 high, 16 medium, 9 low) across security, race conditions, performance, correctness, and dead code categories.

### New Files (2)
- **`src/version.ts`** — Single `VERSION` constant replacing 11 hardcoded strings across 8 files
- **`src/auth.ts`** — Shared `timingSafeCompare()` using `crypto.timingSafeEqual` + `VIEWER_CSP` constant

### Security Fixes
- Timing-safe auth comparison in all 3 auth implementations (api.ts, viewer/server.ts, mcp/server.ts)
- Snapshot `commitHash` validation with `/^[0-9a-f]{7,40}$/i` regex to prevent command injection
- Content-Type enforcement on POST/DELETE routes in viewer server
- CSP header on viewer HTML response
- Added `npm_`, `glpat-`, `dop_v1_` token patterns to privacy scanner

### Input Validation
- Governance bulk delete requires at least one filter for non-dryRun operations
- Team `itemType` validation against `Set(["memory", "pattern"])` whitelist
- `maxObservationsPerSession` enforcement in observe function

### Race Condition Fixes
- In-memory mutex around remember read-find-supersede-write cycle
- In-memory mutex around relations read-modify-write for relatedIds

### Bug Fixes
- Schema version validation updated to accept both 0.3.0 and 0.4.0
- `GraphNode.properties` typed as `Record<string, unknown>` (was `Record<string, string>`)
- Standalone MCP `tools/list` filtered to only 5 implemented tools
- Export version uses `VERSION` constant

### Config & Cleanup
- Circuit breaker thresholds configurable via constructor opts (with current values as defaults)
- Health monitor `interval.unref()` to prevent blocking process shutdown
- Removed unused `getCounters()`/`getHistograms()` telemetry exports
- Centralized version string via `VERSION` import in 7 files

### Modified Files (19)
`src/triggers/api.ts`, `src/viewer/server.ts`, `src/mcp/server.ts`, `src/mcp/standalone.ts`, `src/index.ts`, `src/functions/observe.ts`, `src/functions/compress.ts` (no change needed), `src/functions/remember.ts`, `src/functions/relations.ts`, `src/functions/snapshot.ts`, `src/functions/governance.ts`, `src/functions/team.ts`, `src/functions/privacy.ts`, `src/functions/export-import.ts`, `src/eval/schemas.ts`, `src/types.ts`, `src/providers/circuit-breaker.ts`, `src/health/monitor.ts`, `src/telemetry/setup.ts`

## Test plan
- [x] `npm run build` — succeeds with no errors
- [x] `npm test` — 216 tests pass (29 test files)
- [x] Updated snapshot test to use valid 7-char commit hash
- [ ] Manual: verify timing-safe auth rejects invalid tokens
- [ ] Manual: verify bulk delete with no filters returns error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session observation limits and a keyed locking mechanism to serialize related operations
  * Configurable circuit breaker options; dynamic service/version reporting

* **Security**
  * Timing-safe authorization checks and a stricter viewer Content Security Policy
  * Extended secret detection for npm, GitHub, and Doppler tokens

* **Bug Fixes**
  * Added validations (governance filters, commit hash format, item types) and relaxed export version acceptance

* **Tests**
  * Updated snapshot test expectations and mock outputs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->