### PR TITLE
fix: increase systemic timeouts for summarization and consolidation

### DIFF
--- a/src/hooks/session-end.ts
+++ b/src/hooks/session-end.ts
@@ -37,7 +37,7 @@ async function main() {
       method: "POST",
       headers: authHeaders(),
       body: JSON.stringify({ sessionId }),
-      signal: AbortSignal.timeout(5000),
+      signal: AbortSignal.timeout(30000), // Increased from 5s
     });
   } catch {
     // best-effort
@@ -49,7 +49,7 @@ async function main() {
         method: "POST",
         headers: authHeaders(),
         body: JSON.stringify({ olderThanDays: 0 }),
-        signal: AbortSignal.timeout(15000),
+        signal: AbortSignal.timeout(60000), // Increased from 15s
       });
     } catch {}
 
@@ -58,7 +58,7 @@ async function main() {
         method: "POST",
         headers: authHeaders(),
         body: JSON.stringify({ tier: "all", force: true }),
-        signal: AbortSignal.timeout(30000),
+        signal: AbortSignal.timeout(120000), // Increased from 30s
       });
     } catch {}
   }
@@ -68,7 +68,7 @@ async function main() {
       await fetch(`${REST_URL}/agentmemory/claude-bridge/sync`, {
         method: "POST",
         headers: authHeaders(),
-        signal: AbortSignal.timeout(5000),
+        signal: AbortSignal.timeout(30000), // Increased from 5s
       });
     } catch {
       // best-effort

--- a/src/hooks/stop.ts
+++ b/src/hooks/stop.ts
@@ -44,7 +44,7 @@ async function main() {
       method: "POST",
       headers: authHeaders(),
       body: JSON.stringify({ sessionId }),
-      signal: AbortSignal.timeout(30000),
+      signal: AbortSignal.timeout(120000), // Increased from 30s to 120s
     });
   } catch {
     // summarize is best-effort

--- a/src/index.ts
+++ b/src/index.ts
@@ -160,6 +160,7 @@ async function main() {
 
   const sdk = registerWorker(config.engineUrl, {
     workerName: "agentmemory",
+    invocationTimeoutMs: 180000,
     otel: {
       serviceName: OTEL_CONFIG.serviceName,
       serviceVersion: OTEL_CONFIG.serviceVersion,


### PR DESCRIPTION
## Summary
This PR addresses systemic timeout issues encountered during long coding sessions (e.g., sessions with 300+ observations).

### Changes:
1.  **Increased Default SDK Timeout**: Updated `registerWorker` in `src/index.ts` to use a 180s `invocationTimeoutMs` instead of the 30s default. This provides sufficient head-room for heavy LLM summarization and consolidation tasks.
2.  **Increased Hook Script Timeouts**:
    *   `src/hooks/stop.ts`: Increased `fetch` timeout for `/agentmemory/summarize` to 120s.
    *   `src/hooks/session-end.ts`: Increased timeouts for session end (30s), crystallization (60s), and consolidation pipeline (120s).

### Context:
In high-volume sessions, the `mem::summarize` and `mem::consolidate-pipeline` functions often require more than 30s of LLM execution time. Without these adjustments, the hooks fail and the memory system misses critical summary/consolidation steps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Increased timeout durations for session management, memory consolidation, and summarization operations.
  * Increased worker invocation timeout to 3 minutes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->