### PR TITLE
fix(website): mobile overflow + OG/Twitter preview images

### DIFF
--- a/website/app/opengraph-image.tsx
+++ b/website/app/opengraph-image.tsx
@@ -1,0 +1,107 @@
+import { ImageResponse } from "next/og";
+
+export const alt = "agentmemory — persistent memory for AI coding agents";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default function Image() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          padding: "72px 80px",
+          background:
+            "radial-gradient(ellipse at 20% 0%, #1a1407 0%, #0a0a0a 55%, #000 100%)",
+          color: "#fff",
+          fontFamily: "system-ui, -apple-system, sans-serif",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 16,
+            fontSize: 20,
+            letterSpacing: 3,
+            fontWeight: 700,
+            color: "#f3b840",
+            textTransform: "uppercase",
+          }}
+        >
+          <div
+            style={{
+              width: 14,
+              height: 14,
+              background: "#f3b840",
+              boxShadow: "0 0 24px #f3b840",
+            }}
+          />
+          <span>AGENTMEMORY</span>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 28 }}>
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              fontSize: 128,
+              fontWeight: 900,
+              lineHeight: 0.95,
+              letterSpacing: -3,
+              textTransform: "uppercase",
+            }}
+          >
+            <span>AGENT</span>
+            <span style={{ color: "#f3b840" }}>MEMORY</span>
+          </div>
+          <div
+            style={{
+              display: "flex",
+              fontSize: 32,
+              color: "#b8b8b8",
+              letterSpacing: 0.5,
+              maxWidth: 900,
+              lineHeight: 1.35,
+            }}
+          >
+            Persistent memory for AI coding agents. Runs locally. Zero external
+            databases.
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            gap: 48,
+            fontSize: 22,
+            color: "#888",
+            letterSpacing: 2,
+            textTransform: "uppercase",
+            fontWeight: 700,
+            borderTop: "1px solid #222",
+            paddingTop: 28,
+          }}
+        >
+          <div style={{ display: "flex", gap: 10 }}>
+            <span style={{ color: "#f3b840" }}>95.2%</span>
+            <span>RETRIEVAL R@5</span>
+          </div>
+          <div style={{ display: "flex", gap: 10 }}>
+            <span style={{ color: "#f3b840" }}>92%</span>
+            <span>FEWER TOKENS</span>
+          </div>
+          <div style={{ display: "flex", gap: 10 }}>
+            <span style={{ color: "#f3b840" }}>0</span>
+            <span>EXTERNAL DBs</span>
+          </div>
+        </div>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/website/app/twitter-image.tsx
+++ b/website/app/twitter-image.tsx
@@ -1,0 +1,5 @@
+export const alt = "agentmemory — persistent memory for AI coding agents";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export { default } from "./opengraph-image";

--- a/website/components/AgentInstall.module.css
+++ b/website/components/AgentInstall.module.css
@@ -1,6 +1,8 @@
 .wrap {
   display: grid;
+  grid-template-columns: minmax(0, 1fr);
   gap: 16px;
+  min-width: 0;
 }
 
 .stepLabel {
@@ -21,14 +23,16 @@
 
 .split {
   display: grid;
-  grid-template-columns: minmax(220px, 0.9fr) 1.3fr;
+  grid-template-columns: minmax(220px, 0.9fr) minmax(0, 1.3fr);
   gap: 16px;
   align-items: start;
+  min-width: 0;
 }
 .chipsCol {
   display: flex;
   flex-direction: column;
   gap: 12px;
+  min-width: 0;
 }
 .colHead {
   font-size: 11px;
@@ -39,8 +43,9 @@
 }
 .chips {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   gap: 8px;
+  min-width: 0;
 }
 .chip {
   appearance: none;
@@ -96,6 +101,7 @@
 
 .snippetCol {
   display: block;
+  min-width: 0;
 }
 
 .snippet {
@@ -197,15 +203,26 @@
 
 @media (max-width: 900px) {
   .split {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 
 @media (max-width: 640px) {
   .chips {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
   }
   .code {
     font-size: 12px;
+    padding: 16px;
+  }
+  .snippetHead {
+    padding: 10px 14px;
+  }
+  .snippetHint {
+    font-size: 9px;
+    letter-spacing: 0.6px;
+  }
+  .copyRow {
+    padding: 10px 12px;
   }
 }

--- a/website/components/CommandCenter.module.css
+++ b/website/components/CommandCenter.module.css
@@ -57,7 +57,7 @@
   margin: 0 auto;
   padding: 0 40px;
   display: grid;
-  grid-template-columns: minmax(320px, 1fr) 1.3fr;
+  grid-template-columns: minmax(320px, 1fr) minmax(0, 1.3fr);
   gap: 40px;
   align-items: start;
 }
@@ -161,7 +161,7 @@
 
 @media (max-width: 960px) {
   .panel {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
   }
   .tabs {
     grid-template-columns: 1fr 1fr;
@@ -177,5 +177,19 @@
   .tabs,
   .panel {
     padding: 0 20px;
+  }
+  .tab {
+    padding: 14px 12px;
+  }
+  .tabLabel {
+    font-size: 13px;
+  }
+  .tabSub {
+    font-size: 9px;
+    letter-spacing: 0.6px;
+  }
+  .launch {
+    padding: 12px 14px;
+    font-size: 11px;
   }
 }

--- a/website/components/Install.module.css
+++ b/website/components/Install.module.css
@@ -8,6 +8,7 @@
   margin: 0 auto 56px;
   padding: 0 40px;
   display: grid;
+  grid-template-columns: minmax(0, 1fr);
   gap: 28px;
 }
 .step {
@@ -23,7 +24,7 @@
 }
 .box {
   display: grid;
-  grid-template-columns: auto 1fr auto;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   gap: 16px;
   align-items: center;
   padding: 22px 28px;
@@ -34,6 +35,7 @@
   font-size: 14px;
   text-align: left;
   width: 100%;
+  min-width: 0;
   transition:
     border-color 200ms ease,
     background 200ms ease;
@@ -58,6 +60,7 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  min-width: 0;
 }
 .hint {
   color: var(--ash);
@@ -77,5 +80,14 @@
   .cards,
   .cta {
     padding: 0 20px;
+  }
+  .box {
+    padding: 18px 16px;
+    gap: 10px;
+    font-size: 13px;
+  }
+  .hint {
+    font-size: 10px;
+    letter-spacing: 0.6px;
   }
 }

--- a/website/components/Stats.module.css
+++ b/website/components/Stats.module.css
@@ -51,6 +51,16 @@
   .row {
     grid-template-columns: 1fr 1fr;
   }
+  .stat {
+    padding: 32px 12px;
+  }
+  .num {
+    font-size: 36px;
+  }
+  .label {
+    font-size: 10px;
+    letter-spacing: 0.6px;
+  }
   .stat:nth-child(3n) {
     border-right: 1px solid var(--charcoal);
   }


### PR DESCRIPTION
## Summary

- **Mobile horizontal scroll (375px):** body was rendering at ~430px because grid tracks on `.cards`, `.box`, `.wrap`, `.split`, `.chips`, `.panel` were defaulting to min-content and getting pinned wider than the viewport by nowrap copy (install commands, "RUNS ON :3111 · VIEWER ON :3113", "CURL + HASH + PIN VERSION", etc.). Fix: swap `1fr` / implicit tracks for `minmax(0, 1fr)` and add `min-width: 0` on the relevant flex/grid containers so `overflow: hidden` + `text-overflow: ellipsis` on `.cmd` can actually clip.
- **Mobile polish (<=640px):** tightened padding, font-size, and letter-spacing for Install boxes, AgentInstall snippet header/code/copy row, CommandCenter tabs + launch strip, and Stats tiles so dense uppercase content stops crowding itself.
- **Social previews:** `layout.tsx` declared `openGraph` and `twitter` metadata but shipped no image file, so shares rendered as blank cards. Added `app/opengraph-image.tsx` and `app/twitter-image.tsx` using `next/og` `ImageResponse`. Statically prerendered at build (no `runtime = "edge"`) so Next emits a cacheable 1200x630 PNG.

### Before / after

| | before | after |
|---|---|---|
| body scrollWidth @ 375px viewport | 430px (horizontal scroll) | 375px (no overflow) |
| `/opengraph-image` | (absent) | 1200x630 PNG, ~90 KB, static |
| `/twitter-image` | (absent) | 1200x630 PNG, static |

Build output confirms both routes are now `○ (Static)` rather than `ƒ (Dynamic)`.

## Test plan

- [x] `npm run build` in `website/` — typechecks, 3 static routes generated
- [x] Dev at 375x812: `document.documentElement.scrollWidth === 375`
- [x] Screenshots of hero, stats, Install, CommandCenter, MCP list, Compare, Footer on mobile — no visual regressions, overflow gone
- [x] `curl http://localhost:3000/opengraph-image` → `image/png`, 1200x630
- [x] Meta tags render `og:image`, `og:image:width=1200`, `twitter:image`, `twitter:card=summary_large_image`
- [ ] After deploy: verify with [cards-dev.twitter.com/validator](https://cards-dev.twitter.com/validator) and OpenGraph.xyz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added social media preview images for improved sharing across platforms.

* **Style**
  * Enhanced responsive layout and grid constraints for better mobile viewing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->