### PR TITLE
doctor: detect Claude Code plugin-hooks load state (refs #212)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,10 +6,10 @@ import {
   spawnSync,
   type ChildProcess,
 } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, readlinkSync, statSync } from "node:fs";
 import { join, dirname, delimiter as PATH_DELIMITER } from "node:path";
 import { fileURLToPath } from "node:url";
-import { platform } from "node:os";
+import { homedir, platform } from "node:os";
 import * as p from "@clack/prompts";
 import { generateId } from "./state/schema.js";
 
@@ -511,6 +511,55 @@ function formatChecks(checks: DoctorCheck[]): string {
     .join("\n");
 }
 
+type CCHooksCheck =
+  | { state: "loaded"; manifestPath?: string }
+  | { state: "not-loaded" }
+  | { state: "no-debug-log" }
+  | { state: "no-cc-dir" };
+
+function findLatestDebugLog(debugDir: string): string | undefined {
+  const latestLink = join(debugDir, "latest");
+  try {
+    if (existsSync(latestLink)) {
+      const target = readlinkSync(latestLink);
+      const resolved = target.startsWith("/") ? target : join(debugDir, target);
+      if (existsSync(resolved)) return resolved;
+    }
+  } catch {}
+
+  try {
+    const newest = readdirSync(debugDir)
+      .filter((f) => f.endsWith(".txt"))
+      .map((f) => ({ f, m: statSync(join(debugDir, f)).mtimeMs }))
+      .sort((a, b) => b.m - a.m)[0];
+    if (newest) return join(debugDir, newest.f);
+  } catch {}
+
+  return undefined;
+}
+
+function checkClaudeCodeHooks(): CCHooksCheck {
+  const debugDir = join(homedir(), ".claude", "debug");
+  if (!existsSync(debugDir)) return { state: "no-cc-dir" };
+
+  const logPath = findLatestDebugLog(debugDir);
+  if (!logPath) return { state: "no-debug-log" };
+
+  let content: string;
+  try {
+    content = readFileSync(logPath, "utf8");
+  } catch {
+    return { state: "no-debug-log" };
+  }
+
+  const match = content.match(
+    /Loaded hooks from standard location for plugin agentmemory:\s*(\S+)/
+  );
+  if (match) return { state: "loaded", manifestPath: match[1] };
+  if (content.includes("Loading hooks from plugin: agentmemory")) return { state: "loaded" };
+  return { state: "not-loaded" };
+}
+
 async function runDoctor() {
   p.intro("agentmemory doctor");
   const base = getBaseUrl();
@@ -570,6 +619,30 @@ async function runDoctor() {
   for (const f of (flags?.flags || []) as { label: string; enabled: boolean; enableHow: string }[]) {
     checks.push({ name: f.label, ok: f.enabled, hint: f.enabled ? undefined : f.enableHow });
   }
+
+  const cc = checkClaudeCodeHooks();
+  const ccCheck = (() => {
+    switch (cc.state) {
+      case "loaded":
+        return {
+          ok: true,
+          hint: cc.manifestPath ? `manifest: ${cc.manifestPath}` : undefined,
+        };
+      case "not-loaded":
+        return {
+          ok: false,
+          hint: "Plugin enabled but hooks not loaded by Claude Code. Try: /plugin uninstall agentmemory@agentmemory && /plugin install agentmemory@agentmemory, then restart the session. CC must be >= 2.1.x for plugin-hook auto-load.",
+        };
+      case "no-debug-log":
+        return {
+          ok: false,
+          hint: "Cannot verify — no Claude Code debug log found. Run once with `claude --debug -p \"x\"`, then re-run doctor.",
+        };
+      case "no-cc-dir":
+        return undefined;
+    }
+  })();
+  if (ccCheck) checks.push({ name: "Claude Code plugin hooks registered", ...ccCheck });
 
   checks.push({
     name: "Knowledge graph populated",


### PR DESCRIPTION
## Summary

- `agentmemory doctor` gains a check that verifies whether Claude Code actually loaded the plugin's hooks
- Scans `~/.claude/debug/latest` for the `Loaded hooks from standard location for plugin agentmemory` log line
- Surfaces the silent failure mode reported in #212: plugin enabled, hooks.json present, but hooks never fire

## Why

#212 reports plugin hooks not auto-registering after `/plugin install`. Bug does not reproduce on macOS + CC 2.1.120 + agentmemory 0.9.3 (verified via debug log + injected probe), but when it does happen the user gets no signal — hooks silently do nothing. This adds a diagnostic so doctor can flag the failure mode and point at a remediation (reinstall + restart, CC version floor).

## Check states

| State | UI | Meaning |
|---|---|---|
| loaded | ✓ + manifest path | CC picked up `hooks/hooks.json` |
| not-loaded | ✗ + reinstall hint | debug log exists but no agentmemory hook-load line |
| no-debug-log | ✗ + run-with-debug hint | `~/.claude/debug` exists, no `.txt` log yet |
| no-cc-dir | (skipped) | no `~/.claude/debug` — user likely doesn't use Claude Code |

## Test plan

- [x] Build clean (`npm run build`)
- [x] Pre-existing test failures (mcp-standalone, fs-watcher) unchanged
- [x] Smoke-tested `checkClaudeCodeHooks()` against current `~/.claude/debug/latest` — returns `loaded` with manifest path
- [ ] Run `agentmemory doctor` end-to-end with server up (manual)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `doctor` command now includes enhanced verification for Claude Code plugin registration, checking local debug logs to report loading status and provide remediation guidance when issues are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->