### PR TITLE
fix(website): bake meta at build time, stop regressing to V0.0.0

### DIFF
--- a/website/lib/generated-meta.json
+++ b/website/lib/generated-meta.json
@@ -1,0 +1,8 @@
+{
+  "version": "0.9.1",
+  "mcpTools": 45,
+  "hooks": 12,
+  "restEndpoints": 112,
+  "testsPassing": 819,
+  "generatedAt": "2026-04-21T12:25:41.163Z"
+}

--- a/website/lib/meta.ts
+++ b/website/lib/meta.ts
@@ -1,7 +1,5 @@
 import "server-only";
-import { readFileSync, readdirSync } from "node:fs";
-import { join, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
+import generated from "./generated-meta.json" with { type: "json" };
 
 export interface ProjectMeta {
   version: string;
@@ -11,107 +9,17 @@ export interface ProjectMeta {
   testsPassing: number;
 }
 
-export const DEFAULT_META: Omit<ProjectMeta, "version"> = {
-  mcpTools: 44,
-  hooks: 12,
-  restEndpoints: 49,
-  testsPassing: 777,
-};
-
-const here = dirname(fileURLToPath(import.meta.url));
-const repoRoot = join(here, "..", "..");
-
-function readFileSafe(path: string): string {
-  try {
-    return readFileSync(path, "utf-8");
-  } catch {
-    return "";
-  }
-}
-
-function safeReadJson<T>(path: string): T | null {
-  const txt = readFileSafe(path);
-  if (!txt) return null;
-  try {
-    return JSON.parse(txt) as T;
-  } catch {
-    return null;
-  }
-}
-
-function safeCountMatches(path: string, pattern: RegExp): number {
-  const txt = readFileSafe(path);
-  if (!txt) return 0;
-  const m = txt.match(pattern);
-  return m ? m.length : 0;
-}
-
-function countHookTypes(typesPath: string): number {
-  const txt = readFileSafe(typesPath);
-  if (!txt) return 0;
-  const union = txt.match(/export type HookType[\s\S]*?;/);
-  if (!union) return 0;
-  const body = union[0].replace(/export type HookType\s*=/, "").replace(/;$/, "");
-  const members = body
-    .split("|")
-    .map((s) => s.trim())
-    .filter((s) => /^["'`]/.test(s));
-  return members.length;
-}
-
-function countTestCases(testDir: string): number {
-  let total = 0;
-  let entries: import("node:fs").Dirent[];
-  try {
-    entries = readdirSync(testDir, { withFileTypes: true });
-  } catch {
-    return 0;
-  }
-  for (const entry of entries) {
-    const full = join(testDir, entry.name);
-    if (entry.isDirectory()) {
-      total += countTestCases(full);
-      continue;
-    }
-    if (!/\.test\.[jt]sx?$/.test(entry.name)) continue;
-    const txt = readFileSafe(full);
-    if (!txt) continue;
-    const m = txt.match(/(?:^|\s)(?:it|test)(?:\.\w+)?\s*\(/g);
-    if (m) total += m.length;
-  }
-  return total;
-}
-
+// Values are baked at build time by scripts/gen-meta.mjs (see package.json
+// prebuild). Runtime file lookups via import.meta.url break after Next.js
+// moves server components into .next/server/ — `../..` from there stays
+// inside the build cache, not at the repo root, and version silently falls
+// back to "0.0.0". Static JSON import sidesteps that entirely.
 export function getProjectMeta(): ProjectMeta {
-  const pkg = safeReadJson<{ version?: string }>(
-    join(repoRoot, "package.json"),
-  );
-
-  // REST endpoints: registerTrigger entries in src/triggers/api.ts with an
-  // api_path config. The tight regex matches the exact declaration shape the
-  // codebase uses; loose forms (comments, example strings) are not counted.
-  const restEndpoints = safeCountMatches(
-    join(repoRoot, "src", "triggers", "api.ts"),
-    /config:\s*\{\s*api_path:\s*"/g,
-  );
-
-  // MCP tools: count memory_* entries in the tools registry.
-  const mcpTools = safeCountMatches(
-    join(repoRoot, "src", "mcp", "tools-registry.ts"),
-    /name:\s*"memory_/g,
-  );
-
-  // Hooks: count actual members of the HookType union, not quote characters.
-  const hooks = countHookTypes(join(repoRoot, "src", "types.ts"));
-
-  // Tests: walk the test/ tree, count it()/test() call sites.
-  const testsPassing = countTestCases(join(repoRoot, "test"));
-
   return {
-    version: pkg?.version ?? "0.0.0",
-    mcpTools: mcpTools || DEFAULT_META.mcpTools,
-    hooks: hooks || DEFAULT_META.hooks,
-    restEndpoints: restEndpoints || DEFAULT_META.restEndpoints,
-    testsPassing: testsPassing || DEFAULT_META.testsPassing,
+    version: generated.version,
+    mcpTools: generated.mcpTools,
+    hooks: generated.hooks,
+    restEndpoints: generated.restEndpoints,
+    testsPassing: generated.testsPassing,
   };
 }

--- a/website/package.json
+++ b/website/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "gen-meta": "node scripts/gen-meta.mjs",
+    "predev": "node scripts/gen-meta.mjs",
+    "prebuild": "node scripts/gen-meta.mjs",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",

--- a/website/scripts/gen-meta.mjs
+++ b/website/scripts/gen-meta.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/**
+ * Build-time meta generator.
+ *
+ * Runs before `next build` (see package.json prebuild). Walks the real repo
+ * (one level up from website/) and writes website/lib/generated-meta.json with
+ * the version, MCP tool count, hook count, REST endpoint count, and test count.
+ *
+ * Reason this exists: meta.ts used to read package.json at runtime via
+ * import.meta.url, but after Next.js compiles server components the URL
+ * resolves into .next/server/ — ../.. stays inside the build cache, not at the
+ * repo root, and the version silently falls back to "0.0.0". By resolving
+ * files at build time from a known working directory (where this script
+ * actually runs), we avoid the runtime path-guessing entirely.
+ */
+import { readFileSync, readdirSync, writeFileSync, mkdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const websiteDir = join(here, "..");
+const repoRoot = join(websiteDir, "..");
+
+function readFileSafe(path) {
+  try {
+    return readFileSync(path, "utf-8");
+  } catch {
+    return "";
+  }
+}
+
+function safeReadJson(path) {
+  const txt = readFileSafe(path);
+  if (!txt) return null;
+  try {
+    return JSON.parse(txt);
+  } catch {
+    return null;
+  }
+}
+
+function safeCountMatches(path, pattern) {
+  const txt = readFileSafe(path);
+  if (!txt) return 0;
+  const m = txt.match(pattern);
+  return m ? m.length : 0;
+}
+
+function countHookTypes(typesPath) {
+  const txt = readFileSafe(typesPath);
+  if (!txt) return 0;
+  const union = txt.match(/export type HookType[\s\S]*?;/);
+  if (!union) return 0;
+  const body = union[0].replace(/export type HookType\s*=/, "").replace(/;$/, "");
+  return body
+    .split("|")
+    .map((s) => s.trim())
+    .filter((s) => /^["'`]/.test(s)).length;
+}
+
+function countTestCases(testDir) {
+  let total = 0;
+  let entries;
+  try {
+    entries = readdirSync(testDir, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+  for (const entry of entries) {
+    const full = join(testDir, entry.name);
+    if (entry.isDirectory()) {
+      total += countTestCases(full);
+      continue;
+    }
+    if (!/\.test\.[jt]sx?$/.test(entry.name)) continue;
+    const txt = readFileSafe(full);
+    if (!txt) continue;
+    const m = txt.match(/(?:^|\s)(?:it|test)(?:\.\w+)?\s*\(/g);
+    if (m) total += m.length;
+  }
+  return total;
+}
+
+const pkg = safeReadJson(join(repoRoot, "package.json"));
+const version = pkg?.version;
+if (!version) {
+  throw new Error(
+    `gen-meta: could not read version from ${join(repoRoot, "package.json")}. ` +
+      `Check Vercel Root Directory — the full repo must be checked out, not just website/.`,
+  );
+}
+
+const restEndpoints = safeCountMatches(
+  join(repoRoot, "src", "triggers", "api.ts"),
+  /config:\s*\{\s*api_path:\s*"/g,
+);
+const mcpTools = safeCountMatches(
+  join(repoRoot, "src", "mcp", "tools-registry.ts"),
+  /name:\s*"memory_/g,
+);
+const hooks = countHookTypes(join(repoRoot, "src", "types.ts"));
+const testsPassing = countTestCases(join(repoRoot, "test"));
+
+const meta = {
+  version,
+  mcpTools: mcpTools || 45,
+  hooks: hooks || 12,
+  restEndpoints: restEndpoints || 107,
+  testsPassing: testsPassing || 794,
+  generatedAt: new Date().toISOString(),
+};
+
+const outDir = join(websiteDir, "lib");
+mkdirSync(outDir, { recursive: true });
+const outPath = join(outDir, "generated-meta.json");
+writeFileSync(outPath, JSON.stringify(meta, null, 2) + "\n", "utf-8");
+
+console.log(
+  `[gen-meta] wrote ${outPath}: v${meta.version}, ${meta.mcpTools} tools, ${meta.hooks} hooks, ${meta.restEndpoints} endpoints, ${meta.testsPassing} tests`,
+);


### PR DESCRIPTION
## Summary

Landing page hero kept reverting to **V0.0.0** after releases. Reproduced on v0.9.1 deploy (attached screenshot confirms).

## Root cause

\`website/lib/meta.ts\` resolved the repo at runtime via \`import.meta.url\`:

\`\`\`ts
const here = dirname(fileURLToPath(import.meta.url));
const repoRoot = join(here, \"..\", \"..\");
// ...
const pkg = safeReadJson(join(repoRoot, \"package.json\"));
return { version: pkg?.version ?? \"0.0.0\", ... };
\`\`\`

Locally \`here\` = \`website/lib\`, so \`../..\` correctly lands at the repo root. But Next.js 16 / Turbopack compiles server components and moves them into \`.next/server/app/page/...\`. At runtime \`import.meta.url\` resolves **there**, not in the source tree. \`../..\` stays inside \`.next/server/\`, \`readFileSync(join(repoRoot, \"package.json\"))\` throws, \`safeReadJson\` swallows it, and the \`?? \"0.0.0\"\` fallback renders. Earlier deploys happened to work because of how prior Turbopack versions laid out the bundles — not because the logic was correct.

## Fix: bake meta at build time

- **\`website/scripts/gen-meta.mjs\`** (new): runs from \`website/scripts/\`, walks one level up to find the real repo root, reads \`package.json\`, \`src/mcp/tools-registry.ts\`, \`src/triggers/api.ts\`, \`src/types.ts\`, and \`test/\`, writes \`website/lib/generated-meta.json\`. **Throws loud** if version is missing — no more silent \"0.0.0\" fallback.
- **\`website/package.json\`**: \`predev\` + \`prebuild\` hooks run the generator before Next spins up.
- **\`website/lib/meta.ts\`**: collapsed from 117 lines of runtime file walking to a static \`import generated from \"./generated-meta.json\"\`. Next.js bundles the values directly into server component output — zero runtime filesystem resolution, zero \`../..\` guessing.
- **\`website/lib/generated-meta.json\`**: committed seed so the import target exists for editors; prebuild overwrites on every run.

## Verified locally

\`\`\`
$ npx next build
$ grep \"ZERO EXTERNAL\" .next/server/app/index.html
ZERO EXTERNAL DATABASES · v\\\",\\\"0.9.1\\\"]}]
\`\`\`

Version baked into the static prerender. No fallback path left.

## Test plan

- [x] \`npm run build\` for website passes
- [x] Rendered HTML contains v0.9.1, not v0.0.0
- [ ] Post-merge: confirm Vercel deploy at https://www.agent-memory.dev/ renders v0.9.1 in hero badge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized metadata generation by moving project metrics from runtime computation to build-time pre-generation. Metrics (version, tool counts) are automatically compiled before development and production builds for improved startup performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->