### PR TITLE
feat(shutdown): graceful shutdown timeout with force exit | 优雅关闭超时

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -416,6 +416,12 @@ async function main() {
 
   const shutdown = async () => {
     console.log(`\n[agentmemory] Shutting down...`);
+    const timeoutMs = parseInt(process.env["AGENTMEMORY_SHUTDOWN_TIMEOUT_MS"] || "10000", 10);
+    const forceExit = setTimeout(() => {
+      console.warn(`[agentmemory] Shutdown timed out after ${timeoutMs}ms, forcing exit`);
+      process.exit(0);
+    }, timeoutMs);
+    forceExit.unref();
     healthMonitor.stop();
     dedupMap.stop();
     indexPersistence.stop();
@@ -424,6 +430,7 @@ async function main() {
       console.warn(`[agentmemory] Failed to save index on shutdown:`, err);
     });
     await sdk.shutdown();
+    clearTimeout(forceExit);
     process.exit(0);
   };
   process.on("SIGINT", shutdown);


### PR DESCRIPTION
## Summary | 概述

Add a shutdown timeout that force-exits the process if graceful shutdown hangs, preventing zombie processes that require manual kill.

添加关闭超时机制，防止进程因 sdk 连接卡死而僵死。

## Motivation | 动机

When the iii-engine WebSocket connection is stuck or the viewer server refuses to close, the shutdown handler hangs indefinitely. SIGTERM from systemd times out after 90s and sends SIGKILL, but during those 90s the process is unresponsive. Adding a configurable force-exit timeout ensures clean termination in bounded time.

当 iii-engine 连接卡死或 viewer 服务器拒绝关闭时，shutdown 流程永久挂起，形成僵尸进程。

## Changes | 改动

- Added `AGENTMEMORY_SHUTDOWN_TIMEOUT_MS` env var (default: 10000ms)
- On SIGINT/SIGTERM, starts a timer that calls `process.exit(0)` if shutdown exceeds the timeout
- Timer uses `unref()` so it doesn't prevent normal exit if shutdown completes quickly
- Calls `clearTimeout` when shutdown completes normally

## Backwards Compatibility | 向后兼容

Default timeout is 10s. Completely transparent when shutdown works normally — the timer is cleared before firing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown robustness by implementing a configurable timeout mechanism (default 10 seconds) that ensures the application exits cleanly rather than hanging indefinitely during shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->