### PR TITLE
feat(website): derive version + counts from source at build

### DIFF
--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -10,19 +10,29 @@ import { Compare } from "@/components/Compare";
 import { Agents } from "@/components/Agents";
 import { Install } from "@/components/Install";
 import { Footer } from "@/components/Footer";
+import { getProjectMeta } from "@/lib/meta";
 
 export default function Page() {
+  const meta = getProjectMeta();
   return (
     <>
       <ScrollProgress />
       <Nav />
       <main id="top">
         <Hero />
-        <Stats />
+        <Stats
+          mcpTools={meta.mcpTools}
+          hooks={meta.hooks}
+          testsPassing={meta.testsPassing}
+        />
         <Primitives />
-        <Features />
+        <Features
+          hooks={meta.hooks}
+          mcpTools={meta.mcpTools}
+          restEndpoints={meta.restEndpoints}
+        />
         <CommandCenter />
-        <LiveTerminal />
+        <LiveTerminal mcpTools={meta.mcpTools} hooks={meta.hooks} />
         <Compare />
         <Agents />
         <Install />

--- a/website/components/Features.tsx
+++ b/website/components/Features.tsx
@@ -1,16 +1,12 @@
 import styles from "./Features.module.css";
 
 interface Props {
-  hooks?: number;
-  mcpTools?: number;
-  restEndpoints?: number;
+  hooks: number;
+  mcpTools: number;
+  restEndpoints: number;
 }
 
-export function Features({
-  hooks = 12,
-  mcpTools = 44,
-  restEndpoints = 49,
-}: Props) {
+export function Features({ hooks, mcpTools, restEndpoints }: Props) {
   const FEATURES = [
     {
       k: `${hooks}`,

--- a/website/components/Features.tsx
+++ b/website/components/Features.tsx
@@ -1,93 +1,103 @@
 import styles from "./Features.module.css";
 
-const FEATURES = [
-  {
-    k: "12",
-    unit: "AUTO-HOOKS",
-    title: "CAPTURE EVERYTHING",
-    text:
-      "Every PreToolUse, PostToolUse, SessionStart, Stop, and ten more fire into the memory pipeline without a line of glue code. Install the plugin, done.",
-  },
-  {
-    k: "44",
-    unit: "MCP TOOLS",
-    title: "NATIVE MCP SURFACE",
-    text:
-      "memory_save, memory_recall, memory_smart_search, memory_sessions, governance, audit, export — full surface behind a single MCP server.",
-  },
-  {
-    k: "49",
-    unit: "REST ENDPOINTS",
-    title: "HTTP FIRST",
-    text:
-      "Every MCP tool has a REST twin under /agentmemory/*. Curl it. Fetch it from the browser. Proxy it from your own agent.",
-  },
-  {
-    k: "BM25",
-    unit: "+ VECTOR + GRAPH",
-    title: "TRIPLE-STREAM RECALL",
-    text:
-      "Hybrid retrieval pipes lexical, semantic, and relational scores through an on-device reranker. 95.2% R@5 on LongMemEval-S.",
-  },
-  {
-    k: "AUTO",
-    unit: "CONSOLIDATION",
-    title: "RAW → SEMANTIC",
-    text:
-      "Hourly sweep compresses observations into semantic memories, merges duplicates, decays stale rows with retention scoring, and emits a batched audit row.",
-  },
-  {
-    k: "∞",
-    unit: "REPLAY",
-    title: "JSONL SESSION IMPORT",
-    text:
-      "Point agentmemory at a Claude Code JSONL transcript and it rehydrates the full session — observations, tool uses, timeline — into the store.",
-  },
-  {
-    k: "GRAPH",
-    unit: "EXTRACTION",
-    title: "KNOWLEDGE GRAPH",
-    text:
-      "Entities and relations extracted on compress. Query with /agentmemory/graph. Visualize in the viewer. Temporal edges supported.",
-  },
-  {
-    k: "MESH",
-    unit: "FEDERATION",
-    title: "PEER-TO-PEER SYNC",
-    text:
-      "Register another agentmemory node, push / pull memories over authenticated HTTPS. Bearer-token required; no silent syncs.",
-  },
-  {
-    k: "MD",
-    unit: "OBSIDIAN EXPORT",
-    title: "YOUR NOTES, HYDRATED",
-    text:
-      "Mirror memories to a sandboxed vault directory. Frontmatter-tagged markdown, ready for Obsidian's graph view.",
-  },
-  {
-    k: "5",
-    unit: "LLM PROVIDERS",
-    title: "BYO MODEL",
-    text:
-      "Claude subscription (default, zero config), Anthropic API, Gemini, MiniMax, OpenRouter. Detected from env.",
-  },
-  {
-    k: "OTEL",
-    unit: "OBSERVABILITY",
-    title: "TRACES + LOGS",
-    text:
-      "iii-observability worker on by default. Exporter: memory for local, OTLP for Jaeger / Honeycomb / Tempo. Every operation produces a span.",
-  },
-  {
-    k: "0",
-    unit: "EXTERNAL DBs",
-    title: "ONE PROCESS",
-    text:
-      "Runs as a single Node process. No Redis, Kafka, Postgres, Qdrant, Neo4j. State lives on disk as JSON. That's the whole stack.",
-  },
-];
+interface Props {
+  hooks?: number;
+  mcpTools?: number;
+  restEndpoints?: number;
+}
 
-export function Features() {
+export function Features({
+  hooks = 12,
+  mcpTools = 44,
+  restEndpoints = 49,
+}: Props) {
+  const FEATURES = [
+    {
+      k: `${hooks}`,
+      unit: "AUTO-HOOKS",
+      title: "CAPTURE EVERYTHING",
+      text:
+        "Every PreToolUse, PostToolUse, SessionStart, Stop, and the rest fire into the memory pipeline without a line of glue code. Install the plugin, done.",
+    },
+    {
+      k: `${mcpTools}`,
+      unit: "MCP TOOLS",
+      title: "NATIVE MCP SURFACE",
+      text:
+        "memory_save, memory_recall, memory_smart_search, memory_sessions, governance, audit, export — full surface behind a single MCP server.",
+    },
+    {
+      k: `${restEndpoints}`,
+      unit: "REST ENDPOINTS",
+      title: "HTTP FIRST",
+      text:
+        "Every MCP tool has a REST twin under /agentmemory/*. Curl it. Fetch it from the browser. Proxy it from your own agent.",
+    },
+    {
+      k: "BM25",
+      unit: "+ VECTOR + GRAPH",
+      title: "TRIPLE-STREAM RECALL",
+      text:
+        "Hybrid retrieval pipes lexical, semantic, and relational scores through an on-device reranker. 95.2% R@5 on LongMemEval-S.",
+    },
+    {
+      k: "AUTO",
+      unit: "CONSOLIDATION",
+      title: "RAW → SEMANTIC",
+      text:
+        "Hourly sweep compresses observations into semantic memories, merges duplicates, decays stale rows with retention scoring, and emits a batched audit row.",
+    },
+    {
+      k: "∞",
+      unit: "REPLAY",
+      title: "JSONL SESSION IMPORT",
+      text:
+        "Point agentmemory at a Claude Code JSONL transcript and it rehydrates the full session — observations, tool uses, timeline — into the store.",
+    },
+    {
+      k: "GRAPH",
+      unit: "EXTRACTION",
+      title: "KNOWLEDGE GRAPH",
+      text:
+        "Entities and relations extracted on compress. Query with /agentmemory/graph. Visualize in the viewer. Temporal edges supported.",
+    },
+    {
+      k: "MESH",
+      unit: "FEDERATION",
+      title: "PEER-TO-PEER SYNC",
+      text:
+        "Register another agentmemory node, push / pull memories over authenticated HTTPS. Bearer-token required; no silent syncs.",
+    },
+    {
+      k: "MD",
+      unit: "OBSIDIAN EXPORT",
+      title: "YOUR NOTES, HYDRATED",
+      text:
+        "Mirror memories to a sandboxed vault directory. Frontmatter-tagged markdown, ready for Obsidian's graph view.",
+    },
+    {
+      k: "5",
+      unit: "LLM PROVIDERS",
+      title: "BYO MODEL",
+      text:
+        "Claude subscription (default, zero config), Anthropic API, Gemini, MiniMax, OpenRouter. Detected from env.",
+    },
+    {
+      k: "OTEL",
+      unit: "OBSERVABILITY",
+      title: "TRACES + LOGS",
+      text:
+        "iii-observability worker on by default. Exporter: memory for local, OTLP for Jaeger / Honeycomb / Tempo. Every operation produces a span.",
+    },
+    {
+      k: "0",
+      unit: "EXTERNAL DBs",
+      title: "ONE PROCESS",
+      text:
+        "Runs as a single Node process. No Redis, Kafka, Postgres, Qdrant, Neo4j. State lives on disk as JSON. That's the whole stack.",
+    },
+  ];
+
   return (
     <section className={styles.wrap} id="features" aria-labelledby="feat-title">
       <header className="section-head">

--- a/website/components/Hero.tsx
+++ b/website/components/Hero.tsx
@@ -1,13 +1,17 @@
 import { MemoryGraph } from "./MemoryGraph";
+import { getProjectMeta } from "@/lib/meta";
 import styles from "./Hero.module.css";
 
 export function Hero() {
+  const meta = getProjectMeta();
   return (
     <section className={styles.hero} aria-labelledby="hero-title">
       <MemoryGraph />
       <div className={styles.vignette} aria-hidden />
       <div className={styles.content}>
-        <div className={styles.chip}>ZERO EXTERNAL DATABASES · v0.8.13</div>
+        <div className={styles.chip}>
+          ZERO EXTERNAL DATABASES · v{meta.version}
+        </div>
         <h1 className={styles.title} id="hero-title">
           <span className={styles.word}>AGENT</span>
           <span className={`${styles.word} ${styles.accent}`}>MEMORY</span>

--- a/website/components/LiveTerminal.tsx
+++ b/website/components/LiveTerminal.tsx
@@ -57,11 +57,11 @@ function classFor(type: SegType) {
 }
 
 export function LiveTerminal({
-  mcpTools = 44,
-  hooks = 12,
+  mcpTools,
+  hooks,
 }: {
-  mcpTools?: number;
-  hooks?: number;
+  mcpTools: number;
+  hooks: number;
 }) {
   const termRef = useRef<HTMLElement>(null);
   const [status, setStatus] = useState("IDLE");

--- a/website/components/LiveTerminal.tsx
+++ b/website/components/LiveTerminal.tsx
@@ -9,35 +9,37 @@ interface Seg {
   text: string;
 }
 
-const SCRIPT: Seg[] = [
-  { t: "prompt", text: "$ " },
-  { t: "typed", text: "npx @agentmemory/agentmemory\n" },
-  { t: "plain", text: "[agentmemory] iii-engine ready on :3111\n" },
-  { t: "plain", text: "[agentmemory] 44 MCP tools registered\n" },
-  { t: "plain", text: "[agentmemory] 12 autohooks armed\n\n" },
-  { t: "prompt", text: "$ " },
-  {
-    t: "typed",
-    text: 'memory.recall({ query: "where did we land the retry logic?" })\n',
-  },
-  { t: "comment", text: "// triple-stream retrieval: BM25 + vector + graph\n" },
-  { t: "ok", text: "✓ 3 memories · p50 18ms · reranked on device\n\n" },
-  { t: "plain", text: "→ " },
-  { t: "val", text: "src/retry.ts:47 · exponentialBackoff(max=5, jitter=true)\n" },
-  { t: "plain", text: "→ " },
-  {
-    t: "val",
-    text: 'commit 8f2e14c · "resolve conflict + honor x-amz headers"\n',
-  },
-  { t: "plain", text: "→ " },
-  {
-    t: "val",
-    text: 'session 2026-04-16 · "bug: race when Retry-After is empty"\n\n',
-  },
-  { t: "prompt", text: "$ " },
-  { t: "typed", text: "memory.consolidate({ project: 'pay-api' })\n" },
-  { t: "ok", text: "✓ 18 raw observations → 4 semantic memories · audit row emitted\n" },
-];
+function buildScript(mcpTools: number, hooks: number): Seg[] {
+  return [
+    { t: "prompt", text: "$ " },
+    { t: "typed", text: "npx @agentmemory/agentmemory\n" },
+    { t: "plain", text: "[agentmemory] iii-engine ready on :3111\n" },
+    { t: "plain", text: `[agentmemory] ${mcpTools} MCP tools registered\n` },
+    { t: "plain", text: `[agentmemory] ${hooks} autohooks armed\n\n` },
+    { t: "prompt", text: "$ " },
+    {
+      t: "typed",
+      text: 'memory.recall({ query: "where did we land the retry logic?" })\n',
+    },
+    { t: "comment", text: "// triple-stream retrieval: BM25 + vector + graph\n" },
+    { t: "ok", text: "✓ 3 memories · p50 18ms · reranked on device\n\n" },
+    { t: "plain", text: "→ " },
+    { t: "val", text: "src/retry.ts:47 · exponentialBackoff(max=5, jitter=true)\n" },
+    { t: "plain", text: "→ " },
+    {
+      t: "val",
+      text: 'commit 8f2e14c · "resolve conflict + honor x-amz headers"\n',
+    },
+    { t: "plain", text: "→ " },
+    {
+      t: "val",
+      text: 'session 2026-04-16 · "bug: race when Retry-After is empty"\n\n',
+    },
+    { t: "prompt", text: "$ " },
+    { t: "typed", text: "memory.consolidate({ project: 'pay-api' })\n" },
+    { t: "ok", text: "✓ 18 raw observations → 4 semantic memories · audit row emitted\n" },
+  ];
+}
 
 function classFor(type: SegType) {
   switch (type) {
@@ -54,7 +56,13 @@ function classFor(type: SegType) {
   }
 }
 
-export function LiveTerminal() {
+export function LiveTerminal({
+  mcpTools = 44,
+  hooks = 12,
+}: {
+  mcpTools?: number;
+  hooks?: number;
+}) {
   const termRef = useRef<HTMLElement>(null);
   const [status, setStatus] = useState("IDLE");
   const runningRef = useRef(false);
@@ -70,8 +78,9 @@ export function LiveTerminal() {
     caret.className = styles.caret;
     term.appendChild(caret);
     const reduce = matchMedia("(prefers-reduced-motion: reduce)").matches;
+    const script = buildScript(mcpTools, hooks);
 
-    for (const seg of SCRIPT) {
+    for (const seg of script) {
       const span = document.createElement("span");
       const c = classFor(seg.t);
       if (c) span.className = c;
@@ -91,7 +100,7 @@ export function LiveTerminal() {
     }
     setStatus("DONE");
     runningRef.current = false;
-  }, []);
+  }, [mcpTools, hooks]);
 
   useEffect(() => {
     const term = termRef.current;

--- a/website/components/Stats.tsx
+++ b/website/components/Stats.tsx
@@ -11,13 +11,13 @@ interface StatItem {
 }
 
 export function Stats({
-  mcpTools = 44,
-  hooks = 12,
-  testsPassing = 777,
+  mcpTools,
+  hooks,
+  testsPassing,
 }: {
-  mcpTools?: number;
-  hooks?: number;
-  testsPassing?: number;
+  mcpTools: number;
+  hooks: number;
+  testsPassing: number;
 }) {
   const rootRef = useRef<HTMLDivElement>(null);
 
@@ -32,6 +32,13 @@ export function Stats({
 
   useEffect(() => {
     if (!rootRef.current) return;
+    const root = rootRef.current;
+
+    // Reset per-element done flag so deps changing (e.g. a new meta snapshot
+    // at build) replays the count animation against the new target.
+    root
+      .querySelectorAll<HTMLDivElement>("[data-num]")
+      .forEach((el) => delete el.dataset.done);
 
     const count = (el: HTMLDivElement) => {
       const target = Number(el.dataset.target);
@@ -71,7 +78,7 @@ export function Stats({
       { threshold: 0.5 },
     );
 
-    rootRef.current
+    root
       .querySelectorAll<HTMLDivElement>("[data-stat]")
       .forEach((el) => io.observe(el));
 

--- a/website/components/Stats.tsx
+++ b/website/components/Stats.tsx
@@ -10,23 +10,28 @@ interface StatItem {
   float?: boolean;
 }
 
-const STATS: StatItem[] = [
-  { target: 95.2, suffix: "%", label: "RETRIEVAL R@5 · LONGMEMEVAL-S", float: true },
-  { target: 92, suffix: "%", label: "FEWER INPUT TOKENS PER SESSION" },
-  { target: 44, label: "MCP TOOLS" },
-  { target: 12, label: "AUTOHOOKS" },
-  { target: 0, label: "EXTERNAL DATABASES" },
-  { target: 769, label: "TESTS PASSING" },
-];
-
-export function Stats() {
+export function Stats({
+  mcpTools = 44,
+  hooks = 12,
+  testsPassing = 777,
+}: {
+  mcpTools?: number;
+  hooks?: number;
+  testsPassing?: number;
+}) {
   const rootRef = useRef<HTMLDivElement>(null);
+
+  const STATS: StatItem[] = [
+    { target: 95.2, suffix: "%", label: "RETRIEVAL R@5 · LONGMEMEVAL-S", float: true },
+    { target: 92, suffix: "%", label: "FEWER INPUT TOKENS PER SESSION" },
+    { target: mcpTools, label: "MCP TOOLS" },
+    { target: hooks, label: "AUTOHOOKS" },
+    { target: 0, label: "EXTERNAL DATABASES" },
+    { target: testsPassing, label: "TESTS PASSING" },
+  ];
 
   useEffect(() => {
     if (!rootRef.current) return;
-    const numEls = rootRef.current.querySelectorAll<HTMLDivElement>(
-      "[data-num]",
-    );
 
     const count = (el: HTMLDivElement) => {
       const target = Number(el.dataset.target);
@@ -71,7 +76,7 @@ export function Stats() {
       .forEach((el) => io.observe(el));
 
     return () => io.disconnect();
-  }, []);
+  }, [mcpTools, hooks, testsPassing]);
 
   return (
     <section className={styles.stats} aria-label="Benchmarks">

--- a/website/lib/meta.ts
+++ b/website/lib/meta.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -11,60 +11,15 @@ export interface ProjectMeta {
   testsPassing: number;
 }
 
+export const DEFAULT_META: Omit<ProjectMeta, "version"> = {
+  mcpTools: 44,
+  hooks: 12,
+  restEndpoints: 49,
+  testsPassing: 777,
+};
+
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(here, "..", "..");
-
-function safeReadJson<T>(path: string): T | null {
-  try {
-    return JSON.parse(readFileSync(path, "utf-8")) as T;
-  } catch {
-    return null;
-  }
-}
-
-function safeCountMatches(path: string, pattern: RegExp): number {
-  try {
-    const txt = readFileSync(path, "utf-8");
-    const m = txt.match(pattern);
-    return m ? m.length : 0;
-  } catch {
-    return 0;
-  }
-}
-
-export function getProjectMeta(): ProjectMeta {
-  const pkg = safeReadJson<{ version?: string }>(
-    join(repoRoot, "package.json"),
-  );
-
-  // REST endpoints: count api_path declarations in src/triggers/api.ts
-  const restEndpoints = safeCountMatches(
-    join(repoRoot, "src", "triggers", "api.ts"),
-    /api_path:/g,
-  );
-
-  // MCP tools: count name: entries in tools-registry
-  const mcpTools =
-    safeCountMatches(
-      join(repoRoot, "src", "mcp", "tools-registry.ts"),
-      /name:\s*"memory_/g,
-    ) || 44;
-
-  // Hooks: count HookType union members
-  const hookUnionFile = readFileSafe(join(repoRoot, "src", "types.ts"));
-  const hookUnion = hookUnionFile.match(
-    /export type HookType[\s\S]*?;(?=\s*\n)/,
-  );
-  const hooks = hookUnion ? (hookUnion[0].match(/"/g)?.length ?? 0) / 2 : 12;
-
-  return {
-    version: pkg?.version ?? "0.0.0",
-    mcpTools: mcpTools || 44,
-    hooks: hooks || 12,
-    restEndpoints: restEndpoints || 49,
-    testsPassing: 777,
-  };
-}
 
 function readFileSafe(path: string): string {
   try {
@@ -72,4 +27,91 @@ function readFileSafe(path: string): string {
   } catch {
     return "";
   }
+}
+
+function safeReadJson<T>(path: string): T | null {
+  const txt = readFileSafe(path);
+  if (!txt) return null;
+  try {
+    return JSON.parse(txt) as T;
+  } catch {
+    return null;
+  }
+}
+
+function safeCountMatches(path: string, pattern: RegExp): number {
+  const txt = readFileSafe(path);
+  if (!txt) return 0;
+  const m = txt.match(pattern);
+  return m ? m.length : 0;
+}
+
+function countHookTypes(typesPath: string): number {
+  const txt = readFileSafe(typesPath);
+  if (!txt) return 0;
+  const union = txt.match(/export type HookType[\s\S]*?;/);
+  if (!union) return 0;
+  const body = union[0].replace(/export type HookType\s*=/, "").replace(/;$/, "");
+  const members = body
+    .split("|")
+    .map((s) => s.trim())
+    .filter((s) => /^["'`]/.test(s));
+  return members.length;
+}
+
+function countTestCases(testDir: string): number {
+  let total = 0;
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = readdirSync(testDir, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+  for (const entry of entries) {
+    const full = join(testDir, entry.name);
+    if (entry.isDirectory()) {
+      total += countTestCases(full);
+      continue;
+    }
+    if (!/\.test\.[jt]sx?$/.test(entry.name)) continue;
+    const txt = readFileSafe(full);
+    if (!txt) continue;
+    const m = txt.match(/(?:^|\s)(?:it|test)(?:\.\w+)?\s*\(/g);
+    if (m) total += m.length;
+  }
+  return total;
+}
+
+export function getProjectMeta(): ProjectMeta {
+  const pkg = safeReadJson<{ version?: string }>(
+    join(repoRoot, "package.json"),
+  );
+
+  // REST endpoints: registerTrigger entries in src/triggers/api.ts with an
+  // api_path config. The tight regex matches the exact declaration shape the
+  // codebase uses; loose forms (comments, example strings) are not counted.
+  const restEndpoints = safeCountMatches(
+    join(repoRoot, "src", "triggers", "api.ts"),
+    /config:\s*\{\s*api_path:\s*"/g,
+  );
+
+  // MCP tools: count memory_* entries in the tools registry.
+  const mcpTools = safeCountMatches(
+    join(repoRoot, "src", "mcp", "tools-registry.ts"),
+    /name:\s*"memory_/g,
+  );
+
+  // Hooks: count actual members of the HookType union, not quote characters.
+  const hooks = countHookTypes(join(repoRoot, "src", "types.ts"));
+
+  // Tests: walk the test/ tree, count it()/test() call sites.
+  const testsPassing = countTestCases(join(repoRoot, "test"));
+
+  return {
+    version: pkg?.version ?? "0.0.0",
+    mcpTools: mcpTools || DEFAULT_META.mcpTools,
+    hooks: hooks || DEFAULT_META.hooks,
+    restEndpoints: restEndpoints || DEFAULT_META.restEndpoints,
+    testsPassing: testsPassing || DEFAULT_META.testsPassing,
+  };
 }

--- a/website/lib/meta.ts
+++ b/website/lib/meta.ts
@@ -1,0 +1,75 @@
+import "server-only";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export interface ProjectMeta {
+  version: string;
+  mcpTools: number;
+  hooks: number;
+  restEndpoints: number;
+  testsPassing: number;
+}
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, "..", "..");
+
+function safeReadJson<T>(path: string): T | null {
+  try {
+    return JSON.parse(readFileSync(path, "utf-8")) as T;
+  } catch {
+    return null;
+  }
+}
+
+function safeCountMatches(path: string, pattern: RegExp): number {
+  try {
+    const txt = readFileSync(path, "utf-8");
+    const m = txt.match(pattern);
+    return m ? m.length : 0;
+  } catch {
+    return 0;
+  }
+}
+
+export function getProjectMeta(): ProjectMeta {
+  const pkg = safeReadJson<{ version?: string }>(
+    join(repoRoot, "package.json"),
+  );
+
+  // REST endpoints: count api_path declarations in src/triggers/api.ts
+  const restEndpoints = safeCountMatches(
+    join(repoRoot, "src", "triggers", "api.ts"),
+    /api_path:/g,
+  );
+
+  // MCP tools: count name: entries in tools-registry
+  const mcpTools =
+    safeCountMatches(
+      join(repoRoot, "src", "mcp", "tools-registry.ts"),
+      /name:\s*"memory_/g,
+    ) || 44;
+
+  // Hooks: count HookType union members
+  const hookUnionFile = readFileSafe(join(repoRoot, "src", "types.ts"));
+  const hookUnion = hookUnionFile.match(
+    /export type HookType[\s\S]*?;(?=\s*\n)/,
+  );
+  const hooks = hookUnion ? (hookUnion[0].match(/"/g)?.length ?? 0) / 2 : 12;
+
+  return {
+    version: pkg?.version ?? "0.0.0",
+    mcpTools: mcpTools || 44,
+    hooks: hooks || 12,
+    restEndpoints: restEndpoints || 49,
+    testsPassing: 777,
+  };
+}
+
+function readFileSafe(path: string): string {
+  try {
+    return readFileSync(path, "utf-8");
+  } catch {
+    return "";
+  }
+}


### PR DESCRIPTION
Fixes the hardcoded-drift issue. The hero chip still said \`v0.8.13\` after v0.9.0 shipped, and the MCP/hook/REST counts were literal strings sprinkled across four components.

## What
- \`lib/meta.ts\` (server-only) reads version + counts from the real source of truth at build:
  - \`package.json\` → version
  - \`src/triggers/api.ts\` → REST endpoint count (\`api_path:\` grep)
  - \`src/mcp/tools-registry.ts\` → MCP tool count (\`name: \"memory_\"\` grep)
  - \`src/types.ts\` \`HookType\` union → hook count
- Hero chip, Stats, LiveTerminal, Features all consume counts through props.

## Result
Cutting the next release bumps the hero to v<new> automatically. Any new MCP tool or REST endpoint raises the displayed count without a component edit.

Build: \`next build\` clean, single static page prerendered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hero version now updates dynamically from project metadata
  * Statistics (MCP Tools, Auto-Hooks, REST Endpoints, Tests Passing) show live project counts and replay count animations when values change
  * Live Terminal output adapts to current project metrics
  * Features list phrasing updated to say “the rest” for AUTO-HOOKS instead of “ten more”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->