### PR TITLE
fix(config): strip inline # comments + route /config/flags through merged env (#200, #201)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -30,11 +30,10 @@ function loadEnvFile(): Record<string, string> {
     if (eqIdx === -1) continue;
     const key = trimmed.slice(0, eqIdx).trim();
     let val = trimmed.slice(eqIdx + 1).trim();
-    const quoted =
-      (val.startsWith('"') && val.endsWith('"')) ||
-      (val.startsWith("'") && val.endsWith("'"));
-    if (quoted) {
-      val = val.slice(1, -1);
+    const quoteChar = val[0] === '"' || val[0] === "'" ? val[0] : "";
+    if (quoteChar) {
+      const closeIdx = val.indexOf(quoteChar, 1);
+      if (closeIdx !== -1) val = val.slice(1, closeIdx);
     } else {
       const hashIdx = val.indexOf(" #");
       if (hashIdx !== -1) val = val.slice(0, hashIdx).trim();
@@ -148,6 +147,20 @@ function getMergedEnv(
 
 export function getEnvVar(key: string): string | undefined {
   return getMergedEnv()[key];
+}
+
+export function detectLlmProviderKind(): "llm" | "noop" {
+  const env = getMergedEnv();
+  if (
+    hasRealValue(env["ANTHROPIC_API_KEY"]) ||
+    hasRealValue(env["GEMINI_API_KEY"]) ||
+    hasRealValue(env["GOOGLE_API_KEY"]) ||
+    hasRealValue(env["OPENROUTER_API_KEY"]) ||
+    hasRealValue(env["MINIMAX_API_KEY"])
+  ) {
+    return "llm";
+  }
+  return "noop";
 }
 
 export function loadEmbeddingConfig(): EmbeddingConfig {

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,11 +30,14 @@ function loadEnvFile(): Record<string, string> {
     if (eqIdx === -1) continue;
     const key = trimmed.slice(0, eqIdx).trim();
     let val = trimmed.slice(eqIdx + 1).trim();
-    if (
+    const quoted =
       (val.startsWith('"') && val.endsWith('"')) ||
-      (val.startsWith("'") && val.endsWith("'"))
-    ) {
+      (val.startsWith("'") && val.endsWith("'"));
+    if (quoted) {
       val = val.slice(1, -1);
+    } else {
+      const hashIdx = val.indexOf(" #");
+      if (hashIdx !== -1) val = val.slice(0, hashIdx).trim();
     }
     vars[key] = val;
   }

--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -14,7 +14,7 @@ import {
   isAutoCompressEnabled,
   isContextInjectionEnabled,
   detectEmbeddingProvider,
-  getEnvVar,
+  detectLlmProviderKind,
 } from "../config.js";
 
 type Response = {
@@ -154,13 +154,7 @@ export function registerApiTriggers(
     async (req: ApiRequest): Promise<Response> => {
       const authErr = checkAuth(req, secret);
       if (authErr) return authErr;
-      const providerKind =
-        getEnvVar("ANTHROPIC_API_KEY") ||
-        getEnvVar("GEMINI_API_KEY") ||
-        getEnvVar("OPENROUTER_API_KEY") ||
-        getEnvVar("MINIMAX_API_KEY")
-          ? "llm"
-          : "noop";
+      const providerKind = detectLlmProviderKind();
       const embeddingProvider = detectEmbeddingProvider() ? "embeddings" : "none";
       const flags = [
         {

--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -14,6 +14,7 @@ import {
   isAutoCompressEnabled,
   isContextInjectionEnabled,
   detectEmbeddingProvider,
+  getEnvVar,
 } from "../config.js";
 
 type Response = {
@@ -153,8 +154,13 @@ export function registerApiTriggers(
     async (req: ApiRequest): Promise<Response> => {
       const authErr = checkAuth(req, secret);
       if (authErr) return authErr;
-      const env = process.env;
-      const providerKind = env["ANTHROPIC_API_KEY"] || env["GEMINI_API_KEY"] || env["OPENROUTER_API_KEY"] || env["MINIMAX_API_KEY"] ? "llm" : "noop";
+      const providerKind =
+        getEnvVar("ANTHROPIC_API_KEY") ||
+        getEnvVar("GEMINI_API_KEY") ||
+        getEnvVar("OPENROUTER_API_KEY") ||
+        getEnvVar("MINIMAX_API_KEY")
+          ? "llm"
+          : "noop";
       const embeddingProvider = detectEmbeddingProvider() ? "embeddings" : "none";
       const flags = [
         {

--- a/test/env-loader.test.ts
+++ b/test/env-loader.test.ts
@@ -32,8 +32,10 @@ describe("loadEnvFile", () => {
   });
 
   afterEach(() => {
-    process.env["HOME"] = ORIGINAL_HOME;
-    process.env["USERPROFILE"] = ORIGINAL_USERPROFILE;
+    if (ORIGINAL_HOME === undefined) delete process.env["HOME"];
+    else process.env["HOME"] = ORIGINAL_HOME;
+    if (ORIGINAL_USERPROFILE === undefined) delete process.env["USERPROFILE"];
+    else process.env["USERPROFILE"] = ORIGINAL_USERPROFILE;
     rmSync(sandboxHome, { recursive: true, force: true });
   });
 
@@ -67,5 +69,17 @@ describe("loadEnvFile", () => {
     writeEnv("HASHVAL=abc#def");
     const cfg = await freshConfig();
     expect(cfg.getEnvVar("HASHVAL")).toBe("abc#def");
+  });
+
+  it("strips inline comment after a quoted value and unwraps quotes", async () => {
+    writeEnv('TOKEN="abc" # trailing comment');
+    const cfg = await freshConfig();
+    expect(cfg.getEnvVar("TOKEN")).toBe("abc");
+  });
+
+  it("strips inline comment after a single-quoted value and unwraps quotes", async () => {
+    writeEnv("TOKEN='abc' # trailing comment");
+    const cfg = await freshConfig();
+    expect(cfg.getEnvVar("TOKEN")).toBe("abc");
   });
 });

--- a/test/env-loader.test.ts
+++ b/test/env-loader.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const ORIGINAL_HOME = process.env["HOME"];
+const ORIGINAL_USERPROFILE = process.env["USERPROFILE"];
+
+let sandboxHome: string;
+
+async function freshConfig() {
+  vi.resetModules();
+  return await import("../src/config.js");
+}
+
+function writeEnv(contents: string) {
+  const dir = join(sandboxHome, ".agentmemory");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, ".env"), contents);
+}
+
+describe("loadEnvFile", () => {
+  beforeEach(() => {
+    sandboxHome = mkdtempSync(join(tmpdir(), "agentmemory-env-"));
+    process.env["HOME"] = sandboxHome;
+    process.env["USERPROFILE"] = sandboxHome;
+    delete process.env["AGENTMEMORY_AUTO_COMPRESS"];
+    delete process.env["CONSOLIDATION_ENABLED"];
+    delete process.env["GRAPH_EXTRACTION_ENABLED"];
+    delete process.env["TOKEN"];
+    delete process.env["HASHVAL"];
+  });
+
+  afterEach(() => {
+    process.env["HOME"] = ORIGINAL_HOME;
+    process.env["USERPROFILE"] = ORIGINAL_USERPROFILE;
+    rmSync(sandboxHome, { recursive: true, force: true });
+  });
+
+  it("strips trailing inline # comments on unquoted values", async () => {
+    writeEnv(
+      [
+        "AGENTMEMORY_AUTO_COMPRESS=true   # opt in to LLM compression",
+        "CONSOLIDATION_ENABLED=true       # daily summarization",
+        "GRAPH_EXTRACTION_ENABLED=true    # entity graph",
+      ].join("\n"),
+    );
+    const cfg = await freshConfig();
+    expect(cfg.isAutoCompressEnabled()).toBe(true);
+    expect(cfg.isConsolidationEnabled()).toBe(true);
+    expect(cfg.isGraphExtractionEnabled()).toBe(true);
+  });
+
+  it("preserves # inside double-quoted values", async () => {
+    writeEnv('TOKEN="abc#def"');
+    const cfg = await freshConfig();
+    expect(cfg.getEnvVar("TOKEN")).toBe("abc#def");
+  });
+
+  it("preserves # inside single-quoted values", async () => {
+    writeEnv("TOKEN='abc#def'");
+    const cfg = await freshConfig();
+    expect(cfg.getEnvVar("TOKEN")).toBe("abc#def");
+  });
+
+  it("treats hash without leading space as part of value", async () => {
+    writeEnv("HASHVAL=abc#def");
+    const cfg = await freshConfig();
+    expect(cfg.getEnvVar("HASHVAL")).toBe("abc#def");
+  });
+});


### PR DESCRIPTION
## Summary

Two related env-loading bugs that combined to make valid \`~/.agentmemory/.env\` configs silently behave as if half the user's flags were unset.

### #200 — \`.env\` loader doesn't strip inline \`#\` comments
\`loadEnvFile()\` only handled full-line \`#\` comments. Trailing inline comments (a natural urge when annotating the boolean toggles) survived into the value, so the strict \`=== \"true\"\` checks downstream always returned false:

\`\`\`env
AGENTMEMORY_AUTO_COMPRESS=true   # opt in to LLM compression  → parsed as 'true   # opt in to LLM compression' → off
\`\`\`

Fixed by stripping a trailing \` #...\` segment outside quotes. Preserves \`#\` inside double/single quoted values and \`#\` as a non-leading character of unquoted values.

### #201 — \`/config/flags\` reads \`process.env\` directly
\`api::config-flags\` read provider keys from \`process.env\` instead of \`getMergedEnv()\`. With the key set in \`~/.agentmemory/.env\` (the README's recommended path) the provider was actually working, but the diagnostics endpoint reported \`provider: \"noop\"\` and the viewer falsely showed the prominent **\"No LLM provider key set\"** warning.

Fixed by routing through the existing \`getEnvVar()\` helper.

## Tests

- New \`test/env-loader.test.ts\` (4 cases) covering inline-comment stripping, quoted-value preservation, embedded-hash unquoted values
- Full suite: 831/831 passing

Thanks @bloodcarter for the precise repros and source-pointers in #200/#201.

Closes #200
Closes #201

## Test plan

- [ ] Cold-start with \`~/.agentmemory/.env\` containing inline \`#\` comments — flags must boot \`enabled: true\`
- [ ] Cold-start with provider key only in \`~/.agentmemory/.env\` (not exported) — viewer banner must NOT warn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic detection of whether an LLM provider is configured, impacting feature availability.

* **Bug Fixes**
  * Environment configuration parsing now correctly handles inline comments and quoted values, avoiding accidental inclusion of comment text.

* **Tests**
  * Added comprehensive tests for env-file parsing covering comment stripping and quote behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->