### PR TITLE
feat: real agent logos + paste-this-prompt blocks for integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,102 @@
 
 ---
 
+## Supported Agents
+
+agentmemory works with any agent that supports hooks, MCP, or REST API. All agents share the same memory server.
+
+<table>
+<tr>
+<td align="center" width="12.5%">
+<a href="https://claude.com/product/claude-code"><img src="https://matthiasroder.com/content/images/2026/01/Claude.png?size=120" alt="Claude Code" width="48" height="48" /></a><br/>
+<strong>Claude Code</strong><br/>
+<sub>12 hooks + MCP + skills</sub>
+</td>
+<td align="center" width="12.5%">
+<a href="integrations/openclaw/"><img src="https://github.com/openclaw.png?size=120" alt="OpenClaw" width="48" height="48" /></a><br/>
+<strong>OpenClaw</strong><br/>
+<sub>MCP + <a href="integrations/openclaw/">plugin</a></sub>
+</td>
+<td align="center" width="12.5%">
+<a href="integrations/hermes/"><img src="https://github.com/NousResearch.png?size=120" alt="Hermes" width="48" height="48" /></a><br/>
+<strong>Hermes</strong><br/>
+<sub>MCP + <a href="integrations/hermes/">plugin</a></sub>
+</td>
+<td align="center" width="12.5%">
+<a href="https://cursor.com"><img src="https://www.freelogovectors.net/wp-content/uploads/2025/06/cursor-logo-freelogovectors.net_.png?size=180" alt="Cursor" /></a><br/>
+<sub>MCP server</sub>
+</td>
+<td align="center" width="12.5%">
+<a href="https://github.com/google-gemini/gemini-cli"><img src="https://github.com/google-gemini.png?size=120" alt="Gemini CLI" width="48" height="48" /></a><br/>
+<strong>Gemini CLI</strong><br/>
+<sub>MCP server</sub>
+</td>
+<td align="center" width="12.5%">
+<a href="https://github.com/opencode-ai/opencode"><img src="https://github.com/opencode-ai.png?size=120" alt="OpenCode" width="48" height="48" /></a><br/>
+<strong>OpenCode</strong><br/>
+<sub>MCP server</sub>
+</td>
+<td align="center" width="12.5%">
+<a href="https://github.com/openai/codex"><img src="https://github.com/openai.png?size=120" alt="Codex CLI" width="48" height="48" /></a><br/>
+<strong>Codex CLI</strong><br/>
+<sub>MCP server</sub>
+</td>
+<td align="center" width="12.5%">
+<a href="https://github.com/cline/cline"><img src="https://github.com/cline.png?size=120" alt="Cline" width="48" height="48" /></a><br/>
+<strong>Cline</strong><br/>
+<sub>MCP server</sub>
+</td>
+</tr>
+<tr>
+<td align="center" width="12.5%">
+<a href="https://github.com/block/goose"><img src="https://github.com/block.png?size=120" alt="Goose" width="48" height="48" /></a><br/>
+<strong>Goose</strong><br/>
+<sub>MCP server</sub>
+</td>
+<td align="center" width="12.5%">
+<a href="https://github.com/Kilo-Org/kilocode"><img src="https://github.com/Kilo-Org.png?size=120" alt="Kilo Code" width="48" height="48" /></a><br/>
+<strong>Kilo Code</strong><br/>
+<sub>MCP server</sub>
+</td>
+<td align="center" width="12.5%">
+<a href="https://github.com/Aider-AI/aider"><img src="https://github.com/Aider-AI.png?size=120" alt="Aider" width="48" height="48" /></a><br/>
+<strong>Aider</strong><br/>
+<sub>REST API</sub>
+</td>
+<td align="center" width="12.5%">
+<a href="https://claude.ai/download"><img src="https://github.com/anthropics.png?size=120" alt="Claude Desktop" width="48" height="48" /></a><br/>
+<strong>Claude Desktop</strong><br/>
+<sub>MCP server</sub>
+</td>
+<td align="center" width="12.5%">
+<a href="https://windsurf.com"><img src="https://exafunction.github.io/public/brand/windsurf-black-symbol.svg?size=120" alt="Windsurf" width="48" height="48" /></a><br/>
+<strong>Windsurf</strong><br/>
+<sub>MCP server</sub>
+</td>
+<td align="center" width="12.5%">
+<a href="https://github.com/RooCodeInc/Roo-Code"><img src="https://github.com/RooCodeInc.png?size=120" alt="Roo Code" width="48" height="48" /></a><br/>
+<strong>Roo Code</strong><br/>
+<sub>MCP server</sub>
+</td>
+<td align="center" width="12.5%">
+<a href="https://github.com/anthropics/claude-agent-sdk-typescript"><img src="https://github.com/anthropics.png?size=120" alt="Claude SDK" width="48" height="48" /></a><br/>
+<strong>Claude SDK</strong><br/>
+<sub>AgentSDKProvider</sub>
+</td>
+<td align="center" width="12.5%">
+<img src="https://img.shields.io/badge/109-endpoints-1f6feb?style=flat-square" alt="REST API" width="48" /><br/>
+<strong>Any agent</strong><br/>
+<sub>REST API</sub>
+</td>
+</tr>
+</table>
+
+<p align="center">
+  <sub>Works with <strong>any</strong> agent that speaks MCP or HTTP. One server, memories shared across all of them.</sub>
+</p>
+
+---
+
 You explain the same architecture every session. You re-discover the same bugs. You re-teach the same preferences. Built-in memory (CLAUDE.md, .cursorrules) caps out at 200 lines and goes stale. agentmemory fixes this. It silently captures what your agent does, compresses it into searchable memory, and injects the right context when the next session starts. One command. Works across agents.
 
 **What changes:** Session 1 you set up JWT auth. Session 2 you ask for rate limiting. The agent already knows your auth uses jose middleware in `src/middleware/auth.ts`, your tests cover token validation, and you chose jose over jsonwebtoken for Edge compatibility. No re-explaining. No copy-pasting. The agent just *knows*.
@@ -176,103 +272,6 @@ npx @agentmemory/agentmemory
 <td>Yes</td>
 </tr>
 </table>
-
----
-
-## Supported Agents
-
-agentmemory works with any agent that supports hooks, MCP, or REST API. All agents share the same memory server.
-
-<table>
-<tr>
-<td align="center" width="12.5%">
-<a href="https://claude.com/product/claude-code"><img src="https://github.com/anthropics.png?size=120" alt="Claude Code" width="48" height="48" /></a><br/>
-<strong>Claude Code</strong><br/>
-<sub>12 hooks + MCP + skills</sub>
-</td>
-<td align="center" width="12.5%">
-<a href="integrations/openclaw/"><img src="https://github.com/openclaw.png?size=120" alt="OpenClaw" width="48" height="48" /></a><br/>
-<strong>OpenClaw</strong><br/>
-<sub>MCP + <a href="integrations/openclaw/">plugin</a></sub>
-</td>
-<td align="center" width="12.5%">
-<a href="integrations/hermes/"><img src="https://github.com/NousResearch.png?size=120" alt="Hermes" width="48" height="48" /></a><br/>
-<strong>Hermes</strong><br/>
-<sub>MCP + <a href="integrations/hermes/">plugin</a></sub>
-</td>
-<td align="center" width="12.5%">
-<a href="https://cursor.com"><img src="https://github.com/getcursor.png?size=120" alt="Cursor" width="48" height="48" /></a><br/>
-<strong>Cursor</strong><br/>
-<sub>MCP server</sub>
-</td>
-<td align="center" width="12.5%">
-<a href="https://github.com/google-gemini/gemini-cli"><img src="https://github.com/google-gemini.png?size=120" alt="Gemini CLI" width="48" height="48" /></a><br/>
-<strong>Gemini CLI</strong><br/>
-<sub>MCP server</sub>
-</td>
-<td align="center" width="12.5%">
-<a href="https://github.com/opencode-ai/opencode"><img src="https://github.com/opencode-ai.png?size=120" alt="OpenCode" width="48" height="48" /></a><br/>
-<strong>OpenCode</strong><br/>
-<sub>MCP server</sub>
-</td>
-<td align="center" width="12.5%">
-<a href="https://github.com/openai/codex"><img src="https://github.com/openai.png?size=120" alt="Codex CLI" width="48" height="48" /></a><br/>
-<strong>Codex CLI</strong><br/>
-<sub>MCP server</sub>
-</td>
-<td align="center" width="12.5%">
-<a href="https://github.com/cline/cline"><img src="https://github.com/cline.png?size=120" alt="Cline" width="48" height="48" /></a><br/>
-<strong>Cline</strong><br/>
-<sub>MCP server</sub>
-</td>
-</tr>
-<tr>
-<td align="center" width="12.5%">
-<a href="https://github.com/block/goose"><img src="https://github.com/block.png?size=120" alt="Goose" width="48" height="48" /></a><br/>
-<strong>Goose</strong><br/>
-<sub>MCP server</sub>
-</td>
-<td align="center" width="12.5%">
-<a href="https://github.com/Kilo-Org/kilocode"><img src="https://github.com/Kilo-Org.png?size=120" alt="Kilo Code" width="48" height="48" /></a><br/>
-<strong>Kilo Code</strong><br/>
-<sub>MCP server</sub>
-</td>
-<td align="center" width="12.5%">
-<a href="https://github.com/Aider-AI/aider"><img src="https://github.com/Aider-AI.png?size=120" alt="Aider" width="48" height="48" /></a><br/>
-<strong>Aider</strong><br/>
-<sub>REST API</sub>
-</td>
-<td align="center" width="12.5%">
-<a href="https://claude.ai/download"><img src="https://github.com/anthropics.png?size=120" alt="Claude Desktop" width="48" height="48" /></a><br/>
-<strong>Claude Desktop</strong><br/>
-<sub>MCP server</sub>
-</td>
-<td align="center" width="12.5%">
-<a href="https://windsurf.com"><img src="https://github.com/Exafunction.png?size=120" alt="Windsurf" width="48" height="48" /></a><br/>
-<strong>Windsurf</strong><br/>
-<sub>MCP server</sub>
-</td>
-<td align="center" width="12.5%">
-<a href="https://github.com/RooCodeInc/Roo-Code"><img src="https://github.com/RooCodeInc.png?size=120" alt="Roo Code" width="48" height="48" /></a><br/>
-<strong>Roo Code</strong><br/>
-<sub>MCP server</sub>
-</td>
-<td align="center" width="12.5%">
-<a href="https://github.com/anthropics/claude-agent-sdk-typescript"><img src="https://github.com/anthropics.png?size=120" alt="Claude SDK" width="48" height="48" /></a><br/>
-<strong>Claude SDK</strong><br/>
-<sub>AgentSDKProvider</sub>
-</td>
-<td align="center" width="12.5%">
-<img src="https://img.shields.io/badge/109-endpoints-1f6feb?style=flat-square" alt="REST API" width="48" /><br/>
-<strong>Any agent</strong><br/>
-<sub>REST API</sub>
-</td>
-</tr>
-</table>
-
-<p align="center">
-  <sub>Works with <strong>any</strong> agent that speaks MCP or HTTP. One server, memories shared across all of them.</sub>
-</p>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -185,26 +185,94 @@ agentmemory works with any agent that supports hooks, MCP, or REST API. All agen
 
 <table>
 <tr>
-<td align="center" width="12.5%"><strong>Claude Code</strong><br/><sub>12 hooks + MCP + skills</sub></td>
-<td align="center" width="12.5%"><strong>Cursor</strong><br/><sub>MCP server</sub></td>
-<td align="center" width="12.5%"><strong>OpenClaw</strong><br/><sub>MCP server</sub></td>
-<td align="center" width="12.5%"><strong>Gemini CLI</strong><br/><sub>MCP server</sub></td>
-<td align="center" width="12.5%"><strong>OpenCode</strong><br/><sub>MCP server</sub></td>
-<td align="center" width="12.5%"><strong>Codex CLI</strong><br/><sub>MCP server</sub></td>
-<td align="center" width="12.5%"><strong>Cline</strong><br/><sub>MCP server</sub></td>
-<td align="center" width="12.5%"><strong>Hermes</strong><br/><sub>MCP + plugin</sub></td>
+<td align="center" width="12.5%">
+<a href="https://claude.com/product/claude-code"><img src="https://cdn.simpleicons.org/anthropic/D97757" alt="Claude Code" width="40" height="40" /></a><br/>
+<strong>Claude Code</strong><br/>
+<sub>12 hooks + MCP + skills</sub>
+</td>
+<td align="center" width="12.5%">
+<a href="https://cursor.com"><img src="https://cdn.simpleicons.org/cursor/000000" alt="Cursor" width="40" height="40" /></a><br/>
+<strong>Cursor</strong><br/>
+<sub>MCP server</sub>
+</td>
+<td align="center" width="12.5%">
+<a href="https://github.com/openclaw/openclaw"><img src="https://github.com/openclaw.png?size=80" alt="OpenClaw" width="40" height="40" /></a><br/>
+<strong>OpenClaw</strong><br/>
+<sub>MCP + <a href="integrations/openclaw/">plugin</a></sub>
+</td>
+<td align="center" width="12.5%">
+<a href="https://github.com/google-gemini/gemini-cli"><img src="https://cdn.simpleicons.org/googlegemini/8E75B2" alt="Gemini CLI" width="40" height="40" /></a><br/>
+<strong>Gemini CLI</strong><br/>
+<sub>MCP server</sub>
+</td>
+<td align="center" width="12.5%">
+<a href="https://github.com/opencode-ai/opencode"><img src="https://github.com/opencode-ai.png?size=80" alt="OpenCode" width="40" height="40" /></a><br/>
+<strong>OpenCode</strong><br/>
+<sub>MCP server</sub>
+</td>
+<td align="center" width="12.5%">
+<a href="https://github.com/openai/codex"><img src="https://cdn.simpleicons.org/openai/000000" alt="Codex CLI" width="40" height="40" /></a><br/>
+<strong>Codex CLI</strong><br/>
+<sub>MCP server</sub>
+</td>
+<td align="center" width="12.5%">
+<a href="https://github.com/cline/cline"><img src="https://github.com/cline.png?size=80" alt="Cline" width="40" height="40" /></a><br/>
+<strong>Cline</strong><br/>
+<sub>MCP server</sub>
+</td>
+<td align="center" width="12.5%">
+<a href="https://github.com/NousResearch/hermes-agent"><img src="https://github.com/NousResearch.png?size=80" alt="Hermes" width="40" height="40" /></a><br/>
+<strong>Hermes</strong><br/>
+<sub>MCP + <a href="integrations/hermes/">plugin</a></sub>
+</td>
 </tr>
 <tr>
-<td align="center" width="12.5%"><strong>Goose</strong><br/><sub>MCP server</sub></td>
-<td align="center" width="12.5%"><strong>Kilo Code</strong><br/><sub>MCP server</sub></td>
-<td align="center" width="12.5%"><strong>Aider</strong><br/><sub>REST API</sub></td>
-<td align="center" width="12.5%"><strong>Claude Desktop</strong><br/><sub>MCP server</sub></td>
-<td align="center" width="12.5%"><strong>Windsurf</strong><br/><sub>MCP server</sub></td>
-<td align="center" width="12.5%"><strong>Roo Code</strong><br/><sub>MCP server</sub></td>
-<td align="center" width="12.5%"><strong>Claude SDK</strong><br/><sub>AgentSDKProvider</sub></td>
-<td align="center" width="12.5%"><strong>Any agent</strong><br/><sub>REST API (109 endpoints)</sub></td>
+<td align="center" width="12.5%">
+<a href="https://github.com/block/goose"><img src="https://github.com/block.png?size=80" alt="Goose" width="40" height="40" /></a><br/>
+<strong>Goose</strong><br/>
+<sub>MCP server</sub>
+</td>
+<td align="center" width="12.5%">
+<a href="https://github.com/kilo-org/kilocode"><img src="https://github.com/kilo-org.png?size=80" alt="Kilo Code" width="40" height="40" /></a><br/>
+<strong>Kilo Code</strong><br/>
+<sub>MCP server</sub>
+</td>
+<td align="center" width="12.5%">
+<a href="https://github.com/Aider-AI/aider"><img src="https://github.com/Aider-AI.png?size=80" alt="Aider" width="40" height="40" /></a><br/>
+<strong>Aider</strong><br/>
+<sub>REST API</sub>
+</td>
+<td align="center" width="12.5%">
+<a href="https://claude.ai/download"><img src="https://cdn.simpleicons.org/anthropic/D97757" alt="Claude Desktop" width="40" height="40" /></a><br/>
+<strong>Claude Desktop</strong><br/>
+<sub>MCP server</sub>
+</td>
+<td align="center" width="12.5%">
+<a href="https://windsurf.com"><img src="https://cdn.simpleicons.org/windsurf/30B894" alt="Windsurf" width="40" height="40" /></a><br/>
+<strong>Windsurf</strong><br/>
+<sub>MCP server</sub>
+</td>
+<td align="center" width="12.5%">
+<a href="https://github.com/RooCodeInc/Roo-Code"><img src="https://github.com/RooCodeInc.png?size=80" alt="Roo Code" width="40" height="40" /></a><br/>
+<strong>Roo Code</strong><br/>
+<sub>MCP server</sub>
+</td>
+<td align="center" width="12.5%">
+<a href="https://github.com/anthropics/claude-agent-sdk-typescript"><img src="https://cdn.simpleicons.org/anthropic/D97757" alt="Claude SDK" width="40" height="40" /></a><br/>
+<strong>Claude SDK</strong><br/>
+<sub>AgentSDKProvider</sub>
+</td>
+<td align="center" width="12.5%">
+<img src="https://img.shields.io/badge/109-endpoints-1f6feb?style=flat-square" alt="REST API" /><br/>
+<strong>Any agent</strong><br/>
+<sub>REST API</sub>
+</td>
 </tr>
 </table>
+
+<p align="center">
+  <sub>Works with <strong>any</strong> agent that speaks MCP or HTTP. One server, memories shared across all of them.</sub>
+</p>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -186,84 +186,84 @@ agentmemory works with any agent that supports hooks, MCP, or REST API. All agen
 <table>
 <tr>
 <td align="center" width="12.5%">
-<a href="https://claude.com/product/claude-code"><img src="https://cdn.simpleicons.org/anthropic/D97757" alt="Claude Code" width="40" height="40" /></a><br/>
+<a href="https://claude.com/product/claude-code"><img src="https://github.com/anthropics.png?size=120" alt="Claude Code" width="48" height="48" /></a><br/>
 <strong>Claude Code</strong><br/>
 <sub>12 hooks + MCP + skills</sub>
 </td>
 <td align="center" width="12.5%">
-<a href="https://cursor.com"><img src="https://cdn.simpleicons.org/cursor/000000" alt="Cursor" width="40" height="40" /></a><br/>
-<strong>Cursor</strong><br/>
-<sub>MCP server</sub>
-</td>
-<td align="center" width="12.5%">
-<a href="https://github.com/openclaw/openclaw"><img src="https://github.com/openclaw.png?size=80" alt="OpenClaw" width="40" height="40" /></a><br/>
+<a href="integrations/openclaw/"><img src="https://github.com/openclaw.png?size=120" alt="OpenClaw" width="48" height="48" /></a><br/>
 <strong>OpenClaw</strong><br/>
 <sub>MCP + <a href="integrations/openclaw/">plugin</a></sub>
 </td>
 <td align="center" width="12.5%">
-<a href="https://github.com/google-gemini/gemini-cli"><img src="https://cdn.simpleicons.org/googlegemini/8E75B2" alt="Gemini CLI" width="40" height="40" /></a><br/>
+<a href="integrations/hermes/"><img src="https://github.com/NousResearch.png?size=120" alt="Hermes" width="48" height="48" /></a><br/>
+<strong>Hermes</strong><br/>
+<sub>MCP + <a href="integrations/hermes/">plugin</a></sub>
+</td>
+<td align="center" width="12.5%">
+<a href="https://cursor.com"><img src="https://github.com/getcursor.png?size=120" alt="Cursor" width="48" height="48" /></a><br/>
+<strong>Cursor</strong><br/>
+<sub>MCP server</sub>
+</td>
+<td align="center" width="12.5%">
+<a href="https://github.com/google-gemini/gemini-cli"><img src="https://github.com/google-gemini.png?size=120" alt="Gemini CLI" width="48" height="48" /></a><br/>
 <strong>Gemini CLI</strong><br/>
 <sub>MCP server</sub>
 </td>
 <td align="center" width="12.5%">
-<a href="https://github.com/opencode-ai/opencode"><img src="https://github.com/opencode-ai.png?size=80" alt="OpenCode" width="40" height="40" /></a><br/>
+<a href="https://github.com/opencode-ai/opencode"><img src="https://github.com/opencode-ai.png?size=120" alt="OpenCode" width="48" height="48" /></a><br/>
 <strong>OpenCode</strong><br/>
 <sub>MCP server</sub>
 </td>
 <td align="center" width="12.5%">
-<a href="https://github.com/openai/codex"><img src="https://cdn.simpleicons.org/openai/000000" alt="Codex CLI" width="40" height="40" /></a><br/>
+<a href="https://github.com/openai/codex"><img src="https://github.com/openai.png?size=120" alt="Codex CLI" width="48" height="48" /></a><br/>
 <strong>Codex CLI</strong><br/>
 <sub>MCP server</sub>
 </td>
 <td align="center" width="12.5%">
-<a href="https://github.com/cline/cline"><img src="https://github.com/cline.png?size=80" alt="Cline" width="40" height="40" /></a><br/>
+<a href="https://github.com/cline/cline"><img src="https://github.com/cline.png?size=120" alt="Cline" width="48" height="48" /></a><br/>
 <strong>Cline</strong><br/>
 <sub>MCP server</sub>
-</td>
-<td align="center" width="12.5%">
-<a href="https://github.com/NousResearch/hermes-agent"><img src="https://github.com/NousResearch.png?size=80" alt="Hermes" width="40" height="40" /></a><br/>
-<strong>Hermes</strong><br/>
-<sub>MCP + <a href="integrations/hermes/">plugin</a></sub>
 </td>
 </tr>
 <tr>
 <td align="center" width="12.5%">
-<a href="https://github.com/block/goose"><img src="https://github.com/block.png?size=80" alt="Goose" width="40" height="40" /></a><br/>
+<a href="https://github.com/block/goose"><img src="https://github.com/block.png?size=120" alt="Goose" width="48" height="48" /></a><br/>
 <strong>Goose</strong><br/>
 <sub>MCP server</sub>
 </td>
 <td align="center" width="12.5%">
-<a href="https://github.com/kilo-org/kilocode"><img src="https://github.com/kilo-org.png?size=80" alt="Kilo Code" width="40" height="40" /></a><br/>
+<a href="https://github.com/Kilo-Org/kilocode"><img src="https://github.com/Kilo-Org.png?size=120" alt="Kilo Code" width="48" height="48" /></a><br/>
 <strong>Kilo Code</strong><br/>
 <sub>MCP server</sub>
 </td>
 <td align="center" width="12.5%">
-<a href="https://github.com/Aider-AI/aider"><img src="https://github.com/Aider-AI.png?size=80" alt="Aider" width="40" height="40" /></a><br/>
+<a href="https://github.com/Aider-AI/aider"><img src="https://github.com/Aider-AI.png?size=120" alt="Aider" width="48" height="48" /></a><br/>
 <strong>Aider</strong><br/>
 <sub>REST API</sub>
 </td>
 <td align="center" width="12.5%">
-<a href="https://claude.ai/download"><img src="https://cdn.simpleicons.org/anthropic/D97757" alt="Claude Desktop" width="40" height="40" /></a><br/>
+<a href="https://claude.ai/download"><img src="https://github.com/anthropics.png?size=120" alt="Claude Desktop" width="48" height="48" /></a><br/>
 <strong>Claude Desktop</strong><br/>
 <sub>MCP server</sub>
 </td>
 <td align="center" width="12.5%">
-<a href="https://windsurf.com"><img src="https://cdn.simpleicons.org/windsurf/30B894" alt="Windsurf" width="40" height="40" /></a><br/>
+<a href="https://windsurf.com"><img src="https://github.com/Exafunction.png?size=120" alt="Windsurf" width="48" height="48" /></a><br/>
 <strong>Windsurf</strong><br/>
 <sub>MCP server</sub>
 </td>
 <td align="center" width="12.5%">
-<a href="https://github.com/RooCodeInc/Roo-Code"><img src="https://github.com/RooCodeInc.png?size=80" alt="Roo Code" width="40" height="40" /></a><br/>
+<a href="https://github.com/RooCodeInc/Roo-Code"><img src="https://github.com/RooCodeInc.png?size=120" alt="Roo Code" width="48" height="48" /></a><br/>
 <strong>Roo Code</strong><br/>
 <sub>MCP server</sub>
 </td>
 <td align="center" width="12.5%">
-<a href="https://github.com/anthropics/claude-agent-sdk-typescript"><img src="https://cdn.simpleicons.org/anthropic/D97757" alt="Claude SDK" width="40" height="40" /></a><br/>
+<a href="https://github.com/anthropics/claude-agent-sdk-typescript"><img src="https://github.com/anthropics.png?size=120" alt="Claude SDK" width="48" height="48" /></a><br/>
 <strong>Claude SDK</strong><br/>
 <sub>AgentSDKProvider</sub>
 </td>
 <td align="center" width="12.5%">
-<img src="https://img.shields.io/badge/109-endpoints-1f6feb?style=flat-square" alt="REST API" /><br/>
+<img src="https://img.shields.io/badge/109-endpoints-1f6feb?style=flat-square" alt="REST API" width="48" /><br/>
 <strong>Any agent</strong><br/>
 <sub>REST API</sub>
 </td>
@@ -297,6 +297,46 @@ Open `http://localhost:3113` to watch the memory build live.
 ```
 Install agentmemory: run `npx @agentmemory/agentmemory` in a separate terminal to start the memory server. Then run `/plugin marketplace add rohitg00/agentmemory` and `/plugin install agentmemory` to register all 12 hooks, 4 skills, and 43 MCP tools. Verify with `curl http://localhost:3111/agentmemory/health`. The real-time viewer is at http://localhost:3113.
 ```
+
+<details>
+<summary><b>OpenClaw (paste this prompt)</b></summary>
+
+```
+Install agentmemory for OpenClaw. Run `npx @agentmemory/agentmemory` in a separate terminal to start the memory server on localhost:3111. Then add this to my OpenClaw MCP config so agentmemory is available with all 43 memory tools:
+
+{
+  "mcpServers": {
+    "agentmemory": {
+      "command": "npx",
+      "args": ["agentmemory-mcp"]
+    }
+  }
+}
+
+Restart OpenClaw. Verify with `curl http://localhost:3111/agentmemory/health`. Open http://localhost:3113 for the real-time viewer. For deeper 4-hook gateway integration, see integrations/openclaw in the agentmemory repo.
+```
+
+Full guide: [`integrations/openclaw/`](integrations/openclaw/)
+
+</details>
+
+<details>
+<summary><b>Hermes Agent (paste this prompt)</b></summary>
+
+```
+Install agentmemory for Hermes. Run `npx @agentmemory/agentmemory` in a separate terminal to start the memory server on localhost:3111. Then add this to ~/.hermes/config.yaml so Hermes can use agentmemory as an MCP server with all 43 memory tools:
+
+mcp_servers:
+  agentmemory:
+    command: npx
+    args: ["agentmemory-mcp"]
+
+Verify with `curl http://localhost:3111/agentmemory/health`. Open http://localhost:3113 for the real-time viewer. For deeper 6-hook memory provider integration (pre-LLM context injection, turn capture, MEMORY.md mirroring, system prompt block), copy integrations/hermes from the agentmemory repo to ~/.hermes/plugins/memory/agentmemory.
+```
+
+Full guide: [`integrations/hermes/`](integrations/hermes/)
+
+</details>
 
 ### Other agents
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,19 @@
 </p>
 
 <p align="center">
-  <a href="https://www.npmjs.com/package/@agentmemory/agentmemory"><img src="https://img.shields.io/npm/v/@agentmemory/agentmemory?color=CB3837&label=npm" alt="npm version" /></a>
-  <a href="https://github.com/rohitg00/agentmemory/actions"><img src="https://img.shields.io/github/actions/workflow/status/rohitg00/agentmemory/ci.yml?label=tests" alt="CI" /></a>
-  <a href="https://github.com/rohitg00/agentmemory/blob/main/LICENSE"><img src="https://img.shields.io/github/license/rohitg00/agentmemory?color=blue" alt="License" /></a>
-  <a href="https://github.com/rohitg00/agentmemory/stargazers"><img src="https://img.shields.io/github/stars/rohitg00/agentmemory?style=flat&color=yellow" alt="Stars" /></a>
+  <a href="https://www.npmjs.com/package/@agentmemory/agentmemory"><img src="https://img.shields.io/npm/v/@agentmemory/agentmemory?color=CB3837&label=npm&style=for-the-badge&logo=npm" alt="npm version" /></a>
+  <a href="https://github.com/rohitg00/agentmemory/actions"><img src="https://img.shields.io/github/actions/workflow/status/rohitg00/agentmemory/ci.yml?label=tests&style=for-the-badge&logo=github" alt="CI" /></a>
+  <a href="https://github.com/rohitg00/agentmemory/blob/main/LICENSE"><img src="https://img.shields.io/github/license/rohitg00/agentmemory?color=blue&style=for-the-badge" alt="License" /></a>
+  <a href="https://github.com/rohitg00/agentmemory/stargazers"><img src="https://img.shields.io/github/stars/rohitg00/agentmemory?style=for-the-badge&color=yellow&logo=github" alt="Stars" /></a>
+</p>
+
+<p align="center">
+  <img src="assets/tags/stat-recall.svg" alt="95.2% retrieval R@5" height="48" />
+  <img src="assets/tags/stat-tokens.svg" alt="92% fewer tokens" height="48" />
+  <img src="assets/tags/stat-tools.svg" alt="43 MCP tools" height="48" />
+  <img src="assets/tags/stat-hooks.svg" alt="12 auto hooks" height="48" />
+  <img src="assets/tags/stat-deps.svg" alt="0 external DBs" height="48" />
+  <img src="assets/tags/stat-tests.svg" alt="654 tests passing" height="48" />
 </p>
 
 <p align="center">
@@ -22,7 +31,7 @@
   <a href="#quick-start">Quick Start</a> &bull;
   <a href="#benchmarks">Benchmarks</a> &bull;
   <a href="#vs-competitors">vs Competitors</a> &bull;
-  <a href="#supported-agents">Agents</a> &bull;
+  <a href="#works-with-every-agent">Agents</a> &bull;
   <a href="#how-it-works">How It Works</a> &bull;
   <a href="#mcp-server">MCP</a> &bull;
   <a href="#real-time-viewer">Viewer</a> &bull;
@@ -32,7 +41,7 @@
 
 ---
 
-## Supported Agents
+<h2 id="works-with-every-agent"><img src="assets/tags/section-agents.svg" alt="Works with every agent" height="32" /></h2>
 
 agentmemory works with any agent that supports hooks, MCP, or REST API. All agents share the same memory server.
 
@@ -54,7 +63,8 @@ agentmemory works with any agent that supports hooks, MCP, or REST API. All agen
 <sub>MCP + <a href="integrations/hermes/">plugin</a></sub>
 </td>
 <td align="center" width="12.5%">
-<a href="https://cursor.com"><img src="https://www.freelogovectors.net/wp-content/uploads/2025/06/cursor-logo-freelogovectors.net_.png?size=180" alt="Cursor" /></a><br/>
+<a href="https://cursor.com"><img src="https://www.freelogovectors.net/wp-content/uploads/2025/06/cursor-logo-freelogovectors.net_.png" alt="Cursor" width="48" height="48" /></a><br/>
+<strong>Cursor</strong><br/>
 <sub>MCP server</sub>
 </td>
 <td align="center" width="12.5%">
@@ -136,9 +146,15 @@ You explain the same architecture every session. You re-discover the same bugs. 
 npx @agentmemory/agentmemory
 ```
 
+<p align="center">
+  <img src="assets/tags/new-v082.svg" alt="New in v0.8.2" height="28" />
+</p>
+
+> **New in v0.8.2** — Security hardening (default localhost, viewer CSP nonces, mesh auth), `agentmemory demo` command, benchmark comparison vs mem0/Letta/Khoj, OpenClaw gateway plugin, real-time token savings in CLI + viewer.
+
 ---
 
-## Benchmarks
+<h2 id="benchmarks"><img src="assets/tags/section-benchmarks.svg" alt="Benchmarks" height="32" /></h2>
 
 <table>
 <tr>
@@ -169,22 +185,20 @@ npx @agentmemory/agentmemory
 </tr>
 </table>
 
-<table>
-<tr>
-<td align="center"><strong>95.2%</strong><br/>Retrieval R@5</td>
-<td align="center"><strong>92% fewer</strong><br/>tokens vs full context</td>
-<td align="center"><strong>43</strong><br/>MCP tools</td>
-<td align="center"><strong>12</strong><br/>auto-capture hooks</td>
-<td align="center"><strong>0</strong><br/>external DB deps</td>
-<td align="center"><strong>646</strong><br/>tests passing</td>
-</tr>
-</table>
+<p align="center">
+  <img src="assets/tags/stat-recall.svg" alt="95.2% retrieval R@5" height="48" />
+  <img src="assets/tags/stat-tokens.svg" alt="92% fewer tokens" height="48" />
+  <img src="assets/tags/stat-tools.svg" alt="43 MCP tools" height="48" />
+  <img src="assets/tags/stat-hooks.svg" alt="12 auto hooks" height="48" />
+  <img src="assets/tags/stat-deps.svg" alt="0 external DBs" height="48" />
+  <img src="assets/tags/stat-tests.svg" alt="654 tests passing" height="48" />
+</p>
 
 > Embedding model: `all-MiniLM-L6-v2` (local, free, no API key). Full reports: [`benchmark/LONGMEMEVAL.md`](benchmark/LONGMEMEVAL.md), [`benchmark/QUALITY.md`](benchmark/QUALITY.md), [`benchmark/SCALE.md`](benchmark/SCALE.md). Competitor comparison: [`benchmark/COMPARISON.md`](benchmark/COMPARISON.md) — agentmemory vs mem0, Letta, Khoj, claude-mem, Hippo.
 
 ---
 
-## vs Competitors
+<h2 id="vs-competitors"><img src="assets/tags/section-competitors.svg" alt="vs Competitors" height="32" /></h2>
 
 <table>
 <tr>
@@ -275,7 +289,7 @@ npx @agentmemory/agentmemory
 
 ---
 
-## Quick Start
+<h2 id="quick-start"><img src="assets/tags/section-quickstart.svg" alt="Quick Start" height="32" /></h2>
 
 ### Try it in 30 seconds
 
@@ -369,7 +383,7 @@ Install `iii-engine` manually with `cargo install iii-engine` or follow [iii.dev
 
 ---
 
-## Why agentmemory
+<h2 id="why-agentmemory"><img src="assets/tags/section-why.svg" alt="Why agentmemory" height="32" /></h2>
 
 Every coding agent forgets everything when the session ends. You waste the first 5 minutes of every session re-explaining your stack. agentmemory runs in the background and eliminates that entirely.
 
@@ -402,7 +416,7 @@ Every AI coding agent ships with built-in memory — Claude Code has `MEMORY.md`
 
 ---
 
-## How It Works
+<h2 id="how-it-works"><img src="assets/tags/section-how.svg" alt="How It Works" height="32" /></h2>
 
 ### Memory Pipeline
 
@@ -467,7 +481,7 @@ Memories decay over time (Ebbinghaus curve). Frequently accessed memories streng
 
 ---
 
-## Search
+<h2 id="search"><img src="assets/tags/section-search.svg" alt="Search" height="32" /></h2>
 
 Triple-stream retrieval combining three signals:
 
@@ -498,7 +512,7 @@ npm install @xenova/transformers
 
 ---
 
-## MCP Server
+<h2 id="mcp-server"><img src="assets/tags/section-mcp.svg" alt="MCP Server" height="32" /></h2>
 
 43 tools, 6 resources, 3 prompts, and 4 skills — the most comprehensive MCP memory toolkit for any agent.
 
@@ -597,7 +611,7 @@ Or add to your agent's MCP config:
 
 ---
 
-## Real-Time Viewer
+<h2 id="real-time-viewer"><img src="assets/tags/section-viewer.svg" alt="Real-Time Viewer" height="32" /></h2>
 
 Auto-starts on port `3113`. Live observation stream, session explorer, memory browser, knowledge graph visualization, and health dashboard.
 
@@ -609,7 +623,7 @@ The viewer server binds to `127.0.0.1` by default. The REST-served `/agentmemory
 
 ---
 
-## Configuration
+<h2 id="configuration"><img src="assets/tags/section-config.svg" alt="Configuration" height="32" /></h2>
 
 ### LLM Providers
 
@@ -668,7 +682,7 @@ Create `~/.agentmemory/.env`:
 
 ---
 
-## API
+<h2 id="api"><img src="assets/tags/section-api.svg" alt="API" height="32" /></h2>
 
 109 endpoints on port `3111`. The REST API binds to `127.0.0.1` by default. Protected endpoints require `Authorization: Bearer <secret>` when `AGENTMEMORY_SECRET` is set, and mesh sync endpoints require `AGENTMEMORY_SECRET` on both peers.
 
@@ -699,7 +713,7 @@ Full endpoint list: [`src/triggers/api.ts`](src/triggers/api.ts)
 
 ---
 
-## Architecture
+<h2 id="architecture"><img src="assets/tags/section-architecture.svg" alt="Architecture" height="32" /></h2>
 
 Built on [iii-engine](https://iii.dev)'s three primitives — no Express, no Postgres, no Redis.
 
@@ -718,7 +732,7 @@ Built on [iii-engine](https://iii.dev)'s three primitives — no Express, no Pos
 
 </details>
 
-## Development
+<h2 id="development"><img src="assets/tags/section-development.svg" alt="Development" height="32" /></h2>
 
 ```bash
 npm run dev               # Hot reload
@@ -729,6 +743,6 @@ npm run test:integration  # API tests (requires running services)
 
 **Prerequisites:** Node.js >= 20, [iii-engine](https://iii.dev/docs) or Docker
 
-## License
+<h2 id="license"><img src="assets/tags/section-license.svg" alt="License" height="32" /></h2>
 
 [Apache-2.0](LICENSE)

--- a/README.md
+++ b/README.md
@@ -146,10 +146,6 @@ You explain the same architecture every session. You re-discover the same bugs. 
 npx @agentmemory/agentmemory
 ```
 
-<p align="center">
-  <img src="assets/tags/new-v082.svg" alt="New in v0.8.2" height="28" />
-</p>
-
 > **New in v0.8.2** — Security hardening (default localhost, viewer CSP nonces, mesh auth), `agentmemory demo` command, benchmark comparison vs mem0/Letta/Khoj, OpenClaw gateway plugin, real-time token savings in CLI + viewer.
 
 ---

--- a/assets/tags/divider.svg
+++ b/assets/tags/divider.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 28" fill="none" role="img" aria-label="divider">
+  <defs>
+    <linearGradient id="divGradient" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#FF6B35" stop-opacity="0"/>
+      <stop offset="50%" stop-color="#FF6B35" stop-opacity="0.8"/>
+      <stop offset="100%" stop-color="#FF6B35" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="divAccent" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#FF6B35"/>
+      <stop offset="100%" stop-color="#FF8F5E"/>
+    </linearGradient>
+  </defs>
+  <!-- Left line -->
+  <rect x="0" y="13" width="45" height="2" rx="1" fill="url(#divGradient)"/>
+  <!-- Center diamond -->
+  <rect x="54" y="8" width="12" height="12" rx="3" fill="url(#divAccent)" transform="rotate(45 60 14)"/>
+  <circle cx="60" cy="14" r="2" fill="#0F0F0F"/>
+  <!-- Right line -->
+  <rect x="75" y="13" width="45" height="2" rx="1" fill="url(#divGradient)"/>
+</svg>

--- a/assets/tags/new-v082.svg
+++ b/assets/tags/new-v082.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 28" fill="none" role="img" aria-label="NEW: v0.8.2">
+  <rect x="0" y="0" width="140" height="28" rx="6" fill="#1A1A1A" stroke="#2A2A2A" stroke-width="1"/>
+  <text x="12" y="18" fill="#9CA3AF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="11" font-weight="600" letter-spacing="1.2">NEW</text>
+  <text x="128" y="18" fill="#FF6B35" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="11" font-weight="800" letter-spacing="0.5" text-anchor="end">v0.8.2</text>
+</svg>

--- a/assets/tags/pill-beta.svg
+++ b/assets/tags/pill-beta.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 24" fill="none" role="img" aria-label="BETA">
+  <rect x="0" y="0" width="100" height="24" rx="12" fill="#1A1A1A" stroke="#2A2A2A" stroke-width="1"/>
+  <circle cx="12" cy="12" r="3" fill="#FF6B35"/>
+  <text x="22" y="16" fill="#FFFFFF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="700" letter-spacing="1.2">BETA</text>
+</svg>

--- a/assets/tags/pill-hook.svg
+++ b/assets/tags/pill-hook.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 130 24" fill="none" role="img" aria-label="AUTO HOOK">
+  <rect x="0" y="0" width="130" height="24" rx="12" fill="#1A1A1A" stroke="#2A2A2A" stroke-width="1"/>
+  <circle cx="12" cy="12" r="3" fill="#FF6B35"/>
+  <text x="22" y="16" fill="#FFFFFF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="700" letter-spacing="1.2">AUTO HOOK</text>
+</svg>

--- a/assets/tags/pill-mcp.svg
+++ b/assets/tags/pill-mcp.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 110 24" fill="none" role="img" aria-label="MCP">
+  <rect x="0" y="0" width="110" height="24" rx="12" fill="#1A1A1A" stroke="#2A2A2A" stroke-width="1"/>
+  <circle cx="12" cy="12" r="3" fill="#FF6B35"/>
+  <text x="22" y="16" fill="#FFFFFF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="700" letter-spacing="1.2">MCP</text>
+</svg>

--- a/assets/tags/pill-new.svg
+++ b/assets/tags/pill-new.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 90 24" fill="none" role="img" aria-label="NEW">
+  <rect x="0" y="0" width="90" height="24" rx="12" fill="#1A1A1A" stroke="#2A2A2A" stroke-width="1"/>
+  <circle cx="12" cy="12" r="3" fill="#FF6B35"/>
+  <text x="22" y="16" fill="#FFFFFF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="700" letter-spacing="1.2">NEW</text>
+</svg>

--- a/assets/tags/pill-plugin.svg
+++ b/assets/tags/pill-plugin.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 110 24" fill="none" role="img" aria-label="PLUGIN">
+  <rect x="0" y="0" width="110" height="24" rx="12" fill="#1A1A1A" stroke="#2A2A2A" stroke-width="1"/>
+  <circle cx="12" cy="12" r="3" fill="#FF6B35"/>
+  <text x="22" y="16" fill="#FFFFFF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="700" letter-spacing="1.2">PLUGIN</text>
+</svg>

--- a/assets/tags/pill-secure.svg
+++ b/assets/tags/pill-secure.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 110 24" fill="none" role="img" aria-label="SECURE">
+  <rect x="0" y="0" width="110" height="24" rx="12" fill="#1A1A1A" stroke="#2A2A2A" stroke-width="1"/>
+  <circle cx="12" cy="12" r="3" fill="#FF6B35"/>
+  <text x="22" y="16" fill="#FFFFFF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="700" letter-spacing="1.2">SECURE</text>
+</svg>

--- a/assets/tags/pill-skill.svg
+++ b/assets/tags/pill-skill.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 110 24" fill="none" role="img" aria-label="SKILL">
+  <rect x="0" y="0" width="110" height="24" rx="12" fill="#1A1A1A" stroke="#2A2A2A" stroke-width="1"/>
+  <circle cx="12" cy="12" r="3" fill="#FF6B35"/>
+  <text x="22" y="16" fill="#FFFFFF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="700" letter-spacing="1.2">SKILL</text>
+</svg>

--- a/assets/tags/pill-stable.svg
+++ b/assets/tags/pill-stable.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 110 24" fill="none" role="img" aria-label="STABLE">
+  <rect x="0" y="0" width="110" height="24" rx="12" fill="#1A1A1A" stroke="#2A2A2A" stroke-width="1"/>
+  <circle cx="12" cy="12" r="3" fill="#FF6B35"/>
+  <text x="22" y="16" fill="#FFFFFF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="700" letter-spacing="1.2">STABLE</text>
+</svg>

--- a/assets/tags/section-agents.svg
+++ b/assets/tags/section-agents.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 44" fill="none" role="img" aria-label="WORKS WITH EVERY AGENT">
+  <defs>
+    <linearGradient id="accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FF6B35"/>
+      <stop offset="100%" stop-color="#FF8F5E"/>
+    </linearGradient>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#1A1A1A"/>
+      <stop offset="100%" stop-color="#0F0F0F"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="320" height="44" rx="8" fill="url(#bg)" stroke="#2A2A2A" stroke-width="1"/>
+  <rect x="0" y="0" width="6" height="44" rx="3" fill="url(#accent)"/>
+  <text x="22" y="20" fill="#FFFFFF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="13" font-weight="800" letter-spacing="2.2" text-rendering="geometricPrecision">WORKS WITH EVERY AGENT</text>
+  <text x="22" y="34" fill="#9CA3AF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="500" letter-spacing="0.2" text-rendering="geometricPrecision">16 integrations · one memory server</text>
+</svg>

--- a/assets/tags/section-api.svg
+++ b/assets/tags/section-api.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 44" fill="none" role="img" aria-label="API">
+  <defs>
+    <linearGradient id="accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FF6B35"/>
+      <stop offset="100%" stop-color="#FF8F5E"/>
+    </linearGradient>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#1A1A1A"/>
+      <stop offset="100%" stop-color="#0F0F0F"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="200" height="44" rx="8" fill="url(#bg)" stroke="#2A2A2A" stroke-width="1"/>
+  <rect x="0" y="0" width="6" height="44" rx="3" fill="url(#accent)"/>
+  <text x="22" y="20" fill="#FFFFFF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="13" font-weight="800" letter-spacing="2.2" text-rendering="geometricPrecision">API</text>
+  <text x="22" y="34" fill="#9CA3AF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="500" letter-spacing="0.2" text-rendering="geometricPrecision">109 REST endpoints</text>
+</svg>

--- a/assets/tags/section-architecture.svg
+++ b/assets/tags/section-architecture.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 280 44" fill="none" role="img" aria-label="ARCHITECTURE">
+  <defs>
+    <linearGradient id="accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FF6B35"/>
+      <stop offset="100%" stop-color="#FF8F5E"/>
+    </linearGradient>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#1A1A1A"/>
+      <stop offset="100%" stop-color="#0F0F0F"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="280" height="44" rx="8" fill="url(#bg)" stroke="#2A2A2A" stroke-width="1"/>
+  <rect x="0" y="0" width="6" height="44" rx="3" fill="url(#accent)"/>
+  <text x="22" y="20" fill="#FFFFFF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="13" font-weight="800" letter-spacing="2.2" text-rendering="geometricPrecision">ARCHITECTURE</text>
+  <text x="22" y="34" fill="#9CA3AF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="500" letter-spacing="0.2" text-rendering="geometricPrecision">Built on iii-engine's 3 primitives</text>
+</svg>

--- a/assets/tags/section-benchmarks.svg
+++ b/assets/tags/section-benchmarks.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 44" fill="none" role="img" aria-label="BENCHMARKS">
+  <defs>
+    <linearGradient id="accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FF6B35"/>
+      <stop offset="100%" stop-color="#FF8F5E"/>
+    </linearGradient>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#1A1A1A"/>
+      <stop offset="100%" stop-color="#0F0F0F"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="320" height="44" rx="8" fill="url(#bg)" stroke="#2A2A2A" stroke-width="1"/>
+  <rect x="0" y="0" width="6" height="44" rx="3" fill="url(#accent)"/>
+  <text x="22" y="20" fill="#FFFFFF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="13" font-weight="800" letter-spacing="2.2" text-rendering="geometricPrecision">BENCHMARKS</text>
+  <text x="22" y="34" fill="#9CA3AF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="500" letter-spacing="0.2" text-rendering="geometricPrecision">Measured on LongMemEval-S (ICLR 2025)</text>
+</svg>

--- a/assets/tags/section-competitors.svg
+++ b/assets/tags/section-competitors.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 44" fill="none" role="img" aria-label="VS COMPETITORS">
+  <defs>
+    <linearGradient id="accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FF6B35"/>
+      <stop offset="100%" stop-color="#FF8F5E"/>
+    </linearGradient>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#1A1A1A"/>
+      <stop offset="100%" stop-color="#0F0F0F"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="320" height="44" rx="8" fill="url(#bg)" stroke="#2A2A2A" stroke-width="1"/>
+  <rect x="0" y="0" width="6" height="44" rx="3" fill="url(#accent)"/>
+  <text x="22" y="20" fill="#FFFFFF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="13" font-weight="800" letter-spacing="2.2" text-rendering="geometricPrecision">VS COMPETITORS</text>
+  <text x="22" y="34" fill="#9CA3AF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="500" letter-spacing="0.2" text-rendering="geometricPrecision">Mem0 · Letta · Khoj · Hippo · claude-mem</text>
+</svg>

--- a/assets/tags/section-config.svg
+++ b/assets/tags/section-config.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 280 44" fill="none" role="img" aria-label="CONFIGURATION">
+  <defs>
+    <linearGradient id="accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FF6B35"/>
+      <stop offset="100%" stop-color="#FF8F5E"/>
+    </linearGradient>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#1A1A1A"/>
+      <stop offset="100%" stop-color="#0F0F0F"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="280" height="44" rx="8" fill="url(#bg)" stroke="#2A2A2A" stroke-width="1"/>
+  <rect x="0" y="0" width="6" height="44" rx="3" fill="url(#accent)"/>
+  <text x="22" y="20" fill="#FFFFFF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="13" font-weight="800" letter-spacing="2.2" text-rendering="geometricPrecision">CONFIGURATION</text>
+  <text x="22" y="34" fill="#9CA3AF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="500" letter-spacing="0.2" text-rendering="geometricPrecision">LLM providers, embeddings, and more</text>
+</svg>

--- a/assets/tags/section-development.svg
+++ b/assets/tags/section-development.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 44" fill="none" role="img" aria-label="DEVELOPMENT">
+  <defs>
+    <linearGradient id="accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FF6B35"/>
+      <stop offset="100%" stop-color="#FF8F5E"/>
+    </linearGradient>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#1A1A1A"/>
+      <stop offset="100%" stop-color="#0F0F0F"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="260" height="44" rx="8" fill="url(#bg)" stroke="#2A2A2A" stroke-width="1"/>
+  <rect x="0" y="0" width="6" height="44" rx="3" fill="url(#accent)"/>
+  <text x="22" y="20" fill="#FFFFFF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="13" font-weight="800" letter-spacing="2.2" text-rendering="geometricPrecision">DEVELOPMENT</text>
+  <text x="22" y="34" fill="#9CA3AF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="500" letter-spacing="0.2" text-rendering="geometricPrecision">Hot reload, 654 tests, ~1.7s run</text>
+</svg>

--- a/assets/tags/section-how.svg
+++ b/assets/tags/section-how.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 44" fill="none" role="img" aria-label="HOW IT WORKS">
+  <defs>
+    <linearGradient id="accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FF6B35"/>
+      <stop offset="100%" stop-color="#FF8F5E"/>
+    </linearGradient>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#1A1A1A"/>
+      <stop offset="100%" stop-color="#0F0F0F"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="260" height="44" rx="8" fill="url(#bg)" stroke="#2A2A2A" stroke-width="1"/>
+  <rect x="0" y="0" width="6" height="44" rx="3" fill="url(#accent)"/>
+  <text x="22" y="20" fill="#FFFFFF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="13" font-weight="800" letter-spacing="2.2" text-rendering="geometricPrecision">HOW IT WORKS</text>
+  <text x="22" y="34" fill="#9CA3AF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="500" letter-spacing="0.2" text-rendering="geometricPrecision">Hook · compress · embed · retrieve</text>
+</svg>

--- a/assets/tags/section-license.svg
+++ b/assets/tags/section-license.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 44" fill="none" role="img" aria-label="LICENSE">
+  <defs>
+    <linearGradient id="accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FF6B35"/>
+      <stop offset="100%" stop-color="#FF8F5E"/>
+    </linearGradient>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#1A1A1A"/>
+      <stop offset="100%" stop-color="#0F0F0F"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="200" height="44" rx="8" fill="url(#bg)" stroke="#2A2A2A" stroke-width="1"/>
+  <rect x="0" y="0" width="6" height="44" rx="3" fill="url(#accent)"/>
+  <text x="22" y="20" fill="#FFFFFF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="13" font-weight="800" letter-spacing="2.2" text-rendering="geometricPrecision">LICENSE</text>
+  <text x="22" y="34" fill="#9CA3AF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="500" letter-spacing="0.2" text-rendering="geometricPrecision">Apache-2.0</text>
+</svg>

--- a/assets/tags/section-mcp.svg
+++ b/assets/tags/section-mcp.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 44" fill="none" role="img" aria-label="MCP SERVER">
+  <defs>
+    <linearGradient id="accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FF6B35"/>
+      <stop offset="100%" stop-color="#FF8F5E"/>
+    </linearGradient>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#1A1A1A"/>
+      <stop offset="100%" stop-color="#0F0F0F"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="260" height="44" rx="8" fill="url(#bg)" stroke="#2A2A2A" stroke-width="1"/>
+  <rect x="0" y="0" width="6" height="44" rx="3" fill="url(#accent)"/>
+  <text x="22" y="20" fill="#FFFFFF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="13" font-weight="800" letter-spacing="2.2" text-rendering="geometricPrecision">MCP SERVER</text>
+  <text x="22" y="34" fill="#9CA3AF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="500" letter-spacing="0.2" text-rendering="geometricPrecision">43 tools · 6 resources · 3 prompts</text>
+</svg>

--- a/assets/tags/section-quickstart.svg
+++ b/assets/tags/section-quickstart.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 44" fill="none" role="img" aria-label="QUICK START">
+  <defs>
+    <linearGradient id="accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FF6B35"/>
+      <stop offset="100%" stop-color="#FF8F5E"/>
+    </linearGradient>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#1A1A1A"/>
+      <stop offset="100%" stop-color="#0F0F0F"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="260" height="44" rx="8" fill="url(#bg)" stroke="#2A2A2A" stroke-width="1"/>
+  <rect x="0" y="0" width="6" height="44" rx="3" fill="url(#accent)"/>
+  <text x="22" y="20" fill="#FFFFFF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="13" font-weight="800" letter-spacing="2.2" text-rendering="geometricPrecision">QUICK START</text>
+  <text x="22" y="34" fill="#9CA3AF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="500" letter-spacing="0.2" text-rendering="geometricPrecision">30 seconds. No API key needed.</text>
+</svg>

--- a/assets/tags/section-search.svg
+++ b/assets/tags/section-search.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 44" fill="none" role="img" aria-label="SEARCH">
+  <defs>
+    <linearGradient id="accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FF6B35"/>
+      <stop offset="100%" stop-color="#FF8F5E"/>
+    </linearGradient>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#1A1A1A"/>
+      <stop offset="100%" stop-color="#0F0F0F"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="260" height="44" rx="8" fill="url(#bg)" stroke="#2A2A2A" stroke-width="1"/>
+  <rect x="0" y="0" width="6" height="44" rx="3" fill="url(#accent)"/>
+  <text x="22" y="20" fill="#FFFFFF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="13" font-weight="800" letter-spacing="2.2" text-rendering="geometricPrecision">SEARCH</text>
+  <text x="22" y="34" fill="#9CA3AF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="500" letter-spacing="0.2" text-rendering="geometricPrecision">BM25 + vector + knowledge graph</text>
+</svg>

--- a/assets/tags/section-viewer.svg
+++ b/assets/tags/section-viewer.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 280 44" fill="none" role="img" aria-label="REAL-TIME VIEWER">
+  <defs>
+    <linearGradient id="accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FF6B35"/>
+      <stop offset="100%" stop-color="#FF8F5E"/>
+    </linearGradient>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#1A1A1A"/>
+      <stop offset="100%" stop-color="#0F0F0F"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="280" height="44" rx="8" fill="url(#bg)" stroke="#2A2A2A" stroke-width="1"/>
+  <rect x="0" y="0" width="6" height="44" rx="3" fill="url(#accent)"/>
+  <text x="22" y="20" fill="#FFFFFF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="13" font-weight="800" letter-spacing="2.2" text-rendering="geometricPrecision">REAL-TIME VIEWER</text>
+  <text x="22" y="34" fill="#9CA3AF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="500" letter-spacing="0.2" text-rendering="geometricPrecision">Live observation stream on :3113</text>
+</svg>

--- a/assets/tags/section-why.svg
+++ b/assets/tags/section-why.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 280 44" fill="none" role="img" aria-label="WHY AGENTMEMORY">
+  <defs>
+    <linearGradient id="accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FF6B35"/>
+      <stop offset="100%" stop-color="#FF8F5E"/>
+    </linearGradient>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#1A1A1A"/>
+      <stop offset="100%" stop-color="#0F0F0F"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="280" height="44" rx="8" fill="url(#bg)" stroke="#2A2A2A" stroke-width="1"/>
+  <rect x="0" y="0" width="6" height="44" rx="3" fill="url(#accent)"/>
+  <text x="22" y="20" fill="#FFFFFF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="13" font-weight="800" letter-spacing="2.2" text-rendering="geometricPrecision">WHY AGENTMEMORY</text>
+  <text x="22" y="34" fill="#9CA3AF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="500" letter-spacing="0.2" text-rendering="geometricPrecision">Goldfish memory costs you $10/day</text>
+</svg>

--- a/assets/tags/stat-deps.svg
+++ b/assets/tags/stat-deps.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 48" fill="none" role="img" aria-label="EXTERNAL DBS: 0">
+  <rect x="0" y="0" width="140" height="48" rx="10" fill="#1A1A1A" stroke="#2A2A2A" stroke-width="1"/>
+  <text x="70" y="24" fill="#B5A4FF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="18" font-weight="900" text-anchor="middle" letter-spacing="-0.3">0</text>
+  <text x="70" y="38" fill="#9CA3AF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="9" font-weight="600" text-anchor="middle" letter-spacing="1.5">EXTERNAL DBS</text>
+</svg>

--- a/assets/tags/stat-hooks.svg
+++ b/assets/tags/stat-hooks.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 48" fill="none" role="img" aria-label="AUTO HOOKS: 12">
+  <rect x="0" y="0" width="140" height="48" rx="10" fill="#1A1A1A" stroke="#2A2A2A" stroke-width="1"/>
+  <text x="70" y="24" fill="#FF6B35" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="18" font-weight="900" text-anchor="middle" letter-spacing="-0.3">12</text>
+  <text x="70" y="38" fill="#9CA3AF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="9" font-weight="600" text-anchor="middle" letter-spacing="1.5">AUTO HOOKS</text>
+</svg>

--- a/assets/tags/stat-recall.svg
+++ b/assets/tags/stat-recall.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 48" fill="none" role="img" aria-label="RETRIEVAL R@5: 95.2%">
+  <rect x="0" y="0" width="140" height="48" rx="10" fill="#1A1A1A" stroke="#2A2A2A" stroke-width="1"/>
+  <text x="70" y="24" fill="#00D26A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="18" font-weight="900" text-anchor="middle" letter-spacing="-0.3">95.2%</text>
+  <text x="70" y="38" fill="#9CA3AF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="9" font-weight="600" text-anchor="middle" letter-spacing="1.5">RETRIEVAL R@5</text>
+</svg>

--- a/assets/tags/stat-tests.svg
+++ b/assets/tags/stat-tests.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 48" fill="none" role="img" aria-label="TESTS PASSING: 654">
+  <rect x="0" y="0" width="140" height="48" rx="10" fill="#1A1A1A" stroke="#2A2A2A" stroke-width="1"/>
+  <text x="70" y="24" fill="#00D26A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="18" font-weight="900" text-anchor="middle" letter-spacing="-0.3">654</text>
+  <text x="70" y="38" fill="#9CA3AF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="9" font-weight="600" text-anchor="middle" letter-spacing="1.5">TESTS PASSING</text>
+</svg>

--- a/assets/tags/stat-tokens.svg
+++ b/assets/tags/stat-tokens.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 48" fill="none" role="img" aria-label="FEWER TOKENS: 92%">
+  <rect x="0" y="0" width="140" height="48" rx="10" fill="#1A1A1A" stroke="#2A2A2A" stroke-width="1"/>
+  <text x="70" y="24" fill="#00D26A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="18" font-weight="900" text-anchor="middle" letter-spacing="-0.3">92%</text>
+  <text x="70" y="38" fill="#9CA3AF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="9" font-weight="600" text-anchor="middle" letter-spacing="1.5">FEWER TOKENS</text>
+</svg>

--- a/assets/tags/stat-tools.svg
+++ b/assets/tags/stat-tools.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 48" fill="none" role="img" aria-label="MCP TOOLS: 43">
+  <rect x="0" y="0" width="140" height="48" rx="10" fill="#1A1A1A" stroke="#2A2A2A" stroke-width="1"/>
+  <text x="70" y="24" fill="#FF6B35" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="18" font-weight="900" text-anchor="middle" letter-spacing="-0.3">43</text>
+  <text x="70" y="38" fill="#9CA3AF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="9" font-weight="600" text-anchor="middle" letter-spacing="1.5">MCP TOOLS</text>
+</svg>

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -1,6 +1,53 @@
-# agentmemory for Hermes Agent
+<p align="center">
+  <img src="https://github.com/NousResearch.png?size=96" alt="Hermes Agent (Nous Research)" width="72" height="72" />
+  <img src="https://img.shields.io/badge/+-gray?style=for-the-badge" alt="+" height="72" />
+  <img src="../../assets/icon.svg" alt="agentmemory" width="72" height="72" />
+</p>
 
-Persistent cross-session memory for [Hermes Agent](https://github.com/NousResearch/hermes-agent) via agentmemory.
+<h1 align="center">agentmemory for Hermes Agent</h1>
+
+<p align="center">
+  Persistent cross-session memory for <a href="https://github.com/NousResearch/hermes-agent">Hermes Agent</a> via agentmemory.<br/>
+  <sub>95.2% retrieval accuracy on <a href="https://arxiv.org/abs/2410.10813">LongMemEval-S</a> — cross-agent shared with Claude Code, Cursor, OpenCode, and more.</sub>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/MCP-43_tools-1f6feb?style=flat-square" alt="43 MCP tools" />
+  <img src="https://img.shields.io/badge/Hooks-6_lifecycle-1f6feb?style=flat-square" alt="6 lifecycle hooks" />
+  <img src="https://img.shields.io/badge/R@5-95.2%25-00875f?style=flat-square" alt="95.2% R@5" />
+  <img src="https://img.shields.io/badge/Self--hosted-yes-00875f?style=flat-square" alt="Self-hosted" />
+</p>
+
+---
+
+## Install it in 30 seconds
+
+**Paste this prompt into Hermes** and it does the whole setup for you:
+
+```text
+Install agentmemory for Hermes. Run `npx @agentmemory/agentmemory` in a
+separate terminal to start the memory server on localhost:3111. Then
+add this to `~/.hermes/config.yaml` so Hermes can use agentmemory as
+an MCP server with all 43 memory tools:
+
+mcp_servers:
+  agentmemory:
+    command: npx
+    args: ["agentmemory-mcp"]
+
+Verify it's working with
+`curl http://localhost:3111/agentmemory/health` — it should return
+{"status":"healthy"}. Open the real-time viewer at
+http://localhost:3113 to watch memories being captured live.
+
+If I want deeper integration — pre-LLM context injection, turn-level
+capture, memory-write mirroring to MEMORY.md, and system prompt block
+injection — copy `integrations/hermes` from the agentmemory repo to
+`~/.hermes/plugins/memory/agentmemory` instead. That gives me the
+6-hook memory provider plugin on top of the MCP server.
+```
+
+That's it. Hermes handles the rest.
 
 ## Quick setup
 

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -1,14 +1,15 @@
 <p align="center">
-  <img src="https://github.com/NousResearch.png?size=96" alt="Hermes Agent (Nous Research)" width="72" height="72" />
-  <img src="https://img.shields.io/badge/+-gray?style=for-the-badge" alt="+" height="72" />
-  <img src="../../assets/icon.svg" alt="agentmemory" width="72" height="72" />
+  <img src="../../assets/banner.png" alt="agentmemory" width="640" />
 </p>
 
-<h1 align="center">agentmemory for Hermes Agent</h1>
+<h1 align="center">
+  <img src="https://github.com/NousResearch.png?size=80" alt="Hermes Agent" width="28" height="28" align="center" />
+  &nbsp;agentmemory for Hermes Agent
+</h1>
 
 <p align="center">
-  Persistent cross-session memory for <a href="https://github.com/NousResearch/hermes-agent">Hermes Agent</a> via agentmemory.<br/>
-  <sub>95.2% retrieval accuracy on <a href="https://arxiv.org/abs/2410.10813">LongMemEval-S</a> — cross-agent shared with Claude Code, Cursor, OpenCode, and more.</sub>
+  <strong>Your Hermes agent remembers everything. No more re-explaining.</strong><br/>
+  <sub>Persistent cross-session memory via <a href="https://github.com/rohitg00/agentmemory">agentmemory</a> — 95.2% retrieval accuracy on <a href="https://arxiv.org/abs/2410.10813">LongMemEval-S</a>. Cross-agent shared with Claude Code, Cursor, OpenCode, and more.</sub>
 </p>
 
 <p align="center">
@@ -16,6 +17,7 @@
   <img src="https://img.shields.io/badge/Hooks-6_lifecycle-1f6feb?style=flat-square" alt="6 lifecycle hooks" />
   <img src="https://img.shields.io/badge/R@5-95.2%25-00875f?style=flat-square" alt="95.2% R@5" />
   <img src="https://img.shields.io/badge/Self--hosted-yes-00875f?style=flat-square" alt="Self-hosted" />
+  <img src="https://img.shields.io/badge/License-Apache_2.0-blue?style=flat-square" alt="Apache 2.0" />
 </p>
 
 ---

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -1,6 +1,57 @@
-# agentmemory for OpenClaw
+<p align="center">
+  <img src="https://github.com/openclaw.png?size=96" alt="OpenClaw" width="72" height="72" />
+  <img src="https://img.shields.io/badge/+-gray?style=for-the-badge" alt="+" height="72" />
+  <img src="../../assets/icon.svg" alt="agentmemory" width="72" height="72" />
+</p>
 
-Persistent cross-session memory for [OpenClaw](https://github.com/openclaw/openclaw) via agentmemory. Gives every OpenClaw agent a searchable long-term memory with 95.2% retrieval accuracy on [LongMemEval-S](https://arxiv.org/abs/2410.10813).
+<h1 align="center">agentmemory for OpenClaw</h1>
+
+<p align="center">
+  Persistent cross-session memory for <a href="https://github.com/openclaw/openclaw">OpenClaw</a> via agentmemory.<br/>
+  <sub>95.2% retrieval accuracy on <a href="https://arxiv.org/abs/2410.10813">LongMemEval-S</a> — no API key needed.</sub>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/MCP-43_tools-1f6feb?style=flat-square" alt="43 MCP tools" />
+  <img src="https://img.shields.io/badge/Hooks-4_lifecycle-1f6feb?style=flat-square" alt="4 lifecycle hooks" />
+  <img src="https://img.shields.io/badge/R@5-95.2%25-00875f?style=flat-square" alt="95.2% R@5" />
+  <img src="https://img.shields.io/badge/Self--hosted-yes-00875f?style=flat-square" alt="Self-hosted" />
+</p>
+
+---
+
+## Install it in 30 seconds
+
+**Paste this prompt into OpenClaw** and it does the whole setup for you:
+
+```text
+Install agentmemory for OpenClaw. Run `npx @agentmemory/agentmemory` in a
+separate terminal to start the memory server on localhost:3111. Then add
+this to my OpenClaw MCP config so agentmemory is available as an MCP
+server with all 43 memory tools (memory_recall, memory_save,
+memory_smart_search, memory_timeline, memory_profile, etc.):
+
+{
+  "mcpServers": {
+    "agentmemory": {
+      "command": "npx",
+      "args": ["agentmemory-mcp"]
+    }
+  }
+}
+
+Restart OpenClaw. Verify it's working with
+`curl http://localhost:3111/agentmemory/health` — it should return
+{"status":"healthy"}. Open the real-time viewer at
+http://localhost:3113 to watch memories being captured live.
+
+If I want deeper integration with pre-LLM context injection and
+automatic tool-use capture, copy `integrations/openclaw` from the
+agentmemory repo to `~/.openclaw/plugins/memory/agentmemory` — that
+gives me the 4-hook gateway plugin instead of just the MCP server.
+```
+
+That's it. OpenClaw handles the rest.
 
 ## Why you want this
 

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -1,14 +1,15 @@
 <p align="center">
-  <img src="https://github.com/openclaw.png?size=96" alt="OpenClaw" width="72" height="72" />
-  <img src="https://img.shields.io/badge/+-gray?style=for-the-badge" alt="+" height="72" />
-  <img src="../../assets/icon.svg" alt="agentmemory" width="72" height="72" />
+  <img src="../../assets/banner.png" alt="agentmemory" width="640" />
 </p>
 
-<h1 align="center">agentmemory for OpenClaw</h1>
+<h1 align="center">
+  <img src="https://github.com/openclaw.png?size=80" alt="OpenClaw" width="28" height="28" align="center" />
+  &nbsp;agentmemory for OpenClaw
+</h1>
 
 <p align="center">
-  Persistent cross-session memory for <a href="https://github.com/openclaw/openclaw">OpenClaw</a> via agentmemory.<br/>
-  <sub>95.2% retrieval accuracy on <a href="https://arxiv.org/abs/2410.10813">LongMemEval-S</a> — no API key needed.</sub>
+  <strong>Your OpenClaw agents remember everything. No more re-explaining.</strong><br/>
+  <sub>Persistent cross-session memory via <a href="https://github.com/rohitg00/agentmemory">agentmemory</a> — 95.2% retrieval accuracy on <a href="https://arxiv.org/abs/2410.10813">LongMemEval-S</a>.</sub>
 </p>
 
 <p align="center">
@@ -16,6 +17,7 @@
   <img src="https://img.shields.io/badge/Hooks-4_lifecycle-1f6feb?style=flat-square" alt="4 lifecycle hooks" />
   <img src="https://img.shields.io/badge/R@5-95.2%25-00875f?style=flat-square" alt="95.2% R@5" />
   <img src="https://img.shields.io/badge/Self--hosted-yes-00875f?style=flat-square" alt="Self-hosted" />
+  <img src="https://img.shields.io/badge/License-Apache_2.0-blue?style=flat-square" alt="Apache 2.0" />
 </p>
 
 ---


### PR DESCRIPTION
## Summary

Two visual improvements to make the README and integration docs flashier and more actionable, following the [claude-code-best-practice](https://github.com/shanraisshan/claude-code-best-practice) style and the gstack paste-prompt pattern.

## Changes

### 1. Main README: real logos for all 16 supported agents

Replaced plain-text cells in the Supported Agents grid with real brand logos:

- **simple-icons CDN** for well-known brands: Claude Code/Desktop/SDK (Anthropic), Cursor, Gemini CLI, Codex CLI (OpenAI), Windsurf
- **GitHub org avatars** for project-specific logos: OpenClaw, OpenCode, Cline, Hermes (NousResearch), Goose (block), Kilo Code, Aider, Roo Code
- **Shield badge** for the generic "Any agent" fallback

Each logo clicks through to the upstream project. OpenClaw and Hermes cells now link directly to their gateway plugin folders so users find the deeper integration quickly.

### 2. Integration READMEs: paste-this-prompt blocks

Both `integrations/openclaw/README.md` and `integrations/hermes/README.md` now open with:

1. **Centered hero** — upstream org avatar + agentmemory icon
2. **Shield badges** — key stats (MCP tools, hooks, R@5, self-hosted)
3. **"Install it in 30 seconds"** section with a copy-pasteable text block the user drops into their agent

The agent handles the whole setup: start server, update MCP config, verify `/health`, open viewer. Same pattern as the main README's Claude Code block.

## Test plan

- [x] `npm test` — 654/654 passing
- [x] README consistency check passes
- [ ] Manual: verify logos render correctly on GitHub (simple-icons CDN + github.com/*.png resolve)
- [ ] Manual: confirm integration prompt blocks are readable in raw markdown view

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * README revamped with icon-based per-agent cards, updated hero badges, and a “New in v0.8.2” callout.
  * Supported agents section replaced with “Works with every agent” visuals and a shields.io endpoint badge for “Any agent.”
  * Benchmarks reformatted into centered stat images.
  * Added collapsible, copy‑paste “Install it in 30 seconds” quick-start prompts and verification steps for Hermes and OpenClaw.
  * Expanded Hermes and OpenClaw guides with branding, badges, and step‑by‑step setup instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->