### PR TITLE
fix: persist memories to disk immediately after memory_save

### DIFF
--- a/src/mcp/standalone.ts
+++ b/src/mcp/standalone.ts
@@ -5,6 +5,7 @@ import { createStdioTransport } from "./transport.js";
 import { getVisibleTools } from "./tools-registry.js";
 import { getStandalonePersistPath } from "../config.js";
 import { VERSION } from "../version.js";
+import { generateId } from "../state/schema.js";
 
 const IMPLEMENTED_TOOLS = new Set([
   "memory_save",
@@ -31,7 +32,8 @@ export async function handleToolCall(
     case "memory_save": {
       const content = args.content as string;
       if (!content?.trim()) throw new Error("content is required");
-      const id = `mem_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+      const id = generateId("mem");
+      const isoNow = new Date().toISOString();
       await kvInstance.set("mem:memories", id, {
         id,
         type: (args.type as string) || "fact",
@@ -43,8 +45,8 @@ export async function handleToolCall(
         files: args.files
           ? (args.files as string).split(",").map((f) => f.trim())
           : [],
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
+        createdAt: isoNow,
+        updatedAt: isoNow,
         strength: 7,
         version: 1,
         isLatest: true,

--- a/src/mcp/standalone.ts
+++ b/src/mcp/standalone.ts
@@ -22,16 +22,17 @@ const SERVER_INFO = {
 
 const kv = new InMemoryKV(getStandalonePersistPath());
 
-async function handleToolCall(
+export async function handleToolCall(
   toolName: string,
   args: Record<string, unknown>,
+  kvInstance: InMemoryKV = kv,
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
   switch (toolName) {
     case "memory_save": {
       const content = args.content as string;
       if (!content?.trim()) throw new Error("content is required");
       const id = `mem_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
-      await kv.set("mem:memories", id, {
+      await kvInstance.set("mem:memories", id, {
         id,
         type: (args.type as string) || "fact",
         title: content.slice(0, 80),
@@ -49,6 +50,7 @@ async function handleToolCall(
         isLatest: true,
         sessionIds: [],
       });
+      kvInstance.persist();
       return {
         content: [{ type: "text", text: JSON.stringify({ saved: id }) }],
       };
@@ -57,7 +59,7 @@ async function handleToolCall(
     case "memory_recall": {
       const query = (args.query as string)?.toLowerCase() || "";
       const limit = (args.limit as number) || 10;
-      const all = await kv.list<Record<string, unknown>>("mem:memories");
+      const all = await kvInstance.list<Record<string, unknown>>("mem:memories");
       const results = all
         .filter((m) => {
           const text = `${m.title} ${m.content}`.toLowerCase();
@@ -70,7 +72,7 @@ async function handleToolCall(
     }
 
     case "memory_sessions": {
-      const sessions = await kv.list("mem:sessions");
+      const sessions = await kvInstance.list("mem:sessions");
       return {
         content: [
           { type: "text", text: JSON.stringify({ sessions }, null, 2) },
@@ -79,8 +81,8 @@ async function handleToolCall(
     }
 
     case "memory_export": {
-      const memories = await kv.list("mem:memories");
-      const sessions = await kv.list("mem:sessions");
+      const memories = await kvInstance.list("mem:memories");
+      const sessions = await kvInstance.list("mem:sessions");
       return {
         content: [
           {
@@ -96,7 +98,7 @@ async function handleToolCall(
     }
 
     case "memory_audit": {
-      const entries = await kv.list("mem:audit");
+      const entries = await kvInstance.list("mem:audit");
       const limit = (args.limit as number) || 50;
       return {
         content: [

--- a/test/mcp-standalone.test.ts
+++ b/test/mcp-standalone.test.ts
@@ -13,12 +13,21 @@ vi.mock("node:fs", () => ({
   mkdirSync: vi.fn(),
 }));
 
+vi.mock("../src/mcp/transport.js", () => ({
+  createStdioTransport: vi.fn(() => ({ start: vi.fn(), stop: vi.fn() })),
+}));
+
+vi.mock("../src/config.js", () => ({
+  getStandalonePersistPath: vi.fn(() => "/tmp/test-standalone.json"),
+}));
+
 import {
   getAllTools,
   CORE_TOOLS,
   V040_TOOLS,
 } from "../src/mcp/tools-registry.js";
 import { InMemoryKV } from "../src/mcp/in-memory-kv.js";
+import { handleToolCall } from "../src/mcp/standalone.js";
 import { writeFileSync } from "node:fs";
 
 describe("Tools Registry", () => {
@@ -109,5 +118,54 @@ describe("InMemoryKV", () => {
     expect(result).toBe("second");
     const list = await kv.list("scope1");
     expect(list.length).toBe(1);
+  });
+});
+
+describe("handleToolCall", () => {
+  beforeEach(() => {
+    vi.mocked(writeFileSync).mockClear();
+  });
+
+  it("memory_save persists to disk immediately after saving", async () => {
+    const kv = new InMemoryKV("/tmp/test-handle.json");
+    const result = await handleToolCall(
+      "memory_save",
+      { content: "Test memory content" },
+      kv,
+    );
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.saved).toMatch(/^mem_/);
+    expect(writeFileSync).toHaveBeenCalledWith(
+      "/tmp/test-handle.json",
+      expect.any(String),
+      "utf-8",
+    );
+  });
+
+  it("memory_save without persist path does not call writeFileSync", async () => {
+    const kv = new InMemoryKV();
+    await handleToolCall("memory_save", { content: "No persist path" }, kv);
+    expect(writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it("memory_save throws when content is missing", async () => {
+    const kv = new InMemoryKV();
+    await expect(
+      handleToolCall("memory_save", {}, kv),
+    ).rejects.toThrow("content is required");
+  });
+
+  it("memory_recall returns matching memories", async () => {
+    const kv = new InMemoryKV();
+    await handleToolCall("memory_save", { content: "TypeScript is great" }, kv);
+    await handleToolCall("memory_save", { content: "Python is also great" }, kv);
+    const result = await handleToolCall(
+      "memory_recall",
+      { query: "typescript" },
+      kv,
+    );
+    const memories = JSON.parse(result.content[0].text);
+    expect(memories).toHaveLength(1);
+    expect(memories[0].content).toBe("TypeScript is great");
   });
 });


### PR DESCRIPTION
## Problem

In `standalone.ts`, `kv.persist()` (which writes the in-memory store to `~/.agentmemory/standalone.json`) was only called on `SIGINT`/`SIGTERM` signal handlers:

```ts
process.on("SIGINT", () => { kv.persist(); process.exit(0); });
process.on("SIGTERM", () => { kv.persist(); process.exit(0); });
```

If the MCP server process is killed with `SIGKILL`, crashes unexpectedly, or the host terminates it forcefully (e.g. when an AI coding agent session ends), **all memories saved during that session are permanently lost** because `standalone.json` is never written.

## Fix

Call `kv.persist()` immediately after `kv.set()` in the `memory_save` handler, so data is written to disk on every save:

```ts
await kvInstance.set("mem:memories", id, { ... });
kvInstance.persist();  // ← ensure data survives unexpected termination
```

## Additional Changes

- **Exported `handleToolCall`** with an injectable `kvInstance` parameter (defaults to the module-level `kv`) to enable unit testing
- **Mocked `transport.js` and `config.js`** in `test/mcp-standalone.test.ts` to prevent side effects when importing the module
- **Added 4 new tests** in a `handleToolCall` describe block:
  - `memory_save persists to disk immediately after saving` — verifies `writeFileSync` is called
  - `memory_save without persist path does not call writeFileSync` — no unnecessary writes when no path configured
  - `memory_save throws when content is missing` — validates error handling
  - `memory_recall returns matching memories` — end-to-end recall test

All 625 existing tests continue to pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory save and retrieval so saved items are consistently persisted, timestamped, and retrievable across sessions; save now reliably triggers disk persistence when configured.
  * Validation tightened so attempts to save without required content produce clear errors.
  * Memory listing/recall now reads from the active storage instance for accurate results.

* **Tests**
  * Added isolated tests covering persistence behavior, save/recall flows, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->