### PR TITLE
ci(publish): add @agentmemory/fs-watcher to the release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,12 @@ name: Publish to npm
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      packages:
+        description: "Packages to publish (comma-separated: agentmemory,mcp,fs-watcher)"
+        required: false
+        default: "agentmemory,mcp,fs-watcher"
 
 permissions:
   contents: read
@@ -72,4 +78,31 @@ jobs:
             sleep 5
           done
           echo "ERROR: shim never propagated after 2 minutes" >&2
+          exit 1
+
+      - name: Publish @agentmemory/fs-watcher connector
+        working-directory: integrations/filesystem-watcher
+        run: |
+          FSW_VERSION=$(node -p "require('./package.json').version")
+          if npm view "@agentmemory/fs-watcher@$FSW_VERSION" version >/dev/null 2>&1; then
+            echo "fs-watcher version already published, skipping"
+          else
+            npm publish --provenance --access public
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Wait for @agentmemory/fs-watcher registry propagation
+        working-directory: integrations/filesystem-watcher
+        run: |
+          FSW_VERSION=$(node -p "require('./package.json').version")
+          for i in $(seq 1 24); do
+            if npm view "@agentmemory/fs-watcher@$FSW_VERSION" version >/dev/null 2>&1; then
+              echo "fs-watcher propagated after ${i} attempt(s)"
+              exit 0
+            fi
+            echo "Attempt $i: not yet available, sleeping 5s..."
+            sleep 5
+          done
+          echo "ERROR: fs-watcher never propagated after 2 minutes" >&2
           exit 1


### PR DESCRIPTION
Backfills the new filesystem connector into the npm publish pipeline.

## What
- Adds a \`Publish @agentmemory/fs-watcher connector\` step to \`.github/workflows/publish.yml\`.
- Adds \`workflow_dispatch\` so any of the three packages can be published manually without cutting a release.

## Why
The v0.9.0 release shipped \`@agentmemory/agentmemory\` and \`@agentmemory/mcp\` to npm via the existing workflow, but \`@agentmemory/fs-watcher\` (new in this release) wasn't in the workflow yet so it didn't go out. Fixing it so future releases pick it up automatically, plus giving us a manual trigger to back-fill v0.9.0 without re-releasing.

## After merge
Run the \"Publish to npm\" workflow via the Actions UI with \`workflow_dispatch\` to publish fs-watcher@0.1.0 for v0.9.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release automation with manual workflow trigger and selective package publishing options.
  * Improved package propagation verification to the npm registry with automated polling (up to 24 attempts over 2 minutes) to ensure successful deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->