### PR TITLE
fix: preserve a distinct backup path for *.original.md inputs

### DIFF
--- a/src/functions/compress-file.ts
+++ b/src/functions/compress-file.ts
@@ -85,7 +85,9 @@ function validateCompression(original: string, compressed: string): string[] {
 
 function resolveBackupPath(filePath: string): string {
   const base = basename(filePath, extname(filePath));
-  const name = base.endsWith(".original") ? base : `${base}.original`;
+  const name = base.endsWith(".original")
+    ? `${base}.backup`
+    : `${base}.original`;
   return join(dirname(filePath), `${name}.md`);
 }
 

--- a/test/compress-file.test.ts
+++ b/test/compress-file.test.ts
@@ -127,4 +127,21 @@ describe("mem::compress-file", () => {
     expect(result.details.some((d) => d.includes("url"))).toBe(true);
     expect(fileStore.get("/tmp/guide.original.md")).toBeUndefined();
   });
+
+  it("uses a distinct backup path for *.original.md inputs", async () => {
+    const path = "/tmp/notes.original.md";
+    fileStore.set(path, "# Title\n\nLong original body.");
+    summarize.mockResolvedValue("# Title\n\nShort body.");
+
+    const result = (await sdk.trigger("mem::compress-file", {
+      filePath: path,
+    })) as { success: boolean; backupPath: string };
+
+    expect(result.success).toBe(true);
+    expect(result.backupPath).toBe("/tmp/notes.original.backup.md");
+    expect(fileStore.get("/tmp/notes.original.backup.md")).toBe(
+      "# Title\n\nLong original body.",
+    );
+    expect(fileStore.get(path)).toBe("# Title\n\nShort body.");
+  });
 });


### PR DESCRIPTION
## Problem

PR #150 added automatic backup creation for `memory_compress_file`, but there is one filename shape where that contract breaks.

For inputs already ending in `*.original.md`, `resolveBackupPath()` returns the same path as the input file, so the function writes the backup and then immediately overwrites that same path with the compressed content.

## Fix

Keep the existing behavior for ordinary Markdown files:
- `notes.md` -> `notes.original.md`

But make already-suffixed inputs produce a distinct backup path:
- `notes.original.md` -> `notes.original.backup.md`

This keeps the diff narrow and preserves the existing naming convention for the common case while making the advertised backup behavior true for `*.original.md` inputs.

## Verification

- `npm test -- test/compress-file.test.ts`
- `npm run build`

### Regression coverage added

New test case:
- `notes.original.md` writes its backup to `notes.original.backup.md`
- the backup contains the original Markdown
- the input file contains the compressed Markdown
