### PR TITLE
feat(multimodal): Phase 1 — CLIP visual embeddings + vision-search

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 <p align="center">
   <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-recall.svg"><img src="assets/tags/stat-recall.svg" alt="95.2% retrieval R@5" height="38" /></picture>
   <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-tokens.svg"><img src="assets/tags/stat-tokens.svg" alt="92% fewer tokens" height="38" /></picture>
-  <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-tools.svg"><img src="assets/tags/stat-tools.svg" alt="44 MCP tools" height="38" /></picture>
+  <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-tools.svg"><img src="assets/tags/stat-tools.svg" alt="45 MCP tools" height="38" /></picture>
   <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-hooks.svg"><img src="assets/tags/stat-hooks.svg" alt="12 auto hooks" height="38" /></picture>
   <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-deps.svg"><img src="assets/tags/stat-deps.svg" alt="0 external DBs" height="38" /></picture>
   <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-tests.svg"><img src="assets/tags/stat-tests.svg" alt="654 tests passing" height="38" /></picture>
@@ -334,7 +334,7 @@ Implementation details live in `src/cli.ts` (see `runUpgrade` around the `src/cl
 ### Claude Code (one block, paste it)
 
 ```
-Install agentmemory: run `npx @agentmemory/agentmemory` in a separate terminal to start the memory server. Then run `/plugin marketplace add rohitg00/agentmemory` and `/plugin install agentmemory` — the plugin registers all 12 hooks, 4 skills, AND auto-wires the `@agentmemory/mcp` stdio server via its `.mcp.json`, so you get 44 MCP tools (memory_smart_search, memory_save, memory_sessions, memory_governance_delete, etc.) without any extra config step. Verify with `curl http://localhost:3111/agentmemory/health`. The real-time viewer is at http://localhost:3113.
+Install agentmemory: run `npx @agentmemory/agentmemory` in a separate terminal to start the memory server. Then run `/plugin marketplace add rohitg00/agentmemory` and `/plugin install agentmemory` — the plugin registers all 12 hooks, 4 skills, AND auto-wires the `@agentmemory/mcp` stdio server via its `.mcp.json`, so you get 45 MCP tools (memory_smart_search, memory_save, memory_sessions, memory_governance_delete, etc.) without any extra config step. Verify with `curl http://localhost:3111/agentmemory/health`. The real-time viewer is at http://localhost:3113.
 ```
 
 <details>
@@ -593,7 +593,7 @@ npm install @xenova/transformers
 
 <h2 id="mcp-server"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/section-mcp.svg"><img src="assets/tags/section-mcp.svg" alt="MCP Server" height="32" /></picture></h2>
 
-44 tools, 6 resources, 3 prompts, and 4 skills — the most comprehensive MCP memory toolkit for any agent.
+45 tools, 6 resources, 3 prompts, and 4 skills — the most comprehensive MCP memory toolkit for any agent.
 
 ### 44 Tools
 
@@ -843,7 +843,7 @@ Create `~/.agentmemory/.env`:
 # USER_ID=
 # TEAM_MODE=private
 
-# Tool visibility: "core" (8 tools) or "all" (44 tools)
+# Tool visibility: "core" (8 tools) or "all" (45 tools)
 # AGENTMEMORY_TOOLS=core
 ```
 

--- a/README.md
+++ b/README.md
@@ -816,6 +816,17 @@ Create `~/.agentmemory/.env`:
                                    # LLM provider to compress the
                                    # observation — expect significant
                                    # token spend on active sessions.
+# AGENTMEMORY_IMAGE_EMBEDDINGS=false # OFF by default. When on, loads
+                                   # CLIP ViT-B/32 (512d) via
+                                   # @xenova/transformers and embeds
+                                   # every captured screenshot into
+                                   # mem:image-embeddings. Enables
+                                   # memory_vision_search (cross-modal:
+                                   # text→image or image→image cosine).
+                                   # Model downloads (~350 MB) on first
+                                   # use — lazy. Observe pipeline fires
+                                   # mem::vision-embed via triggerVoid,
+                                   # so capture latency is unchanged.
 # AGENTMEMORY_INJECT_CONTEXT=false # OFF by default (#143). When on:
                                    # - SessionStart may inject ~1-2K
                                    #   chars of project context into

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agentmemory",
   "version": "0.9.1",
-  "description": "Persistent memory for AI coding agents -- captures tool usage, compresses via LLM, injects context into future sessions. 12 hooks, 44 MCP tools, 4 skills, real-time viewer.",
+  "description": "Persistent memory for AI coding agents -- captures tool usage, compresses via LLM, injects context into future sessions. 12 hooks, 45 MCP tools, 4 skills, real-time viewer.",
   "author": {
     "name": "Rohit Ghumare",
     "url": "https://github.com/rohitg00"

--- a/src/functions/image-refs.ts
+++ b/src/functions/image-refs.ts
@@ -22,6 +22,7 @@ export async function decrementImageRef(kv: StateKV, sdk: ISdk, filePath: string
     const current = await getImageRefCount(kv, filePath);
     if (current <= 1) {
       await kv.delete(KV.imageRefs, filePath);
+      await kv.delete(KV.imageEmbeddings, filePath).catch(() => {});
       const { deletedBytes } = await deleteImage(filePath);
       if (deletedBytes > 0) {
         sdk.triggerVoid("mem::disk-size-delta", { deltaBytes: -deletedBytes });

--- a/src/functions/image-refs.ts
+++ b/src/functions/image-refs.ts
@@ -21,8 +21,8 @@ export async function decrementImageRef(kv: StateKV, sdk: ISdk, filePath: string
   return withKeyedLock(`imgRef:${filePath}`, async () => {
     const current = await getImageRefCount(kv, filePath);
     if (current <= 1) {
+      await kv.delete(KV.imageEmbeddings, filePath);
       await kv.delete(KV.imageRefs, filePath);
-      await kv.delete(KV.imageEmbeddings, filePath).catch(() => {});
       const { deletedBytes } = await deleteImage(filePath);
       if (deletedBytes > 0) {
         sdk.triggerVoid("mem::disk-size-delta", { deltaBytes: -deletedBytes });

--- a/src/functions/observe.ts
+++ b/src/functions/observe.ts
@@ -140,6 +140,13 @@ export function registerObserveFunction(
           const { incrementImageRef } = await import("./image-refs.js");
           await incrementImageRef(kv, filePath);
           sdk.triggerVoid("mem::disk-size-delta", { deltaBytes: bytesWritten });
+          if (process.env["AGENTMEMORY_IMAGE_EMBEDDINGS"] === "true") {
+            sdk.triggerVoid("mem::vision-embed", {
+              imageRef: filePath,
+              sessionId: payload.sessionId,
+              observationId: obsId,
+            });
+          }
         }
 
         try {

--- a/src/functions/vision-search.ts
+++ b/src/functions/vision-search.ts
@@ -1,0 +1,117 @@
+import type { ISdk } from "iii-sdk";
+import type { EmbeddingProvider } from "../types.js";
+import { KV } from "../state/schema.js";
+import { StateKV } from "../state/kv.js";
+import { logger } from "../logger.js";
+
+interface StoredEmbedding {
+  imageRef: string;
+  vector: number[];
+  modelName: string;
+  dimensions: number;
+  updatedAt: string;
+  sessionId?: string;
+  observationId?: string;
+}
+
+export function registerVisionSearchFunctions(
+  sdk: ISdk,
+  kv: StateKV,
+  imageProvider: EmbeddingProvider | null,
+): void {
+  sdk.registerFunction(
+    "mem::vision-embed",
+    async (data: {
+      imageRef: string;
+      sessionId?: string;
+      observationId?: string;
+    }) => {
+      if (!imageProvider?.embedImage) {
+        return { success: false, error: "image embeddings disabled (set AGENTMEMORY_IMAGE_EMBEDDINGS=true)" };
+      }
+      if (!data?.imageRef || typeof data.imageRef !== "string") {
+        return { success: false, error: "imageRef required" };
+      }
+      try {
+        const vec = await imageProvider.embedImage(data.imageRef);
+        const stored: StoredEmbedding = {
+          imageRef: data.imageRef,
+          vector: Array.from(vec),
+          modelName: imageProvider.name,
+          dimensions: imageProvider.dimensions,
+          updatedAt: new Date().toISOString(),
+          sessionId: data.sessionId,
+          observationId: data.observationId,
+        };
+        await kv.set(KV.imageEmbeddings, data.imageRef, stored);
+        return { success: true, imageRef: data.imageRef, dimensions: stored.dimensions };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        logger.warn("vision-embed failed", { imageRef: data.imageRef, error: msg });
+        return { success: false, error: msg };
+      }
+    },
+  );
+
+  sdk.registerFunction(
+    "mem::vision-search",
+    async (data: {
+      queryText?: string;
+      queryImageRef?: string;
+      queryImageBase64?: string;
+      topK?: number;
+      sessionId?: string;
+    }) => {
+      if (!imageProvider?.embedImage) {
+        return { success: false, error: "image embeddings disabled (set AGENTMEMORY_IMAGE_EMBEDDINGS=true)" };
+      }
+      const topK = Math.min(50, Math.max(1, data?.topK ?? 10));
+
+      let queryVec: Float32Array | null = null;
+      try {
+        if (data?.queryText) {
+          queryVec = await imageProvider.embed(data.queryText);
+        } else if (data?.queryImageBase64 || data?.queryImageRef) {
+          const src = data.queryImageBase64 || (data.queryImageRef as string);
+          queryVec = await imageProvider.embedImage(src);
+        } else {
+          return { success: false, error: "queryText, queryImageRef, or queryImageBase64 required" };
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return { success: false, error: `query embed failed: ${msg}` };
+      }
+
+      if (!queryVec) return { success: false, error: "failed to build query vector" };
+
+      const stored = await kv.list<StoredEmbedding>(KV.imageEmbeddings);
+      const filtered = data?.sessionId
+        ? stored.filter((s) => s.sessionId === data.sessionId)
+        : stored;
+
+      const scored = filtered.map((s) => ({
+        imageRef: s.imageRef,
+        score: cosine(queryVec!, s.vector),
+        sessionId: s.sessionId,
+        observationId: s.observationId,
+        updatedAt: s.updatedAt,
+      }));
+      scored.sort((a, b) => b.score - a.score);
+      return { success: true, results: scored.slice(0, topK), total: scored.length };
+    },
+  );
+}
+
+function cosine(a: Float32Array, b: number[]): number {
+  if (a.length !== b.length) return 0;
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+  const denom = Math.sqrt(normA) * Math.sqrt(normB);
+  return denom === 0 ? 0 : dot / denom;
+}

--- a/src/functions/vision-search.ts
+++ b/src/functions/vision-search.ts
@@ -2,6 +2,7 @@ import type { ISdk } from "iii-sdk";
 import type { EmbeddingProvider } from "../types.js";
 import { KV } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
+import { recordAudit } from "./audit.js";
 import { logger } from "../logger.js";
 
 interface StoredEmbedding {
@@ -44,6 +45,12 @@ export function registerVisionSearchFunctions(
           observationId: data.observationId,
         };
         await kv.set(KV.imageEmbeddings, data.imageRef, stored);
+        await recordAudit(kv, "vision_embed", "mem::vision-embed", [data.imageRef], {
+          modelName: imageProvider.name,
+          dimensions: stored.dimensions,
+          sessionId: data.sessionId,
+          observationId: data.observationId,
+        });
         return { success: true, imageRef: data.imageRef, dimensions: stored.dimensions };
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
@@ -71,9 +78,13 @@ export function registerVisionSearchFunctions(
       try {
         if (data?.queryText) {
           queryVec = await imageProvider.embed(data.queryText);
-        } else if (data?.queryImageBase64 || data?.queryImageRef) {
-          const src = data.queryImageBase64 || (data.queryImageRef as string);
-          queryVec = await imageProvider.embedImage(src);
+        } else if (data?.queryImageBase64) {
+          const b64 = data.queryImageBase64.startsWith("data:")
+            ? data.queryImageBase64
+            : `data:image/png;base64,${data.queryImageBase64}`;
+          queryVec = await imageProvider.embedImage(b64);
+        } else if (data?.queryImageRef) {
+          queryVec = await imageProvider.embedImage(data.queryImageRef);
         } else {
           return { success: false, error: "queryText, queryImageRef, or queryImageBase64 required" };
         }

--- a/src/functions/vision-search.ts
+++ b/src/functions/vision-search.ts
@@ -2,6 +2,7 @@ import type { ISdk } from "iii-sdk";
 import type { EmbeddingProvider } from "../types.js";
 import { KV } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
+import { isManagedImagePath } from "../utils/image-store.js";
 import { recordAudit } from "./audit.js";
 import { logger } from "../logger.js";
 
@@ -32,6 +33,13 @@ export function registerVisionSearchFunctions(
       }
       if (!data?.imageRef || typeof data.imageRef !== "string") {
         return { success: false, error: "imageRef required" };
+      }
+      if (!isManagedImagePath(data.imageRef)) {
+        return { success: false, error: "imageRef must point to a file under the managed image store" };
+      }
+      const refCount = await kv.get<number>(KV.imageRefs, data.imageRef);
+      if (!refCount || Number(refCount) < 1) {
+        return { success: false, error: "imageRef not registered in mem:image-refs" };
       }
       try {
         const vec = await imageProvider.embedImage(data.imageRef);
@@ -72,7 +80,11 @@ export function registerVisionSearchFunctions(
       if (!imageProvider?.embedImage) {
         return { success: false, error: "image embeddings disabled (set AGENTMEMORY_IMAGE_EMBEDDINGS=true)" };
       }
-      const topK = Math.min(50, Math.max(1, data?.topK ?? 10));
+      const requestedTopK =
+        typeof data?.topK === "number" && Number.isFinite(data.topK)
+          ? Math.trunc(data.topK)
+          : 10;
+      const topK = Math.min(50, Math.max(1, requestedTopK));
 
       let queryVec: Float32Array | null = null;
       try {
@@ -84,6 +96,13 @@ export function registerVisionSearchFunctions(
             : `data:image/png;base64,${data.queryImageBase64}`;
           queryVec = await imageProvider.embedImage(b64);
         } else if (data?.queryImageRef) {
+          if (!isManagedImagePath(data.queryImageRef)) {
+            return { success: false, error: "queryImageRef must point to a file under the managed image store" };
+          }
+          const refCount = await kv.get<number>(KV.imageRefs, data.queryImageRef);
+          if (!refCount || Number(refCount) < 1) {
+            return { success: false, error: "queryImageRef not registered in mem:image-refs" };
+          }
           queryVec = await imageProvider.embedImage(data.queryImageRef);
         } else {
           return { success: false, error: "queryText, queryImageRef, or queryImageBase64 required" };

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import {
   createProvider,
   createFallbackProvider,
   createEmbeddingProvider,
+  createImageEmbeddingProvider,
 } from "./providers/index.js";
 import { StateKV } from "./state/kv.js";
 import { VectorIndex } from "./state/vector-index.js";
@@ -24,6 +25,7 @@ import { IndexPersistence } from "./state/index-persistence.js";
 import { registerPrivacyFunction } from "./functions/privacy.js";
 import { registerObserveFunction } from "./functions/observe.js";
 import { registerImageQuotaCleanup } from "./functions/image-quota-cleanup.js";
+import { registerVisionSearchFunctions } from "./functions/vision-search.js";
 import { registerDiskSizeManager } from "./functions/disk-size-manager.js";
 import { registerCompressFunction } from "./functions/compress.js";
 import {
@@ -111,6 +113,7 @@ async function main() {
       : createProvider(config.provider);
 
   const embeddingProvider = createEmbeddingProvider();
+  const imageEmbeddingProvider = createImageEmbeddingProvider();
 
   console.log(`[agentmemory] Starting worker v${VERSION}...`);
   console.log(`[agentmemory] Engine: ${config.engineUrl}`);
@@ -123,6 +126,11 @@ async function main() {
     );
   } else {
     console.log(`[agentmemory] Embedding provider: none (BM25-only mode)`);
+  }
+  if (imageEmbeddingProvider) {
+    console.log(
+      `[agentmemory] Image embedding provider: ${imageEmbeddingProvider.name} (${imageEmbeddingProvider.dimensions} dims) — vision-search active`,
+    );
   }
   console.log(
     `[agentmemory] REST API: http://localhost:${config.restPort}/agentmemory/*`,
@@ -154,6 +162,7 @@ async function main() {
   registerPrivacyFunction(sdk);
   registerObserveFunction(sdk, kv, dedupMap, config.maxObservationsPerSession);
   registerImageQuotaCleanup(sdk, kv);
+  registerVisionSearchFunctions(sdk, kv, imageEmbeddingProvider);
   registerDiskSizeManager(sdk, kv);
   registerCompressFunction(sdk, kv, provider, metricsStore);
   registerSearchFunction(sdk, kv);

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -275,6 +275,32 @@ export function registerMcpEndpoints(
             };
           }
 
+          case "memory_vision_search": {
+            const queryText = typeof args.queryText === "string" ? args.queryText : undefined;
+            const queryImageRef = typeof args.queryImageRef === "string" ? args.queryImageRef : undefined;
+            const queryImageBase64 = typeof args.queryImageBase64 === "string" ? args.queryImageBase64 : undefined;
+            if (!queryText && !queryImageRef && !queryImageBase64) {
+              return {
+                status_code: 400,
+                body: { error: "queryText, queryImageRef, or queryImageBase64 required" },
+              };
+            }
+            const topK = Math.max(1, Math.min(50, asNumber(args.topK, 10) ?? 10));
+            const sessionId = typeof args.sessionId === "string" ? args.sessionId : undefined;
+            const result = await sdk.trigger({
+              function_id: "mem::vision-search",
+              payload: { queryText, queryImageRef, queryImageBase64, topK, sessionId },
+            });
+            return {
+              status_code: 200,
+              body: {
+                content: [
+                  { type: "text", text: JSON.stringify(result, null, 2) },
+                ],
+              },
+            };
+          }
+
           case "memory_timeline": {
             if (typeof args.anchor !== "string" || !args.anchor.trim()) {
               return {

--- a/src/mcp/tools-registry.ts
+++ b/src/mcp/tools-registry.ts
@@ -127,6 +127,21 @@ export const CORE_TOOLS: McpToolDef[] = [
     },
   },
   {
+    name: "memory_vision_search",
+    description:
+      "Cross-modal image search via CLIP embeddings. Pass queryText to find screenshots matching a description, or queryImageBase64/queryImageRef to find similar images. Requires AGENTMEMORY_IMAGE_EMBEDDINGS=true.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        queryText: { type: "string", description: "Text query (e.g. 'login form with error banner')" },
+        queryImageRef: { type: "string", description: "Absolute path to a stored image to match against" },
+        queryImageBase64: { type: "string", description: "Raw base64 image bytes or data URL" },
+        topK: { type: "number", description: "Max results (default 10, max 50)" },
+        sessionId: { type: "string", description: "Filter to a single session" },
+      },
+    },
+  },
+  {
     name: "memory_timeline",
     description: "Chronological observations around an anchor point.",
     inputSchema: {

--- a/src/providers/embedding/clip.ts
+++ b/src/providers/embedding/clip.ts
@@ -1,0 +1,114 @@
+import { readFile } from "node:fs/promises";
+import type { EmbeddingProvider } from "../../types.js";
+
+type TransformersModule = {
+  pipeline: (
+    task: string,
+    model: string,
+  ) => Promise<ClipPipeline>;
+  RawImage: {
+    read: (src: string | Blob | Buffer) => Promise<RawImageInstance>;
+    fromBlob: (blob: Blob) => Promise<RawImageInstance>;
+  };
+};
+
+type RawImageInstance = unknown;
+
+type ClipPipeline = (
+  input: string[] | RawImageInstance | RawImageInstance[],
+  options?: { pooling?: string; normalize?: boolean },
+) => Promise<{ tolist: () => number[][]; data: Float32Array }>;
+
+const DEFAULT_MODEL = "Xenova/clip-vit-base-patch32";
+const DIMENSIONS = 512;
+
+export class ClipEmbeddingProvider implements EmbeddingProvider {
+  readonly name = "clip";
+  readonly dimensions = DIMENSIONS;
+  private textExtractor: ClipPipeline | null = null;
+  private imageExtractor: ClipPipeline | null = null;
+  private transformers: TransformersModule | null = null;
+  private readonly modelId: string;
+
+  constructor(modelId: string = DEFAULT_MODEL) {
+    this.modelId = modelId;
+  }
+
+  async embed(text: string): Promise<Float32Array> {
+    const [vec] = await this.embedBatch([text]);
+    return vec;
+  }
+
+  async embedBatch(texts: string[]): Promise<Float32Array[]> {
+    const extractor = await this.getTextExtractor();
+    const output = await extractor(texts, { pooling: "mean", normalize: true });
+    return output.tolist().map((v) => new Float32Array(v));
+  }
+
+  async embedImage(imageBase64OrPath: string): Promise<Float32Array> {
+    const t = await this.getTransformers();
+    const image = await loadImage(t, imageBase64OrPath);
+    const extractor = await this.getImageExtractor();
+    const output = await extractor(image);
+    const raw = output.data ?? new Float32Array(output.tolist()[0] || []);
+    const vec = new Float32Array(raw);
+    return normalize(vec);
+  }
+
+  private async getTransformers(): Promise<TransformersModule> {
+    if (this.transformers) return this.transformers;
+    try {
+      this.transformers = (await import("@xenova/transformers")) as unknown as TransformersModule;
+    } catch {
+      throw new Error(
+        "Install @xenova/transformers for CLIP image embeddings: npm install @xenova/transformers",
+      );
+    }
+    return this.transformers;
+  }
+
+  private async getTextExtractor(): Promise<ClipPipeline> {
+    if (this.textExtractor) return this.textExtractor;
+    const t = await this.getTransformers();
+    this.textExtractor = await t.pipeline("feature-extraction", this.modelId);
+    return this.textExtractor;
+  }
+
+  private async getImageExtractor(): Promise<ClipPipeline> {
+    if (this.imageExtractor) return this.imageExtractor;
+    const t = await this.getTransformers();
+    this.imageExtractor = await t.pipeline("image-feature-extraction", this.modelId);
+    return this.imageExtractor;
+  }
+}
+
+async function loadImage(
+  t: TransformersModule,
+  src: string,
+): Promise<RawImageInstance> {
+  if (src.startsWith("data:")) {
+    const comma = src.indexOf(",");
+    const b64 = comma >= 0 ? src.slice(comma + 1) : src;
+    const buf = Buffer.from(b64, "base64");
+    const blob = new Blob([buf]);
+    return t.RawImage.fromBlob(blob);
+  }
+  if (/^[A-Za-z0-9+/=]+$/.test(src.slice(0, 64)) && !src.includes("/")) {
+    const buf = Buffer.from(src, "base64");
+    const blob = new Blob([buf]);
+    return t.RawImage.fromBlob(blob);
+  }
+  const data = await readFile(src);
+  const blob = new Blob([data]);
+  return t.RawImage.fromBlob(blob);
+}
+
+function normalize(vec: Float32Array): Float32Array {
+  let sum = 0;
+  for (let i = 0; i < vec.length; i++) sum += vec[i] * vec[i];
+  const norm = Math.sqrt(sum);
+  if (norm === 0) return vec;
+  const out = new Float32Array(vec.length);
+  for (let i = 0; i < vec.length; i++) out[i] = vec[i] / norm;
+  return out;
+}

--- a/src/providers/embedding/clip.ts
+++ b/src/providers/embedding/clip.ts
@@ -7,7 +7,6 @@ type TransformersModule = {
     model: string,
   ) => Promise<ClipPipeline>;
   RawImage: {
-    read: (src: string | Blob | Buffer) => Promise<RawImageInstance>;
     fromBlob: (blob: Blob) => Promise<RawImageInstance>;
   };
 };
@@ -45,13 +44,12 @@ export class ClipEmbeddingProvider implements EmbeddingProvider {
     return output.tolist().map((v) => new Float32Array(v));
   }
 
-  async embedImage(imageBase64OrPath: string): Promise<Float32Array> {
+  async embedImage(src: string): Promise<Float32Array> {
     const t = await this.getTransformers();
-    const image = await loadImage(t, imageBase64OrPath);
+    const image = await loadImage(t, src);
     const extractor = await this.getImageExtractor();
     const output = await extractor(image);
-    const raw = output.data ?? new Float32Array(output.tolist()[0] || []);
-    const vec = new Float32Array(raw);
+    const vec = output.data ?? new Float32Array(output.tolist()[0] || []);
     return normalize(vec);
   }
 
@@ -90,11 +88,6 @@ async function loadImage(
     const comma = src.indexOf(",");
     const b64 = comma >= 0 ? src.slice(comma + 1) : src;
     const buf = Buffer.from(b64, "base64");
-    const blob = new Blob([buf]);
-    return t.RawImage.fromBlob(blob);
-  }
-  if (/^[A-Za-z0-9+/=]+$/.test(src.slice(0, 64)) && !src.includes("/")) {
-    const buf = Buffer.from(src, "base64");
     const blob = new Blob([buf]);
     return t.RawImage.fromBlob(blob);
   }

--- a/src/providers/embedding/index.ts
+++ b/src/providers/embedding/index.ts
@@ -6,6 +6,7 @@ import { VoyageEmbeddingProvider } from "./voyage.js";
 import { CohereEmbeddingProvider } from "./cohere.js";
 import { OpenRouterEmbeddingProvider } from "./openrouter.js";
 import { LocalEmbeddingProvider } from "./local.js";
+import { ClipEmbeddingProvider } from "./clip.js";
 
 export {
   GeminiEmbeddingProvider,
@@ -14,7 +15,17 @@ export {
   CohereEmbeddingProvider,
   OpenRouterEmbeddingProvider,
   LocalEmbeddingProvider,
+  ClipEmbeddingProvider,
 };
+
+let imageEmbeddingProvider: EmbeddingProvider | null = null;
+
+export function createImageEmbeddingProvider(): EmbeddingProvider | null {
+  if (process.env["AGENTMEMORY_IMAGE_EMBEDDINGS"] !== "true") return null;
+  if (imageEmbeddingProvider) return imageEmbeddingProvider;
+  imageEmbeddingProvider = new ClipEmbeddingProvider();
+  return imageEmbeddingProvider;
+}
 
 export function createEmbeddingProvider(): EmbeddingProvider | null {
   const detected = detectEmbeddingProvider();

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -11,7 +11,7 @@ import { ResilientProvider } from "./resilient.js";
 import { FallbackChainProvider } from "./fallback-chain.js";
 import { getEnvVar } from "../config.js";
 
-export { createEmbeddingProvider } from "./embedding/index.js";
+export { createEmbeddingProvider, createImageEmbeddingProvider } from "./embedding/index.js";
 
 function requireEnvVar(key: string): string {
   const value = getEnvVar(key);

--- a/src/state/schema.ts
+++ b/src/state/schema.ts
@@ -42,6 +42,7 @@ export const KV = {
   retentionScores: "mem:retention",
   accessLog: "mem:access",
   imageRefs: "mem:image-refs",
+  imageEmbeddings: "mem:image-embeddings",
 } as const;
 
 export const STREAM = {

--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -1279,6 +1279,69 @@ export function registerApiTriggers(
     config: { api_path: "/agentmemory/relations", http_method: "GET" },
   });
 
+  sdk.registerFunction("api::vision-search",
+    async (
+      req: ApiRequest<{
+        queryText?: string;
+        queryImageRef?: string;
+        queryImageBase64?: string;
+        topK?: number;
+        sessionId?: string;
+      }>,
+    ): Promise<Response> => {
+      const authErr = checkAuth(req, secret);
+      if (authErr) return authErr;
+      if (
+        !req.body?.queryText &&
+        !req.body?.queryImageRef &&
+        !req.body?.queryImageBase64
+      ) {
+        return {
+          status_code: 400,
+          body: { error: "queryText, queryImageRef, or queryImageBase64 required" },
+        };
+      }
+      const result = await sdk.trigger({ function_id: "mem::vision-search", payload: req.body });
+      const body = result as { success?: boolean; error?: string };
+      if (body?.success === false) {
+        return { status_code: body.error?.includes("disabled") ? 503 : 400, body };
+      }
+      return { status_code: 200, body: result };
+    },
+  );
+  sdk.registerTrigger({
+    type: "http",
+    function_id: "api::vision-search",
+    config: { api_path: "/agentmemory/vision-search", http_method: "POST" },
+  });
+
+  sdk.registerFunction("api::vision-embed",
+    async (
+      req: ApiRequest<{
+        imageRef: string;
+        sessionId?: string;
+        observationId?: string;
+      }>,
+    ): Promise<Response> => {
+      const authErr = checkAuth(req, secret);
+      if (authErr) return authErr;
+      if (!req.body?.imageRef) {
+        return { status_code: 400, body: { error: "imageRef is required" } };
+      }
+      const result = await sdk.trigger({ function_id: "mem::vision-embed", payload: req.body });
+      const body = result as { success?: boolean; error?: string };
+      if (body?.success === false) {
+        return { status_code: body.error?.includes("disabled") ? 503 : 400, body };
+      }
+      return { status_code: 200, body: result };
+    },
+  );
+  sdk.registerTrigger({
+    type: "http",
+    function_id: "api::vision-embed",
+    config: { api_path: "/agentmemory/vision-embed", http_method: "POST" },
+  });
+
   sdk.registerFunction("api::action-create",
     async (
       req: ApiRequest<{

--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -1280,31 +1280,34 @@ export function registerApiTriggers(
   });
 
   sdk.registerFunction("api::vision-search",
-    async (
-      req: ApiRequest<{
-        queryText?: string;
-        queryImageRef?: string;
-        queryImageBase64?: string;
-        topK?: number;
-        sessionId?: string;
-      }>,
-    ): Promise<Response> => {
+    async (req: ApiRequest): Promise<Response> => {
       const authErr = checkAuth(req, secret);
       if (authErr) return authErr;
-      if (
-        !req.body?.queryText &&
-        !req.body?.queryImageRef &&
-        !req.body?.queryImageBase64
-      ) {
+      const body = (req.body ?? {}) as Record<string, unknown>;
+      const queryText = asNonEmptyString(body["queryText"]);
+      const queryImageRef = asNonEmptyString(body["queryImageRef"]);
+      const queryImageBase64 = asNonEmptyString(body["queryImageBase64"]);
+      const sessionId = asNonEmptyString(body["sessionId"]);
+      if (!queryText && !queryImageRef && !queryImageBase64) {
         return {
           status_code: 400,
           body: { error: "queryText, queryImageRef, or queryImageBase64 required" },
         };
       }
-      const result = await sdk.trigger({ function_id: "mem::vision-search", payload: req.body });
-      const body = result as { success?: boolean; error?: string };
-      if (body?.success === false) {
-        return { status_code: body.error?.includes("disabled") ? 503 : 400, body };
+      const topKParsed = parseOptionalPositiveInt(body["topK"]);
+      if (topKParsed === null) {
+        return { status_code: 400, body: { error: "topK must be a positive integer" } };
+      }
+      const payload: Record<string, unknown> = {};
+      if (queryText) payload["queryText"] = queryText;
+      if (queryImageRef) payload["queryImageRef"] = queryImageRef;
+      if (queryImageBase64) payload["queryImageBase64"] = queryImageBase64;
+      if (sessionId) payload["sessionId"] = sessionId;
+      if (topKParsed !== undefined) payload["topK"] = Math.min(50, topKParsed);
+      const result = await sdk.trigger({ function_id: "mem::vision-search", payload });
+      const resp = result as { success?: boolean; error?: string };
+      if (resp?.success === false) {
+        return { status_code: resp.error?.includes("disabled") ? 503 : 400, body: resp };
       }
       return { status_code: 200, body: result };
     },
@@ -1316,22 +1319,23 @@ export function registerApiTriggers(
   });
 
   sdk.registerFunction("api::vision-embed",
-    async (
-      req: ApiRequest<{
-        imageRef: string;
-        sessionId?: string;
-        observationId?: string;
-      }>,
-    ): Promise<Response> => {
+    async (req: ApiRequest): Promise<Response> => {
       const authErr = checkAuth(req, secret);
       if (authErr) return authErr;
-      if (!req.body?.imageRef) {
+      const body = (req.body ?? {}) as Record<string, unknown>;
+      const imageRef = asNonEmptyString(body["imageRef"]);
+      const sessionId = asNonEmptyString(body["sessionId"]);
+      const observationId = asNonEmptyString(body["observationId"]);
+      if (!imageRef) {
         return { status_code: 400, body: { error: "imageRef is required" } };
       }
-      const result = await sdk.trigger({ function_id: "mem::vision-embed", payload: req.body });
-      const body = result as { success?: boolean; error?: string };
-      if (body?.success === false) {
-        return { status_code: body.error?.includes("disabled") ? 503 : 400, body };
+      const payload: Record<string, unknown> = { imageRef };
+      if (sessionId) payload["sessionId"] = sessionId;
+      if (observationId) payload["observationId"] = observationId;
+      const result = await sdk.trigger({ function_id: "mem::vision-embed", payload });
+      const resp = result as { success?: boolean; error?: string };
+      if (resp?.success === false) {
+        return { status_code: resp.error?.includes("disabled") ? 503 : 400, body: resp };
       }
       return { status_code: 200, body: result };
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -208,6 +208,7 @@ export interface EmbeddingProvider {
   dimensions: number;
   embed(text: string): Promise<Float32Array>;
   embedBatch(texts: string[]): Promise<Float32Array[]>;
+  embedImage?(imageBase64OrPath: string): Promise<Float32Array>;
 }
 
 export interface MemoryRelation {

--- a/src/types.ts
+++ b/src/types.ts
@@ -208,7 +208,7 @@ export interface EmbeddingProvider {
   dimensions: number;
   embed(text: string): Promise<Float32Array>;
   embedBatch(texts: string[]): Promise<Float32Array[]>;
-  embedImage?(imageBase64OrPath: string): Promise<Float32Array>;
+  embedImage?(src: string): Promise<Float32Array>;
 }
 
 export interface MemoryRelation {
@@ -502,7 +502,8 @@ export interface AuditEntry {
     | "skill_extract"
     | "core_add"
     | "core_remove"
-    | "auto_page";
+    | "auto_page"
+    | "vision_embed";
   userId?: string;
   functionId: string;
   targetIds: string[];

--- a/test/mcp-standalone.test.ts
+++ b/test/mcp-standalone.test.ts
@@ -46,8 +46,8 @@ describe("Tools Registry", () => {
     }
   });
 
-  it("CORE_TOOLS has 11 items", () => {
-    expect(CORE_TOOLS.length).toBe(11);
+  it("CORE_TOOLS has 12 items", () => {
+    expect(CORE_TOOLS.length).toBe(12);
   });
 
   it("V040_TOOLS has 8 items", () => {

--- a/test/vision-search.test.ts
+++ b/test/vision-search.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { registerVisionSearchFunctions } from "../src/functions/vision-search.js";
+import type { EmbeddingProvider } from "../src/types.js";
+import { KV } from "../src/state/schema.js";
+
+function mockKV() {
+  const store = new Map<string, Map<string, unknown>>();
+  return {
+    get: async <T>(scope: string, key: string): Promise<T | null> => {
+      return (store.get(scope)?.get(key) as T) ?? null;
+    },
+    set: async <T>(scope: string, key: string, data: T): Promise<T> => {
+      if (!store.has(scope)) store.set(scope, new Map());
+      store.get(scope)!.set(key, data);
+      return data;
+    },
+    delete: async (scope: string, key: string): Promise<void> => {
+      store.get(scope)?.delete(key);
+    },
+    list: async <T>(scope: string): Promise<T[]> => {
+      if (!store.has(scope)) return [];
+      return Array.from(store.get(scope)!.values()) as T[];
+    },
+  };
+}
+
+function unit(v: number[]): Float32Array {
+  let norm = 0;
+  for (const x of v) norm += x * x;
+  norm = Math.sqrt(norm);
+  return new Float32Array(v.map((x) => x / (norm || 1)));
+}
+
+describe("vision-search", () => {
+  let visionSearch: (data: Record<string, unknown>) => Promise<Record<string, unknown>>;
+  let visionEmbed: (data: Record<string, unknown>) => Promise<Record<string, unknown>>;
+  let kv: ReturnType<typeof mockKV>;
+
+  const fakeProvider: EmbeddingProvider = {
+    name: "fake-clip",
+    dimensions: 3,
+    embed: async (text: string) => {
+      if (text.includes("login")) return unit([1, 0, 0]);
+      if (text.includes("dashboard")) return unit([0, 1, 0]);
+      return unit([0, 0, 1]);
+    },
+    embedBatch: async (texts: string[]) => Promise.all(texts.map((t) => fakeProvider.embed(t))),
+    embedImage: async (ref: string) => {
+      if (ref.endsWith("login.png")) return unit([1, 0.1, 0]);
+      if (ref.endsWith("dashboard.png")) return unit([0, 1, 0.1]);
+      return unit([0, 0.1, 1]);
+    },
+  };
+
+  beforeEach(() => {
+    kv = mockKV();
+    const handlers: Record<string, (data: Record<string, unknown>) => Promise<Record<string, unknown>>> = {};
+    const sdk = {
+      registerFunction: vi.fn((id: string, cb) => {
+        handlers[id] = cb;
+      }),
+    } as unknown as import("iii-sdk").ISdk;
+    registerVisionSearchFunctions(sdk, kv as never, fakeProvider);
+    visionSearch = handlers["mem::vision-search"]!;
+    visionEmbed = handlers["mem::vision-embed"]!;
+  });
+
+  it("embeds and stores image vectors in KV.imageEmbeddings", async () => {
+    const res = (await visionEmbed({ imageRef: "/tmp/login.png" })) as { success: boolean; dimensions: number };
+    expect(res.success).toBe(true);
+    expect(res.dimensions).toBe(3);
+    const stored = await kv.list(KV.imageEmbeddings);
+    expect(stored.length).toBe(1);
+  });
+
+  it("text query ranks the matching image first", async () => {
+    await visionEmbed({ imageRef: "/tmp/login.png" });
+    await visionEmbed({ imageRef: "/tmp/dashboard.png" });
+    await visionEmbed({ imageRef: "/tmp/other.png" });
+
+    const res = (await visionSearch({ queryText: "the login form", topK: 3 })) as {
+      success: boolean;
+      results: Array<{ imageRef: string; score: number }>;
+    };
+    expect(res.success).toBe(true);
+    expect(res.results[0].imageRef).toBe("/tmp/login.png");
+    expect(res.results[0].score).toBeGreaterThan(res.results[1].score);
+  });
+
+  it("image-to-image query finds the same image first", async () => {
+    await visionEmbed({ imageRef: "/tmp/login.png" });
+    await visionEmbed({ imageRef: "/tmp/dashboard.png" });
+
+    const res = (await visionSearch({ queryImageRef: "/tmp/login.png", topK: 2 })) as {
+      success: boolean;
+      results: Array<{ imageRef: string; score: number }>;
+    };
+    expect(res.results[0].imageRef).toBe("/tmp/login.png");
+    expect(res.results[0].score).toBeGreaterThan(0.9);
+  });
+
+  it("sessionId filters out embeddings from other sessions", async () => {
+    await visionEmbed({ imageRef: "/tmp/login.png", sessionId: "sess_a" });
+    await visionEmbed({ imageRef: "/tmp/dashboard.png", sessionId: "sess_b" });
+
+    const res = (await visionSearch({ queryText: "anything", sessionId: "sess_a", topK: 5 })) as {
+      success: boolean;
+      results: Array<{ sessionId?: string }>;
+    };
+    expect(res.results.every((r) => r.sessionId === "sess_a")).toBe(true);
+    expect(res.results.length).toBe(1);
+  });
+
+  it("returns 503-equivalent error when provider is absent", async () => {
+    const handlers: Record<string, (data: Record<string, unknown>) => Promise<Record<string, unknown>>> = {};
+    const sdk = {
+      registerFunction: vi.fn((id: string, cb) => {
+        handlers[id] = cb;
+      }),
+    } as unknown as import("iii-sdk").ISdk;
+    registerVisionSearchFunctions(sdk, kv as never, null);
+    const res = (await handlers["mem::vision-search"]!({ queryText: "login" })) as {
+      success: boolean;
+      error: string;
+    };
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/disabled/);
+  });
+
+  it("rejects missing query", async () => {
+    const res = (await visionSearch({})) as { success: boolean; error: string };
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/required/);
+  });
+});

--- a/test/vision-search.test.ts
+++ b/test/vision-search.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { registerVisionSearchFunctions } from "../src/functions/vision-search.js";
 import type { EmbeddingProvider } from "../src/types.js";
 import { KV } from "../src/state/schema.js";
+
+const IMAGES_DIR = join(homedir(), ".agentmemory", "images");
+const LOGIN_REF = join(IMAGES_DIR, "login.png");
+const DASH_REF = join(IMAGES_DIR, "dashboard.png");
+const OTHER_REF = join(IMAGES_DIR, "other.png");
 
 function mockKV() {
   const store = new Map<string, Map<string, unknown>>();
@@ -52,6 +59,10 @@ describe("vision-search", () => {
     },
   };
 
+  async function seedRef(ref: string): Promise<void> {
+    await kv.set(KV.imageRefs, ref, 1);
+  }
+
   beforeEach(() => {
     kv = mockKV();
     const handlers: Record<string, (data: Record<string, unknown>) => Promise<Record<string, unknown>>> = {};
@@ -66,42 +77,66 @@ describe("vision-search", () => {
   });
 
   it("embeds and stores image vectors in KV.imageEmbeddings", async () => {
-    const res = (await visionEmbed({ imageRef: "/tmp/login.png" })) as { success: boolean; dimensions: number };
+    await seedRef(LOGIN_REF);
+    const res = (await visionEmbed({ imageRef: LOGIN_REF })) as { success: boolean; dimensions: number };
     expect(res.success).toBe(true);
     expect(res.dimensions).toBe(3);
     const stored = await kv.list(KV.imageEmbeddings);
     expect(stored.length).toBe(1);
   });
 
+  it("rejects imageRef outside the managed image store", async () => {
+    const res = (await visionEmbed({ imageRef: "/etc/passwd" })) as { success: boolean; error: string };
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/managed/);
+  });
+
+  it("rejects imageRef not registered in mem:image-refs", async () => {
+    const res = (await visionEmbed({ imageRef: LOGIN_REF })) as { success: boolean; error: string };
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/not registered/);
+  });
+
   it("text query ranks the matching image first", async () => {
-    await visionEmbed({ imageRef: "/tmp/login.png" });
-    await visionEmbed({ imageRef: "/tmp/dashboard.png" });
-    await visionEmbed({ imageRef: "/tmp/other.png" });
+    for (const r of [LOGIN_REF, DASH_REF, OTHER_REF]) await seedRef(r);
+    await visionEmbed({ imageRef: LOGIN_REF });
+    await visionEmbed({ imageRef: DASH_REF });
+    await visionEmbed({ imageRef: OTHER_REF });
 
     const res = (await visionSearch({ queryText: "the login form", topK: 3 })) as {
       success: boolean;
       results: Array<{ imageRef: string; score: number }>;
     };
     expect(res.success).toBe(true);
-    expect(res.results[0].imageRef).toBe("/tmp/login.png");
+    expect(res.results[0].imageRef).toBe(LOGIN_REF);
     expect(res.results[0].score).toBeGreaterThan(res.results[1].score);
   });
 
   it("image-to-image query finds the same image first", async () => {
-    await visionEmbed({ imageRef: "/tmp/login.png" });
-    await visionEmbed({ imageRef: "/tmp/dashboard.png" });
+    await seedRef(LOGIN_REF);
+    await seedRef(DASH_REF);
+    await visionEmbed({ imageRef: LOGIN_REF });
+    await visionEmbed({ imageRef: DASH_REF });
 
-    const res = (await visionSearch({ queryImageRef: "/tmp/login.png", topK: 2 })) as {
+    const res = (await visionSearch({ queryImageRef: LOGIN_REF, topK: 2 })) as {
       success: boolean;
       results: Array<{ imageRef: string; score: number }>;
     };
-    expect(res.results[0].imageRef).toBe("/tmp/login.png");
+    expect(res.results[0].imageRef).toBe(LOGIN_REF);
     expect(res.results[0].score).toBeGreaterThan(0.9);
   });
 
+  it("queryImageRef outside managed store is rejected", async () => {
+    const res = (await visionSearch({ queryImageRef: "/etc/passwd" })) as { success: boolean; error: string };
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/managed/);
+  });
+
   it("sessionId filters out embeddings from other sessions", async () => {
-    await visionEmbed({ imageRef: "/tmp/login.png", sessionId: "sess_a" });
-    await visionEmbed({ imageRef: "/tmp/dashboard.png", sessionId: "sess_b" });
+    await seedRef(LOGIN_REF);
+    await seedRef(DASH_REF);
+    await visionEmbed({ imageRef: LOGIN_REF, sessionId: "sess_a" });
+    await visionEmbed({ imageRef: DASH_REF, sessionId: "sess_b" });
 
     const res = (await visionSearch({ queryText: "anything", sessionId: "sess_a", topK: 5 })) as {
       success: boolean;
@@ -109,6 +144,20 @@ describe("vision-search", () => {
     };
     expect(res.results.every((r) => r.sessionId === "sess_a")).toBe(true);
     expect(res.results.length).toBe(1);
+  });
+
+  it("clamps NaN/fractional topK to a valid integer", async () => {
+    await seedRef(LOGIN_REF);
+    await visionEmbed({ imageRef: LOGIN_REF });
+    const resNan = (await visionSearch({ queryText: "x", topK: Number.NaN })) as {
+      success: boolean;
+      results: unknown[];
+    };
+    expect(resNan.success).toBe(true);
+    expect(resNan.results.length).toBe(1);
+    const resFrac = (await visionSearch({ queryText: "x", topK: 3.7 })) as { success: boolean; results: unknown[] };
+    expect(resFrac.success).toBe(true);
+    expect(resFrac.results.length).toBe(1);
   });
 
   it("returns 503-equivalent error when provider is absent", async () => {


### PR DESCRIPTION
## Summary

Phase 1 of the multimodal plan. Builds on **PR #111** (image store + ref counting + VLM description). Adds the missing piece: a **direct visual embedding space** so agents can search screenshots by natural language or by similar image, without routing through VLM-describe → BM25-text.

**Depends on #111.** This PR is stacked on top of `fix/multimodal-conflicts`. Rebase cleanly once #111 merges.

## Motivation

- Mem0 / Zep / Letta are publicly text-only in the 2026 landscape comparisons — explicit multimodal gap.
- AgenticVision ships CLIP ViT-B/32 but requires manual `vision_capture` invocation.
- agentmemory already auto-captures screenshots via the 12 Claude Code hooks. Adding CLIP on top means **the agent sees what it sees, and you can retrieve cross-modally without asking**. No comparable system ships this combination.

Full design doc lives locally at `~/specs-backup/agentmemory-multimodal-plan.md` (per our no-SPEC-in-PR convention).

## What ships

### New

- `ClipEmbeddingProvider` — CLIP ViT-B/32 (`Xenova/clip-vit-base-patch32`) via `@xenova/transformers` (already a dep). 512-dim normalized vectors. Handles base64, data URL, and file paths. Lazy model download on first call.
- `createImageEmbeddingProvider()` — gated on `AGENTMEMORY_IMAGE_EMBEDDINGS=true`. Default OFF, same opt-in pattern as `AGENTMEMORY_AUTO_COMPRESS` (#138) and `AGENTMEMORY_INJECT_CONTEXT` (#143).
- `KV.imageEmbeddings` scope keyed by imageRef path.
- `mem::vision-embed` — stores a CLIP vector for a given `imageRef`.
- `mem::vision-search` — cosine similarity over stored vectors. Accepts text query (text→image cross-modal), image path (image→image), or base64. `topK` clamped to 50. Optional `sessionId` filter.
- `POST /agentmemory/vision-embed`, `POST /agentmemory/vision-search` — auth-gated HTTP triggers, 503 when the flag is off.
- MCP tool `memory_vision_search` — exposed via the running-server handler in `src/mcp/server.ts` (standalone MCP unchanged by design; this is server-backed).

### Wired into existing flows

- `EmbeddingProvider.embedImage?()` — optional slot on the interface. Non-breaking.
- Observe pipeline: when an image is persisted and the flag is on, fires `mem::vision-embed` via `triggerVoid` so embedding runs off the critical path.
- `decrementImageRef` now drops the embedding alongside the disk file + ref row. Forget / evict / retention won't orphan vectors.

### README / counts

MCP tool count 44 → 45 across README stats, install instructions, config block. `CORE_TOOLS` test expectation bumped accordingly.

## Design choices

| Decision | Why |
|---|---|
| Opt-in default | Matches #138 / #143 / #160. Don't surprise users with 350MB model download. |
| Lazy model load | Same pattern as iii-engine's curl installer. Avoid npx install bloat. |
| Brute-force cosine | Image memory counts are small (hundreds to thousands). ANN index is premature optimization — Phase 2+ work if warranted. |
| triggerVoid for auto-embed | Don't block observe on model inference; fire-and-forget. |
| `memory_vision_search` server-only | Standalone MCP is a deliberately narrow offline fallback; vision needs the server anyway. |

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — **794/794 pass** (+6 new vision-search tests)
- [x] Unit coverage: embed→store, text→image ranking, image→image self-match, sessionId filter, provider-absent 503 error, missing-query 400 error
- [ ] Manual: `AGENTMEMORY_IMAGE_EMBEDDINGS=true npx @agentmemory/agentmemory`, hook-capture a screenshot, `curl -sX POST :3111/agentmemory/vision-search -d '{"queryText":"error banner"}'`
- [ ] Manual: confirm `decrementImageRef` cleans up the vector when refcount hits 0 (via evict dry-run then real run)

## Not in this PR (Phase 2+)

- Thumbnail cache (`/images/thumb/{sha}`)
- Viewer "Screenshots" tab
- Hybrid BM25 + CLIP ranking in `mem::smart-search` (reciprocal rank fusion)
- Entity↔image graph edges
- `vision_diff`, OCR fallback, video keyframes

Ship Phase 1 first, watch real usage, then pick the next axis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vision search: cross-modal image search using CLIP embeddings.
  * New HTTP endpoints and MCP tool for vision search and embedding.
  * Optional image-embedding provider, toggleable via AGENTMEMORY_IMAGE_EMBEDDINGS.

* **Bug Fixes**
  * Improved image reference cleanup to also remove related stored embeddings when images are deleted.

* **Documentation**
  * README and plugin metadata updated to reflect 45 tools and the new env var.

* **Tests**
  * Added end-to-end tests for vision-embed/search, validation, ranking, and session scoping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->