### PR TITLE
feat: add --host flag and AGENTMEMORY_HOST for configurable bind address

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -14,6 +14,11 @@ export function createViewerNonce(): string {
 }
 
 export function buildViewerCsp(nonce: string): string {
+  const host = process.env.AGENTMEMORY_HOST;
+  const connectSrc =
+    host === "0.0.0.0"
+      ? "connect-src *"
+      : "connect-src 'self' http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:* wss://localhost:* wss://127.0.0.1:*";
   return [
     "default-src 'none'",
     "base-uri 'none'",
@@ -23,7 +28,7 @@ export function buildViewerCsp(nonce: string): string {
     `script-src 'nonce-${nonce}'`,
     "script-src-attr 'none'",
     "style-src 'unsafe-inline'",
-    "connect-src 'self' http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:* wss://localhost:* wss://127.0.0.1:*",
+    connectSrc,
     "img-src 'self'",
     "font-src 'self'",
   ].join("; ");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -88,6 +88,13 @@ if (hostIdx !== -1 && args[hostIdx + 1]) {
 
 const skipEngine = args.includes("--no-engine");
 
+function isLoopbackHost(host: string): boolean {
+  if (host === "localhost" || host === "::1" || host === "::ffff:127.0.0.1") {
+    return true;
+  }
+  return host.startsWith("127.");
+}
+
 function getRestPort(): number {
   const url = process.env["AGENTMEMORY_URL"];
   if (url) {
@@ -259,7 +266,7 @@ async function startEngine(): Promise<boolean> {
   if (iiiBin && configPath) {
     const hostOverride = process.env["AGENTMEMORY_HOST"];
     const effectiveConfig =
-      hostOverride && hostOverride !== "127.0.0.1"
+      hostOverride && !isLoopbackHost(hostOverride)
         ? patchIiiConfigHost(configPath, hostOverride)
         : configPath;
     const s = p.spinner();
@@ -303,7 +310,7 @@ async function startEngine(): Promise<boolean> {
   if (iiiBin && configPath) {
     const hostOverride = process.env["AGENTMEMORY_HOST"];
     const effectiveConfig =
-      hostOverride && hostOverride !== "127.0.0.1"
+      hostOverride && !isLoopbackHost(hostOverride)
         ? patchIiiConfigHost(configPath, hostOverride)
         : configPath;
     const s = p.spinner();
@@ -377,11 +384,13 @@ async function main() {
   p.intro("agentmemory");
 
   const hostOverride = process.env["AGENTMEMORY_HOST"];
-  if (hostOverride && hostOverride !== "127.0.0.1") {
+  if (hostOverride && !isLoopbackHost(hostOverride)) {
     const secret = process.env["AGENTMEMORY_SECRET"];
     if (!secret) {
-      p.log.warn(
-        `Binding to ${hostOverride} without AGENTMEMORY_SECRET exposes your memory store to the network. Set AGENTMEMORY_SECRET in ~/.agentmemory/.env for authentication.`,
+      console.warn(
+        `[agentmemory] WARNING: bound to ${hostOverride} with no AGENTMEMORY_SECRET set.\n` +
+          `              Anyone on the network can write to memory and read observations.\n` +
+          `              Set AGENTMEMORY_SECRET, or bind to 127.0.0.1 (the default).`,
       );
     }
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -376,12 +376,6 @@ function portInUseDiagnostic(port: number): string {
 async function main() {
   p.intro("agentmemory");
 
-  if (skipEngine) {
-    p.log.info("Skipping engine check (--no-engine)");
-    await import("./index.js");
-    return;
-  }
-
   const hostOverride = process.env["AGENTMEMORY_HOST"];
   if (hostOverride && hostOverride !== "127.0.0.1") {
     const secret = process.env["AGENTMEMORY_SECRET"];
@@ -390,6 +384,12 @@ async function main() {
         `Binding to ${hostOverride} without AGENTMEMORY_SECRET exposes your memory store to the network. Set AGENTMEMORY_SECRET in ~/.agentmemory/.env for authentication.`,
       );
     }
+  }
+
+  if (skipEngine) {
+    p.log.info("Skipping engine check (--no-engine)");
+    await import("./index.js");
+    return;
   }
 
   if (await isEngineRunning()) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,10 +6,18 @@ import {
   spawnSync,
   type ChildProcess,
 } from "node:child_process";
-import { existsSync, readdirSync, readFileSync, readlinkSync, statSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  readlinkSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { join, dirname, delimiter as PATH_DELIMITER } from "node:path";
 import { fileURLToPath } from "node:url";
-import { homedir, platform } from "node:os";
+import { homedir, platform, tmpdir } from "node:os";
 import * as p from "@clack/prompts";
 import { generateId } from "./state/schema.js";
 
@@ -45,6 +53,7 @@ Options:
   --tools all|core   Tool visibility (default: core = 7 tools)
   --no-engine        Skip auto-starting iii-engine
   --port <N>         Override REST port (default: 3111)
+  --host <addr>      Override bind address (default: 127.0.0.1)
 
 Environment:
   AGENTMEMORY_URL    Full REST base URL (e.g. http://localhost:3111).
@@ -70,6 +79,11 @@ if (toolsIdx !== -1 && args[toolsIdx + 1]) {
 const portIdx = args.indexOf("--port");
 if (portIdx !== -1 && args[portIdx + 1]) {
   process.env["III_REST_PORT"] = args[portIdx + 1];
+}
+
+const hostIdx = args.indexOf("--host");
+if (hostIdx !== -1 && args[hostIdx + 1]) {
+  process.env["AGENTMEMORY_HOST"] = args[hostIdx + 1];
 }
 
 const skipEngine = args.includes("--no-engine");
@@ -135,6 +149,22 @@ function findIiiConfig(): string {
     if (existsSync(c)) return c;
   }
   return "";
+}
+
+function patchIiiConfigHost(configPath: string, host: string): string {
+  let content = readFileSync(configPath, "utf-8");
+  content = content.replace(/host:\s*127\.0\.0\.1/g, `host: ${host}`);
+  if (host === "0.0.0.0") {
+    content = content.replace(
+      /allowed_origins:\s*\[.*?\]/,
+      `allowed_origins: ["*"]`,
+    );
+  }
+  const tmpDir = mkdtempSync(join(tmpdir(), "agentmemory-"));
+  const tmpConfig = join(tmpDir, "iii-config.yaml");
+  writeFileSync(tmpConfig, content, "utf-8");
+  vlog(`Patched iii-config host to ${host}: ${tmpConfig}`);
+  return tmpConfig;
 }
 
 function whichBinary(name: string): string | null {
@@ -227,9 +257,14 @@ async function startEngine(): Promise<boolean> {
   vlog(`iii binary: ${iiiBin ?? "(not on PATH)"}, config: ${configPath || "(not found)"}`);
 
   if (iiiBin && configPath) {
+    const hostOverride = process.env["AGENTMEMORY_HOST"];
+    const effectiveConfig =
+      hostOverride && hostOverride !== "127.0.0.1"
+        ? patchIiiConfigHost(configPath, hostOverride)
+        : configPath;
     const s = p.spinner();
     s.start(`Starting iii-engine: ${iiiBin}`);
-    spawnEngineBackground(iiiBin, ["--config", configPath], "iii-engine");
+    spawnEngineBackground(iiiBin, ["--config", effectiveConfig], "iii-engine");
     s.stop("iii-engine process started");
     return true;
   }
@@ -266,9 +301,14 @@ async function startEngine(): Promise<boolean> {
   }
 
   if (iiiBin && configPath) {
+    const hostOverride = process.env["AGENTMEMORY_HOST"];
+    const effectiveConfig =
+      hostOverride && hostOverride !== "127.0.0.1"
+        ? patchIiiConfigHost(configPath, hostOverride)
+        : configPath;
     const s = p.spinner();
     s.start(`Starting iii-engine: ${iiiBin}`);
-    spawnEngineBackground(iiiBin, ["--config", configPath], "iii-engine");
+    spawnEngineBackground(iiiBin, ["--config", effectiveConfig], "iii-engine");
     s.stop("iii-engine process started");
     return true;
   }
@@ -340,6 +380,16 @@ async function main() {
     p.log.info("Skipping engine check (--no-engine)");
     await import("./index.js");
     return;
+  }
+
+  const hostOverride = process.env["AGENTMEMORY_HOST"];
+  if (hostOverride && hostOverride !== "127.0.0.1") {
+    const secret = process.env["AGENTMEMORY_SECRET"];
+    if (!secret) {
+      p.log.warn(
+        `Binding to ${hostOverride} without AGENTMEMORY_SECRET exposes your memory store to the network. Set AGENTMEMORY_SECRET in ~/.agentmemory/.env for authentication.`,
+      );
+    }
   }
 
   if (await isEngineRunning()) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -128,6 +128,7 @@ export function loadConfig(): AgentMemoryConfig {
 
   return {
     engineUrl: env["III_ENGINE_URL"] || "ws://localhost:49134",
+    host: env["AGENTMEMORY_HOST"] || "127.0.0.1",
     restPort: parseInt(env["III_REST_PORT"] || "3111", 10) || 3111,
     streamsPort: parseInt(env["III_STREAMS_PORT"] || "3112", 10) || 3112,
     provider,

--- a/src/index.ts
+++ b/src/index.ts
@@ -153,10 +153,11 @@ async function main() {
       `[agentmemory] Image embedding provider: ${imageEmbeddingProvider.name} (${imageEmbeddingProvider.dimensions} dims) — vision-search active`,
     );
   }
+  const displayHost = config.host === "0.0.0.0" ? "0.0.0.0" : "localhost";
   console.log(
-    `[agentmemory] REST API: http://localhost:${config.restPort}/agentmemory/*`,
+    `[agentmemory] REST API: http://${displayHost}:${config.restPort}/agentmemory/*`,
   );
-  console.log(`[agentmemory] Streams: ws://localhost:${config.streamsPort}`);
+  console.log(`[agentmemory] Streams: ws://${displayHost}:${config.streamsPort}`);
 
   const sdk = registerWorker(config.engineUrl, {
     workerName: "agentmemory",
@@ -371,6 +372,7 @@ async function main() {
     sdk,
     secret,
     config.restPort,
+    config.host,
   );
 
   const autoForgetIntervalMs = parseInt(process.env.AUTO_FORGET_INTERVAL_MS || "3600000", 10);

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,6 +140,7 @@ export interface MemoryProvider {
 
 export interface AgentMemoryConfig {
   engineUrl: string;
+  host: string;
   restPort: number;
   streamsPort: number;
   provider: ProviderConfig;

--- a/src/viewer/server.ts
+++ b/src/viewer/server.ts
@@ -6,16 +6,35 @@ import {
 } from "node:http";
 import { renderViewerDocument } from "./document.js";
 
+const DEFAULT_ORIGINS =
+  "http://localhost:3111,http://localhost:3113,http://127.0.0.1:3111,http://127.0.0.1:3113";
+
 const ALLOWED_ORIGINS = (
-  process.env.VIEWER_ALLOWED_ORIGINS ||
-  "http://localhost:3111,http://localhost:3113,http://127.0.0.1:3111,http://127.0.0.1:3113"
+  process.env.VIEWER_ALLOWED_ORIGINS || DEFAULT_ORIGINS
 )
   .split(",")
   .map((o) => o.trim());
 
+function isAllowedOrigin(origin: string): boolean {
+  if (ALLOWED_ORIGINS.includes(origin)) return true;
+  const host = process.env.AGENTMEMORY_HOST;
+  if (host === "0.0.0.0") {
+    try {
+      const url = new URL(origin);
+      const port = url.port || (url.protocol === "https:" ? "443" : "80");
+      const restPort = process.env.III_REST_PORT || "3111";
+      const viewerPort = String(parseInt(restPort, 10) + 2);
+      return port === restPort || port === viewerPort;
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
 function corsHeaders(req: IncomingMessage): Record<string, string> {
   const origin = req.headers.origin || "";
-  const allowed = ALLOWED_ORIGINS.includes(origin)
+  const allowed = isAllowedOrigin(origin)
     ? origin
     : ALLOWED_ORIGINS[0];
   return {
@@ -64,8 +83,10 @@ export function startViewerServer(
   _sdk: unknown,
   secret?: string,
   restPort?: number,
+  host?: string,
 ): Server {
   const resolvedRestPort = restPort ?? port - 2;
+  const resolvedHost = host ?? "127.0.0.1";
 
   const server = createServer(async (req, res) => {
     const raw = req.url || "/";
@@ -120,8 +141,9 @@ export function startViewerServer(
     }
   });
 
-  server.listen(port, "127.0.0.1", () => {
-    console.log(`[agentmemory] Viewer: http://localhost:${port}`);
+  server.listen(port, resolvedHost, () => {
+    const displayHost = resolvedHost === "0.0.0.0" ? "0.0.0.0" : "localhost";
+    console.log(`[agentmemory] Viewer: http://${displayHost}:${port}`);
   });
 
   return server;


### PR DESCRIPTION
## Summary

Adds opt-in support for binding agentmemory services to non-localhost addresses (e.g. `0.0.0.0` for LAN access). The default remains `127.0.0.1` per security advisory GHSA #03.

## Motivation

Users deploying agentmemory on remote dev servers or shared machines need to access the Viewer (port 3113), REST API (3111), and WebSocket streams (3112) from other hosts on the network. Currently this is impossible without patching source or running a reverse proxy, since all three services hardcode `127.0.0.1`.

## Changes (6 files, ~85 lines added)

- **`src/cli.ts`**: New `--host <addr>` flag, security warning when binding without `AGENTMEMORY_SECRET`, runtime patching of `iii-config.yaml` for iii-engine host override
- **`src/config.ts`**: Read `AGENTMEMORY_HOST` env var into config
- **`src/types.ts`**: Add `host` field to `AgentMemoryConfig` interface
- **`src/index.ts`**: Pass `host` to viewer server, display actual bind address in logs
- **`src/viewer/server.ts`**: Accept `host` param in `startViewerServer()`, dynamic CORS origin checking when bound to `0.0.0.0`
- **`src/auth.ts`**: Relax CSP `connect-src` to `*` when externally bound

## Usage

```bash
# CLI flag
npx @agentmemory/agentmemory --host 0.0.0.0

# Or via env in ~/.agentmemory/.env
AGENTMEMORY_HOST=0.0.0.0
```

## Security Considerations

- Default behavior is **unchanged** (`127.0.0.1`)
- Explicit opt-in required via `--host` flag or `AGENTMEMORY_HOST` env
- Startup warning when binding externally without `AGENTMEMORY_SECRET`
- CSP and CORS only relaxed when `AGENTMEMORY_HOST=0.0.0.0`
- iii-engine config patched at runtime via temp file (original untouched)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --host CLI option to set the server bind address.
  * Server can bind to non-local interfaces; host is now configurable.
  * Startup warning when binding to a non-local host without a secret.

* **Improvements**
  * CORS and content-security policies adapt based on chosen host (more permissive for 0.0.0.0).
  * Startup logging now shows the actual host used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->