### PR TITLE
fix(graph): auto-fire mem::graph-extract at session end (closes #210)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- **`mem::graph-extract` now auto-fires at session end.** When `GRAPH_EXTRACTION_ENABLED=true`, the function was registered and the REST endpoint was live, but no internal caller invoked it — the graph KV stayed empty unless users manually `POST`ed to `/agentmemory/graph/extract`. `event::session::stopped` now triggers it (fire-and-forget, idempotent via existing node/edge merge keys), so enabling the flag actually populates the graph. README pipeline diagram updated to show graph extraction at the Stop/SessionEnd phase rather than implying it runs per PostToolUse. (#210)
+
 ## [0.9.3] — 2026-04-24
 
 Developer-experience patch. Every disabled feature flag is now visible in the viewer, the CLI, and REST error responses, so devs no longer hit empty tabs wondering whether the install is broken or just opt-in. Adds a `doctor` command that diagnoses the whole stack in one shot and a first-run hero in the viewer that points at the magical-moment `demo` command.

--- a/README.md
+++ b/README.md
@@ -506,7 +506,12 @@ PostToolUse hook fires
   -> Store raw observation
   -> LLM compress -> structured facts + concepts + narrative
   -> Vector embedding (6 providers + local)
-  -> Index in BM25 + vector + knowledge graph
+  -> Index in BM25 + vector
+
+Stop / SessionEnd hook fires
+  -> Summarize session
+  -> Knowledge graph extraction (if GRAPH_EXTRACTION_ENABLED=true)
+  -> Slot reflection (if SLOT_REFLECT_ENABLED=true)
 
 SessionStart hook fires
   -> Load project profile (top concepts, files, patterns)

--- a/src/triggers/events.ts
+++ b/src/triggers/events.ts
@@ -1,8 +1,9 @@
 import { TriggerAction, type ISdk } from "iii-sdk";
-import type { HookPayload, Session } from "../types.js";
+import type { CompressedObservation, HookPayload, Session } from "../types.js";
 import { KV, STREAM } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
 import { isReflectEnabled } from "../functions/slots.js";
+import { isGraphExtractionEnabled } from "../config.js";
 import { logger } from "../logger.js";
 
 export function registerEventTriggers(sdk: ISdk, kv: StateKV): void {
@@ -50,6 +51,22 @@ export function registerEventTriggers(sdk: ISdk, kv: StateKV): void {
         sdk.triggerVoid("mem::slot-reflect", { sessionId: data.sessionId });
       } catch (err) {
         logger.warn("slot-reflect triggerVoid failed", {
+          sessionId: data.sessionId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    if (isGraphExtractionEnabled()) {
+      try {
+        const observations = await kv.list<CompressedObservation>(
+          KV.observations(data.sessionId),
+        );
+        const compressed = observations.filter((o) => o.title);
+        if (compressed.length > 0) {
+          sdk.triggerVoid("mem::graph-extract", { observations: compressed });
+        }
+      } catch (err) {
+        logger.warn("graph-extract triggerVoid failed", {
           sessionId: data.sessionId,
           error: err instanceof Error ? err.message : String(err),
         });


### PR DESCRIPTION
## Summary

Closes #210. `mem::graph-extract` was registered and exposed via REST, but **never auto-invoked**. Graph KV stayed empty even with `GRAPH_EXTRACTION_ENABLED=true` unless users manually `POST`ed to `/agentmemory/graph/extract`.

Reporter @jco-analyst traced this thoroughly: zero callers in `observe.ts`, `compress.ts`, `consolidation-pipeline.ts`, `flow-compress.ts`, or `registerEventTriggers`. README pipeline diagram (`-> Index in BM25 + vector + knowledge graph`) implied per-PostToolUse extraction that didn't exist.

## Fix

Wire `mem::graph-extract` into `event::session::stopped` — fire-and-forget, gated on `isGraphExtractionEnabled()`, mirrors the existing `mem::slot-reflect` glue.

```ts
if (isGraphExtractionEnabled()) {
  try {
    const observations = await kv.list<CompressedObservation>(KV.observations(data.sessionId));
    const compressed = observations.filter((o) => o.title);
    if (compressed.length > 0) {
      sdk.triggerVoid("mem::graph-extract", { observations: compressed });
    }
  } catch (err) {
    logger.warn("graph-extract triggerVoid failed", { ... });
  }
}
```

Idempotent on re-run via existing merge keys (`name+type` for nodes, `source|target|type` for edges) at `src/functions/graph.ts:115-149`.

## README

Pipeline diagram split: BM25 + vector at PostToolUse (unchanged), graph extraction now correctly shown at Stop/SessionEnd phase.

## Out of scope

- `mem::temporal-graph-extract` has the same orphan status — separate follow-up
- Missing `graph-prune/decay/gc/clear` (raised in the issue) — separate follow-up; graph KV will grow unbounded until those land

## Test plan

- [x] Build clean (`npm run build`)
- [x] Pre-existing test failures unchanged (mcp-standalone, fs-watcher flake)
- [ ] Manual: set `GRAPH_EXTRACTION_ENABLED=true`, run a session through Claude Code, end session, `curl /agentmemory/graph/stats` → expect non-zero `totalNodes`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Graph extraction now automatically triggers at session end when the feature flag is enabled, eliminating the need for manual REST API calls.

* **Documentation**
  * Updated pipeline documentation to show graph extraction occurs at session end instead of during tool use, and documented feature flags controlling extraction and reflection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->