### PR TITLE
fix(cli): harden import-jsonl + use curl installer for iii-engine upgrade

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -770,7 +770,7 @@ async function runUpgrade() {
       );
       if (!installerOk) {
         p.log.warn(
-          "iii-engine installer failed. Fallbacks: Docker (`docker pull iiidev/iii:latest`) or releases at https://github.com/iii-dev/iii-engine/releases.",
+          "iii-engine installer failed. Fallbacks: Docker (`docker pull iiidev/iii:latest`) or releases at https://github.com/iii-hq/iii/releases/latest.",
         );
       }
     } else {
@@ -813,17 +813,24 @@ async function runImportJsonl(): Promise<void> {
   const base = `http://localhost:${port}`;
 
   let probeOk = false;
+  let probeDetail = "";
   try {
     const probe = await fetch(`${base}/agentmemory/livez`, {
       signal: AbortSignal.timeout(2000),
     });
     probeOk = probe.ok;
-  } catch {
+    if (!probeOk) {
+      const probeBody = await probe.text().catch(() => "");
+      probeDetail = `reachable but unhealthy (HTTP ${probe.status}${probeBody ? `: ${probeBody.slice(0, 200)}` : ""})`;
+    }
+  } catch (err) {
     probeOk = false;
+    const msg = err instanceof Error ? err.message : String(err);
+    probeDetail = `unreachable (${msg})`;
   }
   if (!probeOk) {
     p.log.error(
-      `agentmemory is not running on port ${port}. Start it with \`npx @agentmemory/agentmemory\` in another terminal, then re-run this command.`,
+      `agentmemory livez probe failed on port ${port}: ${probeDetail}. Start it with \`npx @agentmemory/agentmemory\` in another terminal, then re-run this command.`,
     );
     process.exit(1);
   }
@@ -865,9 +872,15 @@ async function runImportJsonl(): Promise<void> {
         process.exit(1);
       }
     }
-    if (!res.ok || json.success === false) {
+    if (!res.ok || json.success !== true) {
       spinner.stop("failed");
-      const detail = json.error || (text.length === 0 ? "empty response body" : `HTTP ${res.status}`);
+      const detail =
+        json.error ||
+        (text.length === 0
+          ? "empty response body"
+          : json.success === undefined
+            ? `HTTP ${res.status} (response missing success field)`
+            : `HTTP ${res.status}`);
       if (res.status === 401) {
         p.log.error(
           `${detail}. Set AGENTMEMORY_SECRET to match the server's secret and re-run.`,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -714,7 +714,6 @@ async function runUpgrade() {
 
   const pnpmBin = whichBinary("pnpm");
   const npmBin = whichBinary("npm");
-  const cargoBin = whichBinary("cargo");
   const dockerBin = whichBinary("docker");
 
   p.log.info(`Working directory: ${cwd}`);
@@ -752,9 +751,11 @@ async function runUpgrade() {
     p.log.warn("No package.json in current directory. Skipping JS dependency upgrade.");
   }
 
-  if (cargoBin) {
+  const shBin = whichBinary("sh");
+  const curlBin = whichBinary("curl");
+  if (shBin && curlBin) {
     const upgradeEngine = await p.confirm({
-      message: "Upgrade iii-engine via cargo install --force?",
+      message: "Re-run the iii-engine install script (curl | sh)?",
       initialValue: true,
     });
     if (p.isCancel(upgradeEngine)) {
@@ -762,15 +763,21 @@ async function runUpgrade() {
       return process.exit(0);
     }
     if (upgradeEngine === true) {
-      const cargoOk = runCommand(cargoBin, ["install", "iii-engine", "--force"], {
-        label: "Upgrading iii-engine (cargo)",
-      });
-      requireSuccess(cargoOk, "cargo install iii-engine --force");
+      const installerOk = runCommand(
+        shBin,
+        ["-c", "curl -fsSL https://install.iii.dev/iii/main/install.sh | sh"],
+        { label: "Upgrading iii-engine via installer", optional: true },
+      );
+      if (!installerOk) {
+        p.log.warn(
+          "iii-engine installer failed. Fallbacks: Docker (`docker pull iiidev/iii:latest`) or releases at https://github.com/iii-dev/iii-engine/releases.",
+        );
+      }
     } else {
-      p.log.info("Skipped cargo-based iii-engine upgrade.");
+      p.log.info("Skipped iii-engine installer.");
     }
   } else {
-    p.log.warn("Cargo not found. Skipping iii-engine binary upgrade.");
+    p.log.warn("curl or sh not found. Skipping iii-engine installer.");
   }
 
   if (dockerBin) {
@@ -805,12 +812,19 @@ async function runImportJsonl(): Promise<void> {
   const port = getRestPort();
   const base = `http://localhost:${port}`;
 
+  let probeOk = false;
   try {
-    await fetch(`${base}/agentmemory/livez`, {
+    const probe = await fetch(`${base}/agentmemory/livez`, {
       signal: AbortSignal.timeout(2000),
     });
+    probeOk = probe.ok;
   } catch {
-    p.log.error(`agentmemory is not running on port ${port}. Start it first.`);
+    probeOk = false;
+  }
+  if (!probeOk) {
+    p.log.error(
+      `agentmemory is not running on port ${port}. Start it with \`npx @agentmemory/agentmemory\` in another terminal, then re-run this command.`,
+    );
     process.exit(1);
   }
 
@@ -832,20 +846,43 @@ async function runImportJsonl(): Promise<void> {
       body: JSON.stringify(body),
       signal: AbortSignal.timeout(120_000),
     });
-    const json = (await res.json()) as {
+    const text = await res.text();
+    let json: {
       success?: boolean;
       error?: string;
       imported?: number;
       sessionIds?: string[];
       observations?: number;
-    };
+    } = {};
+    if (text.length > 0) {
+      try {
+        json = JSON.parse(text);
+      } catch {
+        spinner.stop("failed");
+        p.log.error(
+          `server returned non-JSON response (HTTP ${res.status}): ${text.slice(0, 200)}`,
+        );
+        process.exit(1);
+      }
+    }
     if (!res.ok || json.success === false) {
       spinner.stop("failed");
-      p.log.error(json.error || `HTTP ${res.status}`);
+      const detail = json.error || (text.length === 0 ? "empty response body" : `HTTP ${res.status}`);
+      if (res.status === 401) {
+        p.log.error(
+          `${detail}. Set AGENTMEMORY_SECRET to match the server's secret and re-run.`,
+        );
+      } else if (res.status === 404) {
+        p.log.error(
+          `${detail}. The running agentmemory server does not expose /agentmemory/replay/import-jsonl — upgrade to v0.8.13 or later.`,
+        );
+      } else {
+        p.log.error(detail);
+      }
       process.exit(1);
     }
     spinner.stop(
-      `imported ${json.imported} file(s), ${json.observations} observation(s) across ${json.sessionIds?.length || 0} session(s)`,
+      `imported ${json.imported ?? 0} file(s), ${json.observations ?? 0} observation(s) across ${json.sessionIds?.length || 0} session(s)`,
     );
     if (json.sessionIds && json.sessionIds.length > 0) {
       p.log.info(`View at http://localhost:${port + 2} → Replay tab`);


### PR DESCRIPTION
## Summary

Two hard-fails reported from a fresh \`npx @agentmemory/agentmemory\` session:

1. \`import-jsonl\` crashed with \`Unexpected end of JSON input\` when anything other than a 2xx-with-JSON came back from the server — including the server simply not being up.
2. \`upgrade\` prompted \`cargo install iii-engine --force\`, which 404s because the crate isn't on crates.io, then aborted the whole upgrade before Docker pull ran.

## Changes

### \`runImportJsonl\` — src/cli.ts

- Livez probe now checks \`res.ok\`, not just \`fetch\` success. A stray service on port 3111 used to pass silently, then the POST would 404 with an empty body and explode at \`res.json()\`.
- Response handling reads body as text, parses only if non-empty, and maps 401 → \"set AGENTMEMORY_SECRET\" and 404 → \"upgrade server to v0.8.13+\".

### \`runUpgrade\` — src/cli.ts

- Replaced \`cargo install iii-engine --force\` with the same installer used in the README, demo command, and docs:

  \`\`\`sh
  curl -fsSL https://install.iii.dev/iii/main/install.sh | sh
  \`\`\`

- Installer marked optional — failure no longer kills the Docker pull that follows. Warn points at \`iiidev/iii:latest\` and GitHub releases as fallbacks.
- Dropped the unused \`cargoBin\` lookup.

## Test plan

- [x] \`npm run build\` — clean
- [x] \`npm test\` — 777 pass
- [ ] Manual: \`agentmemory import-jsonl\` with server stopped → clear \"not running\" error (not JSON parse crash)
- [ ] Manual: \`agentmemory upgrade\` → installer runs, failure degrades gracefully, Docker pull still proceeds

Reported in-session by @rohitg00 testing v0.9.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upgrade flow now uses a network installer script (sh + curl) for broader compatibility.
  * Added a preflight health check before importing data to ensure the service is reachable.

* **Bug Fixes**
  * Improved error handling with clearer guidance for authorization/endpoint issues.
  * Enhanced response parsing to handle empty or non-JSON responses and report HTTP status/snippets.
  * Safer success reporting with defaults when import counts are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->