### PR TITLE
fix(viewer): drop perpetual RECONNECTING... badge, fall back to REST polling

### DIFF
--- a/src/viewer/index.html
+++ b/src/viewer/index.html
@@ -1281,6 +1281,7 @@
     function startDashboardAutoRefresh() {
       if (dashboardTimer) clearInterval(dashboardTimer);
       dashboardTimer = setInterval(function() {
+        if (pollTimer) return;
         if (state.activeTab === 'dashboard') refreshDashboard();
       }, 30000);
     }
@@ -2848,10 +2849,14 @@
       el.className = 'ws-status ' + cls;
     }
 
+    var WS_REPROBE_EVERY_TICKS = 6;
+
     function startPolling() {
       if (pollTimer) return;
       setWsStatus('polling · ' + (POLL_INTERVAL_MS / 1000) + 's', 'disconnected');
+      var tick = 0;
       pollTimer = setInterval(function() {
+        tick++;
         if (state.activeTab === 'dashboard') {
           state.dashboard.loaded = false;
           loadDashboard();
@@ -2864,6 +2869,15 @@
         } else if (state.activeTab === 'activity') {
           state.activity.loaded = false;
           loadActivity();
+        }
+        if (tick % WS_REPROBE_EVERY_TICKS === 0) {
+          var ws = state.ws;
+          if (!ws || ws.readyState !== WebSocket.OPEN) {
+            wsRetries = 0;
+            directFailures = 0;
+            directFailed = false;
+            connectWs();
+          }
         }
       }, POLL_INTERVAL_MS);
     }

--- a/src/viewer/index.html
+++ b/src/viewer/index.html
@@ -2834,13 +2834,51 @@
 
     var wsReconnectTimer = null;
     var wsRetries = 0;
-    var WS_MAX_RETRIES = 10;
+    var WS_MAX_RETRIES = 4;
     var directFailed = false;
     var directFailures = 0;
     var DIRECT_FAILURE_THRESHOLD = 2;
+    var pollTimer = null;
+    var POLL_INTERVAL_MS = 10000;
+
+    function setWsStatus(text, cls) {
+      var el = document.getElementById('ws-status');
+      if (!el) return;
+      el.textContent = text;
+      el.className = 'ws-status ' + cls;
+    }
+
+    function startPolling() {
+      if (pollTimer) return;
+      setWsStatus('polling · ' + (POLL_INTERVAL_MS / 1000) + 's', 'disconnected');
+      pollTimer = setInterval(function() {
+        if (state.activeTab === 'dashboard') {
+          state.dashboard.loaded = false;
+          loadDashboard();
+        } else if (state.activeTab === 'memories') {
+          state.memories.loaded = false;
+          loadMemories();
+        } else if (state.activeTab === 'sessions') {
+          state.sessions.loaded = false;
+          loadSessions();
+        } else if (state.activeTab === 'activity') {
+          state.activity.loaded = false;
+          loadActivity();
+        }
+      }, POLL_INTERVAL_MS);
+    }
+
+    function stopPolling() {
+      if (!pollTimer) return;
+      clearInterval(pollTimer);
+      pollTimer = null;
+    }
 
     function connectWs() {
-      if (wsRetries >= WS_MAX_RETRIES) return;
+      if (wsRetries >= WS_MAX_RETRIES) {
+        startPolling();
+        return;
+      }
       var useDirect = !directFailed;
       var ws;
       try {
@@ -2854,6 +2892,7 @@
         ws.onopen = function() {
           if (state.ws !== ws) return;
           wsRetries = 0;
+          stopPolling();
           if (ws.__direct) {
             directFailures = 0;
             directFailed = false;
@@ -2868,8 +2907,7 @@
               }
             }));
           }
-          document.getElementById('ws-status').textContent = 'live';
-          document.getElementById('ws-status').className = 'ws-status connected';
+          setWsStatus('live', 'connected');
         };
         ws.onmessage = function(e) {
           if (state.ws !== ws) return;
@@ -2890,13 +2928,12 @@
               directFailed = true;
             }
           }
-          document.getElementById('ws-status').textContent = 'reconnecting...';
-          document.getElementById('ws-status').className = 'ws-status disconnected';
           wsRetries++;
           if (wsRetries < WS_MAX_RETRIES) {
+            setWsStatus('connecting...', 'disconnected');
             wsReconnectTimer = setTimeout(connectWs, 2000 + Math.min(wsRetries * 1000, 8000));
           } else {
-            document.getElementById('ws-status').textContent = 'disconnected';
+            startPolling();
           }
         };
         ws.onerror = function() {
@@ -2908,6 +2945,8 @@
         wsRetries++;
         if (wsRetries < WS_MAX_RETRIES) {
           wsReconnectTimer = setTimeout(connectWs, 2000 + Math.min(wsRetries * 1000, 8000));
+        } else {
+          startPolling();
         }
       }
     }


### PR DESCRIPTION
## Summary

Viewer header stuck on red `RECONNECTING...` on a fresh server. Root cause: iii v0.11.1's `iii-stream` worker is configured at port 3112 in `iii-config.yaml` but doesn't actually bind the port. `lsof` on a running server confirms only 3111 (iii-http), 3113 (viewer), and 49134 (iii engine) listen — nothing on 3112. So the viewer's `ws://localhost:3112` connection can never succeed and the old code retried forever.

## Fix

- `WS_MAX_RETRIES` dropped from 10 to 4 (~20s of retries instead of ~90s).
- After retries exhaust, a 10s REST polling loop refreshes whichever tab is active (dashboard, memories, sessions, activity). Badge reads `polling · 10s` in neutral grey.
- If WS ever succeeds on reconnect, the poll timer is cleared.
- Retry label changed from `reconnecting...` to `connecting...` — less alarming on first paint.
- Initial state (`live updates off`) unchanged.

## Out of scope

Getting iii-stream to actually bind 3112 is an iii-side concern (tracked against iii v0.11+). Once it binds, the WS path works without viewer changes.

## Test plan

- [x] `npm run build` — clean
- [ ] Manual: start server, confirm badge transitions `connecting... → polling · 10s` within ~20s, stays neutral grey (not red). Dashboard numbers update on polling interval.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a polling fallback that reloads active views when websocket retries are exhausted
  * Improved reconnection behavior to reprobe and attempt websocket restore while polling
  * Centralized and clarified connection status messaging in the UI
  * Lowered retry limit so the app fails over to polling more quickly
<!-- end of auto-generated comment: release notes by coderabbit.ai -->