### PR TITLE
Fix Hermes availability check for agentmemory health endpoint

### DIFF
--- a/integrations/hermes/__init__.py
+++ b/integrations/hermes/__init__.py
@@ -91,9 +91,8 @@ class AgentMemoryProvider(MemoryProvider):
         if not _validate_url(base):
             return False
         try:
-            req = Request(f"{base}/", method="GET")
-            with urlopen(req, timeout=2):
-                return True
+            health = _api(base, "health", method="GET")
+            return bool(health and health.get("status") in ("healthy", "ok"))
         except Exception:
             return False
 


### PR DESCRIPTION
## Summary
- Update the Hermes integration availability probe to call `/agentmemory/health` instead of `/`
- Accept both `healthy` and `ok` health statuses for compatibility with existing health checks

## Why
`agentmemory` serves its REST API under `/agentmemory/*`; `/` can return 404 even while the server is healthy. This makes Hermes report the provider as unavailable despite the documented health endpoint working.

## Verification
- `python3 -m py_compile integrations/hermes/__init__.py`
- `npm run build`
- `npm test` (initial run failed because a local agentmemory server forced standalone MCP tests into proxy mode; after stopping the local server, all 75 test files / 838 tests passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Agentmemory service availability detection to more accurately and reliably determine when the service is operational and ready for user requests.
  * Improved system stability and initialization by strengthening how critical service dependencies are verified, ensuring consistent and proper operation of all downstream features that depend on the Agentmemory service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->