### PR TITLE
fix(website): stats render target values in SSR, animate on scroll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ dist/
 plugin/scripts/*.map
 plugin/scripts/*.d.mts
 data/
+.gstack/

--- a/website/components/Stats.tsx
+++ b/website/components/Stats.tsx
@@ -97,7 +97,8 @@ export function Stats({
               data-suffix={s.suffix || ""}
               data-float={s.float ? "1" : "0"}
             >
-              0{s.suffix || ""}
+              {s.float ? s.target.toFixed(1) : s.target}
+              {s.suffix || ""}
             </div>
             <div className={styles.label}>{s.label}</div>
           </article>


### PR DESCRIPTION
## Problem

Live site at https://www.agent-memory.dev/ shows every stat at **0**:

- 0% retrieval R@5
- 0% fewer tokens
- 0 MCP tools
- 0 auto hooks
- 0 external databases
- 0 tests passing

Confirmed via gstack browse — \`data-target\` is correct (\"44\", \"12\", \"809\", etc.) but the rendered text starts at \"0\" and only animates to the target when IntersectionObserver fires.

## Root cause

\`website/components/Stats.tsx\` writes initial text as \`0{suffix}\`. The count animation runs inside an \`IntersectionObserver\` with \`threshold: 0.5\` — it fires only when the user scrolls the stats row at least half into view. For:

- real users scrolling past the section: animation runs, numbers count up, everything is fine
- SEO crawlers, headless browsers (playwright/puppeteer), social preview bots, screenshot services: no scroll, no IO trigger, page stays on \"0\"

This is also why v0.9.1's landing page thumbnail on cards posted to X / Discord / Slack shows zeros — the preview renderer doesn't scroll.

## Fix

Render the target value as the initial text so the page ships the right numbers even without animation. The count animation still plays for real users: the \`requestAnimationFrame\` tick inside the \`count(el)\` callback overwrites \`el.textContent\` unconditionally when the section scrolls into view.

\`\`\`diff
-              0{s.suffix || \"\"}
+              {s.float ? s.target.toFixed(1) : s.target}
+              {s.suffix || \"\"}
\`\`\`

Zero animation changes, zero behavior changes for humans.

## Verified

\`\`\`
$ node website/scripts/gen-meta.mjs
[gen-meta] wrote …/generated-meta.json: v0.9.1, 44 tools, 12 hooks, 110 endpoints, 809 tests

$ npx next build
$ grep -oE 'data-num[^>]*>[^<]+' .next/server/app/index.html | head
data-num=\"true\" data-target=\"44\" …>44</div>
data-num=\"true\" data-target=\"12\" …>12</div>
data-num=\"true\" data-target=\"0\" …>0</div>
data-num=\"true\" data-target=\"809\" …>809</div>
\`\`\`

Numbers baked into the SSR output. IntersectionObserver still attached — when a real user scrolls, the RAF overwrites from 0 to target the same as before.

Also: `.gitignore` adds `.gstack/` (local session data from the browse skill used while debugging this).

## Test plan

- [x] `npx next build` clean
- [x] Rendered HTML contains target values, not zeros
- [ ] Post-merge: confirm Vercel deploy at https://www.agent-memory.dev/ shows real numbers even before scrolling
- [ ] Verify count animation still plays when scrolling into the stats section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Changes

* **Bug Fixes**
  * Corrected stat number display to show final values immediately instead of starting with zero, improving visual clarity before animation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->