### PR TITLE
feat(providers): add Azure OpenAI provider

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -87,12 +87,25 @@ function detectProvider(env: Record<string, string>): ProviderConfig {
       maxTokens,
     };
   }
+  if (
+    hasRealValue(env["AZURE_OPENAI_API_KEY"]) &&
+    hasRealValue(env["AZURE_OPENAI_ENDPOINT"]) &&
+    hasRealValue(env["AZURE_OPENAI_DEPLOYMENT"])
+  ) {
+    return {
+      provider: "azure-openai",
+      model: env["AZURE_OPENAI_DEPLOYMENT"],
+      maxTokens,
+      baseURL: env["AZURE_OPENAI_ENDPOINT"],
+    };
+  }
 
   const allowAgentSdk = env["AGENTMEMORY_ALLOW_AGENT_SDK"] === "true";
   if (!allowAgentSdk) {
     process.stderr.write(
       "[agentmemory] No LLM provider key found " +
-        "(ANTHROPIC_API_KEY, GEMINI_API_KEY, OPENROUTER_API_KEY, MINIMAX_API_KEY). " +
+        "(ANTHROPIC_API_KEY, GEMINI_API_KEY, OPENROUTER_API_KEY, MINIMAX_API_KEY, " +
+        "or AZURE_OPENAI_API_KEY + AZURE_OPENAI_ENDPOINT + AZURE_OPENAI_DEPLOYMENT). " +
         "LLM-backed compression and summarization are DISABLED — using no-op provider. " +
         "This is the safe default: the agent-sdk fallback used to spawn Claude Agent SDK " +
         "child sessions which inherit Claude Code's plugin hooks and cause infinite Stop-hook " +
@@ -156,7 +169,10 @@ export function detectLlmProviderKind(): "llm" | "noop" {
     hasRealValue(env["GEMINI_API_KEY"]) ||
     hasRealValue(env["GOOGLE_API_KEY"]) ||
     hasRealValue(env["OPENROUTER_API_KEY"]) ||
-    hasRealValue(env["MINIMAX_API_KEY"])
+    hasRealValue(env["MINIMAX_API_KEY"]) ||
+    (hasRealValue(env["AZURE_OPENAI_API_KEY"]) &&
+      hasRealValue(env["AZURE_OPENAI_ENDPOINT"]) &&
+      hasRealValue(env["AZURE_OPENAI_DEPLOYMENT"]))
   ) {
     return "llm";
   }

--- a/src/providers/azure-openai.ts
+++ b/src/providers/azure-openai.ts
@@ -1,0 +1,71 @@
+import type { MemoryProvider } from "../types.js";
+
+export class AzureOpenAIProvider implements MemoryProvider {
+  name = "azure-openai";
+  private apiKey: string;
+  private endpoint: string;
+  private deploymentName: string;
+  private apiVersion: string;
+  private maxTokens: number;
+
+  constructor(
+    apiKey: string,
+    endpoint: string,
+    deploymentName: string,
+    maxTokens: number,
+    apiVersion = "2024-08-01-preview",
+  ) {
+    this.apiKey = apiKey;
+    this.endpoint = endpoint.replace(/\/$/, "");
+    this.deploymentName = deploymentName;
+    this.maxTokens = maxTokens;
+    this.apiVersion = apiVersion;
+  }
+
+  async compress(systemPrompt: string, userPrompt: string): Promise<string> {
+    return this.call(systemPrompt, userPrompt);
+  }
+
+  async summarize(systemPrompt: string, userPrompt: string): Promise<string> {
+    return this.call(systemPrompt, userPrompt);
+  }
+
+  private async call(systemPrompt: string, userPrompt: string): Promise<string> {
+    const url =
+      `${this.endpoint}/openai/deployments/${this.deploymentName}` +
+      `/chat/completions?api-version=${this.apiVersion}`;
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "api-key": this.apiKey,
+      },
+      body: JSON.stringify({
+        model: this.deploymentName,
+        max_tokens: this.maxTokens,
+        messages: [
+          { role: "system", content: systemPrompt },
+          { role: "user", content: userPrompt },
+        ],
+      }),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`azure-openai API error (${response.status}): ${text}`);
+    }
+
+    const data = (await response.json()) as Record<string, unknown>;
+    const choices = data.choices as
+      | Array<{ message: { content: string } }>
+      | undefined;
+    const content = choices?.[0]?.message?.content;
+    if (!content) {
+      throw new Error(
+        `azure-openai returned unexpected response: ${JSON.stringify(data).slice(0, 200)}`,
+      );
+    }
+    return content;
+  }
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -5,6 +5,7 @@ import type {
 } from "../types.js";
 import { AgentSDKProvider } from "./agent-sdk.js";
 import { AnthropicProvider } from "./anthropic.js";
+import { AzureOpenAIProvider } from "./azure-openai.js";
 import { MinimaxProvider } from "./minimax.js";
 import { NoopProvider } from "./noop.js";
 import { OpenRouterProvider } from "./openrouter.js";
@@ -94,6 +95,17 @@ function createBaseProvider(config: ProviderConfig): MemoryProvider {
         config.maxTokens,
         "https://openrouter.ai/api/v1/chat/completions",
       );
+    case "azure-openai": {
+      const endpoint = config.baseURL || requireEnvVar("AZURE_OPENAI_ENDPOINT");
+      const apiVersion = getEnvVar("AZURE_OPENAI_API_VERSION");
+      return new AzureOpenAIProvider(
+        requireEnvVar("AZURE_OPENAI_API_KEY"),
+        endpoint,
+        config.model,
+        config.maxTokens,
+        apiVersion || undefined,
+      );
+    }
     case "noop":
       return new NoopProvider();
     case "agent-sdk":

--- a/src/types.ts
+++ b/src/types.ts
@@ -129,7 +129,7 @@ export interface ProviderConfig {
   baseURL?: string;
 }
 
-export type ProviderType = "agent-sdk" | "anthropic" | "gemini" | "openrouter" | "minimax" | "noop";
+export type ProviderType = "agent-sdk" | "anthropic" | "azure-openai" | "gemini" | "openrouter" | "minimax" | "noop";
 
 export interface MemoryProvider {
   name: string;

--- a/src/viewer/index.html
+++ b/src/viewer/index.html
@@ -3320,9 +3320,9 @@
           kind: 'warn',
           icon: '&#128274;',
           title: 'No LLM provider key set',
-          keyLabel: 'ANTHROPIC_API_KEY',
+          keyLabel: 'ANTHROPIC_API_KEY / AZURE_OPENAI_API_KEY',
           desc: 'Compression, summarization, and graph extraction stay disabled until a key is provided.',
-          enable: 'export ANTHROPIC_API_KEY=sk-ant-...\n# then restart: npx @agentmemory/agentmemory',
+          enable: '# Option A — direct Anthropic key:\nexport ANTHROPIC_API_KEY=sk-ant-...\n\n# Option B — Azure OpenAI:\nexport AZURE_OPENAI_API_KEY=<key>\nexport AZURE_OPENAI_ENDPOINT=https://<resource>.openai.azure.com\nexport AZURE_OPENAI_DEPLOYMENT=<deployment-name>\n\n# then restart: npx @agentmemory/agentmemory',
           docs: 'https://github.com/rohitg00/agentmemory#quick-start',
           dismissKey: '__provider_noop',
         });


### PR DESCRIPTION
## Summary

Adds support for Azure OpenAI Service as an LLM provider for compression, summarization, and graph extraction.

### Changes

- **`src/providers/azure-openai.ts`** (new) — `AzureOpenAIProvider` class. Constructs the Azure-style URL (`/openai/deployments/{name}/chat/completions?api-version=...`), uses `api-key` header instead of `Authorization: Bearer`, otherwise follows the same OpenAI-compatible request/response shape as the existing `OpenRouterProvider`.

- **`src/types.ts`** — adds `"azure-openai"` to the `ProviderType` union.

- **`src/config.ts`** — detects all three required Azure env vars and returns `provider: "azure-openai"` config; updates `detectLlmProviderKind()` to return `"llm"` when Azure vars are set; updates the "no key found" error message.

- **`src/providers/index.ts`** — wires the `case "azure-openai"` branch into `createBaseProvider`.

- **`src/viewer/index.html`** — updates the "No LLM provider key set" flag banner to show both Anthropic and Azure setup instructions.

### Usage

Add to `~/.agentmemory/.env`:

```env
AZURE_OPENAI_API_KEY=<your-azure-api-key>
AZURE_OPENAI_ENDPOINT=https://<resource-name>.openai.azure.com
AZURE_OPENAI_DEPLOYMENT=<deployment-name>

# Optional — defaults to 2024-08-01-preview
AZURE_OPENAI_API_VERSION=2024-08-01-preview
```

Then restart: `npx @agentmemory/agentmemory`

## Test plan

- [ ] Server starts without error when all three Azure env vars are set
- [ ] `provider` shows as `azure-openai` in health endpoint response
- [ ] Compression runs successfully against an Azure-hosted deployment
- [ ] Missing `AZURE_OPENAI_ENDPOINT` or `AZURE_OPENAI_DEPLOYMENT` falls through to noop (no partial config accepted)
- [ ] Viewer flag banner shows Azure setup instructions when provider is noop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Azure OpenAI as a supported LLM provider option
  
* **Documentation**
  * Updated configuration guidance to include Azure OpenAI environment variables as a valid setup alternative

<!-- end of auto-generated comment: release notes by coderabbit.ai -->