### PR TITLE
fix(viewer): register GET endpoints dashboard needs (semantic, procedural, relations)

### DIFF
--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -1237,7 +1237,49 @@ export function registerApiTriggers(
     config: { api_path: "/agentmemory/memories", http_method: "GET" },
   });
 
-  sdk.registerFunction("api::action-create", 
+  sdk.registerFunction("api::semantic-list",
+    async (req: ApiRequest): Promise<Response> => {
+      const authErr = checkAuth(req, secret);
+      if (authErr) return authErr;
+      const semantic = await kv.list<import("../types.js").SemanticMemory>(KV.semantic);
+      return { status_code: 200, body: { semantic } };
+    },
+  );
+  sdk.registerTrigger({
+    type: "http",
+    function_id: "api::semantic-list",
+    config: { api_path: "/agentmemory/semantic", http_method: "GET" },
+  });
+
+  sdk.registerFunction("api::procedural-list",
+    async (req: ApiRequest): Promise<Response> => {
+      const authErr = checkAuth(req, secret);
+      if (authErr) return authErr;
+      const procedural = await kv.list<import("../types.js").ProceduralMemory>(KV.procedural);
+      return { status_code: 200, body: { procedural } };
+    },
+  );
+  sdk.registerTrigger({
+    type: "http",
+    function_id: "api::procedural-list",
+    config: { api_path: "/agentmemory/procedural", http_method: "GET" },
+  });
+
+  sdk.registerFunction("api::relations-list",
+    async (req: ApiRequest): Promise<Response> => {
+      const authErr = checkAuth(req, secret);
+      if (authErr) return authErr;
+      const relations = await kv.list<import("../types.js").MemoryRelation>(KV.relations);
+      return { status_code: 200, body: { relations } };
+    },
+  );
+  sdk.registerTrigger({
+    type: "http",
+    function_id: "api::relations-list",
+    config: { api_path: "/agentmemory/relations", http_method: "GET" },
+  });
+
+  sdk.registerFunction("api::action-create",
     async (
       req: ApiRequest<{
         title: string;

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -235,6 +235,35 @@ describe("agentmemory integration", () => {
     });
   });
 
+  describe("dashboard list endpoints", () => {
+    it("GET /semantic returns { semantic: [...] }", async () => {
+      const res = await fetch(url("/agentmemory/semantic"), {
+        headers: SECRET ? authHeaders() : undefined,
+      });
+      expect(res.status).toBe(200);
+      const body = (await json(res)) as { semantic: unknown[] };
+      expect(Array.isArray(body.semantic)).toBe(true);
+    });
+
+    it("GET /procedural returns { procedural: [...] }", async () => {
+      const res = await fetch(url("/agentmemory/procedural"), {
+        headers: SECRET ? authHeaders() : undefined,
+      });
+      expect(res.status).toBe(200);
+      const body = (await json(res)) as { procedural: unknown[] };
+      expect(Array.isArray(body.procedural)).toBe(true);
+    });
+
+    it("GET /relations returns { relations: [...] }", async () => {
+      const res = await fetch(url("/agentmemory/relations"), {
+        headers: SECRET ? authHeaders() : undefined,
+      });
+      expect(res.status).toBe(200);
+      const body = (await json(res)) as { relations: unknown[] };
+      expect(Array.isArray(body.relations)).toBe(true);
+    });
+  });
+
   describe("auth", () => {
     it("health endpoint is always public", async () => {
       const res = await fetch(url("/agentmemory/health"));


### PR DESCRIPTION
## Summary

Dashboard viewer (port 3113) calls three list endpoints that never reached the REST server (3111):

- `GET /agentmemory/semantic` — no handler registered → **404**
- `GET /agentmemory/procedural` — no handler registered → **404**
- `GET /agentmemory/relations` — only `POST` registered → **405**

Because `loadDashboard()` fans out with `Promise.all`, the cards for these sections stayed empty even when memories, sessions, and crystals fetched cleanly. Jay Ferguson hit this while running agentmemory with Hermes — he saw `{ memories: Array(3) }` arriving but cards stuck on 0.

## Fix

Added three auth-gated GET handlers next to `api::memories` in `src/triggers/api.ts`:

| Function | Path | Returns |
|----------|------|---------|
| `api::semantic-list` | `GET /agentmemory/semantic` | `{ semantic: SemanticMemory[] }` |
| `api::procedural-list` | `GET /agentmemory/procedural` | `{ procedural: ProceduralMemory[] }` |
| `api::relations-list` | `GET /agentmemory/relations` | `{ relations: MemoryRelation[] }` |

Each handler reads from the same `KV.semantic` / `KV.procedural` / `KV.relations` keys that `mesh/export` already uses. Shapes match what `renderDashboard` parses in `src/viewer/index.html`:

```js
state.dashboard.semantic   = (results[5] && results[5].facts) || (results[5] && results[5].semantic) || [];
state.dashboard.procedural = (results[6] && results[6].procedures) || (results[6] && results[6].procedural) || [];
state.dashboard.relations  = (results[7] && results[7].relations) || [];
```

The existing `POST /agentmemory/relations` (create-edge) is untouched; iii's trigger registry routes (path, method) pairs independently — same pattern as `/agentmemory/actions` POST/GET.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 776 pass (unrelated fs-watcher timing flake)
- [x] `npx tsc --noEmit` — no new errors
- [x] Added 3 integration tests in `test/integration.test.ts` asserting each endpoint returns 200 with an array
- [ ] Manual verify: start server + viewer, confirm dashboard shows counts for semantic / procedural / relations when populated

Fixes the user-visible issue in https://x.com/fergusonJC/status/... (empty dashboard with Hermes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three authenticated API endpoints to retrieve different types of agent memory data: semantic memory, procedural memory, and memory relations. Each endpoint validates authorization and returns formatted list data.

* **Tests**
  * Added integration tests to validate that the new memory endpoints correctly authenticate requests and return expected data structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->