### PR TITLE
feat: light-mode SVG variants for GitHub dark theme compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@
 </p>
 
 <p align="center">
-  <img src="assets/tags/stat-recall.svg" alt="95.2% retrieval R@5" height="38" />
-  <img src="assets/tags/stat-tokens.svg" alt="92% fewer tokens" height="38" />
-  <img src="assets/tags/stat-tools.svg" alt="43 MCP tools" height="38" />
-  <img src="assets/tags/stat-hooks.svg" alt="12 auto hooks" height="38" />
-  <img src="assets/tags/stat-deps.svg" alt="0 external DBs" height="38" />
-  <img src="assets/tags/stat-tests.svg" alt="654 tests passing" height="38" />
+  <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-recall.svg"><img src="assets/tags/stat-recall.svg" alt="95.2% retrieval R@5" height="38" /></picture>
+  <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-tokens.svg"><img src="assets/tags/stat-tokens.svg" alt="92% fewer tokens" height="38" /></picture>
+  <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-tools.svg"><img src="assets/tags/stat-tools.svg" alt="43 MCP tools" height="38" /></picture>
+  <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-hooks.svg"><img src="assets/tags/stat-hooks.svg" alt="12 auto hooks" height="38" /></picture>
+  <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-deps.svg"><img src="assets/tags/stat-deps.svg" alt="0 external DBs" height="38" /></picture>
+  <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-tests.svg"><img src="assets/tags/stat-tests.svg" alt="654 tests passing" height="38" /></picture>
 </p>
 
 <p align="center">
@@ -41,7 +41,7 @@
 
 ---
 
-<h2 id="works-with-every-agent"><img src="assets/tags/section-agents.svg" alt="Works with every agent" height="32" /></h2>
+<h2 id="works-with-every-agent"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/section-agents.svg"><img src="assets/tags/section-agents.svg" alt="Works with every agent" height="32" /></picture></h2>
 
 agentmemory works with any agent that supports hooks, MCP, or REST API. All agents share the same memory server.
 
@@ -150,7 +150,7 @@ npx @agentmemory/agentmemory
 
 ---
 
-<h2 id="benchmarks"><img src="assets/tags/section-benchmarks.svg" alt="Benchmarks" height="32" /></h2>
+<h2 id="benchmarks"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/section-benchmarks.svg"><img src="assets/tags/section-benchmarks.svg" alt="Benchmarks" height="32" /></picture></h2>
 
 <table>
 <tr>
@@ -182,19 +182,19 @@ npx @agentmemory/agentmemory
 </table>
 
 <p align="center">
-  <img src="assets/tags/stat-recall.svg" alt="95.2% retrieval R@5" height="48" />
-  <img src="assets/tags/stat-tokens.svg" alt="92% fewer tokens" height="48" />
-  <img src="assets/tags/stat-tools.svg" alt="43 MCP tools" height="48" />
-  <img src="assets/tags/stat-hooks.svg" alt="12 auto hooks" height="48" />
-  <img src="assets/tags/stat-deps.svg" alt="0 external DBs" height="48" />
-  <img src="assets/tags/stat-tests.svg" alt="654 tests passing" height="48" />
+  <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-recall.svg"><img src="assets/tags/stat-recall.svg" alt="95.2% retrieval R@5" height="48" /></picture>
+  <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-tokens.svg"><img src="assets/tags/stat-tokens.svg" alt="92% fewer tokens" height="48" /></picture>
+  <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-tools.svg"><img src="assets/tags/stat-tools.svg" alt="43 MCP tools" height="48" /></picture>
+  <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-hooks.svg"><img src="assets/tags/stat-hooks.svg" alt="12 auto hooks" height="48" /></picture>
+  <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-deps.svg"><img src="assets/tags/stat-deps.svg" alt="0 external DBs" height="48" /></picture>
+  <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-tests.svg"><img src="assets/tags/stat-tests.svg" alt="654 tests passing" height="48" /></picture>
 </p>
 
 > Embedding model: `all-MiniLM-L6-v2` (local, free, no API key). Full reports: [`benchmark/LONGMEMEVAL.md`](benchmark/LONGMEMEVAL.md), [`benchmark/QUALITY.md`](benchmark/QUALITY.md), [`benchmark/SCALE.md`](benchmark/SCALE.md). Competitor comparison: [`benchmark/COMPARISON.md`](benchmark/COMPARISON.md) — agentmemory vs mem0, Letta, Khoj, claude-mem, Hippo.
 
 ---
 
-<h2 id="vs-competitors"><img src="assets/tags/section-competitors.svg" alt="vs Competitors" height="32" /></h2>
+<h2 id="vs-competitors"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/section-competitors.svg"><img src="assets/tags/section-competitors.svg" alt="vs Competitors" height="32" /></picture></h2>
 
 <table>
 <tr>
@@ -285,7 +285,7 @@ npx @agentmemory/agentmemory
 
 ---
 
-<h2 id="quick-start"><img src="assets/tags/section-quickstart.svg" alt="Quick Start" height="32" /></h2>
+<h2 id="quick-start"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/section-quickstart.svg"><img src="assets/tags/section-quickstart.svg" alt="Quick Start" height="32" /></picture></h2>
 
 ### Try it in 30 seconds
 
@@ -379,7 +379,7 @@ Install `iii-engine` manually with `cargo install iii-engine` or follow [iii.dev
 
 ---
 
-<h2 id="why-agentmemory"><img src="assets/tags/section-why.svg" alt="Why agentmemory" height="32" /></h2>
+<h2 id="why-agentmemory"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/section-why.svg"><img src="assets/tags/section-why.svg" alt="Why agentmemory" height="32" /></picture></h2>
 
 Every coding agent forgets everything when the session ends. You waste the first 5 minutes of every session re-explaining your stack. agentmemory runs in the background and eliminates that entirely.
 
@@ -412,7 +412,7 @@ Every AI coding agent ships with built-in memory — Claude Code has `MEMORY.md`
 
 ---
 
-<h2 id="how-it-works"><img src="assets/tags/section-how.svg" alt="How It Works" height="32" /></h2>
+<h2 id="how-it-works"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/section-how.svg"><img src="assets/tags/section-how.svg" alt="How It Works" height="32" /></picture></h2>
 
 ### Memory Pipeline
 
@@ -477,7 +477,7 @@ Memories decay over time (Ebbinghaus curve). Frequently accessed memories streng
 
 ---
 
-<h2 id="search"><img src="assets/tags/section-search.svg" alt="Search" height="32" /></h2>
+<h2 id="search"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/section-search.svg"><img src="assets/tags/section-search.svg" alt="Search" height="32" /></picture></h2>
 
 Triple-stream retrieval combining three signals:
 
@@ -508,7 +508,7 @@ npm install @xenova/transformers
 
 ---
 
-<h2 id="mcp-server"><img src="assets/tags/section-mcp.svg" alt="MCP Server" height="32" /></h2>
+<h2 id="mcp-server"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/section-mcp.svg"><img src="assets/tags/section-mcp.svg" alt="MCP Server" height="32" /></picture></h2>
 
 43 tools, 6 resources, 3 prompts, and 4 skills — the most comprehensive MCP memory toolkit for any agent.
 
@@ -607,7 +607,7 @@ Or add to your agent's MCP config:
 
 ---
 
-<h2 id="real-time-viewer"><img src="assets/tags/section-viewer.svg" alt="Real-Time Viewer" height="32" /></h2>
+<h2 id="real-time-viewer"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/section-viewer.svg"><img src="assets/tags/section-viewer.svg" alt="Real-Time Viewer" height="32" /></picture></h2>
 
 Auto-starts on port `3113`. Live observation stream, session explorer, memory browser, knowledge graph visualization, and health dashboard.
 
@@ -619,7 +619,7 @@ The viewer server binds to `127.0.0.1` by default. The REST-served `/agentmemory
 
 ---
 
-<h2 id="configuration"><img src="assets/tags/section-config.svg" alt="Configuration" height="32" /></h2>
+<h2 id="configuration"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/section-config.svg"><img src="assets/tags/section-config.svg" alt="Configuration" height="32" /></picture></h2>
 
 ### LLM Providers
 
@@ -678,7 +678,7 @@ Create `~/.agentmemory/.env`:
 
 ---
 
-<h2 id="api"><img src="assets/tags/section-api.svg" alt="API" height="32" /></h2>
+<h2 id="api"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/section-api.svg"><img src="assets/tags/section-api.svg" alt="API" height="32" /></picture></h2>
 
 109 endpoints on port `3111`. The REST API binds to `127.0.0.1` by default. Protected endpoints require `Authorization: Bearer <secret>` when `AGENTMEMORY_SECRET` is set, and mesh sync endpoints require `AGENTMEMORY_SECRET` on both peers.
 
@@ -709,7 +709,7 @@ Full endpoint list: [`src/triggers/api.ts`](src/triggers/api.ts)
 
 ---
 
-<h2 id="architecture"><img src="assets/tags/section-architecture.svg" alt="Architecture" height="32" /></h2>
+<h2 id="architecture"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/section-architecture.svg"><img src="assets/tags/section-architecture.svg" alt="Architecture" height="32" /></picture></h2>
 
 Built on [iii-engine](https://iii.dev)'s three primitives — no Express, no Postgres, no Redis.
 
@@ -728,7 +728,7 @@ Built on [iii-engine](https://iii.dev)'s three primitives — no Express, no Pos
 
 </details>
 
-<h2 id="development"><img src="assets/tags/section-development.svg" alt="Development" height="32" /></h2>
+<h2 id="development"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/section-development.svg"><img src="assets/tags/section-development.svg" alt="Development" height="32" /></picture></h2>
 
 ```bash
 npm run dev               # Hot reload
@@ -739,6 +739,6 @@ npm run test:integration  # API tests (requires running services)
 
 **Prerequisites:** Node.js >= 20, [iii-engine](https://iii.dev/docs) or Docker
 
-<h2 id="license"><img src="assets/tags/section-license.svg" alt="License" height="32" /></h2>
+<h2 id="license"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/section-license.svg"><img src="assets/tags/section-license.svg" alt="License" height="32" /></picture></h2>
 
 [Apache-2.0](LICENSE)

--- a/assets/tags/light/divider.svg
+++ b/assets/tags/light/divider.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 28" fill="none" role="img" aria-label="divider">
+  <defs>
+    <linearGradient id="divGradient" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#FF6B35" stop-opacity="0"/>
+      <stop offset="50%" stop-color="#FF6B35" stop-opacity="0.8"/>
+      <stop offset="100%" stop-color="#FF6B35" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="divAccent" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#FF6B35"/>
+      <stop offset="100%" stop-color="#FF8F5E"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="13" width="45" height="2" rx="1" fill="url(#divGradient)"/>
+  <rect x="54" y="8" width="12" height="12" rx="3" fill="url(#divAccent)" transform="rotate(45 60 14)"/>
+  <circle cx="60" cy="14" r="2" fill="#FFFFFF"/>
+  <rect x="75" y="13" width="45" height="2" rx="1" fill="url(#divGradient)"/>
+</svg>

--- a/assets/tags/light/new-v082.svg
+++ b/assets/tags/light/new-v082.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 28" fill="none" role="img" aria-label="NEW: v0.8.2">
+  <rect x="0" y="0" width="140" height="28" rx="6" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1"/>
+  <text x="12" y="18" fill="#64748B" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="11" font-weight="600" letter-spacing="1.2">NEW</text>
+  <text x="128" y="18" fill="#FF6B35" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="11" font-weight="800" letter-spacing="0.5" text-anchor="end">v0.8.2</text>
+</svg>

--- a/assets/tags/light/pill-beta.svg
+++ b/assets/tags/light/pill-beta.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 24" fill="none" role="img" aria-label="BETA">
+  <rect x="0" y="0" width="100" height="24" rx="12" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1"/>
+  <circle cx="12" cy="12" r="3" fill="#FF6B35"/>
+  <text x="22" y="16" fill="#0F172A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="700" letter-spacing="1.2">BETA</text>
+</svg>

--- a/assets/tags/light/pill-hook.svg
+++ b/assets/tags/light/pill-hook.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 130 24" fill="none" role="img" aria-label="AUTO HOOK">
+  <rect x="0" y="0" width="130" height="24" rx="12" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1"/>
+  <circle cx="12" cy="12" r="3" fill="#FF6B35"/>
+  <text x="22" y="16" fill="#0F172A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="700" letter-spacing="1.2">AUTO HOOK</text>
+</svg>

--- a/assets/tags/light/pill-mcp.svg
+++ b/assets/tags/light/pill-mcp.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 110 24" fill="none" role="img" aria-label="MCP">
+  <rect x="0" y="0" width="110" height="24" rx="12" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1"/>
+  <circle cx="12" cy="12" r="3" fill="#FF6B35"/>
+  <text x="22" y="16" fill="#0F172A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="700" letter-spacing="1.2">MCP</text>
+</svg>

--- a/assets/tags/light/pill-new.svg
+++ b/assets/tags/light/pill-new.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 90 24" fill="none" role="img" aria-label="NEW">
+  <rect x="0" y="0" width="90" height="24" rx="12" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1"/>
+  <circle cx="12" cy="12" r="3" fill="#FF6B35"/>
+  <text x="22" y="16" fill="#0F172A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="700" letter-spacing="1.2">NEW</text>
+</svg>

--- a/assets/tags/light/pill-plugin.svg
+++ b/assets/tags/light/pill-plugin.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 110 24" fill="none" role="img" aria-label="PLUGIN">
+  <rect x="0" y="0" width="110" height="24" rx="12" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1"/>
+  <circle cx="12" cy="12" r="3" fill="#FF6B35"/>
+  <text x="22" y="16" fill="#0F172A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="700" letter-spacing="1.2">PLUGIN</text>
+</svg>

--- a/assets/tags/light/pill-secure.svg
+++ b/assets/tags/light/pill-secure.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 110 24" fill="none" role="img" aria-label="SECURE">
+  <rect x="0" y="0" width="110" height="24" rx="12" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1"/>
+  <circle cx="12" cy="12" r="3" fill="#FF6B35"/>
+  <text x="22" y="16" fill="#0F172A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="700" letter-spacing="1.2">SECURE</text>
+</svg>

--- a/assets/tags/light/pill-skill.svg
+++ b/assets/tags/light/pill-skill.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 110 24" fill="none" role="img" aria-label="SKILL">
+  <rect x="0" y="0" width="110" height="24" rx="12" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1"/>
+  <circle cx="12" cy="12" r="3" fill="#FF6B35"/>
+  <text x="22" y="16" fill="#0F172A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="700" letter-spacing="1.2">SKILL</text>
+</svg>

--- a/assets/tags/light/pill-stable.svg
+++ b/assets/tags/light/pill-stable.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 110 24" fill="none" role="img" aria-label="STABLE">
+  <rect x="0" y="0" width="110" height="24" rx="12" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1"/>
+  <circle cx="12" cy="12" r="3" fill="#FF6B35"/>
+  <text x="22" y="16" fill="#0F172A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="700" letter-spacing="1.2">STABLE</text>
+</svg>

--- a/assets/tags/light/section-agents.svg
+++ b/assets/tags/light/section-agents.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 44" fill="none" role="img" aria-label="WORKS WITH EVERY AGENT">
+  <defs>
+    <linearGradient id="accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FF6B35"/>
+      <stop offset="100%" stop-color="#FF8F5E"/>
+    </linearGradient>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#FFFFFF"/>
+      <stop offset="100%" stop-color="#F8F9FB"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="320" height="44" rx="8" fill="url(#bg)" stroke="#E5E7EB" stroke-width="1"/>
+  <rect x="0" y="0" width="6" height="44" rx="3" fill="url(#accent)"/>
+  <text x="22" y="20" fill="#0F172A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="13" font-weight="800" letter-spacing="2.2" text-rendering="geometricPrecision">WORKS WITH EVERY AGENT</text>
+  <text x="22" y="34" fill="#64748B" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="500" letter-spacing="0.2" text-rendering="geometricPrecision">16 integrations · one memory server</text>
+</svg>

--- a/assets/tags/light/section-api.svg
+++ b/assets/tags/light/section-api.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 44" fill="none" role="img" aria-label="API">
+  <defs>
+    <linearGradient id="accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FF6B35"/>
+      <stop offset="100%" stop-color="#FF8F5E"/>
+    </linearGradient>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#FFFFFF"/>
+      <stop offset="100%" stop-color="#F8F9FB"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="200" height="44" rx="8" fill="url(#bg)" stroke="#E5E7EB" stroke-width="1"/>
+  <rect x="0" y="0" width="6" height="44" rx="3" fill="url(#accent)"/>
+  <text x="22" y="20" fill="#0F172A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="13" font-weight="800" letter-spacing="2.2" text-rendering="geometricPrecision">API</text>
+  <text x="22" y="34" fill="#64748B" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="500" letter-spacing="0.2" text-rendering="geometricPrecision">109 REST endpoints</text>
+</svg>

--- a/assets/tags/light/section-architecture.svg
+++ b/assets/tags/light/section-architecture.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 280 44" fill="none" role="img" aria-label="ARCHITECTURE">
+  <defs>
+    <linearGradient id="accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FF6B35"/>
+      <stop offset="100%" stop-color="#FF8F5E"/>
+    </linearGradient>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#FFFFFF"/>
+      <stop offset="100%" stop-color="#F8F9FB"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="280" height="44" rx="8" fill="url(#bg)" stroke="#E5E7EB" stroke-width="1"/>
+  <rect x="0" y="0" width="6" height="44" rx="3" fill="url(#accent)"/>
+  <text x="22" y="20" fill="#0F172A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="13" font-weight="800" letter-spacing="2.2" text-rendering="geometricPrecision">ARCHITECTURE</text>
+  <text x="22" y="34" fill="#64748B" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="500" letter-spacing="0.2" text-rendering="geometricPrecision">Built on iii-engine's 3 primitives</text>
+</svg>

--- a/assets/tags/light/section-benchmarks.svg
+++ b/assets/tags/light/section-benchmarks.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 44" fill="none" role="img" aria-label="BENCHMARKS">
+  <defs>
+    <linearGradient id="accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FF6B35"/>
+      <stop offset="100%" stop-color="#FF8F5E"/>
+    </linearGradient>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#FFFFFF"/>
+      <stop offset="100%" stop-color="#F8F9FB"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="320" height="44" rx="8" fill="url(#bg)" stroke="#E5E7EB" stroke-width="1"/>
+  <rect x="0" y="0" width="6" height="44" rx="3" fill="url(#accent)"/>
+  <text x="22" y="20" fill="#0F172A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="13" font-weight="800" letter-spacing="2.2" text-rendering="geometricPrecision">BENCHMARKS</text>
+  <text x="22" y="34" fill="#64748B" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="500" letter-spacing="0.2" text-rendering="geometricPrecision">Measured on LongMemEval-S (ICLR 2025)</text>
+</svg>

--- a/assets/tags/light/section-competitors.svg
+++ b/assets/tags/light/section-competitors.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 44" fill="none" role="img" aria-label="VS COMPETITORS">
+  <defs>
+    <linearGradient id="accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FF6B35"/>
+      <stop offset="100%" stop-color="#FF8F5E"/>
+    </linearGradient>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#FFFFFF"/>
+      <stop offset="100%" stop-color="#F8F9FB"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="320" height="44" rx="8" fill="url(#bg)" stroke="#E5E7EB" stroke-width="1"/>
+  <rect x="0" y="0" width="6" height="44" rx="3" fill="url(#accent)"/>
+  <text x="22" y="20" fill="#0F172A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="13" font-weight="800" letter-spacing="2.2" text-rendering="geometricPrecision">VS COMPETITORS</text>
+  <text x="22" y="34" fill="#64748B" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="500" letter-spacing="0.2" text-rendering="geometricPrecision">Mem0 · Letta · Khoj · Hippo · claude-mem</text>
+</svg>

--- a/assets/tags/light/section-config.svg
+++ b/assets/tags/light/section-config.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 280 44" fill="none" role="img" aria-label="CONFIGURATION">
+  <defs>
+    <linearGradient id="accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FF6B35"/>
+      <stop offset="100%" stop-color="#FF8F5E"/>
+    </linearGradient>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#FFFFFF"/>
+      <stop offset="100%" stop-color="#F8F9FB"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="280" height="44" rx="8" fill="url(#bg)" stroke="#E5E7EB" stroke-width="1"/>
+  <rect x="0" y="0" width="6" height="44" rx="3" fill="url(#accent)"/>
+  <text x="22" y="20" fill="#0F172A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="13" font-weight="800" letter-spacing="2.2" text-rendering="geometricPrecision">CONFIGURATION</text>
+  <text x="22" y="34" fill="#64748B" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="500" letter-spacing="0.2" text-rendering="geometricPrecision">LLM providers, embeddings, and more</text>
+</svg>

--- a/assets/tags/light/section-development.svg
+++ b/assets/tags/light/section-development.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 44" fill="none" role="img" aria-label="DEVELOPMENT">
+  <defs>
+    <linearGradient id="accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FF6B35"/>
+      <stop offset="100%" stop-color="#FF8F5E"/>
+    </linearGradient>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#FFFFFF"/>
+      <stop offset="100%" stop-color="#F8F9FB"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="260" height="44" rx="8" fill="url(#bg)" stroke="#E5E7EB" stroke-width="1"/>
+  <rect x="0" y="0" width="6" height="44" rx="3" fill="url(#accent)"/>
+  <text x="22" y="20" fill="#0F172A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="13" font-weight="800" letter-spacing="2.2" text-rendering="geometricPrecision">DEVELOPMENT</text>
+  <text x="22" y="34" fill="#64748B" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="500" letter-spacing="0.2" text-rendering="geometricPrecision">Hot reload, 654 tests, ~1.7s run</text>
+</svg>

--- a/assets/tags/light/section-how.svg
+++ b/assets/tags/light/section-how.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 44" fill="none" role="img" aria-label="HOW IT WORKS">
+  <defs>
+    <linearGradient id="accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FF6B35"/>
+      <stop offset="100%" stop-color="#FF8F5E"/>
+    </linearGradient>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#FFFFFF"/>
+      <stop offset="100%" stop-color="#F8F9FB"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="260" height="44" rx="8" fill="url(#bg)" stroke="#E5E7EB" stroke-width="1"/>
+  <rect x="0" y="0" width="6" height="44" rx="3" fill="url(#accent)"/>
+  <text x="22" y="20" fill="#0F172A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="13" font-weight="800" letter-spacing="2.2" text-rendering="geometricPrecision">HOW IT WORKS</text>
+  <text x="22" y="34" fill="#64748B" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="500" letter-spacing="0.2" text-rendering="geometricPrecision">Hook · compress · embed · retrieve</text>
+</svg>

--- a/assets/tags/light/section-license.svg
+++ b/assets/tags/light/section-license.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 44" fill="none" role="img" aria-label="LICENSE">
+  <defs>
+    <linearGradient id="accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FF6B35"/>
+      <stop offset="100%" stop-color="#FF8F5E"/>
+    </linearGradient>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#FFFFFF"/>
+      <stop offset="100%" stop-color="#F8F9FB"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="200" height="44" rx="8" fill="url(#bg)" stroke="#E5E7EB" stroke-width="1"/>
+  <rect x="0" y="0" width="6" height="44" rx="3" fill="url(#accent)"/>
+  <text x="22" y="20" fill="#0F172A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="13" font-weight="800" letter-spacing="2.2" text-rendering="geometricPrecision">LICENSE</text>
+  <text x="22" y="34" fill="#64748B" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="500" letter-spacing="0.2" text-rendering="geometricPrecision">Apache-2.0</text>
+</svg>

--- a/assets/tags/light/section-mcp.svg
+++ b/assets/tags/light/section-mcp.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 44" fill="none" role="img" aria-label="MCP SERVER">
+  <defs>
+    <linearGradient id="accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FF6B35"/>
+      <stop offset="100%" stop-color="#FF8F5E"/>
+    </linearGradient>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#FFFFFF"/>
+      <stop offset="100%" stop-color="#F8F9FB"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="260" height="44" rx="8" fill="url(#bg)" stroke="#E5E7EB" stroke-width="1"/>
+  <rect x="0" y="0" width="6" height="44" rx="3" fill="url(#accent)"/>
+  <text x="22" y="20" fill="#0F172A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="13" font-weight="800" letter-spacing="2.2" text-rendering="geometricPrecision">MCP SERVER</text>
+  <text x="22" y="34" fill="#64748B" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="500" letter-spacing="0.2" text-rendering="geometricPrecision">43 tools · 6 resources · 3 prompts</text>
+</svg>

--- a/assets/tags/light/section-quickstart.svg
+++ b/assets/tags/light/section-quickstart.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 44" fill="none" role="img" aria-label="QUICK START">
+  <defs>
+    <linearGradient id="accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FF6B35"/>
+      <stop offset="100%" stop-color="#FF8F5E"/>
+    </linearGradient>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#FFFFFF"/>
+      <stop offset="100%" stop-color="#F8F9FB"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="260" height="44" rx="8" fill="url(#bg)" stroke="#E5E7EB" stroke-width="1"/>
+  <rect x="0" y="0" width="6" height="44" rx="3" fill="url(#accent)"/>
+  <text x="22" y="20" fill="#0F172A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="13" font-weight="800" letter-spacing="2.2" text-rendering="geometricPrecision">QUICK START</text>
+  <text x="22" y="34" fill="#64748B" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="500" letter-spacing="0.2" text-rendering="geometricPrecision">30 seconds. No API key needed.</text>
+</svg>

--- a/assets/tags/light/section-search.svg
+++ b/assets/tags/light/section-search.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 44" fill="none" role="img" aria-label="SEARCH">
+  <defs>
+    <linearGradient id="accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FF6B35"/>
+      <stop offset="100%" stop-color="#FF8F5E"/>
+    </linearGradient>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#FFFFFF"/>
+      <stop offset="100%" stop-color="#F8F9FB"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="260" height="44" rx="8" fill="url(#bg)" stroke="#E5E7EB" stroke-width="1"/>
+  <rect x="0" y="0" width="6" height="44" rx="3" fill="url(#accent)"/>
+  <text x="22" y="20" fill="#0F172A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="13" font-weight="800" letter-spacing="2.2" text-rendering="geometricPrecision">SEARCH</text>
+  <text x="22" y="34" fill="#64748B" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="500" letter-spacing="0.2" text-rendering="geometricPrecision">BM25 + vector + knowledge graph</text>
+</svg>

--- a/assets/tags/light/section-viewer.svg
+++ b/assets/tags/light/section-viewer.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 280 44" fill="none" role="img" aria-label="REAL-TIME VIEWER">
+  <defs>
+    <linearGradient id="accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FF6B35"/>
+      <stop offset="100%" stop-color="#FF8F5E"/>
+    </linearGradient>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#FFFFFF"/>
+      <stop offset="100%" stop-color="#F8F9FB"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="280" height="44" rx="8" fill="url(#bg)" stroke="#E5E7EB" stroke-width="1"/>
+  <rect x="0" y="0" width="6" height="44" rx="3" fill="url(#accent)"/>
+  <text x="22" y="20" fill="#0F172A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="13" font-weight="800" letter-spacing="2.2" text-rendering="geometricPrecision">REAL-TIME VIEWER</text>
+  <text x="22" y="34" fill="#64748B" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="500" letter-spacing="0.2" text-rendering="geometricPrecision">Live observation stream on :3113</text>
+</svg>

--- a/assets/tags/light/section-why.svg
+++ b/assets/tags/light/section-why.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 280 44" fill="none" role="img" aria-label="WHY AGENTMEMORY">
+  <defs>
+    <linearGradient id="accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FF6B35"/>
+      <stop offset="100%" stop-color="#FF8F5E"/>
+    </linearGradient>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#FFFFFF"/>
+      <stop offset="100%" stop-color="#F8F9FB"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="280" height="44" rx="8" fill="url(#bg)" stroke="#E5E7EB" stroke-width="1"/>
+  <rect x="0" y="0" width="6" height="44" rx="3" fill="url(#accent)"/>
+  <text x="22" y="20" fill="#0F172A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="13" font-weight="800" letter-spacing="2.2" text-rendering="geometricPrecision">WHY AGENTMEMORY</text>
+  <text x="22" y="34" fill="#64748B" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="10" font-weight="500" letter-spacing="0.2" text-rendering="geometricPrecision">Goldfish memory costs you $10/day</text>
+</svg>

--- a/assets/tags/light/stat-deps.svg
+++ b/assets/tags/light/stat-deps.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 48" fill="none" role="img" aria-label="EXTERNAL DBS: 0">
+  <rect x="0" y="0" width="140" height="48" rx="10" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1"/>
+  <text x="70" y="24" fill="#7C3AED" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="18" font-weight="900" text-anchor="middle" letter-spacing="-0.3">0</text>
+  <text x="70" y="38" fill="#64748B" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="9" font-weight="600" text-anchor="middle" letter-spacing="1.5">EXTERNAL DBS</text>
+</svg>

--- a/assets/tags/light/stat-hooks.svg
+++ b/assets/tags/light/stat-hooks.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 48" fill="none" role="img" aria-label="AUTO HOOKS: 12">
+  <rect x="0" y="0" width="140" height="48" rx="10" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1"/>
+  <text x="70" y="24" fill="#EA580C" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="18" font-weight="900" text-anchor="middle" letter-spacing="-0.3">12</text>
+  <text x="70" y="38" fill="#64748B" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="9" font-weight="600" text-anchor="middle" letter-spacing="1.5">AUTO HOOKS</text>
+</svg>

--- a/assets/tags/light/stat-recall.svg
+++ b/assets/tags/light/stat-recall.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 48" fill="none" role="img" aria-label="RETRIEVAL R@5: 95.2%">
+  <rect x="0" y="0" width="140" height="48" rx="10" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1"/>
+  <text x="70" y="24" fill="#16A34A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="18" font-weight="900" text-anchor="middle" letter-spacing="-0.3">95.2%</text>
+  <text x="70" y="38" fill="#64748B" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="9" font-weight="600" text-anchor="middle" letter-spacing="1.5">RETRIEVAL R@5</text>
+</svg>

--- a/assets/tags/light/stat-tests.svg
+++ b/assets/tags/light/stat-tests.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 48" fill="none" role="img" aria-label="TESTS PASSING: 654">
+  <rect x="0" y="0" width="140" height="48" rx="10" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1"/>
+  <text x="70" y="24" fill="#16A34A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="18" font-weight="900" text-anchor="middle" letter-spacing="-0.3">654</text>
+  <text x="70" y="38" fill="#64748B" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="9" font-weight="600" text-anchor="middle" letter-spacing="1.5">TESTS PASSING</text>
+</svg>

--- a/assets/tags/light/stat-tokens.svg
+++ b/assets/tags/light/stat-tokens.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 48" fill="none" role="img" aria-label="FEWER TOKENS: 92%">
+  <rect x="0" y="0" width="140" height="48" rx="10" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1"/>
+  <text x="70" y="24" fill="#16A34A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="18" font-weight="900" text-anchor="middle" letter-spacing="-0.3">92%</text>
+  <text x="70" y="38" fill="#64748B" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="9" font-weight="600" text-anchor="middle" letter-spacing="1.5">FEWER TOKENS</text>
+</svg>

--- a/assets/tags/light/stat-tools.svg
+++ b/assets/tags/light/stat-tools.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 48" fill="none" role="img" aria-label="MCP TOOLS: 43">
+  <rect x="0" y="0" width="140" height="48" rx="10" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1"/>
+  <text x="70" y="24" fill="#EA580C" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="18" font-weight="900" text-anchor="middle" letter-spacing="-0.3">43</text>
+  <text x="70" y="38" fill="#64748B" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="9" font-weight="600" text-anchor="middle" letter-spacing="1.5">MCP TOOLS</text>
+</svg>


### PR DESCRIPTION
## Problem

The 30 custom SVG tags from PR #114 have dark backgrounds (\`#1A1A1A\`). They look great on GitHub's **light** theme — the dark badges stand out clearly on the white README background.

On GitHub's **dark** theme, the dark badges blend into the dark README background, hurting readability.

## Solution

Add a complete set of **light-background** SVG variants in \`assets/tags/light/\` and use GitHub's \`<picture>\` element to auto-swap based on the reader's theme preference.

## How GitHub handles it

GitHub supports \`prefers-color-scheme\` media queries inside \`<picture>\` elements in README files. Pattern:

\`\`\`html
<picture>
  <source media=\"(prefers-color-scheme: dark)\" srcset=\"assets/tags/light/section-benchmarks.svg\">
  <img src=\"assets/tags/section-benchmarks.svg\" alt=\"Benchmarks\" height=\"32\" />
</picture>
\`\`\`

When the reader is on GitHub dark theme, the browser picks the \`media=\"(prefers-color-scheme: dark)\"\` source (the light-bg SVG). Otherwise it falls through to the \`<img>\` default (the dark-bg SVG).

## 30 light variants

Same dimensions, same orange \`#FF6B35\` brand accent, same fonts. Changes:

| Element | Dark variant | Light variant |
|---|---|---|
| Background | \`#1A1A1A → #0F0F0F\` (dark gradient) | \`#FFFFFF → #F8F9FB\` (white gradient) |
| Border | \`#2A2A2A\` | \`#E5E7EB\` (GitHub neutral) |
| Title text | \`#FFFFFF\` | \`#0F172A\` (slate-900) |
| Subtitle text | \`#9CA3AF\` | \`#64748B\` (slate-500) |

Stat card accent colors were darkened slightly for better contrast against white backgrounds:
- Green: \`#00D26A → #16A34A\`
- Orange: \`#FF6B35 → #EA580C\`
- Purple: \`#B5A4FF → #7C3AED\`

Orange brand accent strip is unchanged — it's the consistent brand element across both modes.

## README changes

Used a Python regex pass to wrap all 26 tag references in \`<picture>\` elements:
- **14 section headers** (all \`<h2>\` tags)
- **12 stat cards** (6 in hero row × 2 locations — hero + benchmarks section)

No manual edits — one atomic transformation.

## Test plan

- [x] \`xmllint\` validates all 30 light SVGs parse cleanly
- [x] \`npm test\` — 654/654 passing
- [x] Regex-verified 26 \`<picture>\` elements in README
- [ ] Manual: view README on GitHub with light theme (should see dark badges)
- [ ] Manual: view README on GitHub with dark theme (should see light badges)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated image markup across the README to support dark mode, automatically serving appropriate assets based on user color scheme preferences while maintaining existing light mode appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->