### PR TITLE
fix: scope npm package as @agentmemory/agentmemory

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "agentmemory",
+  "name": "@agentmemory/agentmemory",
   "version": "0.7.0",
   "description": "Persistent memory for AI coding agents, powered by iii-engine's three primitives",
   "type": "module",


### PR DESCRIPTION
## Summary
npm rejected unscoped `agentmemory` as too similar to existing `agent-memory`. Scoping under `@agentmemory` org.

## Test plan
- [ ] CI passes
- [ ] After merge, create release v0.7.1 to trigger publish

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  - Updated package name to scoped identifier for distribution and resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->