### PR TITLE
feat(health): configurable health check thresholds via env vars | 健康阈值可配置

### DIFF
--- a/src/health/thresholds.ts
+++ b/src/health/thresholds.ts
@@ -11,13 +11,13 @@ interface ThresholdConfig {
 }
 
 const DEFAULTS: ThresholdConfig = {
-  eventLoopLagWarnMs: 100,
-  eventLoopLagCriticalMs: 500,
-  cpuWarnPercent: 80,
-  cpuCriticalPercent: 90,
-  memoryWarnPercent: 80,
-  memoryCriticalPercent: 95,
-  memoryRssFloorBytes: 512 * 1024 * 1024,
+  eventLoopLagWarnMs: parseInt(process.env["AGENTMEMORY_HEALTH_EVENTLOOP_WARN_MS"] || "100", 10),
+  eventLoopLagCriticalMs: parseInt(process.env["AGENTMEMORY_HEALTH_EVENTLOOP_CRITICAL_MS"] || "500", 10),
+  cpuWarnPercent: parseInt(process.env["AGENTMEMORY_HEALTH_CPU_WARN_PCT"] || "80", 10),
+  cpuCriticalPercent: parseInt(process.env["AGENTMEMORY_HEALTH_CPU_CRITICAL_PCT"] || "90", 10),
+  memoryWarnPercent: parseInt(process.env["AGENTMEMORY_HEALTH_MEM_WARN_PCT"] || "80", 10),
+  memoryCriticalPercent: parseInt(process.env["AGENTMEMORY_HEALTH_MEM_CRITICAL_PCT"] || "95", 10),
+  memoryRssFloorBytes: parseInt(process.env["AGENTMEMORY_HEALTH_MEM_RSS_FLOOR_MB"] || "512", 10) * 1024 * 1024,
 };
 
 export function evaluateHealth(


### PR DESCRIPTION
## Summary | 概述

Make all health check thresholds configurable via environment variables, allowing operators to tune alert sensitivity for their hardware without code changes.

通过环境变量使所有健康检查阈值可配置，适应不同硬件环境。

## Motivation | 动机

The default memory thresholds (95% critical, 512MB RSS floor) produce false `memory_critical` alarms on machines with higher RAM (16GB+). The `memoryCriticalPercent` check uses heap usage ratio which can spike during normal operation on large-memory systems. Operators had no way to adjust these without patching `thresholds.ts`.

默认内存阈值在 16GB+ 机器上频繁误报 memory_critical。阈值被硬编码，运维人员无法调整。

## Changes | 改动

Seven new environment variables (all optional, defaults unchanged):

| Variable | Default | Description |
|----------|---------|-------------|
| `AGENTMEMORY_HEALTH_MEM_CRITICAL_PCT` | 95 | Memory critical threshold % |
| `AGENTMEMORY_HEALTH_MEM_RSS_FLOOR_MB` | 512 | Min RSS (MB) before memory alerts fire |
| `AGENTMEMORY_HEALTH_MEM_WARN_PCT` | 80 | Memory warning threshold % |
| `AGENTMEMORY_HEALTH_CPU_CRITICAL_PCT` | 90 | CPU critical threshold % |
| `AGENTMEMORY_HEALTH_CPU_WARN_PCT` | 80 | CPU warning threshold % |
| `AGENTMEMORY_HEALTH_EVENTLOOP_CRITICAL_MS` | 500 | Event loop lag critical (ms) |
| `AGENTMEMORY_HEALTH_EVENTLOOP_WARN_MS` | 100 | Event loop lag warning (ms) |

## Usage | 用法

```bash
# Raise RSS floor to 1.5GB for high-RAM machines
AGENTMEMORY_HEALTH_MEM_RSS_FLOOR_MB=1536
AGENTMEMORY_HEALTH_MEM_CRITICAL_PCT=98
```

## Backwards Compatibility | 向后兼容

All env vars are optional. Default values unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Health monitoring thresholds (event-loop lag, CPU, memory, and RSS) are now configurable via environment variables instead of using fixed defaults, enabling customization for different deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->