### PR TITLE
fix: reject symlinks in mem::compress-file (#151)

### DIFF
--- a/src/functions/compress-file.ts
+++ b/src/functions/compress-file.ts
@@ -1,4 +1,5 @@
-import { lstat, readFile, writeFile } from "node:fs/promises";
+import { constants } from "node:fs";
+import { lstat, open, readFile, writeFile } from "node:fs/promises";
 import { basename, dirname, extname, join, resolve } from "node:path";
 import type { ISdk } from "iii-sdk";
 import type { MemoryProvider } from "../types.js";
@@ -148,7 +149,23 @@ export function registerCompressFileFunction(
 
       const backupPath = resolveBackupPath(absolutePath);
       await writeFile(backupPath, original, "utf-8");
-      await writeFile(absolutePath, compressed, "utf-8");
+
+      let fd: Awaited<ReturnType<typeof open>> | null = null;
+      try {
+        fd = await open(
+          absolutePath,
+          constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | constants.O_NOFOLLOW,
+        );
+        await fd.writeFile(compressed, "utf-8");
+      } catch (err: unknown) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === "ELOOP" || code === "EINVAL") {
+          return { success: false, error: "symlinks are not supported" };
+        }
+        return { success: false, error: "failed to write compressed file" };
+      } finally {
+        await fd?.close().catch(() => {});
+      }
 
       try {
         await recordAudit(kv, "compress", "mem::compress-file", [], {

--- a/src/functions/compress-file.ts
+++ b/src/functions/compress-file.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile } from "node:fs/promises";
+import { lstat, readFile, writeFile } from "node:fs/promises";
 import { basename, dirname, extname, join, resolve } from "node:path";
 import type { ISdk } from "iii-sdk";
 import type { MemoryProvider } from "../types.js";
@@ -110,6 +110,15 @@ export function registerCompressFileFunction(
       }
       if (SENSITIVE_PATH_TERMS.some((term) => lowerPath.includes(term))) {
         return { success: false, error: "refusing to process sensitive-looking path" };
+      }
+
+      try {
+        const stat = await lstat(absolutePath);
+        if (stat.isSymbolicLink()) {
+          return { success: false, error: "symlinks are not supported" };
+        }
+      } catch {
+        return { success: false, error: "file not found" };
       }
 
       let original: string;

--- a/test/compress-file.test.ts
+++ b/test/compress-file.test.ts
@@ -5,8 +5,12 @@ vi.mock("../src/logger.js", () => ({
 }));
 
 const fileStore = new Map<string, string>();
+const symlinkPaths = new Set<string>();
 
 vi.mock("node:fs/promises", () => ({
+  lstat: vi.fn(async (path: string) => ({
+    isSymbolicLink: () => symlinkPaths.has(path),
+  })),
   readFile: vi.fn(async (path: string) => {
     const value = fileStore.get(path);
     if (value === undefined) throw new Error("ENOENT");
@@ -68,6 +72,7 @@ describe("mem::compress-file", () => {
 
   beforeEach(() => {
     fileStore.clear();
+    symlinkPaths.clear();
     sdk = mockSdk();
     kv = mockKV();
     summarize = vi.fn();
@@ -76,6 +81,15 @@ describe("mem::compress-file", () => {
       kv as never,
       { name: "test-provider", summarize, compress: summarize } as never,
     );
+  });
+
+  it("rejects symlinks", async () => {
+    symlinkPaths.add("/tmp/notes.md");
+    const result = (await sdk.trigger("mem::compress-file", {
+      filePath: "/tmp/notes.md",
+    })) as { success: boolean; error: string };
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("symlink");
   });
 
   it("rejects non-markdown paths", async () => {

--- a/test/compress-file.test.ts
+++ b/test/compress-file.test.ts
@@ -6,11 +6,33 @@ vi.mock("../src/logger.js", () => ({
 
 const fileStore = new Map<string, string>();
 const symlinkPaths = new Set<string>();
+const openEloopPaths = new Set<string>();
 
 vi.mock("node:fs/promises", () => ({
-  lstat: vi.fn(async (path: string) => ({
-    isSymbolicLink: () => symlinkPaths.has(path),
-  })),
+  lstat: vi.fn(async (path: string) => {
+    if (symlinkPaths.has(path)) {
+      return { isSymbolicLink: () => true };
+    }
+    if (!fileStore.has(path)) {
+      throw Object.assign(new Error(`ENOENT: no such file or directory, lstat '${path}'`), {
+        code: "ENOENT",
+      });
+    }
+    return { isSymbolicLink: () => false };
+  }),
+  open: vi.fn(async (path: string) => {
+    if (openEloopPaths.has(path)) {
+      throw Object.assign(new Error("ELOOP: too many levels of symbolic links"), {
+        code: "ELOOP",
+      });
+    }
+    return {
+      writeFile: vi.fn(async (content: string) => {
+        fileStore.set(path, content);
+      }),
+      close: vi.fn(async () => {}),
+    };
+  }),
   readFile: vi.fn(async (path: string) => {
     const value = fileStore.get(path);
     if (value === undefined) throw new Error("ENOENT");
@@ -73,6 +95,7 @@ describe("mem::compress-file", () => {
   beforeEach(() => {
     fileStore.clear();
     symlinkPaths.clear();
+    openEloopPaths.clear();
     sdk = mockSdk();
     kv = mockKV();
     summarize = vi.fn();
@@ -90,6 +113,26 @@ describe("mem::compress-file", () => {
     })) as { success: boolean; error: string };
     expect(result.success).toBe(false);
     expect(result.error).toContain("symlink");
+    expect(summarize).not.toHaveBeenCalled();
+    expect(fileStore.size).toBe(0);
+  });
+
+  it("rejects TOCTOU symlink swap at write time via O_NOFOLLOW", async () => {
+    const path = "/tmp/notes.md";
+    fileStore.set(
+      path,
+      "# Title\n\nVisit https://example.com\n\n```ts\nconst x = 1;\n```\n\nContent.",
+    );
+    summarize.mockResolvedValue(
+      "# Title\n\nVisit https://example.com\n\n```ts\nconst x = 1;\n```\n\nShort.",
+    );
+    openEloopPaths.add(path);
+
+    const result = (await sdk.trigger("mem::compress-file", {
+      filePath: path,
+    })) as { success: boolean; error: string };
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("symlink");
   });
 
   it("rejects non-markdown paths", async () => {
@@ -98,6 +141,14 @@ describe("mem::compress-file", () => {
     })) as { success: boolean; error: string };
     expect(result.success).toBe(false);
     expect(result.error).toContain(".md");
+  });
+
+  it("returns file not found for missing paths", async () => {
+    const result = (await sdk.trigger("mem::compress-file", {
+      filePath: "/tmp/nonexistent.md",
+    })) as { success: boolean; error: string };
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("not found");
   });
 
   it("compresses markdown and writes .original.md backup", async () => {


### PR DESCRIPTION
## Problem

`mem::compress-file` validated the caller-supplied path with `extname()` (checks the symlink name, e.g. `notes.md`) but then called `readFile` / `writeFile` which follow symlinks to the real target. A symlink `notes.md -> vault.txt` passed the `.md` check and caused the function to read and overwrite `vault.txt`, also leaking its contents to `provider.summarize()`.

Closes #151.

## Fix

Added an `lstat()` call immediately after path validation, before any I/O:

```ts
const stat = await lstat(absolutePath);
if (stat.isSymbolicLink()) {
  return { success: false, error: "symlinks are not supported" };
}
```

`lstat` does not follow symlinks, so it reports the true type of the path entry. Symlinks are rejected early; regular files proceed as before.

## Tests

Added `"rejects symlinks"` test case to `test/compress-file.test.ts`. The `node:fs/promises` mock now includes `lstat` and a `symlinkPaths` set so individual tests can mark paths as symlinks without touching the filesystem.

```
✓ test/compress-file.test.ts (4 tests)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File processing now explicitly rejects symbolic links with a clear "symlink" error.
  * Missing or invalid file paths are detected earlier and return clearer "file not found" errors.
  * Write-time symlink swap attempts are detected and reported as "symlink" errors.

* **Tests**
  * Added tests covering symlink rejection, write-time symlink attacks, and missing-path behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->