### PR TITLE
fix(mcp): never respond to JSON-RPC notifications (#129)

### DIFF
--- a/src/mcp/transport.ts
+++ b/src/mcp/transport.ts
@@ -28,6 +28,19 @@ function isNotification(req: JsonRpcRequest): boolean {
   return req.id === undefined || req.id === null;
 }
 
+// Per JSON-RPC 2.0 §4, a valid request id must be a String, Number, or Null
+// (Null is technically only allowed in responses; in requests, omitting id
+// is the convention for notifications, which we treat the same as null).
+// Any other runtime type (object, array, boolean) is an Invalid Request.
+function isValidId(id: unknown): id is string | number | null | undefined {
+  return (
+    id === undefined ||
+    id === null ||
+    typeof id === "string" ||
+    typeof id === "number"
+  );
+}
+
 // Exported for unit tests so the line-handling logic is exercised
 // independently of process.stdin / process.stdout.
 export async function processLine(
@@ -52,18 +65,38 @@ export async function processLine(
   }
 
   const request = parsed as JsonRpcRequest;
+  const rawId = (request as { id?: unknown } | null)?.id;
+
+  // Invalid request shape (missing/wrong jsonrpc, non-string method).
   if (
     !request ||
+    typeof request !== "object" ||
     request.jsonrpc !== "2.0" ||
     typeof request.method !== "string"
   ) {
-    if (request && (request as { id?: unknown }).id != null) {
+    // Echo the id back only if it's a valid string/number. Notifications
+    // (missing/null id) and malformed ids both drop silently — we don't
+    // want to respond to something that could be a notification, and we
+    // can't invent an id for a malformed one.
+    if (typeof rawId === "string" || typeof rawId === "number") {
       writeOut({
         jsonrpc: "2.0",
-        id: (request as JsonRpcRequest).id as string | number,
+        id: rawId,
         error: { code: -32600, message: "Invalid Request" },
       });
     }
+    return;
+  }
+
+  // Request shape is valid but id may still be of the wrong type
+  // (object, array, boolean). Per the spec, that's an Invalid Request.
+  // Respond with id: null because we can't safely echo a non-JSON-RPC id.
+  if (!isValidId(rawId)) {
+    writeOut({
+      jsonrpc: "2.0",
+      id: null,
+      error: { code: -32600, message: "Invalid Request: id must be string, number, or null" },
+    });
     return;
   }
 

--- a/src/mcp/transport.ts
+++ b/src/mcp/transport.ts
@@ -2,14 +2,14 @@ import { createInterface } from "node:readline";
 
 export interface JsonRpcRequest {
   jsonrpc: "2.0";
-  id: string | number;
+  id?: string | number;
   method: string;
   params?: Record<string, unknown>;
 }
 
 export interface JsonRpcResponse {
   jsonrpc: "2.0";
-  id: string | number;
+  id: string | number | null;
   result?: unknown;
   error?: { code: number; message: string; data?: unknown };
 }
@@ -19,64 +19,95 @@ export type RequestHandler = (
   params: Record<string, unknown>,
 ) => Promise<unknown>;
 
+// JSON-RPC 2.0 notifications are messages without an `id` field. The spec
+// (and the MCP transport contract) requires the server to NOT send a
+// response for notifications. Some clients tolerate spurious responses;
+// stricter clients (e.g. Codex CLI) treat them as protocol violations and
+// close the transport. See agentmemory#129.
+function isNotification(req: JsonRpcRequest): boolean {
+  return req.id === undefined || req.id === null;
+}
+
+// Exported for unit tests so the line-handling logic is exercised
+// independently of process.stdin / process.stdout.
+export async function processLine(
+  line: string,
+  handler: RequestHandler,
+  writeOut: (response: JsonRpcResponse) => void,
+  writeErr: (msg: string) => void = (msg) => process.stderr.write(msg),
+): Promise<void> {
+  const trimmed = line.trim();
+  if (!trimmed) return;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    writeOut({
+      jsonrpc: "2.0",
+      id: null,
+      error: { code: -32700, message: "Parse error" },
+    });
+    return;
+  }
+
+  const request = parsed as JsonRpcRequest;
+  if (
+    !request ||
+    request.jsonrpc !== "2.0" ||
+    typeof request.method !== "string"
+  ) {
+    if (request && (request as { id?: unknown }).id != null) {
+      writeOut({
+        jsonrpc: "2.0",
+        id: (request as JsonRpcRequest).id as string | number,
+        error: { code: -32600, message: "Invalid Request" },
+      });
+    }
+    return;
+  }
+
+  const notification = isNotification(request);
+
+  try {
+    const result = await handler(request.method, request.params || {});
+    if (notification) return;
+    writeOut({
+      jsonrpc: "2.0",
+      id: request.id as string | number,
+      result,
+    });
+  } catch (err) {
+    if (notification) {
+      writeErr(
+        `[mcp-transport] notification handler error for ${request.method}: ${
+          err instanceof Error ? err.message : String(err)
+        }\n`,
+      );
+      return;
+    }
+    writeOut({
+      jsonrpc: "2.0",
+      id: request.id as string | number,
+      error: {
+        code: -32603,
+        message: err instanceof Error ? err.message : String(err),
+      },
+    });
+  }
+}
+
 export function createStdioTransport(handler: RequestHandler): {
   start: () => void;
   stop: () => void;
 } {
   let rl: ReturnType<typeof createInterface> | null = null;
 
-  const onLine = async (line: string) => {
-    const trimmed = line.trim();
-    if (!trimmed) return;
-
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(trimmed);
-    } catch {
-      const error: JsonRpcResponse = {
-        jsonrpc: "2.0",
-        id: null as unknown as number,
-        error: { code: -32700, message: "Parse error" },
-      };
-      process.stdout.write(JSON.stringify(error) + "\n");
-      return;
-    }
-
-    const request = parsed as JsonRpcRequest;
-    if (
-      !request ||
-      request.jsonrpc !== "2.0" ||
-      typeof request.method !== "string"
-    ) {
-      const error: JsonRpcResponse = {
-        jsonrpc: "2.0",
-        id: request?.id ?? (null as unknown as number),
-        error: { code: -32600, message: "Invalid Request" },
-      };
-      process.stdout.write(JSON.stringify(error) + "\n");
-      return;
-    }
-
-    try {
-      const result = await handler(request.method, request.params || {});
-      const response: JsonRpcResponse = {
-        jsonrpc: "2.0",
-        id: request.id,
-        result,
-      };
-      process.stdout.write(JSON.stringify(response) + "\n");
-    } catch (err) {
-      const response: JsonRpcResponse = {
-        jsonrpc: "2.0",
-        id: request.id,
-        error: {
-          code: -32603,
-          message: err instanceof Error ? err.message : String(err),
-        },
-      };
-      process.stdout.write(JSON.stringify(response) + "\n");
-    }
+  const writeResponse = (response: JsonRpcResponse) => {
+    process.stdout.write(JSON.stringify(response) + "\n");
   };
+
+  const onLine = (line: string) => processLine(line, handler, writeResponse);
 
   return {
     start() {

--- a/test/mcp-transport.test.ts
+++ b/test/mcp-transport.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  processLine,
+  type JsonRpcResponse,
+  type RequestHandler,
+} from "../src/mcp/transport.js";
+
+function collector() {
+  const out: JsonRpcResponse[] = [];
+  const err: string[] = [];
+  return {
+    out,
+    err,
+    writeOut: (r: JsonRpcResponse) => out.push(r),
+    writeErr: (m: string) => err.push(m),
+  };
+}
+
+const okHandler: RequestHandler = async (method) => ({ method });
+
+describe("processLine — request path", () => {
+  it("emits a response for a request with id", async () => {
+    const c = collector();
+    await processLine(
+      JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize" }),
+      okHandler,
+      c.writeOut,
+      c.writeErr,
+    );
+    expect(c.out).toHaveLength(1);
+    expect(c.out[0]).toEqual({
+      jsonrpc: "2.0",
+      id: 1,
+      result: { method: "initialize" },
+    });
+  });
+
+  it("emits an error response when the handler throws on a request", async () => {
+    const c = collector();
+    const throwingHandler: RequestHandler = async () => {
+      throw new Error("boom");
+    };
+    await processLine(
+      JSON.stringify({ jsonrpc: "2.0", id: 7, method: "tools/list" }),
+      throwingHandler,
+      c.writeOut,
+      c.writeErr,
+    );
+    expect(c.out).toHaveLength(1);
+    expect(c.out[0].id).toBe(7);
+    expect(c.out[0].error?.code).toBe(-32603);
+    expect(c.out[0].error?.message).toBe("boom");
+  });
+});
+
+describe("processLine — notification path (#129)", () => {
+  it("does NOT emit a response for a notification (no id field)", async () => {
+    const c = collector();
+    const handlerCalled = vi.fn(async () => ({ shouldNotEscape: true }));
+    await processLine(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        method: "notifications/initialized",
+      }),
+      handlerCalled,
+      c.writeOut,
+      c.writeErr,
+    );
+    expect(handlerCalled).toHaveBeenCalledOnce();
+    expect(c.out).toHaveLength(0);
+    expect(c.err).toHaveLength(0);
+  });
+
+  it("does NOT emit a response for a notification with id: null", async () => {
+    const c = collector();
+    await processLine(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: null,
+        method: "notifications/cancelled",
+      }),
+      okHandler,
+      c.writeOut,
+      c.writeErr,
+    );
+    expect(c.out).toHaveLength(0);
+  });
+
+  it("logs to stderr but does NOT emit a response when a notification handler throws", async () => {
+    const c = collector();
+    const throwingHandler: RequestHandler = async () => {
+      throw new Error("notification crash");
+    };
+    await processLine(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        method: "notifications/initialized",
+      }),
+      throwingHandler,
+      c.writeOut,
+      c.writeErr,
+    );
+    expect(c.out).toHaveLength(0);
+    expect(c.err).toHaveLength(1);
+    expect(c.err[0]).toContain("notification handler error");
+    expect(c.err[0]).toContain("notification crash");
+  });
+});
+
+describe("processLine — malformed input", () => {
+  it("emits a parse error with id: null for invalid JSON", async () => {
+    const c = collector();
+    await processLine("not-json", okHandler, c.writeOut, c.writeErr);
+    expect(c.out).toHaveLength(1);
+    expect(c.out[0].id).toBeNull();
+    expect(c.out[0].error?.code).toBe(-32700);
+    expect(c.out[0].error?.message).toBe("Parse error");
+  });
+
+  it("ignores empty / whitespace-only lines", async () => {
+    const c = collector();
+    await processLine("", okHandler, c.writeOut, c.writeErr);
+    await processLine("   \t  ", okHandler, c.writeOut, c.writeErr);
+    expect(c.out).toHaveLength(0);
+    expect(c.err).toHaveLength(0);
+  });
+
+  it("emits an Invalid Request error when a request has an id but no jsonrpc", async () => {
+    const c = collector();
+    await processLine(
+      JSON.stringify({ id: 1, method: "tools/list" }),
+      okHandler,
+      c.writeOut,
+      c.writeErr,
+    );
+    expect(c.out).toHaveLength(1);
+    expect(c.out[0].id).toBe(1);
+    expect(c.out[0].error?.code).toBe(-32600);
+  });
+
+  it("silently drops a malformed message that has no id (treated as notification)", async () => {
+    const c = collector();
+    await processLine(
+      JSON.stringify({ method: "broken" }),
+      okHandler,
+      c.writeOut,
+      c.writeErr,
+    );
+    // No jsonrpc field, no id — drop without responding.
+    expect(c.out).toHaveLength(0);
+  });
+});

--- a/test/mcp-transport.test.ts
+++ b/test/mcp-transport.test.ts
@@ -149,4 +149,81 @@ describe("processLine — malformed input", () => {
     // No jsonrpc field, no id — drop without responding.
     expect(c.out).toHaveLength(0);
   });
+
+  it("silently drops a malformed message with a non-primitive id (can't safely echo)", async () => {
+    const c = collector();
+    await processLine(
+      JSON.stringify({ id: { nested: true }, method: "broken" }),
+      okHandler,
+      c.writeOut,
+      c.writeErr,
+    );
+    // Malformed shape + non-primitive id — can't echo id back, drop silently.
+    expect(c.out).toHaveLength(0);
+  });
+});
+
+describe("processLine — id type validation (JSON-RPC §4)", () => {
+  it("rejects a request whose id is an object with -32600 and id: null", async () => {
+    const c = collector();
+    const handlerCalled = vi.fn(okHandler);
+    await processLine(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: { bogus: true },
+        method: "tools/list",
+      }),
+      handlerCalled,
+      c.writeOut,
+      c.writeErr,
+    );
+    expect(handlerCalled).not.toHaveBeenCalled();
+    expect(c.out).toHaveLength(1);
+    expect(c.out[0].id).toBeNull();
+    expect(c.out[0].error?.code).toBe(-32600);
+    expect(c.out[0].error?.message).toContain("id must be");
+  });
+
+  it("rejects a request whose id is an array", async () => {
+    const c = collector();
+    const handlerCalled = vi.fn(okHandler);
+    await processLine(
+      JSON.stringify({ jsonrpc: "2.0", id: [1, 2], method: "tools/list" }),
+      handlerCalled,
+      c.writeOut,
+      c.writeErr,
+    );
+    expect(handlerCalled).not.toHaveBeenCalled();
+    expect(c.out).toHaveLength(1);
+    expect(c.out[0].id).toBeNull();
+    expect(c.out[0].error?.code).toBe(-32600);
+  });
+
+  it("rejects a request whose id is a boolean", async () => {
+    const c = collector();
+    const handlerCalled = vi.fn(okHandler);
+    await processLine(
+      JSON.stringify({ jsonrpc: "2.0", id: true, method: "tools/list" }),
+      handlerCalled,
+      c.writeOut,
+      c.writeErr,
+    );
+    expect(handlerCalled).not.toHaveBeenCalled();
+    expect(c.out).toHaveLength(1);
+    expect(c.out[0].id).toBeNull();
+    expect(c.out[0].error?.code).toBe(-32600);
+  });
+
+  it("accepts a request with string id", async () => {
+    const c = collector();
+    await processLine(
+      JSON.stringify({ jsonrpc: "2.0", id: "abc-123", method: "ping" }),
+      okHandler,
+      c.writeOut,
+      c.writeErr,
+    );
+    expect(c.out).toHaveLength(1);
+    expect(c.out[0].id).toBe("abc-123");
+    expect(c.out[0].result).toEqual({ method: "ping" });
+  });
 });


### PR DESCRIPTION
Fixes #129 reported by @GuillaumeOuint.

## Symptom

\`\`\`
MCP client for agentmemory failed to start: MCP startup failed: Transport closed
\`\`\`

Codex CLI v0.120.0 fails to start the standalone MCP server. Other MCP clients (Claude Desktop, Cursor, OpenClaw) work fine with the same binary. Running \`npx agentmemory-mcp\` directly in a terminal also "works" — it prints the v0.8.1 banner and waits for input. Only Codex's stdio handshake breaks.

## Root cause

\`src/mcp/transport.ts\` unconditionally writes a JSON-RPC response for **every** incoming message, including notifications. Per [JSON-RPC 2.0 §4.1](https://www.jsonrpc.org/specification#notification):

> A Notification is a Request object without an "id" member. [...] **The Server MUST NOT reply to a Notification**, including those that are within a batch request.

Lenient clients (Claude Desktop, Cursor) silently ignore unsolicited responses. Strict clients (Codex CLI) treat them as protocol violations and close the transport. That's exactly what Guillaume sees.

The exact sequence on Codex CLI:

1. Codex sends `initialize` (request, has `id`) → server responds ✓
2. Codex sends `notifications/initialized` (**notification, no `id`**)
3. Our handler in \`standalone.ts:138-139\` returns \`{}\`
4. \`transport.ts:62-67\` writes \`{\"jsonrpc\":\"2.0\",\"result\":{}}\` to stdout (no \`id\` field because \`request.id\` is undefined)
5. Codex parses an unsolicited response → closes transport
6. Guillaume sees \`Transport closed\`

\`memory_save\` / \`memory_recall\` etc never had a chance to fire because the handshake itself was broken.

## Fix

- **\`src/mcp/transport.ts\`**: detect notifications via missing/null \`id\`, run the handler for side effects, then **drop the response**. Errors inside notification handlers are logged to stderr (not silently swallowed) so production debugging still works
- **\`src/mcp/transport.ts\`**: malformed messages with no \`id\` are also dropped silently (consistent with notification semantics) instead of being responded to with \`id: null\`
- **\`src/mcp/transport.ts\`**: extracted \`processLine()\` as an exported function so the line-handling logic is testable independently of \`process.stdin\` / \`process.stdout\`. The \`createStdioTransport\` factory still works the same way externally
- **\`test/mcp-transport.test.ts\`** (new): 9 tests covering all paths
  - Request responses (success + error)
  - Notification suppression (no \`id\` + \`id: null\` + handler-throws)
  - Malformed input (parse error, invalid request with \`id\`, invalid request without \`id\`, empty/whitespace lines)

The existing \`test/mcp-standalone.test.ts\` mocks the transport entirely so it never exercised the notification path. The new file imports the real \`processLine\` and verifies the actual behavior.

## Why the bug went undetected

- All existing MCP clients we test against (Claude Desktop, Cursor, OpenClaw, Hermes, the gateway plugin) tolerate unsolicited responses — they just drop them
- Codex CLI's MCP support is newer and stricter
- The standalone server passes a manual smoke test in a terminal because no client is doing the handshake — only the stderr banner is visible

## Test plan

- [x] \`npm test\` → 693 / 693 passing (684 baseline + 9 new)
- [x] \`npm run build\` → clean
- [ ] After merge + release: ask @GuillaumeOuint to upgrade to the new version and re-test with the same Codex CLI config
- [ ] Should also fix any other strict MCP clients that hit the same issue (probably more to come as MCP adoption broadens)

## Related

- Closes #129 (pending verification from reporter)
- Reporter installed \`@agentmemory/agentmemory\` globally so they're seeing v0.8.1 — this fix needs a release on top of main to actually reach them

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust JSON-RPC handling: malformed JSON yields a Parse error (id null); invalid request shapes return Invalid Request when an id is present; non-primitive ids are rejected.
  * Notifications (no id or id null) no longer generate responses; notification handler failures are logged without replying.
  * Handler exceptions for regular requests produce an internal error response echoing the request id.

* **Tests**
  * Added comprehensive tests covering parsing, request/notification behavior, id validation, and error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->