### PR TITLE
fix: resolve 6 issues — performance, scheduling, TTL, plugin

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentmemory",
-  "version": "0.2.0",
+  "version": "0.6.0",
   "description": "Persistent memory for AI coding agents -- captures tool usage, compresses via LLM, injects context into future sessions. 12 hooks, 5 MCP tools, 4 skills, real-time viewer.",
   "author": "Rohit Ghumare",
   "license": "Apache-2.0",

--- a/src/functions/auto-forget.ts
+++ b/src/functions/auto-forget.ts
@@ -59,27 +59,71 @@ export function registerAutoForgetFunction(sdk: ISdk, kv: StateKV): void {
             new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
         )
         .slice(0, 1000);
-      for (let i = 0; i < latestMemories.length; i++) {
-        for (let j = i + 1; j < latestMemories.length; j++) {
-          const sim = jaccardSimilarity(
-            latestMemories[i].content.toLowerCase(),
-            latestMemories[j].content.toLowerCase(),
-          );
-          if (sim > CONTRADICTION_THRESHOLD) {
-            result.contradictions.push({
-              memoryA: latestMemories[i].id,
-              memoryB: latestMemories[j].id,
-              similarity: sim,
-            });
 
-            if (!dryRun) {
-              const older =
-                new Date(latestMemories[i].createdAt).getTime() <
-                new Date(latestMemories[j].createdAt).getTime()
-                  ? latestMemories[i]
-                  : latestMemories[j];
-              older.isLatest = false;
-              await kv.set(KV.memories, older.id, older);
+      const tokenCache = new Map<string, Set<string>>();
+      for (const mem of latestMemories) {
+        tokenCache.set(
+          mem.id,
+          new Set(
+            mem.content
+              .toLowerCase()
+              .split(/\s+/)
+              .filter((t) => t.length > 2),
+          ),
+        );
+      }
+
+      const memById = new Map(latestMemories.map((m) => [m.id, m]));
+      const conceptIndex = new Map<string, string[]>();
+      for (const mem of latestMemories) {
+        const concepts = mem.concepts || [];
+        for (const c of concepts) {
+          const key = c.toLowerCase();
+          if (!conceptIndex.has(key)) conceptIndex.set(key, []);
+          conceptIndex.get(key)!.push(mem.id);
+        }
+      }
+
+      const compared = new Set<string>();
+      for (const [, memIds] of conceptIndex) {
+        for (let i = 0; i < memIds.length; i++) {
+          for (let j = i + 1; j < memIds.length; j++) {
+            const key =
+              memIds[i] < memIds[j]
+                ? `${memIds[i]}|${memIds[j]}`
+                : `${memIds[j]}|${memIds[i]}`;
+            if (compared.has(key)) continue;
+            compared.add(key);
+
+            const setA = tokenCache.get(memIds[i])!;
+            const setB = tokenCache.get(memIds[j])!;
+            let intersection = 0;
+            if (setA.size === 0 && setB.size === 0) continue;
+            if (setA.size === 0 || setB.size === 0) continue;
+            for (const word of setA) {
+              if (setB.has(word)) intersection++;
+            }
+            const sim =
+              intersection / (setA.size + setB.size - intersection);
+
+            if (sim > CONTRADICTION_THRESHOLD) {
+              const memA = memById.get(memIds[i])!;
+              const memB = memById.get(memIds[j])!;
+              result.contradictions.push({
+                memoryA: memA.id,
+                memoryB: memB.id,
+                similarity: sim,
+              });
+
+              if (!dryRun) {
+                const older =
+                  new Date(memA.createdAt).getTime() <
+                  new Date(memB.createdAt).getTime()
+                    ? memA
+                    : memB;
+                older.isLatest = false;
+                await kv.set(KV.memories, older.id, older);
+              }
             }
           }
         }

--- a/src/functions/consolidate.ts
+++ b/src/functions/consolidate.ts
@@ -117,8 +117,15 @@ export function registerConsolidateFunction(
         existingMemories.map((m) => m.title.toLowerCase()),
       );
 
-      for (const [concept, obsGroup] of conceptGroups) {
-        if (obsGroup.length < 3) continue;
+      const MAX_LLM_CALLS = 10;
+      let llmCallCount = 0;
+
+      const sortedGroups = [...conceptGroups.entries()]
+        .filter(([, g]) => g.length >= 3)
+        .sort((a, b) => b[1].length - a[1].length);
+
+      for (const [concept, obsGroup] of sortedGroups) {
+        if (llmCallCount >= MAX_LLM_CALLS) break;
 
         const top = obsGroup
           .sort((a, b) => b.importance - a.importance)
@@ -142,6 +149,7 @@ export function registerConsolidateFunction(
               setTimeout(() => reject(new Error("compress timeout")), 30_000),
             ),
           ]);
+          llmCallCount++;
           const parsed = parseMemoryXml(response, sessionIds);
           if (!parsed) continue;
 

--- a/src/functions/remember.ts
+++ b/src/functions/remember.ts
@@ -13,6 +13,7 @@ export function registerRememberFunction(sdk: ISdk, kv: StateKV): void {
       type?: string;
       concepts?: string[];
       files?: string[];
+      ttlDays?: number;
     }) => {
       const ctx = getContext();
       if (
@@ -78,6 +79,10 @@ export function registerRememberFunction(sdk: ISdk, kv: StateKV): void {
           supersedes: supersededId ? [supersededId] : [],
           isLatest: true,
         };
+
+        if (data.ttlDays && typeof data.ttlDays === "number" && data.ttlDays > 0) {
+          memory.forgetAfter = new Date(Date.now() + data.ttlDays * 86400000).toISOString();
+        }
 
         if (supersededMemory) {
           supersededMemory.isLatest = false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -281,6 +281,29 @@ async function main() {
     config.restPort,
   );
 
+  const autoForgetIntervalMs = parseInt(process.env.AUTO_FORGET_INTERVAL_MS || "3600000", 10);
+  const consolidationIntervalMs = parseInt(process.env.CONSOLIDATION_INTERVAL_MS || "7200000", 10);
+
+  if (process.env.AUTO_FORGET_ENABLED !== "false") {
+    const autoForgetTimer = setInterval(async () => {
+      try {
+        await sdk.trigger("mem::auto-forget", { dryRun: false });
+      } catch {}
+    }, autoForgetIntervalMs);
+    autoForgetTimer.unref();
+    console.log(`[agentmemory] Auto-forget: enabled (every ${autoForgetIntervalMs / 60000}m)`);
+  }
+
+  if (process.env.CONSOLIDATION_ENABLED === "true") {
+    const consolidationTimer = setInterval(async () => {
+      try {
+        await sdk.trigger("mem::consolidate-pipeline", {});
+      } catch {}
+    }, consolidationIntervalMs);
+    consolidationTimer.unref();
+    console.log(`[agentmemory] Auto-consolidation: enabled (every ${consolidationIntervalMs / 60000}m)`);
+  }
+
   const shutdown = async () => {
     console.log(`\n[agentmemory] Shutting down...`);
     healthMonitor.stop();

--- a/src/state/vector-index.ts
+++ b/src/state/vector-index.ts
@@ -41,14 +41,25 @@ export class VectorIndex {
       sessionId: string;
       score: number;
     }> = [];
+    let minScore = -Infinity;
 
     for (const [obsId, entry] of this.vectors) {
       const score = cosineSimilarity(query, entry.embedding);
-      results.push({ obsId, sessionId: entry.sessionId, score });
+      if (results.length < limit) {
+        results.push({ obsId, sessionId: entry.sessionId, score });
+        if (results.length === limit) {
+          results.sort((a, b) => a.score - b.score);
+          minScore = results[0].score;
+        }
+      } else if (score > minScore) {
+        results[0] = { obsId, sessionId: entry.sessionId, score };
+        results.sort((a, b) => a.score - b.score);
+        minScore = results[0].score;
+      }
     }
 
     results.sort((a, b) => b.score - a.score);
-    return results.slice(0, limit);
+    return results;
   }
 
   get size(): number {


### PR DESCRIPTION
## Summary

Resolves 6 open issues covering performance, scheduling, TTL, and plugin fixes.

| Issue | Title | Fix |
|-------|-------|-----|
| #29 | Auto-forget O(n^2) contradiction detection | Concept-bucketed comparison with pre-tokenized cache |
| #28 | Unbounded sequential LLM calls | Cap at 10, process largest concept groups first |
| #30 | Vector search brute-force scan | Bounded min-heap, skip low-scoring entries |
| #36 | No cron auto-consolidation/forget | setInterval scheduling (1h/2h defaults, configurable) |
| #63 | No memory TTL at save time | ttlDays parameter on mem::remember |
| #75 | Plugin version stale | 0.2.0 -> 0.6.0 |

## Test plan

- [x] 551 tests pass (47 test files)
- [ ] Verify auto-forget runs on schedule with `AUTO_FORGET_ENABLED=true`
- [ ] Verify `mem::remember` with `ttlDays: 7` sets `forgetAfter`
- [ ] Verify vector search returns same results (bounded heap is functionally equivalent)

Closes #28 #29 #30 #36 #63 #75

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Memories can now include expiration dates via configurable time-to-live (TTL)
  - Automatic cleanup and consolidation processes now run on scheduled intervals

* **Chores**
  - Version bumped to 0.6.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->