### PR TITLE
docs(hermes): correct plugin install path (#197)

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ mcp_servers:
     command: npx
     args: ["-y", "@agentmemory/mcp"]
 
-Verify with `curl http://localhost:3111/agentmemory/health`. Open http://localhost:3113 for the real-time viewer. For deeper 6-hook memory provider integration (pre-LLM context injection, turn capture, MEMORY.md mirroring, system prompt block), copy integrations/hermes from the agentmemory repo to ~/.hermes/plugins/memory/agentmemory.
+Verify with `curl http://localhost:3111/agentmemory/health`. Open http://localhost:3113 for the real-time viewer. For deeper 6-hook memory provider integration (pre-LLM context injection, turn capture, MEMORY.md mirroring, system prompt block), copy integrations/hermes from the agentmemory repo to ~/.hermes/plugins/agentmemory.
 ```
 
 Full guide: [`integrations/hermes/`](integrations/hermes/)

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -45,7 +45,7 @@ http://localhost:3113 to watch memories being captured live.
 If I want deeper integration — pre-LLM context injection, turn-level
 capture, memory-write mirroring to MEMORY.md, and system prompt block
 injection — copy `integrations/hermes` from the agentmemory repo to
-`~/.hermes/plugins/memory/agentmemory` instead. That gives me the
+`~/.hermes/plugins/agentmemory` instead. That gives me the
 6-hook memory provider plugin on top of the MCP server.
 ```
 
@@ -75,7 +75,7 @@ npx @agentmemory/agentmemory
 Copy this folder to your Hermes plugins directory:
 
 ```bash
-cp -r integrations/hermes ~/.hermes/plugins/memory/agentmemory
+cp -r integrations/hermes ~/.hermes/plugins/agentmemory
 ```
 
 Start the agentmemory server:


### PR DESCRIPTION
## Summary

- Hermes scans `~/.hermes/plugins/<name>/` flat-only for memory providers
- `memory/` category namespace is reserved for bundled providers, so user plugins nested under it are never discovered
- Fix path in README and `integrations/hermes/README.md` from `~/.hermes/plugins/memory/agentmemory` to `~/.hermes/plugins/agentmemory`

Thanks @LehaoLin for the precise repro and source-pointer to `plugins/memory/__init__.py`.

Closes #197

## Test plan

- [ ] Cold-install on a fresh Hermes setup at `~/.hermes/plugins/agentmemory/`
- [ ] Verify `memory.provider: agentmemory` resolves on Hermes startup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Documentation**
- Updated Hermes integration setup instructions to reference a simplified plugin installation directory path, streamlining the configuration process and providing clearer guidance for users implementing the integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->