### PR TITLE
docs: refresh README + website stats after #186/#187/#188/#189

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
   <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-tools.svg"><img src="assets/tags/stat-tools.svg" alt="51 MCP tools" height="38" /></picture>
   <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-hooks.svg"><img src="assets/tags/stat-hooks.svg" alt="12 auto hooks" height="38" /></picture>
   <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-deps.svg"><img src="assets/tags/stat-deps.svg" alt="0 external DBs" height="38" /></picture>
-  <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-tests.svg"><img src="assets/tags/stat-tests.svg" alt="654 tests passing" height="38" /></picture>
+  <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-tests.svg"><img src="assets/tags/stat-tests.svg" alt="827 tests passing" height="38" /></picture>
 </p>
 
 <p align="center">
@@ -779,25 +779,35 @@ agentmemory auto-detects from your environment. No API key needed if you have a 
 
 | Provider | Config | Notes |
 |----------|--------|-------|
-| **Claude subscription** (default) | No config needed | Uses `@anthropic-ai/claude-agent-sdk` |
+| **No-op (default)** | No config needed | LLM-backed compress/summarize is DISABLED. Synthetic BM25 compression + recall still work. See `AGENTMEMORY_ALLOW_AGENT_SDK` below if you used to rely on the Claude-subscription fallback. |
 | Anthropic API | `ANTHROPIC_API_KEY` | Per-token billing |
 | MiniMax | `MINIMAX_API_KEY` | Anthropic-compatible |
 | Gemini | `GEMINI_API_KEY` | Also enables embeddings |
 | OpenRouter | `OPENROUTER_API_KEY` | Any model |
+| Claude subscription fallback | `AGENTMEMORY_ALLOW_AGENT_SDK=true` | Opt-in only. Spawns `@anthropic-ai/claude-agent-sdk` sessions — used to cause unbounded Stop-hook recursion (#149 follow-up) so it is no longer the default. |
 
 ### Environment Variables
 
 Create `~/.agentmemory/.env`:
 
 ```env
-# LLM provider (pick one, or leave empty for Claude subscription)
+# LLM provider (pick one — default is the no-op provider: no LLM calls)
 # ANTHROPIC_API_KEY=sk-ant-...
+# ANTHROPIC_BASE_URL=...              # Optional: Anthropic-compatible proxy / Azure
 # GEMINI_API_KEY=...
 # OPENROUTER_API_KEY=...
+# MINIMAX_API_KEY=...
+# Opt-in Claude-subscription fallback (spawns @anthropic-ai/claude-agent-sdk);
+# leave OFF unless you understand the Stop-hook recursion risk (#149 follow-up):
+# AGENTMEMORY_ALLOW_AGENT_SDK=true
 
 # Embedding provider (auto-detected, or override)
 # EMBEDDING_PROVIDER=local
 # VOYAGE_API_KEY=...
+# OPENAI_API_KEY=sk-...
+# OPENAI_BASE_URL=https://api.openai.com   # Override for Azure / vLLM / LM Studio / proxies
+# OPENAI_EMBEDDING_MODEL=text-embedding-3-small
+# OPENAI_EMBEDDING_DIMENSIONS=1536        # Required when the model is not in the known-models table
 
 # Search tuning
 # BM25_WEIGHT=0.4

--- a/assets/tags/light/stat-tests.svg
+++ b/assets/tags/light/stat-tests.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 48" fill="none" role="img" aria-label="TESTS PASSING: 654">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 48" fill="none" role="img" aria-label="TESTS PASSING: 827">
   <rect x="0" y="0" width="140" height="48" rx="10" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1"/>
-  <text x="70" y="24" fill="#16A34A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="18" font-weight="900" text-anchor="middle" letter-spacing="-0.3">654</text>
+  <text x="70" y="24" fill="#16A34A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="18" font-weight="900" text-anchor="middle" letter-spacing="-0.3">827</text>
   <text x="70" y="38" fill="#64748B" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="9" font-weight="600" text-anchor="middle" letter-spacing="1.5">TESTS PASSING</text>
 </svg>

--- a/assets/tags/stat-tests.svg
+++ b/assets/tags/stat-tests.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 48" fill="none" role="img" aria-label="TESTS PASSING: 654">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 48" fill="none" role="img" aria-label="TESTS PASSING: 827">
   <rect x="0" y="0" width="140" height="48" rx="10" fill="#1A1A1A" stroke="#2A2A2A" stroke-width="1"/>
-  <text x="70" y="24" fill="#00D26A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="18" font-weight="900" text-anchor="middle" letter-spacing="-0.3">654</text>
+  <text x="70" y="24" fill="#00D26A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="18" font-weight="900" text-anchor="middle" letter-spacing="-0.3">827</text>
   <text x="70" y="38" fill="#9CA3AF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="9" font-weight="600" text-anchor="middle" letter-spacing="1.5">TESTS PASSING</text>
 </svg>

--- a/website/lib/generated-meta.json
+++ b/website/lib/generated-meta.json
@@ -1,8 +1,8 @@
 {
   "version": "0.9.1",
-  "mcpTools": 45,
+  "mcpTools": 51,
   "hooks": 12,
-  "restEndpoints": 112,
-  "testsPassing": 819,
-  "generatedAt": "2026-04-21T12:25:41.163Z"
+  "restEndpoints": 119,
+  "testsPassing": 848,
+  "generatedAt": "2026-04-22T15:17:06.241Z"
 }


### PR DESCRIPTION
## Summary

Bring README + site stats in line with what actually shipped in the last wave of PRs.

- **Provider table (README)** — No-op is the new default since #187 landed; the old `Claude subscription (default)` row was misleading. Moved the subscription path to a separate row with `AGENTMEMORY_ALLOW_AGENT_SDK=true` opt-in and a note about the Stop-hook recursion guard.
- **Env block (README)** — document `OPENAI_BASE_URL` / `OPENAI_EMBEDDING_MODEL` (from #186), `OPENAI_EMBEDDING_DIMENSIONS` + model-dimension lookup (from #189), and `MINIMAX_API_KEY`.
- **Hero test badge** — `assets/tags/stat-tests.svg` + `assets/tags/light/stat-tests.svg` bumped 654 → 827 to match the current suite after recursion-guard tests, content-addressed-id idempotency tests, and openai-dimension tests landed.
- **Website meta** — `website/lib/generated-meta.json` regenerated via `website/scripts/gen-meta.mjs`: v0.9.1 / 51 tools / 12 hooks / 119 endpoints / 848 tests. The script already runs as a `prebuild` step so this is just the checked-in snapshot.

## Verification

- `npm run build` (root) clean.
- `npm test` 827 / 827 pass.
- `cd website && npm run build` clean.
- Runtime smoke: clean boot with no provider key shows the new `Provider: noop` line and the stderr warning from #187.
- `import-jsonl` + re-import: lesson reinforcements bump on re-import (content-addressed IDs from #188 working).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration documentation with new environment variable options for proxies and model setup.
  * Clarified default settings; Claude integration is now opt-in.

* **Chores**
  * Test coverage increased to 827 tests passing.
  * Added 6 new tools and 7 new REST endpoints.

* **Bug Fixes**
  * Resolved a stability issue by making Claude integration opt-in rather than automatic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->