### PR TITLE
fix(replay): preserve real sessionId + surface 200-file scan cap (#202, #203)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,7 +36,8 @@ Commands:
   upgrade            Upgrade local deps + iii runtime (best effort)
   mcp                Start standalone MCP server (no engine required)
   import-jsonl [p]   Import Claude Code JSONL transcripts (default: ~/.claude/projects)
-                     Use --max-files <N> or --max-files=<N> to override the 200-file scan cap (default: 200)
+                     --max-files <N> | --max-files=<N>: override scan cap (default 200, max 1000;
+                     out-of-range is rejected; for trees >1000 files, batch by subdirectory)
 
 Options:
   --help, -h         Show this help
@@ -961,6 +962,11 @@ async function runMcp(): Promise<void> {
 }
 
 async function runImportJsonl(): Promise<void> {
+  // Long-form flags that take a value. Their value tokens must be
+  // consumed alongside the flag so they don't leak into positional
+  // args (e.g. `--port 3112 import-jsonl` would otherwise turn
+  // 3112 into pathArg).
+  const VALUE_FLAGS = new Set(["--port", "--tools"]);
   let maxFiles: number | undefined;
   const tail = args.slice(1);
   const positional: string[] = [];
@@ -985,6 +991,10 @@ async function runImportJsonl(): Promise<void> {
       } else {
         p.log.warn(`Ignoring --max-files=${raw}: expected a positive integer.`);
       }
+      continue;
+    }
+    if (VALUE_FLAGS.has(a)) {
+      i++;
       continue;
     }
     if (a.startsWith("-")) continue;
@@ -1046,7 +1056,9 @@ async function runImportJsonl(): Promise<void> {
       observations?: number;
       discovered?: number;
       truncated?: boolean;
+      traversalCapped?: boolean;
       maxFiles?: number;
+      maxFilesUpperBound?: number;
     } = {};
     if (text.length > 0) {
       try {
@@ -1086,12 +1098,30 @@ async function runImportJsonl(): Promise<void> {
     );
     if (json.truncated) {
       const cap = json.maxFiles ?? 200;
-      const skipped = (json.discovered ?? 0) - (json.imported ?? 0);
-      p.log.warn(
-        `Hit the ${cap}-file scan cap; ${skipped} of ${json.discovered ?? "?"} discovered file(s) were skipped. ` +
-          `Re-run with --max-files=<N> (e.g. --max-files=${Math.max((json.discovered ?? cap) + 100, cap * 2)}) ` +
-          `or batch by subdirectory.`,
-      );
+      const upper = json.maxFilesUpperBound ?? 1000;
+      const discovered = json.discovered ?? 0;
+      const skipped = discovered - (json.imported ?? 0);
+      const discoveredLabel = json.traversalCapped
+        ? `${discovered}+ (traversal halted at safety cap)`
+        : String(discovered);
+      const baseMsg = `Hit the ${cap}-file scan cap; ${skipped} of ${discoveredLabel} discovered file(s) were skipped.`;
+      // If we already saw more than the server's hard cap (or the
+      // walker stopped early), bumping --max-files won't help on its
+      // own — recommend batching by subdirectory.
+      if (discovered > upper || json.traversalCapped) {
+        p.log.warn(
+          `${baseMsg} Tree exceeds the server's --max-files limit of ${upper}; ` +
+            `batch by subdirectory (run import-jsonl once per project under ~/.claude/projects).`,
+        );
+      } else {
+        const suggested = Math.min(
+          Math.max((discovered || cap) + 100, cap * 2),
+          upper,
+        );
+        p.log.warn(
+          `${baseMsg} Re-run with --max-files=${suggested} (max ${upper}) or batch by subdirectory.`,
+        );
+      }
     }
     if (json.sessionIds && json.sessionIds.length > 0) {
       p.log.info(`View at ${getViewerUrl()} → Replay tab`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,6 +36,7 @@ Commands:
   upgrade            Upgrade local deps + iii runtime (best effort)
   mcp                Start standalone MCP server (no engine required)
   import-jsonl [p]   Import Claude Code JSONL transcripts (default: ~/.claude/projects)
+                     Use --max-files <N> to override the 200-file scan cap (default: 200)
 
 Options:
   --help, -h         Show this help
@@ -962,6 +963,20 @@ async function runMcp(): Promise<void> {
 async function runImportJsonl(): Promise<void> {
   const nonFlagArgs = args.slice(1).filter((a) => !a.startsWith("-"));
   const pathArg = nonFlagArgs[0];
+
+  let maxFiles: number | undefined;
+  const flagIdx = args.findIndex((a) => a === "--max-files");
+  if (flagIdx !== -1 && args[flagIdx + 1]) {
+    const parsed = parseInt(args[flagIdx + 1]!, 10);
+    if (!Number.isNaN(parsed) && parsed > 0) maxFiles = parsed;
+  } else {
+    const eqArg = args.find((a) => a.startsWith("--max-files="));
+    if (eqArg) {
+      const parsed = parseInt(eqArg.slice("--max-files=".length), 10);
+      if (!Number.isNaN(parsed) && parsed > 0) maxFiles = parsed;
+    }
+  }
+
   const port = getRestPort();
   const base = `http://localhost:${port}`;
 
@@ -990,6 +1005,7 @@ async function runImportJsonl(): Promise<void> {
 
   const body: Record<string, unknown> = {};
   if (pathArg) body["path"] = pathArg;
+  if (maxFiles !== undefined) body["maxFiles"] = maxFiles;
 
   const headers: Record<string, string> = { "content-type": "application/json" };
   const secret = process.env["AGENTMEMORY_SECRET"];
@@ -1013,6 +1029,9 @@ async function runImportJsonl(): Promise<void> {
       imported?: number;
       sessionIds?: string[];
       observations?: number;
+      discovered?: number;
+      truncated?: boolean;
+      maxFiles?: number;
     } = {};
     if (text.length > 0) {
       try {
@@ -1050,6 +1069,15 @@ async function runImportJsonl(): Promise<void> {
     spinner.stop(
       `imported ${json.imported ?? 0} file(s), ${json.observations ?? 0} observation(s) across ${json.sessionIds?.length || 0} session(s)`,
     );
+    if (json.truncated) {
+      const cap = json.maxFiles ?? 200;
+      const skipped = (json.discovered ?? 0) - (json.imported ?? 0);
+      p.log.warn(
+        `Hit the ${cap}-file scan cap; ${skipped} of ${json.discovered ?? "?"} discovered file(s) were skipped. ` +
+          `Re-run with --max-files=<N> (e.g. --max-files=${Math.max((json.discovered ?? cap) + 100, cap * 2)}) ` +
+          `or batch by subdirectory.`,
+      );
+    }
     if (json.sessionIds && json.sessionIds.length > 0) {
       p.log.info(`View at ${getViewerUrl()} → Replay tab`);
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,7 +36,7 @@ Commands:
   upgrade            Upgrade local deps + iii runtime (best effort)
   mcp                Start standalone MCP server (no engine required)
   import-jsonl [p]   Import Claude Code JSONL transcripts (default: ~/.claude/projects)
-                     Use --max-files <N> to override the 200-file scan cap (default: 200)
+                     Use --max-files <N> or --max-files=<N> to override the 200-file scan cap (default: 200)
 
 Options:
   --help, -h         Show this help
@@ -961,21 +961,36 @@ async function runMcp(): Promise<void> {
 }
 
 async function runImportJsonl(): Promise<void> {
-  const nonFlagArgs = args.slice(1).filter((a) => !a.startsWith("-"));
-  const pathArg = nonFlagArgs[0];
-
   let maxFiles: number | undefined;
-  const flagIdx = args.findIndex((a) => a === "--max-files");
-  if (flagIdx !== -1 && args[flagIdx + 1]) {
-    const parsed = parseInt(args[flagIdx + 1]!, 10);
-    if (!Number.isNaN(parsed) && parsed > 0) maxFiles = parsed;
-  } else {
-    const eqArg = args.find((a) => a.startsWith("--max-files="));
-    if (eqArg) {
-      const parsed = parseInt(eqArg.slice("--max-files=".length), 10);
-      if (!Number.isNaN(parsed) && parsed > 0) maxFiles = parsed;
+  const tail = args.slice(1);
+  const positional: string[] = [];
+  for (let i = 0; i < tail.length; i++) {
+    const a = tail[i]!;
+    if (a === "--max-files") {
+      const raw = tail[i + 1];
+      const parsed = raw !== undefined ? parseInt(raw, 10) : NaN;
+      if (Number.isInteger(parsed) && parsed > 0) {
+        maxFiles = parsed;
+      } else if (raw !== undefined) {
+        p.log.warn(`Ignoring --max-files ${raw}: expected a positive integer.`);
+      }
+      i++;
+      continue;
     }
+    if (a.startsWith("--max-files=")) {
+      const raw = a.slice("--max-files=".length);
+      const parsed = parseInt(raw, 10);
+      if (Number.isInteger(parsed) && parsed > 0) {
+        maxFiles = parsed;
+      } else {
+        p.log.warn(`Ignoring --max-files=${raw}: expected a positive integer.`);
+      }
+      continue;
+    }
+    if (a.startsWith("-")) continue;
+    positional.push(a);
   }
+  const pathArg = positional[0];
 
   const port = getRestPort();
   const base = `http://localhost:${port}`;

--- a/src/functions/replay.ts
+++ b/src/functions/replay.ts
@@ -18,6 +18,9 @@ import { buildSyntheticCompression } from "./compress-synthetic.js";
 import { getSearchIndex } from "./search.js";
 import { logger } from "../logger.js";
 
+export const MAX_FILES_DEFAULT = 200;
+export const MAX_FILES_UPPER_BOUND = 1000;
+
 const SENSITIVE_PATH_PATTERNS: RegExp[] = [
   /(^|[\\/_.-])secret([\\/_.-]|s?$)/i,
   /(^|[\\/_.-])credentials?([\\/_.-]|$)/i,
@@ -203,16 +206,23 @@ async function loadObservations(
 async function findJsonlFiles(
   root: string,
   limit = 200,
-): Promise<{ files: string[]; truncated: boolean; discovered: number }> {
+): Promise<{
+  files: string[];
+  truncated: boolean;
+  discovered: number;
+  traversalCapped: boolean;
+}> {
   const out: string[] = [];
   let discovered = 0;
-  // Cap how far we walk past the user's requested limit. We keep counting
-  // beyond `limit` so we can report `truncated`/`discovered` accurately,
-  // but we stop the walk well before million-file trees can lock the
-  // 30s function timeout.
-  const traversalCap = Math.max(limit * 10, 10_000);
+  let walked = 0;
+  // Hard bound on entries visited (regardless of extension) so trees
+  // dominated by non-jsonl files (node_modules, lockfiles, etc.) cannot
+  // lock the 30s function timeout. `discovered` may underrepresent the
+  // true count when traversalCapped fires — callers should surface that
+  // distinction to the user.
+  const traversalCap = Math.max(limit * 50, 50_000);
   async function walk(dir: string) {
-    if (discovered >= traversalCap) return;
+    if (walked >= traversalCap) return;
     let names: string[];
     try {
       names = await readdir(dir);
@@ -220,7 +230,8 @@ async function findJsonlFiles(
       return;
     }
     for (const name of names) {
-      if (discovered >= traversalCap) return;
+      if (walked >= traversalCap) return;
+      walked++;
       const full = join(dir, name);
       let st;
       try {
@@ -238,7 +249,13 @@ async function findJsonlFiles(
     }
   }
   await walk(root);
-  return { files: out, truncated: discovered > out.length, discovered };
+  const traversalCapped = walked >= traversalCap;
+  return {
+    files: out,
+    truncated: discovered > out.length || traversalCapped,
+    discovered,
+    traversalCapped,
+  };
 }
 
 export function registerReplayFunctions(sdk: ISdk, kv: StateKV): void {
@@ -279,7 +296,9 @@ export function registerReplayFunctions(sdk: ISdk, kv: StateKV): void {
           observations: number;
           discovered: number;
           truncated: boolean;
+          traversalCapped: boolean;
           maxFiles: number;
+          maxFilesUpperBound: number;
         }
       | { success: false; error: string }
     > => {
@@ -306,22 +325,24 @@ export function registerReplayFunctions(sdk: ISdk, kv: StateKV): void {
         return { success: false, error: "path not found" };
       }
 
-      const MAX_FILES_DEFAULT = 200;
-      const MAX_FILES_UPPER_BOUND = 1000;
+      // Valid integer requests are clamped to MAX_FILES_UPPER_BOUND so
+      // callers see a stable maxFiles in the response. Non-integer or
+      // <= 0 falls back to the safe default. The HTTP layer rejects
+      // out-of-range up front; this is the SDK-callable safety net.
       const maxFiles =
-        Number.isInteger(data.maxFiles) &&
-        (data.maxFiles as number) > 0 &&
-        (data.maxFiles as number) <= MAX_FILES_UPPER_BOUND
-          ? (data.maxFiles as number)
+        Number.isInteger(data.maxFiles) && (data.maxFiles as number) > 0
+          ? Math.min(data.maxFiles as number, MAX_FILES_UPPER_BOUND)
           : MAX_FILES_DEFAULT;
       let files: string[] = [];
       let truncated = false;
       let discovered = 0;
+      let traversalCapped = false;
       if (stat.isDirectory()) {
         const found = await findJsonlFiles(abs, maxFiles);
         files = found.files;
         truncated = found.truncated;
         discovered = found.discovered;
+        traversalCapped = found.traversalCapped;
       } else if (stat.isFile() && abs.endsWith(".jsonl")) {
         files = [abs];
         discovered = 1;
@@ -337,7 +358,9 @@ export function registerReplayFunctions(sdk: ISdk, kv: StateKV): void {
           observations: 0,
           discovered,
           truncated,
+          traversalCapped,
           maxFiles,
+          maxFilesUpperBound: MAX_FILES_UPPER_BOUND,
         };
       }
 
@@ -436,7 +459,9 @@ export function registerReplayFunctions(sdk: ISdk, kv: StateKV): void {
         observations: observationCount,
         discovered,
         truncated,
+        traversalCapped,
         maxFiles,
+        maxFilesUpperBound: MAX_FILES_UPPER_BOUND,
       };
     },
   );

--- a/src/functions/replay.ts
+++ b/src/functions/replay.ts
@@ -200,10 +200,13 @@ async function loadObservations(
   return rows.map((r) => (isRawShape(r) ? r : rawFromCompressed(r as CompressedObservation)));
 }
 
-async function findJsonlFiles(root: string, limit = 200): Promise<string[]> {
+async function findJsonlFiles(
+  root: string,
+  limit = 200,
+): Promise<{ files: string[]; truncated: boolean; discovered: number }> {
   const out: string[] = [];
+  let discovered = 0;
   async function walk(dir: string) {
-    if (out.length >= limit) return;
     let names: string[];
     try {
       names = await readdir(dir);
@@ -211,7 +214,6 @@ async function findJsonlFiles(root: string, limit = 200): Promise<string[]> {
       return;
     }
     for (const name of names) {
-      if (out.length >= limit) return;
       const full = join(dir, name);
       let st;
       try {
@@ -223,12 +225,13 @@ async function findJsonlFiles(root: string, limit = 200): Promise<string[]> {
       if (st.isDirectory()) {
         await walk(full);
       } else if (st.isFile() && name.endsWith(".jsonl")) {
-        out.push(full);
+        discovered++;
+        if (out.length < limit) out.push(full);
       }
     }
   }
   await walk(root);
-  return out;
+  return { files: out, truncated: discovered > out.length, discovered };
 }
 
 export function registerReplayFunctions(sdk: ISdk, kv: StateKV): void {
@@ -267,6 +270,9 @@ export function registerReplayFunctions(sdk: ISdk, kv: StateKV): void {
           imported: number;
           sessionIds: string[];
           observations: number;
+          discovered: number;
+          truncated: boolean;
+          maxFiles: number;
         }
       | { success: false; error: string }
     > => {
@@ -293,17 +299,32 @@ export function registerReplayFunctions(sdk: ISdk, kv: StateKV): void {
         return { success: false, error: "path not found" };
       }
 
+      const maxFiles = data.maxFiles && data.maxFiles > 0 ? data.maxFiles : 200;
       let files: string[] = [];
+      let truncated = false;
+      let discovered = 0;
       if (stat.isDirectory()) {
-        files = await findJsonlFiles(abs, data.maxFiles || 200);
+        const found = await findJsonlFiles(abs, maxFiles);
+        files = found.files;
+        truncated = found.truncated;
+        discovered = found.discovered;
       } else if (stat.isFile() && abs.endsWith(".jsonl")) {
         files = [abs];
+        discovered = 1;
       } else {
         return { success: false, error: "path must be a .jsonl file or directory" };
       }
 
       if (files.length === 0) {
-        return { success: true, imported: 0, sessionIds: [], observations: 0 };
+        return {
+          success: true,
+          imported: 0,
+          sessionIds: [],
+          observations: 0,
+          discovered,
+          truncated,
+          maxFiles,
+        };
       }
 
       const sessionIds: string[] = [];
@@ -399,6 +420,9 @@ export function registerReplayFunctions(sdk: ISdk, kv: StateKV): void {
         imported: files.length,
         sessionIds,
         observations: observationCount,
+        discovered,
+        truncated,
+        maxFiles,
       };
     },
   );

--- a/src/functions/replay.ts
+++ b/src/functions/replay.ts
@@ -206,7 +206,13 @@ async function findJsonlFiles(
 ): Promise<{ files: string[]; truncated: boolean; discovered: number }> {
   const out: string[] = [];
   let discovered = 0;
+  // Cap how far we walk past the user's requested limit. We keep counting
+  // beyond `limit` so we can report `truncated`/`discovered` accurately,
+  // but we stop the walk well before million-file trees can lock the
+  // 30s function timeout.
+  const traversalCap = Math.max(limit * 10, 10_000);
   async function walk(dir: string) {
+    if (discovered >= traversalCap) return;
     let names: string[];
     try {
       names = await readdir(dir);
@@ -214,6 +220,7 @@ async function findJsonlFiles(
       return;
     }
     for (const name of names) {
+      if (discovered >= traversalCap) return;
       const full = join(dir, name);
       let st;
       try {
@@ -299,7 +306,14 @@ export function registerReplayFunctions(sdk: ISdk, kv: StateKV): void {
         return { success: false, error: "path not found" };
       }
 
-      const maxFiles = data.maxFiles && data.maxFiles > 0 ? data.maxFiles : 200;
+      const MAX_FILES_DEFAULT = 200;
+      const MAX_FILES_UPPER_BOUND = 1000;
+      const maxFiles =
+        Number.isInteger(data.maxFiles) &&
+        (data.maxFiles as number) > 0 &&
+        (data.maxFiles as number) <= MAX_FILES_UPPER_BOUND
+          ? (data.maxFiles as number)
+          : MAX_FILES_DEFAULT;
       let files: string[] = [];
       let truncated = false;
       let discovered = 0;

--- a/src/replay/jsonl-parser.ts
+++ b/src/replay/jsonl-parser.ts
@@ -90,7 +90,7 @@ export function parseJsonlText(text: string, fallbackSessionId?: string): Parsed
     }
   }
 
-  let sessionId = fallbackSessionId || "";
+  let sessionId = "";
   let cwd = "";
   let firstTs = "";
   let lastTs = "";
@@ -164,7 +164,7 @@ export function parseJsonlText(text: string, fallbackSessionId?: string): Parsed
     }
   }
 
-  const effectiveSessionId = sessionId || generateId("sess");
+  const effectiveSessionId = sessionId || fallbackSessionId || generateId("sess");
   for (const obs of observations) {
     if (obs.sessionId === "imported") obs.sessionId = effectiveSessionId;
   }

--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -8,6 +8,7 @@ import type { ResilientProvider } from "../providers/resilient.js";
 import { VERSION } from "../version.js";
 import { timingSafeCompare } from "../auth.js";
 import { renderViewerDocument } from "../viewer/document.js";
+import { MAX_FILES_UPPER_BOUND } from "../functions/replay.js";
 import {
   isGraphExtractionEnabled,
   isConsolidationEnabled,
@@ -486,13 +487,20 @@ export function registerApiTriggers(
         payload.path = body.path.trim();
       }
       if (body.maxFiles !== undefined) {
-        if (!Number.isInteger(body.maxFiles) || (body.maxFiles as number) < 1) {
+        const n = body.maxFiles as number;
+        if (
+          !Number.isInteger(n) ||
+          n < 1 ||
+          n > MAX_FILES_UPPER_BOUND
+        ) {
           return {
             status_code: 400,
-            body: { error: "maxFiles must be a positive integer" },
+            body: {
+              error: `maxFiles must be an integer between 1 and ${MAX_FILES_UPPER_BOUND}`,
+            },
           };
         }
-        payload.maxFiles = body.maxFiles as number;
+        payload.maxFiles = n;
       }
       const result = await sdk.trigger({
         function_id: "mem::replay::import-jsonl",

--- a/test/replay.test.ts
+++ b/test/replay.test.ts
@@ -58,6 +58,45 @@ describe("parseJsonlText", () => {
     const out = parseJsonlText("");
     expect(out.observations).toHaveLength(0);
   });
+
+  it("prefers the file's sessionId over the fallback", () => {
+    const text = [
+      JSON.stringify({
+        type: "user",
+        sessionId: "real-session-from-file",
+        timestamp: "2026-01-01T00:00:00.000Z",
+        message: { role: "user", content: [{ type: "text", text: "hi" }] },
+      }),
+    ].join("\n");
+    const out = parseJsonlText(text, "fallback-should-be-ignored");
+    expect(out.sessionId).toBe("real-session-from-file");
+    for (const obs of out.observations) {
+      expect(obs.sessionId).toBe("real-session-from-file");
+    }
+  });
+
+  it("returns the same sessionId across repeated parses of one file", () => {
+    const text = JSON.stringify({
+      type: "user",
+      sessionId: "stable-id",
+      timestamp: "2026-01-01T00:00:00.000Z",
+      message: { role: "user", content: [{ type: "text", text: "hi" }] },
+    });
+    const a = parseJsonlText(text, "fb-1");
+    const b = parseJsonlText(text, "fb-2");
+    expect(a.sessionId).toBe("stable-id");
+    expect(b.sessionId).toBe("stable-id");
+  });
+
+  it("uses the fallback only when the file has no sessionId", () => {
+    const text = JSON.stringify({
+      type: "user",
+      timestamp: "2026-01-01T00:00:00.000Z",
+      message: { role: "user", content: [{ type: "text", text: "hi" }] },
+    });
+    const out = parseJsonlText(text, "fb-used");
+    expect(out.sessionId).toBe("fb-used");
+  });
 });
 
 describe("projectTimeline", () => {


### PR DESCRIPTION
## Summary

Two bugs in the JSONL import path that combined to make \`agentmemory import-jsonl\` against a real \`~/.claude/projects\` tree quietly mis-import: ~10% of files scanned, each landing under a fresh random session id even when the file's own header named one.

### #202 — \`parseJsonlText\` ignores the file's sessionId

The parser pre-populated \`sessionId\` from \`fallbackSessionId\` and then guarded \`if (entry.sessionId && !sessionId)\`, so the file's real id was never adopted. Each call returned a freshly generated session, breaking merge-on-reimport and inflating session counts ~4× on real trees.

Fix: don't pre-populate \`sessionId\`; fall back to \`fallbackSessionId\` then \`generateId('sess')\` only after the loop.

### #203 — \`import-jsonl\` CLI silently caps at 200 files

\`findJsonlFiles\` had a hard 200-file cap (sensible for the 30s function timeout) but the CLI exposed no flag to override it and never warned when files were skipped. On a 2167-file tree users got a silent ~10% import.

Fix:
- \`findJsonlFiles\` now reports \`{files, truncated, discovered}\` so the handler can count beyond the cap without retaining the paths
- Handler returns \`discovered\`, \`truncated\`, \`maxFiles\` in the response
- CLI accepts \`--max-files <N>\` and \`--max-files=<N>\`
- CLI warns on truncation, suggests a larger cap

## Tests

- 3 new regression cases in \`test/replay.test.ts\`: file sessionId beats fallback, repeated parses produce the same id, fallback only when file has no id
- Full suite: 830/830 passing

Thanks @bloodcarter for the precise repros and root-cause pointers in #202/#203.

Closes #202
Closes #203

## Test plan

- [ ] \`agentmemory import-jsonl ~/.claude/projects\` on a tree >200 files — must surface a warning + skipped count
- [ ] \`agentmemory import-jsonl --max-files 5000 ~/.claude/projects\` — must scan beyond 200
- [ ] Re-run import twice on the same file — must merge into one Session (no duplicates)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI: added optional --max-files (both forms); imports now report discovered/skipped counts, truncation/traversal caps, and recommend batching or a higher max within the server-provided upper bound.
* **Bug Fixes**
  * Fixed CLI argument parsing so long-form flags consume their values correctly.
  * Enhanced server-side validation of maxFiles with clearer range errors; invalid CLI values emit warnings and are ignored.
* **Tests**
  * Added tests covering session ID precedence and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->