### PR TITLE
fix(cli): capture signal kills + guard empty env paths (#128 followups)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -101,16 +101,16 @@ function whichBinary(name: string): string | null {
 
 function fallbackIiiPaths(): string[] {
   if (IS_WINDOWS) {
-    const userProfile = process.env["USERPROFILE"] || "";
+    const userProfile = process.env["USERPROFILE"];
+    if (!userProfile) return [];
     return [
       join(userProfile, ".local", "bin", "iii.exe"),
       join(userProfile, "bin", "iii.exe"),
-    ].filter(Boolean);
+    ];
   }
-  return [
-    join(process.env["HOME"] || "", ".local", "bin", "iii"),
-    "/usr/local/bin/iii",
-  ];
+  const home = process.env["HOME"];
+  if (!home) return ["/usr/local/bin/iii"];
+  return [join(home, ".local", "bin", "iii"), "/usr/local/bin/iii"];
 }
 
 type StartupFailure = {
@@ -146,11 +146,17 @@ function spawnEngineBackground(
     stderrBytes += slice.length;
   });
   child.on("exit", (code, signal) => {
-    if (code !== 0 && code !== null) {
+    const abnormal =
+      (code !== null && code !== 0) || (code === null && signal !== null);
+    if (abnormal) {
       const stderr = Buffer.concat(stderrChunks).toString("utf-8");
       startupFailure = {
         kind: label.includes("Docker") ? "docker-crashed" : "engine-crashed",
-        stderr: stderr.trim() || `process exited with code ${code}${signal ? ` (${signal})` : ""}`,
+        stderr:
+          stderr.trim() ||
+          (signal
+            ? `process killed by signal ${signal}`
+            : `process exited with code ${code}`),
         binary: bin,
       };
       vlog(`engine exited early: code=${code} signal=${signal}`);


### PR DESCRIPTION
Follow-up to #128. CodeRabbit flagged two remaining minor issues on the Windows diagnostics PR that landed before they were addressed. Both real, both minor, both cheap.

## 1. Signal-only exits weren't captured

**Location:** \`src/cli.ts\` exit handler inside \`spawnEngineBackground\`

When a child process is killed by a signal (SIGSEGV, SIGABRT, SIGKILL, SIGTERM) Node reports \`code === null\` and \`signal !== null\`. The previous guard was:

\`\`\`ts
if (code !== 0 && code !== null) { ... }
\`\`\`

which explicitly excluded signal-only exits. A segfault in iii-engine would be silently dropped from \`startupFailure\`, so the user got the generic \"did not become ready within 15s\" timeout instead of a real crash diagnosis. On Windows this rarely fires (abnormal exits usually carry numeric codes), but on Linux/macOS a segfaulting iii-engine would be invisible to the CLI.

**Fix:**

\`\`\`ts
const abnormal =
  (code !== null && code !== 0) || (code === null && signal !== null);
if (abnormal) { ... }
\`\`\`

Also improved the fallback message when stderr is empty so it reads \"process killed by signal SIGSEGV\" rather than the old \"process exited with code null (SIGSEGV)\".

## 2. Empty \`USERPROFILE\`/\`HOME\` produced relative paths

**Location:** \`src/cli.ts\` \`fallbackIiiPaths()\`

Previously:

\`\`\`ts
const userProfile = process.env[\"USERPROFILE\"] || \"\";
return [
  join(userProfile, \".local\", \"bin\", \"iii.exe\"),
  join(userProfile, \"bin\", \"iii.exe\"),
].filter(Boolean);
\`\`\`

When \`USERPROFILE\` is unset, \`join(\"\", \".local\", \"bin\", \"iii.exe\")\` produces \`.local/bin/iii.exe\` — a relative path. Harmless today (the path is then fed to \`existsSync\` which fails silently), but theoretically it could match a file in the user's current working directory and then trigger an unintended \`spawn()\`.

**Fix:** guard the env var up front, return an empty list (Windows) or skip the per-user path (Unix) when unset. Keep the absolute \`/usr/local/bin/iii\` fallback on Unix since it's valid regardless of \`HOME\`.

## Test plan

- [x] \`npm test\` → 684 / 684 passing
- [x] \`npm run build\` → clean
- [ ] After merge, await further report from @Gakko-IT2 on #127 to see if the #128 + this follow-up resolve their Windows issue (or if we need another round)

## Related

- Follow-up to #128 (Windows startup diagnostics)
- CodeRabbit findings on #128: signal-exits + empty-env, both marked ⚠️ Potential issue (Minor)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed path resolution on Windows to prevent empty directory entries.
  * Improved engine failure detection to properly identify crash conditions.

* **Improvements**
  * Enhanced startup error messages with clearer diagnostics for engine failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->