### PR TITLE
feat(vector): auto-index observations into vector store | 向量索引自动集成

### DIFF
--- a/src/functions/observe.ts
+++ b/src/functions/observe.ts
@@ -1,5 +1,5 @@
 import { TriggerAction, type ISdk } from "iii-sdk";
-import type { RawObservation, HookPayload } from "../types.js";
+import type { RawObservation, HookPayload, EmbeddingProvider } from "../types.js";
 import { KV, STREAM, generateId } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
 import { stripPrivateData } from "./privacy.js";
@@ -8,6 +8,7 @@ import { withKeyedLock } from "../state/keyed-mutex.js";
 import { isAutoCompressEnabled } from "../config.js";
 import { buildSyntheticCompression } from "./compress-synthetic.js";
 import { getSearchIndex } from "./search.js";
+import { VectorIndex } from "../state/vector-index.js";
 import { logger } from "../logger.js";
 
 export function extractImage(d: unknown): string | undefined {
@@ -38,6 +39,8 @@ export function registerObserveFunction(
   kv: StateKV,
   dedupMap?: DedupMap,
   maxObservationsPerSession?: number,
+  vectorIndex?: VectorIndex | null,
+  embeddingProvider?: EmbeddingProvider | null,
 ): void {
   sdk.registerFunction("mem::observe", 
     async (payload: HookPayload) => {
@@ -238,6 +241,18 @@ export function registerObserveFunction(
             synthetic,
           );
           getSearchIndex().add(synthetic);
+          if (vectorIndex && embeddingProvider) {
+            try {
+              const narrative = (synthetic.title || "") + " " + (synthetic.narrative || "");
+              const vec = await embeddingProvider.embed(narrative);
+              vectorIndex.add(obsId, payload.sessionId, vec);
+            } catch (err) {
+              logger.warn("Vector auto-index failed for observation", {
+                obsId,
+                error: err instanceof Error ? err.message : String(err),
+              });
+            }
+          }
           await sdk.trigger({
             function_id: "stream::set",
             payload: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,7 +181,7 @@ async function main() {
   initMetrics(meterAccessor as ((name: string) => import("@opentelemetry/api").Meter) | undefined);
 
   registerPrivacyFunction(sdk);
-  registerObserveFunction(sdk, kv, dedupMap, config.maxObservationsPerSession);
+  registerObserveFunction(sdk, kv, dedupMap, config.maxObservationsPerSession, vectorIndex, embeddingProvider);
   registerImageQuotaCleanup(sdk, kv);
   registerVisionSearchFunctions(sdk, kv, imageEmbeddingProvider);
   if (isSlotsEnabled()) {


### PR DESCRIPTION
## Summary | 概述

Automatically add compressed observations to the VectorIndex during the observe lifecycle, enabling hybrid BM25+Vector search without manual index building.

在观察生命周期中自动将压缩记忆添加到向量索引，实现 BM25+向量混合搜索。

## Motivation | 动机

The VectorIndex and EmbeddingProvider infrastructure exists but observations were only added to the BM25 index. The vector index remained empty unless manually populated. This meant the hybrid search (BM25 + Vector RRF fusion) couldn't leverage semantic similarity — only BM25 keyword matching was active. For non-English content (Chinese, multilingual), BM25 alone is insufficient because the tokenizer can't handle CJK text well. Vector search bridges this gap.

向量索引基础设施已存在，但观察结果仅被添加到 BM25 索引，向量索引保持为空。混合搜索无法利用语义相似度，仅靠 BM25 关键词匹配。对于中文等非英文内容，纯 BM25 效果差，向量搜索可以弥补这一差距。

## Changes | 改动

- `src/functions/observe.ts`: After synthetic compression and BM25 indexing, auto-embed the narrative and add to vector index
- `src/index.ts`: Pass `vectorIndex` and `embeddingProvider` to `registerObserveFunction`
- Auto-indexing runs within try-catch — embedding failures are logged but don't block observation capture
- Only activates when an embedding provider is configured (opt-in by setting AGENTMEMORY_LOCAL_EMBEDDING_MODEL or cloud API keys)

## Combined with PR #223 (configurable embedding)

```bash
# Enable multilingual hybrid search (BM25 + Vector)
AGENTMEMORY_LOCAL_EMBEDDING_MODEL=Xenova/bge-m3
```

This combination gives agentmemory full Chinese/multilingual semantic search capability — BM25 handles exact terms, vector handles meaning.

## Backwards Compatibility | 向后兼容

New params are optional. When `vectorIndex` or `embeddingProvider` is null/undefined (default), the auto-indexing is skipped. No behavior change for existing deployments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional vector indexing and embedding support for observations, enabling automatic metadata indexing when configured
  * Enhanced with external control over vector auto-indexing functionality
  * Improved resilience through graceful error handling that prevents vector operation failures from disrupting observation workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->