### PR TITLE
feat(api): add GET /agentmemory/memories/:id (#196)

### DIFF
--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -1323,7 +1323,7 @@ export function registerApiTriggers(
     config: { api_path: "/agentmemory/snapshot/restore", http_method: "POST" },
   });
 
-  sdk.registerFunction("api::memories", 
+  sdk.registerFunction("api::memories",
     async (req: ApiRequest): Promise<Response> => {
       const authErr = checkAuth(req, secret);
       if (authErr) return authErr;
@@ -1337,6 +1337,27 @@ export function registerApiTriggers(
     type: "http",
     function_id: "api::memories",
     config: { api_path: "/agentmemory/memories", http_method: "GET" },
+  });
+
+  sdk.registerFunction("api::memory-by-id",
+    async (req: ApiRequest): Promise<Response> => {
+      const authErr = checkAuth(req, secret);
+      if (authErr) return authErr;
+      const id = req.path_params?.["id"];
+      if (!id || typeof id !== "string") {
+        return { status_code: 400, body: { error: "id path parameter is required" } };
+      }
+      const memory = await kv.get<import("../types.js").Memory>(KV.memories, id);
+      if (!memory) {
+        return { status_code: 404, body: { error: `memory not found: ${id}` } };
+      }
+      return { status_code: 200, body: { memory } };
+    },
+  );
+  sdk.registerTrigger({
+    type: "http",
+    function_id: "api::memory-by-id",
+    config: { api_path: "/agentmemory/memories/:id", http_method: "GET" },
   });
 
   sdk.registerFunction("api::semantic-list",


### PR DESCRIPTION
## Summary

The route was simply not registered. \`POST /remember\` writes to \`KV.memories\` keyed by the generated id; \`GET /memories\` lists from the same scope. There was no by-id retrieval handler at all, so any \"save then fetch-by-ID\" round-trip returned 404 even though the data was in storage and visible in list responses.

Adds \`api::memory-by-id\` with path-param \`:id\`:
- 200 \`{ memory }\` on hit (matches the POST response shape)
- 404 \`{ error }\` on miss
- 400 if id is empty
- Auth gate matches the rest of the protected endpoints

Thanks @Axialon for the precise repro and root-cause guess (correct: it was a missing handler, not a scope mismatch).

Closes #196

## Test plan

- [ ] \`POST /agentmemory/remember\` then \`GET /agentmemory/memories/<returned-id>\` — must 200 with the same memory object
- [ ] \`GET /agentmemory/memories/does-not-exist\` — must 404
- [ ] Existing \`GET /agentmemory/memories\` list endpoint still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new authenticated API endpoint to retrieve individual memories by ID, with appropriate error handling for invalid or missing requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->