### PR TITLE
fix: plugin install schema validation (#75)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,9 +1,14 @@
 {
+  "name": "agentmemory",
+  "owner": {
+    "name": "Rohit Ghumare",
+    "github": "rohitg00"
+  },
   "plugins": [
     {
       "name": "agentmemory",
       "description": "Persistent memory for AI coding agents -- captures tool usage, compresses via LLM, injects context into future sessions",
-      "path": "./plugin"
+      "source": "./plugin"
     }
   ]
 }

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentmemory",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Persistent memory for AI coding agents -- captures tool usage, compresses via LLM, injects context into future sessions. 12 hooks, 5 MCP tools, 4 skills, real-time viewer.",
   "author": "Rohit Ghumare",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

- Add missing `name` and `owner` top-level fields to `.claude-plugin/marketplace.json`
- Fix `path` → `source` in plugins array (correct field name per schema)
- Bump plugin version to 0.6.1

Fixes #75

## Test plan

- [x] `marketplace.json` now has required `name`, `owner.name`, `owner.github` fields
- [x] `plugins[0].source` points to `./plugin` (was incorrectly `path`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin configuration and bumped version to 0.6.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->