### PR TITLE
fix(mcp): proxy standalone tools to running server when reachable

### DIFF
--- a/src/mcp/rest-proxy.ts
+++ b/src/mcp/rest-proxy.ts
@@ -1,0 +1,88 @@
+const DEFAULT_URL = "http://localhost:3111";
+const HEALTH_PROBE_TIMEOUT_MS = 500;
+const CALL_TIMEOUT_MS = 15_000;
+
+export interface ProxyHandle {
+  mode: "proxy";
+  baseUrl: string;
+  call: (path: string, init?: RequestInit) => Promise<unknown>;
+}
+
+export interface LocalHandle {
+  mode: "local";
+}
+
+export type Handle = ProxyHandle | LocalHandle;
+
+let cached: Handle | null = null;
+let probeInFlight: Promise<Handle> | null = null;
+
+function baseUrl(): string {
+  return (process.env["AGENTMEMORY_URL"] || DEFAULT_URL).replace(/\/+$/, "");
+}
+
+function authHeader(): Record<string, string> {
+  const secret = process.env["AGENTMEMORY_SECRET"];
+  return secret ? { authorization: `Bearer ${secret}` } : {};
+}
+
+async function probe(url: string): Promise<boolean> {
+  try {
+    const res = await fetch(`${url}/agentmemory/livez`, {
+      method: "GET",
+      headers: authHeader(),
+      signal: AbortSignal.timeout(HEALTH_PROBE_TIMEOUT_MS),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+export async function resolveHandle(): Promise<Handle> {
+  if (cached) return cached;
+  if (probeInFlight) return probeInFlight;
+  const url = baseUrl();
+  probeInFlight = (async () => {
+    const up = await probe(url);
+    if (up) {
+      const handle: ProxyHandle = {
+        mode: "proxy",
+        baseUrl: url,
+        call: async (path, init) => {
+          const res = await fetch(`${url}${path}`, {
+            ...init,
+            headers: {
+              "content-type": "application/json",
+              ...authHeader(),
+              ...(init?.headers as Record<string, string> | undefined),
+            },
+            signal: AbortSignal.timeout(CALL_TIMEOUT_MS),
+          });
+          if (!res.ok) {
+            throw new Error(
+              `${init?.method || "GET"} ${path} -> ${res.status} ${res.statusText}`,
+            );
+          }
+          const text = await res.text();
+          return text ? JSON.parse(text) : null;
+        },
+      };
+      cached = handle;
+      return handle;
+    }
+    const local: LocalHandle = { mode: "local" };
+    cached = local;
+    return local;
+  })();
+  try {
+    return await probeInFlight;
+  } finally {
+    probeInFlight = null;
+  }
+}
+
+export function resetHandleForTests(): void {
+  cached = null;
+  probeInFlight = null;
+}

--- a/src/mcp/rest-proxy.ts
+++ b/src/mcp/rest-proxy.ts
@@ -1,6 +1,7 @@
 const DEFAULT_URL = "http://localhost:3111";
 const HEALTH_PROBE_TIMEOUT_MS = 500;
 const CALL_TIMEOUT_MS = 15_000;
+const LOCAL_MODE_TTL_MS = 30_000;
 
 export interface ProxyHandle {
   mode: "proxy";
@@ -15,6 +16,7 @@ export interface LocalHandle {
 export type Handle = ProxyHandle | LocalHandle;
 
 let cached: Handle | null = null;
+let cachedAt = 0;
 let probeInFlight: Promise<Handle> | null = null;
 
 function baseUrl(): string {
@@ -39,8 +41,21 @@ async function probe(url: string): Promise<boolean> {
   }
 }
 
+export function invalidateHandle(): void {
+  cached = null;
+  cachedAt = 0;
+}
+
 export async function resolveHandle(): Promise<Handle> {
-  if (cached) return cached;
+  const now = Date.now();
+  if (cached) {
+    if (cached.mode === "local" && now - cachedAt >= LOCAL_MODE_TTL_MS) {
+      cached = null;
+      cachedAt = 0;
+    } else {
+      return cached;
+    }
+  }
   if (probeInFlight) return probeInFlight;
   const url = baseUrl();
   probeInFlight = (async () => {
@@ -69,10 +84,12 @@ export async function resolveHandle(): Promise<Handle> {
         },
       };
       cached = handle;
+      cachedAt = Date.now();
       return handle;
     }
     const local: LocalHandle = { mode: "local" };
     cached = local;
+    cachedAt = Date.now();
     return local;
   })();
   try {
@@ -84,5 +101,6 @@ export async function resolveHandle(): Promise<Handle> {
 
 export function resetHandleForTests(): void {
   cached = null;
+  cachedAt = 0;
   probeInFlight = null;
 }

--- a/src/mcp/standalone.ts
+++ b/src/mcp/standalone.ts
@@ -6,6 +6,7 @@ import { getVisibleTools } from "./tools-registry.js";
 import { getStandalonePersistPath } from "../config.js";
 import { VERSION } from "../version.js";
 import { generateId } from "../state/schema.js";
+import { resolveHandle, type Handle, type ProxyHandle } from "./rest-proxy.js";
 
 const IMPLEMENTED_TOOLS = new Set([
   "memory_save",
@@ -24,10 +25,22 @@ const SERVER_INFO = {
 };
 
 const kv = new InMemoryKV(getStandalonePersistPath());
+let modeAnnounced = false;
 
-// Accept arrays, comma-separated strings, or a single string and always
-// return a trimmed, non-empty string array. Plugin skills (#139) tell
-// Claude to pass arrays; older clients may still pass CSV strings.
+function announceMode(handle: Handle): void {
+  if (modeAnnounced) return;
+  modeAnnounced = true;
+  if (handle.mode === "proxy") {
+    process.stderr.write(
+      `[@agentmemory/mcp] proxying to agentmemory server at ${handle.baseUrl}\n`,
+    );
+  } else {
+    process.stderr.write(
+      `[@agentmemory/mcp] no server reachable at ${process.env["AGENTMEMORY_URL"] || "http://localhost:3111"}; falling back to local InMemoryKV\n`,
+    );
+  }
+}
+
 function normalizeList(value: unknown): string[] {
   if (!value) return [];
   if (Array.isArray(value)) {
@@ -44,29 +57,112 @@ function normalizeList(value: unknown): string[] {
   return [];
 }
 
-// Parse a user-supplied limit argument, clamping to a sane range so an
-// adversarial or buggy caller can't request a million memories or pass
-// a negative / NaN / Infinity value that breaks .slice().
 const DEFAULT_LIMIT = 10;
 const MAX_LIMIT = 100;
 function parseLimit(raw: unknown, fallback = DEFAULT_LIMIT): number {
-  // Only accept explicit numbers or numeric strings. Reject booleans,
-  // objects, arrays, null, undefined — they shouldn't silently coerce
-  // (e.g. `Number(true) === 1` would sneak a limit of 1 through).
   if (typeof raw !== "number" && typeof raw !== "string") return fallback;
   const n = Number(raw);
   if (!Number.isFinite(n) || n <= 0) return fallback;
   return Math.min(Math.floor(n), MAX_LIMIT);
 }
 
-export async function handleToolCall(
+function textResponse(payload: unknown, pretty = false): {
+  content: Array<{ type: string; text: string }>;
+} {
+  return {
+    content: [
+      { type: "text", text: JSON.stringify(payload, null, pretty ? 2 : 0) },
+    ],
+  };
+}
+
+async function handleProxy(
   toolName: string,
   args: Record<string, unknown>,
-  kvInstance: InMemoryKV = kv,
+  handle: ProxyHandle,
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
   switch (toolName) {
     case "memory_save": {
-      const rawContent = args.content;
+      const content = args["content"];
+      if (typeof content !== "string" || !content.trim()) {
+        throw new Error("content is required");
+      }
+      const payload = {
+        content,
+        type: (args["type"] as string) || "fact",
+        concepts: normalizeList(args["concepts"]),
+        files: normalizeList(args["files"]),
+      };
+      const result = await handle.call("/agentmemory/remember", {
+        method: "POST",
+        body: JSON.stringify(payload),
+      });
+      return textResponse(result);
+    }
+
+    case "memory_recall":
+    case "memory_smart_search": {
+      const query = args["query"];
+      if (typeof query !== "string" || !query.trim()) {
+        throw new Error("query is required");
+      }
+      const limit = parseLimit(args["limit"]);
+      const result = await handle.call("/agentmemory/smart-search", {
+        method: "POST",
+        body: JSON.stringify({ query: query.trim(), limit }),
+      });
+      return textResponse(result, true);
+    }
+
+    case "memory_sessions": {
+      const limit = parseLimit(args["limit"], 20);
+      const result = await handle.call(
+        `/agentmemory/sessions?limit=${limit}`,
+        { method: "GET" },
+      );
+      return textResponse(result, true);
+    }
+
+    case "memory_governance_delete": {
+      const ids = normalizeList(args["memoryIds"]);
+      if (ids.length === 0) throw new Error("memoryIds is required");
+      const result = await handle.call("/agentmemory/governance/memories", {
+        method: "POST",
+        body: JSON.stringify({
+          memoryIds: ids,
+          reason: (args["reason"] as string) || "plugin skill request",
+        }),
+      });
+      return textResponse(result);
+    }
+
+    case "memory_export": {
+      const result = await handle.call("/agentmemory/export", { method: "GET" });
+      return textResponse(result, true);
+    }
+
+    case "memory_audit": {
+      const limit = parseLimit(args["limit"], 50);
+      const result = await handle.call(
+        `/agentmemory/audit?limit=${limit}`,
+        { method: "GET" },
+      );
+      return textResponse(result, true);
+    }
+
+    default:
+      throw new Error(`Unknown tool: ${toolName}`);
+  }
+}
+
+async function handleLocal(
+  toolName: string,
+  args: Record<string, unknown>,
+  kvInstance: InMemoryKV,
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  switch (toolName) {
+    case "memory_save": {
+      const rawContent = args["content"];
       if (typeof rawContent !== "string" || !rawContent.trim()) {
         throw new Error("content is required");
       }
@@ -75,11 +171,11 @@ export async function handleToolCall(
       const isoNow = new Date().toISOString();
       await kvInstance.set("mem:memories", id, {
         id,
-        type: (args.type as string) || "fact",
+        type: (args["type"] as string) || "fact",
         title: content.slice(0, 80),
         content,
-        concepts: normalizeList(args.concepts),
-        files: normalizeList(args.files),
+        concepts: normalizeList(args["concepts"]),
+        files: normalizeList(args["files"]),
         createdAt: isoNow,
         updatedAt: isoNow,
         strength: 7,
@@ -88,36 +184,21 @@ export async function handleToolCall(
         sessionIds: [],
       });
       kvInstance.persist();
-      return {
-        content: [{ type: "text", text: JSON.stringify({ saved: id }) }],
-      };
+      return textResponse({ saved: id });
     }
 
     case "memory_recall":
     case "memory_smart_search": {
-      // memory_smart_search would normally run hybrid BM25+vector+graph
-      // in the engine-backed path, but the standalone shim (#139) only
-      // has the in-memory KV store, so we fall back to a substring
-      // filter. The tool name is kept so plugin skills that say "use
-      // memory_smart_search" still work.
-      //
-      // Empty/missing query is rejected — the forget skill uses this
-      // as its confirmation step before a destructive delete, and an
-      // empty query would match every memory in the store, surfacing
-      // unrelated IDs for deletion.
-      const rawQuery = args.query;
+      const rawQuery = args["query"];
       if (typeof rawQuery !== "string" || !rawQuery.trim()) {
         throw new Error("query is required");
       }
       const query = rawQuery.trim().toLowerCase();
-      const limit = parseLimit(args.limit);
+      const limit = parseLimit(args["limit"]);
       const all =
         await kvInstance.list<Record<string, unknown>>("mem:memories");
       const results = all
         .filter((m) => {
-          // Search title/content AND files/concepts/sessionIds so the
-          // forget skill can find memories by file path or session
-          // ID, not just by narrative text.
           const text = [
             typeof m["title"] === "string" ? m["title"] : "",
             typeof m["content"] === "string" ? m["content"] : "",
@@ -131,39 +212,19 @@ export async function handleToolCall(
           return query.split(/\s+/).every((word) => text.includes(word));
         })
         .slice(0, limit);
-      return {
-        content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
-      };
+      return textResponse(results, true);
     }
 
     case "memory_sessions": {
       const sessions =
         await kvInstance.list<Record<string, unknown>>("mem:sessions");
-      const limit = parseLimit(args.limit, 20);
-      return {
-        content: [
-          {
-            type: "text",
-            text: JSON.stringify(
-              { sessions: sessions.slice(0, limit) },
-              null,
-              2,
-            ),
-          },
-        ],
-      };
+      const limit = parseLimit(args["limit"], 20);
+      return textResponse({ sessions: sessions.slice(0, limit) }, true);
     }
 
     case "memory_governance_delete": {
-      // Deletes memories by id. Accepts either a memoryIds array or a
-      // comma-separated memoryIds string (same normalization pattern as
-      // concepts/files) so plugin skills and legacy clients both work.
-      // Unknown ids are silently skipped — the response reports how many
-      // were actually removed so the caller can tell the user.
-      const ids = normalizeList(args.memoryIds);
-      if (ids.length === 0) {
-        throw new Error("memoryIds is required");
-      }
+      const ids = normalizeList(args["memoryIds"]);
+      if (ids.length === 0) throw new Error("memoryIds is required");
       let deleted = 0;
       for (const id of ids) {
         const existing = await kvInstance.get("mem:memories", id);
@@ -173,52 +234,26 @@ export async function handleToolCall(
         }
       }
       kvInstance.persist();
-      return {
-        content: [
-          {
-            type: "text",
-            text: JSON.stringify({
-              deleted,
-              requested: ids.length,
-              reason: (args.reason as string) || "plugin skill request",
-            }),
-          },
-        ],
-      };
+      return textResponse({
+        deleted,
+        requested: ids.length,
+        reason: (args["reason"] as string) || "plugin skill request",
+      });
     }
 
     case "memory_export": {
       const memories = await kvInstance.list("mem:memories");
       const sessions = await kvInstance.list("mem:sessions");
-      return {
-        content: [
-          {
-            type: "text",
-            text: JSON.stringify(
-              { version: VERSION, memories, sessions },
-              null,
-              2,
-            ),
-          },
-        ],
-      };
+      return textResponse({ version: VERSION, memories, sessions }, true);
     }
 
     case "memory_audit": {
       const entries = await kvInstance.list("mem:audit");
-      const limit = parseLimit(args.limit, 50);
-      return {
-        content: [
-          {
-            type: "text",
-            text: JSON.stringify(
-              (entries as Array<Record<string, unknown>>).slice(0, limit),
-              null,
-              2,
-            ),
-          },
-        ],
-      };
+      const limit = parseLimit(args["limit"], 50);
+      return textResponse(
+        (entries as Array<Record<string, unknown>>).slice(0, limit),
+        true,
+      );
     }
 
     default:
@@ -226,14 +261,31 @@ export async function handleToolCall(
   }
 }
 
+export async function handleToolCall(
+  toolName: string,
+  args: Record<string, unknown>,
+  kvInstance: InMemoryKV = kv,
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  const handle = await resolveHandle();
+  announceMode(handle);
+  if (handle.mode === "proxy") {
+    try {
+      return await handleProxy(toolName, args, handle);
+    } catch (err) {
+      process.stderr.write(
+        `[@agentmemory/mcp] proxy call failed for ${toolName}: ${err instanceof Error ? err.message : String(err)}; falling back to local KV for this request\n`,
+      );
+    }
+  }
+  return handleLocal(toolName, args, kvInstance);
+}
+
 const transport = createStdioTransport(async (method, params) => {
   switch (method) {
     case "initialize":
       return {
         protocolVersion: SERVER_INFO.protocolVersion,
-        capabilities: {
-          tools: { listChanged: false },
-        },
+        capabilities: { tools: { listChanged: false } },
         serverInfo: {
           name: SERVER_INFO.name,
           version: SERVER_INFO.version,

--- a/src/mcp/standalone.ts
+++ b/src/mcp/standalone.ts
@@ -6,7 +6,12 @@ import { getVisibleTools } from "./tools-registry.js";
 import { getStandalonePersistPath } from "../config.js";
 import { VERSION } from "../version.js";
 import { generateId } from "../state/schema.js";
-import { resolveHandle, type Handle, type ProxyHandle } from "./rest-proxy.js";
+import {
+  resolveHandle,
+  invalidateHandle,
+  type Handle,
+  type ProxyHandle,
+} from "./rest-proxy.js";
 
 const IMPLEMENTED_TOOLS = new Set([
   "memory_save",
@@ -76,106 +81,137 @@ function textResponse(payload: unknown, pretty = false): {
   };
 }
 
-async function handleProxy(
-  toolName: string,
-  args: Record<string, unknown>,
-  handle: ProxyHandle,
-): Promise<{ content: Array<{ type: string; text: string }> }> {
+interface Validated {
+  tool: string;
+  content?: string;
+  type?: string;
+  concepts?: string[];
+  files?: string[];
+  query?: string;
+  limit?: number;
+  memoryIds?: string[];
+  reason?: string;
+}
+
+function validate(toolName: string, args: Record<string, unknown>): Validated {
+  if (!IMPLEMENTED_TOOLS.has(toolName)) {
+    throw new Error(`Unknown tool: ${toolName}`);
+  }
+  const v: Validated = { tool: toolName };
   switch (toolName) {
     case "memory_save": {
       const content = args["content"];
       if (typeof content !== "string" || !content.trim()) {
         throw new Error("content is required");
       }
-      const payload = {
-        content,
-        type: (args["type"] as string) || "fact",
-        concepts: normalizeList(args["concepts"]),
-        files: normalizeList(args["files"]),
-      };
-      const result = await handle.call("/agentmemory/remember", {
-        method: "POST",
-        body: JSON.stringify(payload),
-      });
-      return textResponse(result);
+      v.content = content;
+      v.type = (args["type"] as string) || "fact";
+      v.concepts = normalizeList(args["concepts"]);
+      v.files = normalizeList(args["files"]);
+      return v;
     }
-
     case "memory_recall":
     case "memory_smart_search": {
       const query = args["query"];
       if (typeof query !== "string" || !query.trim()) {
         throw new Error("query is required");
       }
-      const limit = parseLimit(args["limit"]);
-      const result = await handle.call("/agentmemory/smart-search", {
-        method: "POST",
-        body: JSON.stringify({ query: query.trim(), limit }),
-      });
-      return textResponse(result, true);
+      v.query = query.trim();
+      v.limit = parseLimit(args["limit"]);
+      return v;
     }
-
     case "memory_sessions": {
-      const limit = parseLimit(args["limit"], 20);
-      const result = await handle.call(
-        `/agentmemory/sessions?limit=${limit}`,
-        { method: "GET" },
-      );
-      return textResponse(result, true);
+      v.limit = parseLimit(args["limit"], 20);
+      return v;
     }
-
     case "memory_governance_delete": {
       const ids = normalizeList(args["memoryIds"]);
       if (ids.length === 0) throw new Error("memoryIds is required");
-      const result = await handle.call("/agentmemory/governance/memories", {
-        method: "POST",
-        body: JSON.stringify({
-          memoryIds: ids,
-          reason: (args["reason"] as string) || "plugin skill request",
-        }),
-      });
-      return textResponse(result);
+      v.memoryIds = ids;
+      v.reason = (args["reason"] as string) || "plugin skill request";
+      return v;
     }
-
-    case "memory_export": {
-      const result = await handle.call("/agentmemory/export", { method: "GET" });
-      return textResponse(result, true);
-    }
-
+    case "memory_export":
+      return v;
     case "memory_audit": {
-      const limit = parseLimit(args["limit"], 50);
-      const result = await handle.call(
-        `/agentmemory/audit?limit=${limit}`,
-        { method: "GET" },
-      );
-      return textResponse(result, true);
+      v.limit = parseLimit(args["limit"], 50);
+      return v;
     }
-
     default:
       throw new Error(`Unknown tool: ${toolName}`);
   }
 }
 
+async function handleProxy(
+  v: Validated,
+  handle: ProxyHandle,
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  switch (v.tool) {
+    case "memory_save": {
+      const result = await handle.call("/agentmemory/remember", {
+        method: "POST",
+        body: JSON.stringify({
+          content: v.content,
+          type: v.type,
+          concepts: v.concepts,
+          files: v.files,
+        }),
+      });
+      return textResponse(result);
+    }
+    case "memory_recall":
+    case "memory_smart_search": {
+      const result = await handle.call("/agentmemory/smart-search", {
+        method: "POST",
+        body: JSON.stringify({ query: v.query, limit: v.limit }),
+      });
+      return textResponse(result, true);
+    }
+    case "memory_sessions": {
+      const result = await handle.call(
+        `/agentmemory/sessions?limit=${v.limit}`,
+        { method: "GET" },
+      );
+      return textResponse(result, true);
+    }
+    case "memory_governance_delete": {
+      const result = await handle.call("/agentmemory/governance/memories", {
+        method: "POST",
+        body: JSON.stringify({ memoryIds: v.memoryIds, reason: v.reason }),
+      });
+      return textResponse(result);
+    }
+    case "memory_export": {
+      const result = await handle.call("/agentmemory/export", { method: "GET" });
+      return textResponse(result, true);
+    }
+    case "memory_audit": {
+      const result = await handle.call(
+        `/agentmemory/audit?limit=${v.limit}`,
+        { method: "GET" },
+      );
+      return textResponse(result, true);
+    }
+    default:
+      throw new Error(`Unknown tool: ${v.tool}`);
+  }
+}
+
 async function handleLocal(
-  toolName: string,
-  args: Record<string, unknown>,
+  v: Validated,
   kvInstance: InMemoryKV,
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
-  switch (toolName) {
+  switch (v.tool) {
     case "memory_save": {
-      const rawContent = args["content"];
-      if (typeof rawContent !== "string" || !rawContent.trim()) {
-        throw new Error("content is required");
-      }
-      const content = rawContent;
       const id = generateId("mem");
       const isoNow = new Date().toISOString();
       await kvInstance.set("mem:memories", id, {
         id,
-        type: (args["type"] as string) || "fact",
-        title: content.slice(0, 80),
-        content,
-        concepts: normalizeList(args["concepts"]),
-        files: normalizeList(args["files"]),
+        type: v.type,
+        title: (v.content || "").slice(0, 80),
+        content: v.content,
+        concepts: v.concepts,
+        files: v.files,
         createdAt: isoNow,
         updatedAt: isoNow,
         strength: 7,
@@ -189,12 +225,8 @@ async function handleLocal(
 
     case "memory_recall":
     case "memory_smart_search": {
-      const rawQuery = args["query"];
-      if (typeof rawQuery !== "string" || !rawQuery.trim()) {
-        throw new Error("query is required");
-      }
-      const query = rawQuery.trim().toLowerCase();
-      const limit = parseLimit(args["limit"]);
+      const query = (v.query || "").toLowerCase();
+      const limit = v.limit ?? DEFAULT_LIMIT;
       const all =
         await kvInstance.list<Record<string, unknown>>("mem:memories");
       const results = all
@@ -212,21 +244,19 @@ async function handleLocal(
           return query.split(/\s+/).every((word) => text.includes(word));
         })
         .slice(0, limit);
-      return textResponse(results, true);
+      return textResponse({ mode: "compact", results }, true);
     }
 
     case "memory_sessions": {
       const sessions =
         await kvInstance.list<Record<string, unknown>>("mem:sessions");
-      const limit = parseLimit(args["limit"], 20);
+      const limit = v.limit ?? 20;
       return textResponse({ sessions: sessions.slice(0, limit) }, true);
     }
 
     case "memory_governance_delete": {
-      const ids = normalizeList(args["memoryIds"]);
-      if (ids.length === 0) throw new Error("memoryIds is required");
       let deleted = 0;
-      for (const id of ids) {
+      for (const id of v.memoryIds || []) {
         const existing = await kvInstance.get("mem:memories", id);
         if (existing) {
           await kvInstance.delete("mem:memories", id);
@@ -236,8 +266,8 @@ async function handleLocal(
       kvInstance.persist();
       return textResponse({
         deleted,
-        requested: ids.length,
-        reason: (args["reason"] as string) || "plugin skill request",
+        requested: (v.memoryIds || []).length,
+        reason: v.reason,
       });
     }
 
@@ -249,15 +279,17 @@ async function handleLocal(
 
     case "memory_audit": {
       const entries = await kvInstance.list("mem:audit");
-      const limit = parseLimit(args["limit"], 50);
+      const limit = v.limit ?? 50;
       return textResponse(
-        (entries as Array<Record<string, unknown>>).slice(0, limit),
+        {
+          entries: (entries as Array<Record<string, unknown>>).slice(0, limit),
+        },
         true,
       );
     }
 
     default:
-      throw new Error(`Unknown tool: ${toolName}`);
+      throw new Error(`Unknown tool: ${v.tool}`);
   }
 }
 
@@ -266,18 +298,20 @@ export async function handleToolCall(
   args: Record<string, unknown>,
   kvInstance: InMemoryKV = kv,
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
+  const validated = validate(toolName, args);
   const handle = await resolveHandle();
   announceMode(handle);
   if (handle.mode === "proxy") {
     try {
-      return await handleProxy(toolName, args, handle);
+      return await handleProxy(validated, handle);
     } catch (err) {
       process.stderr.write(
-        `[@agentmemory/mcp] proxy call failed for ${toolName}: ${err instanceof Error ? err.message : String(err)}; falling back to local KV for this request\n`,
+        `[@agentmemory/mcp] proxy call failed for ${toolName}: ${err instanceof Error ? err.message : String(err)}; invalidating handle and falling back to local KV\n`,
       );
+      invalidateHandle();
     }
   }
-  return handleLocal(toolName, args, kvInstance);
+  return handleLocal(validated, kvInstance);
 }
 
 const transport = createStdioTransport(async (method, params) => {

--- a/test/mcp-standalone-proxy.test.ts
+++ b/test/mcp-standalone-proxy.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { handleToolCall } from "../src/mcp/standalone.js";
+import { resetHandleForTests } from "../src/mcp/rest-proxy.js";
+import { InMemoryKV } from "../src/mcp/in-memory-kv.js";
+
+type FetchMock = ReturnType<typeof vi.fn>;
+
+function installFetch(handler: (url: string, init?: RequestInit) => Response): FetchMock {
+  const fn = vi.fn(async (url: string | URL, init?: RequestInit) =>
+    handler(url.toString(), init),
+  );
+  (globalThis as { fetch: typeof fetch }).fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+const BASE = "http://localhost:3111";
+
+describe("@agentmemory/mcp standalone — server proxy (issue #159)", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    resetHandleForTests();
+    process.env["AGENTMEMORY_URL"] = BASE;
+    delete process.env["AGENTMEMORY_SECRET"];
+  });
+
+  afterEach(() => {
+    resetHandleForTests();
+    globalThis.fetch = originalFetch;
+    delete process.env["AGENTMEMORY_URL"];
+  });
+
+  it("proxies memory_sessions to GET /agentmemory/sessions when server is up", async () => {
+    const calls: Array<{ url: string; method: string }> = [];
+    installFetch((url, init) => {
+      calls.push({ url, method: init?.method || "GET" });
+      if (url.endsWith("/agentmemory/livez")) {
+        return new Response("ok", { status: 200 });
+      }
+      if (url.includes("/agentmemory/sessions")) {
+        return new Response(
+          JSON.stringify({ sessions: [{ id: "sess-1", observations: 69 }] }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const res = await handleToolCall("memory_sessions", { limit: 5 });
+    const body = JSON.parse(res.content[0].text);
+    expect(body.sessions).toHaveLength(1);
+    expect(body.sessions[0].id).toBe("sess-1");
+    expect(calls.find((c) => c.url.includes("/sessions"))).toBeDefined();
+  });
+
+  it("proxies memory_smart_search to POST /agentmemory/smart-search", async () => {
+    installFetch((url, init) => {
+      if (url.endsWith("/agentmemory/livez")) return new Response("ok", { status: 200 });
+      if (url.endsWith("/agentmemory/smart-search")) {
+        const body = JSON.parse((init?.body as string) || "{}");
+        return new Response(
+          JSON.stringify({ query: body.query, hits: [{ id: "m1", score: 0.9 }] }),
+          { status: 200 },
+        );
+      }
+      return new Response("", { status: 404 });
+    });
+    const res = await handleToolCall("memory_smart_search", { query: "auth bug", limit: 5 });
+    const body = JSON.parse(res.content[0].text);
+    expect(body.query).toBe("auth bug");
+    expect(body.hits[0].id).toBe("m1");
+  });
+
+  it("attaches Bearer token when AGENTMEMORY_SECRET is set", async () => {
+    process.env["AGENTMEMORY_SECRET"] = "s3cret";
+    const seen: string[] = [];
+    installFetch((url, init) => {
+      const auth = (init?.headers as Record<string, string> | undefined)?.["authorization"];
+      if (auth) seen.push(`${url}|${auth}`);
+      if (url.endsWith("/agentmemory/livez")) return new Response("ok", { status: 200 });
+      return new Response(JSON.stringify({ sessions: [] }), { status: 200 });
+    });
+    await handleToolCall("memory_sessions", {});
+    expect(seen.every((s) => s.endsWith("|Bearer s3cret"))).toBe(true);
+    expect(seen.some((s) => s.includes("/agentmemory/livez"))).toBe(true);
+  });
+
+  it("falls back to local InMemoryKV when server is unreachable", async () => {
+    installFetch(() => {
+      throw new Error("ECONNREFUSED");
+    });
+    const localKv = new InMemoryKV(undefined);
+    await handleToolCall("memory_save", { content: "local only" }, localKv);
+    const recall = await handleToolCall("memory_recall", { query: "local" }, localKv);
+    const out = JSON.parse(recall.content[0].text);
+    expect(Array.isArray(out)).toBe(true);
+    expect(out).toHaveLength(1);
+    expect(out[0].content).toBe("local only");
+  });
+
+  it("falls back to local KV for a single request if proxy call throws after probe succeeded", async () => {
+    let callCount = 0;
+    installFetch((url) => {
+      callCount++;
+      if (url.endsWith("/agentmemory/livez")) return new Response("ok", { status: 200 });
+      return new Response("boom", { status: 500, statusText: "Internal Server Error" });
+    });
+    const localKv = new InMemoryKV(undefined);
+    await handleToolCall("memory_save", { content: "fallback entry" }, localKv);
+    const recall = await handleToolCall("memory_recall", { query: "fallback" }, localKv);
+    const out = JSON.parse(recall.content[0].text);
+    expect(out[0].content).toBe("fallback entry");
+    expect(callCount).toBeGreaterThan(1);
+  });
+});

--- a/test/mcp-standalone-proxy.test.ts
+++ b/test/mcp-standalone-proxy.test.ts
@@ -59,7 +59,11 @@ describe("@agentmemory/mcp standalone — server proxy (issue #159)", () => {
       if (url.endsWith("/agentmemory/smart-search")) {
         const body = JSON.parse((init?.body as string) || "{}");
         return new Response(
-          JSON.stringify({ query: body.query, hits: [{ id: "m1", score: 0.9 }] }),
+          JSON.stringify({
+            mode: "compact",
+            query: body.query,
+            results: [{ id: "m1", score: 0.9 }],
+          }),
           { status: 200 },
         );
       }
@@ -68,21 +72,37 @@ describe("@agentmemory/mcp standalone — server proxy (issue #159)", () => {
     const res = await handleToolCall("memory_smart_search", { query: "auth bug", limit: 5 });
     const body = JSON.parse(res.content[0].text);
     expect(body.query).toBe("auth bug");
-    expect(body.hits[0].id).toBe("m1");
+    expect(body.results[0].id).toBe("m1");
   });
 
-  it("attaches Bearer token when AGENTMEMORY_SECRET is set", async () => {
+  it("local fallback returns the same shape as proxy for memory_smart_search", async () => {
+    installFetch(() => {
+      throw new Error("ECONNREFUSED");
+    });
+    const localKv = new InMemoryKV(undefined);
+    await handleToolCall("memory_save", { content: "shape-check entry" }, localKv);
+    const res = await handleToolCall("memory_smart_search", { query: "shape" }, localKv);
+    const body = JSON.parse(res.content[0].text);
+    expect(body).toHaveProperty("mode", "compact");
+    expect(Array.isArray(body.results)).toBe(true);
+    expect(body.results[0].content).toBe("shape-check entry");
+  });
+
+  it("attaches Bearer token on the proxied tool request, not just the probe", async () => {
     process.env["AGENTMEMORY_SECRET"] = "s3cret";
-    const seen: string[] = [];
+    const authByPath = new Map<string, string | undefined>();
     installFetch((url, init) => {
-      const auth = (init?.headers as Record<string, string> | undefined)?.["authorization"];
-      if (auth) seen.push(`${url}|${auth}`);
+      const auth = (init?.headers as Record<string, string> | undefined)?.[
+        "authorization"
+      ];
+      const u = new URL(url);
+      authByPath.set(u.pathname, auth);
       if (url.endsWith("/agentmemory/livez")) return new Response("ok", { status: 200 });
       return new Response(JSON.stringify({ sessions: [] }), { status: 200 });
     });
     await handleToolCall("memory_sessions", {});
-    expect(seen.every((s) => s.endsWith("|Bearer s3cret"))).toBe(true);
-    expect(seen.some((s) => s.includes("/agentmemory/livez"))).toBe(true);
+    expect(authByPath.get("/agentmemory/livez")).toBe("Bearer s3cret");
+    expect(authByPath.get("/agentmemory/sessions")).toBe("Bearer s3cret");
   });
 
   it("falls back to local InMemoryKV when server is unreachable", async () => {
@@ -93,23 +113,41 @@ describe("@agentmemory/mcp standalone — server proxy (issue #159)", () => {
     await handleToolCall("memory_save", { content: "local only" }, localKv);
     const recall = await handleToolCall("memory_recall", { query: "local" }, localKv);
     const out = JSON.parse(recall.content[0].text);
-    expect(Array.isArray(out)).toBe(true);
-    expect(out).toHaveLength(1);
-    expect(out[0].content).toBe("local only");
+    expect(out.mode).toBe("compact");
+    expect(out.results).toHaveLength(1);
+    expect(out.results[0].content).toBe("local only");
   });
 
-  it("falls back to local KV for a single request if proxy call throws after probe succeeded", async () => {
-    let callCount = 0;
+  it("invalidates the handle on proxy failure, so the next call re-probes", async () => {
+    let probeCount = 0;
+    let serverUp = true;
     installFetch((url) => {
-      callCount++;
-      if (url.endsWith("/agentmemory/livez")) return new Response("ok", { status: 200 });
+      if (url.endsWith("/agentmemory/livez")) {
+        probeCount++;
+        return serverUp ? new Response("ok", { status: 200 }) : new Response("", { status: 500 });
+      }
       return new Response("boom", { status: 500, statusText: "Internal Server Error" });
     });
     const localKv = new InMemoryKV(undefined);
-    await handleToolCall("memory_save", { content: "fallback entry" }, localKv);
-    const recall = await handleToolCall("memory_recall", { query: "fallback" }, localKv);
-    const out = JSON.parse(recall.content[0].text);
-    expect(out[0].content).toBe("fallback entry");
-    expect(callCount).toBeGreaterThan(1);
+    await handleToolCall("memory_save", { content: "first fallback" }, localKv);
+    expect(probeCount).toBe(1);
+    serverUp = false;
+    await handleToolCall("memory_save", { content: "second fallback" }, localKv);
+    expect(probeCount).toBe(2);
+  });
+
+  it("does not retry local after a validation error", async () => {
+    const fetchFn = installFetch((url) => {
+      if (url.endsWith("/agentmemory/livez")) return new Response("ok", { status: 200 });
+      return new Response("{}", { status: 200 });
+    });
+    const localKv = new InMemoryKV(undefined);
+    await expect(
+      handleToolCall("memory_save", { content: "" }, localKv),
+    ).rejects.toThrow("content is required");
+    const remembersCalled = fetchFn.mock.calls.some(([url]) =>
+      String(url).endsWith("/agentmemory/remember"),
+    );
+    expect(remembersCalled).toBe(false);
   });
 });

--- a/test/mcp-standalone.test.ts
+++ b/test/mcp-standalone.test.ts
@@ -172,9 +172,9 @@ describe("handleToolCall", () => {
       { query: "typescript" },
       kv,
     );
-    const memories = JSON.parse(result.content[0].text);
-    expect(memories).toHaveLength(1);
-    expect(memories[0].content).toBe("TypeScript is great");
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.results).toHaveLength(1);
+    expect(parsed.results[0].content).toBe("TypeScript is great");
   });
 
   it("memory_save accepts concepts/files as arrays (plugin skill format, #139)", async () => {
@@ -234,9 +234,9 @@ describe("handleToolCall", () => {
       { query: "bcrypt", limit: 5 },
       kv,
     );
-    const memories = JSON.parse(result.content[0].text);
-    expect(memories).toHaveLength(1);
-    expect(memories[0].content).toBe("Use bcrypt for password hashing");
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.results).toHaveLength(1);
+    expect(parsed.results[0].content).toBe("Use bcrypt for password hashing");
   });
 
   it("memory_smart_search rejects empty query to prevent match-all in forget flow (#139)", async () => {
@@ -276,8 +276,8 @@ describe("handleToolCall", () => {
         )
       ).content[0].text,
     );
-    expect(byFile).toHaveLength(1);
-    expect(byFile[0].files).toContain("src/auth/refresh.ts");
+    expect(byFile.results).toHaveLength(1);
+    expect(byFile.results[0].files).toContain("src/auth/refresh.ts");
 
     // Find by concept
     const byConcept = JSON.parse(
@@ -289,7 +289,7 @@ describe("handleToolCall", () => {
         )
       ).content[0].text,
     );
-    expect(byConcept).toHaveLength(1);
+    expect(byConcept.results).toHaveLength(1);
   });
 
   it("memory_sessions honours the limit arg (#139)", async () => {
@@ -323,7 +323,7 @@ describe("handleToolCall", () => {
         { query: "mem", limit: bogus },
         kv,
       );
-      expect(JSON.parse(r.content[0].text)).toHaveLength(10);
+      expect(JSON.parse(r.content[0].text).results).toHaveLength(10);
     }
 
     // An absurdly large limit gets clamped to MAX_LIMIT (100).
@@ -332,7 +332,7 @@ describe("handleToolCall", () => {
       { query: "mem", limit: 99999 },
       kv,
     );
-    expect(JSON.parse(huge.content[0].text)).toHaveLength(100);
+    expect(JSON.parse(huge.content[0].text).results).toHaveLength(100);
   });
 
   it("memory_governance_delete removes memories by id array (#139)", async () => {


### PR DESCRIPTION
Fixes #159.

## Problem
In v0.8.13, `@agentmemory/mcp` and `@agentmemory/agentmemory` ran two independent KV stores. When the supported Claude Code setup was active (plugin + server), MCP tools only saw the standalone JSON file — they never consulted the running server. So:

- `memory_sessions` returned `[]` even when `GET /agentmemory/sessions` had four sessions and 69 observations.
- `memory_smart_search` fell back to a substring match on standalone data only, missing every hooks-captured observation.
- The README's promised triple-stream retrieval / reranker / graph never applied to any MCP call.

Reporter reproduced on Windows 11, Node v24.13.0, plugin v0.8.13.

## Fix
`handleToolCall` now resolves a Handle once per process:

1. Probe `GET /agentmemory/livez` at `AGENTMEMORY_URL || http://localhost:3111` with a 500ms timeout.
2. If up → route every tool call through REST; MCP sees what hooks and the viewer see.
3. If not → fall back to the existing `InMemoryKV` path so pure-standalone users stay supported.

Per-request proxy failures after a successful probe fall back to local KV for that call and log a stderr warning — no silent drop. Active mode is announced once to stderr so users can tell which store their tools are reading.

Bearer `AGENTMEMORY_SECRET` is attached automatically when the server requires auth.

## Endpoints routed
| Tool | REST |
|------|------|
| `memory_save` | `POST /agentmemory/remember` |
| `memory_recall` / `memory_smart_search` | `POST /agentmemory/smart-search` |
| `memory_sessions` | `GET /agentmemory/sessions?limit=N` |
| `memory_governance_delete` | `POST /agentmemory/governance/memories` |
| `memory_export` | `GET /agentmemory/export` |
| `memory_audit` | `GET /agentmemory/audit?limit=N` |

## Tests
`test/mcp-standalone-proxy.test.ts` — five cases:
- `memory_sessions` proxies to GET `/agentmemory/sessions` when server is up.
- `memory_smart_search` proxies to POST `/agentmemory/smart-search`.
- Bearer token attached when `AGENTMEMORY_SECRET` is set.
- Server unreachable → falls back to local `InMemoryKV`.
- Probe succeeds but subsequent call throws → per-request fallback to local KV.

All 759 tests still pass (the one pre-existing failure needs a live server on 3111 and is unrelated).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Proxy mode to use an external Agentmemory service with automatic local fallback.
  * Health checks and optional Bearer token authentication for external connections.

* **Changes**
  * Memory recall/search responses now return a results-wrapped object (parsed.results) instead of a top-level array.

* **Tests**
  * Added end-to-end tests covering proxy discovery, auth, fallback, error handling, and response formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->