### PR TITLE
feat(embedding): configurable local model, cache dir, and HF mirror | 嵌入模型可配置

### DIFF
--- a/src/providers/embedding/local.ts
+++ b/src/providers/embedding/local.ts
@@ -12,8 +12,26 @@ type Pipeline = (
 
 export class LocalEmbeddingProvider implements EmbeddingProvider {
   readonly name = "local";
-  readonly dimensions = 384;
+  readonly dimensions: number;
+  private readonly modelName: string;
+  private readonly modelDir: string | undefined;
   private extractor: Awaited<ReturnType<Pipeline>> | null = null;
+
+  constructor() {
+    this.modelName = process.env["AGENTMEMORY_LOCAL_EMBEDDING_MODEL"] || "Xenova/all-MiniLM-L6-v2";
+    this.modelDir = process.env["AGENTMEMORY_LOCAL_EMBEDDING_MODEL_DIR"] || undefined;
+
+    // Known dimensions for common models. Falls back to 384 (MiniLM default).
+    const KNOWN_DIMS: Record<string, number> = {
+      "Xenova/all-MiniLM-L6-v2": 384,
+      "Xenova/bge-m3": 1024,
+      "Xenova/multilingual-e5-large": 1024,
+      "Xenova/bge-small-en-v1.5": 384,
+      "Xenova/bge-base-en-v1.5": 768,
+      "Xenova/bge-large-en-v1.5": 1024,
+    };
+    this.dimensions = KNOWN_DIMS[this.modelName] || 384;
+  }
 
   async embed(text: string): Promise<Float32Array> {
     const [result] = await this.embedBatch([text]);
@@ -33,7 +51,7 @@ export class LocalEmbeddingProvider implements EmbeddingProvider {
   private async getExtractor() {
     if (this.extractor) return this.extractor;
 
-    let transformers: { pipeline: Pipeline };
+    let transformers: { pipeline: Pipeline; env: Record<string, unknown> };
     try {
       // @ts-ignore - optional peer dependency
       transformers = await import("@xenova/transformers");
@@ -43,9 +61,23 @@ export class LocalEmbeddingProvider implements EmbeddingProvider {
       );
     }
 
+    // Allow custom model cache directory (e.g. for pre-downloaded models).
+    if (this.modelDir) {
+      transformers.env.localModelPath = this.modelDir + "/";
+      transformers.env.cacheDir = this.modelDir;
+    }
+
+    // Allow HuggingFace mirror endpoint for users behind firewalls.
+    const hfEndpoint = process.env["HF_ENDPOINT"] || "";
+    if (hfEndpoint) {
+      transformers.env.remoteHost = hfEndpoint.endsWith("/")
+        ? hfEndpoint
+        : hfEndpoint + "/";
+    }
+
     this.extractor = await transformers.pipeline(
       "feature-extraction",
-      "Xenova/all-MiniLM-L6-v2",
+      this.modelName,
     );
     return this.extractor;
   }


### PR DESCRIPTION
## Summary | 概述

Make the local embedding provider configurable via environment variables, enabling multilingual embedding models (bge-m3, multilingual-e5, etc.) and supporting users behind firewalls or in regions with restricted HuggingFace access.

通过环境变量使本地嵌入模型可配置，支持切换多语言模型和配置 HuggingFace 镜像。

## Motivation | 动机

The local embedding provider was hardcoded to `all-MiniLM-L6-v2` (384-dim English-only). Users with non-English content (Chinese, Japanese, Korean, multilingual codebases) had no way to use a multilingual embedding model without forking the codebase. Additionally, users behind corporate firewalls or in regions with slow/unreachable HuggingFace access had no way to configure a mirror endpoint.

本地嵌入模型被硬编码为 all-MiniLM-L6-v2（仅支持英文）。非英文用户无法切换多语言模型。部署在防火墙后或在 HuggingFace 受限地区的用户无法配置镜像。

## Changes | 改动

Three new environment variables (all optional, defaults unchanged):

- `AGENTMEMORY_LOCAL_EMBEDDING_MODEL` — model name (default: Xenova/all-MiniLM-L6-v2). Set to `Xenova/bge-m3` for multilingual 1024-dim embeddings supporting 100+ languages including Chinese.
- `AGENTMEMORY_LOCAL_EMBEDDING_MODEL_DIR` — custom cache directory for pre-downloaded models (useful in air-gapped/offline environments).
- `HF_ENDPOINT` — HuggingFace mirror endpoint (e.g. `https://hf-mirror.com`).

Auto-detects dimensions from a known list; falls back to 384 for unknown models.

## Usage | 用法

```bash
# Multilingual Chinese support via bge-m3
AGENTMEMORY_LOCAL_EMBEDDING_MODEL=Xenova/bge-m3

# Offline/pre-downloaded models
AGENTMEMORY_LOCAL_EMBEDDING_MODEL_DIR=/opt/models/transformers

# HF mirror for China/firewall users
HF_ENDPOINT=https://hf-mirror.com
```

## Backwards Compatibility | 向后兼容

All env vars are optional. Default behavior unchanged — `all-MiniLM-L6-v2` with default HF endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Embedding provider now supports dynamic model and dimension configuration through environment variables instead of fixed defaults
  * Users can specify a custom local model cache directory for embedding models
  * Added support for Hugging Face endpoint configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->