### PR TITLE
fix: split multi-word queries in standalone memory_smart_search

### DIFF
--- a/src/mcp/standalone.ts
+++ b/src/mcp/standalone.ts
@@ -128,7 +128,7 @@ export async function handleToolCall(
           ]
             .join(" ")
             .toLowerCase();
-          return text.includes(query);
+          return query.split(/\s+/).every((word) => text.includes(word));
         })
         .slice(0, limit);
       return {


### PR DESCRIPTION
Fixes #147

## Root cause

`standalone.ts` builds a concatenated searchable string from title, content, files, concepts, and sessionIds, then checks:

```ts
return text.includes(query);
```

A multi-word query like `"BEAM bi-level LLM heuristic"` requires that exact substring to appear contiguously — it won't match when the words are spread across different fields.

## Fix

```ts
// before
return text.includes(query);

// after
return query.split(/\s+/).every((word) => text.includes(word));
```

Each token in the query must appear somewhere in the searchable text (AND semantics). Single-word queries are unaffected.

## Test

- `memory_smart_search({ query: "BEAM" })` — ✅ still works (single word, `.every` on one-element array)
- `memory_smart_search({ query: "BEAM bi-level LLM heuristic" })` — ✅ now returns matching entries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced search matching: search results now require all individual query terms to be present in the content, improving result relevance and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->