### PR TITLE
fix(mcp): proxy all 51 tools to server, not just 7 hardcoded IMPLEMENTED_TOOLS (closes #234)

### DIFF
--- a/src/mcp/standalone.ts
+++ b/src/mcp/standalone.ts
@@ -10,7 +10,6 @@ import {
   resolveHandle,
   invalidateHandle,
   type Handle,
-  type ProxyHandle,
 } from "./rest-proxy.js";
 
 const IMPLEMENTED_TOOLS = new Set([
@@ -142,61 +141,6 @@ function validate(toolName: string, args: Record<string, unknown>): Validated {
   }
 }
 
-async function handleProxy(
-  v: Validated,
-  handle: ProxyHandle,
-): Promise<{ content: Array<{ type: string; text: string }> }> {
-  switch (v.tool) {
-    case "memory_save": {
-      const result = await handle.call("/agentmemory/remember", {
-        method: "POST",
-        body: JSON.stringify({
-          content: v.content,
-          type: v.type,
-          concepts: v.concepts,
-          files: v.files,
-        }),
-      });
-      return textResponse(result);
-    }
-    case "memory_recall":
-    case "memory_smart_search": {
-      const result = await handle.call("/agentmemory/smart-search", {
-        method: "POST",
-        body: JSON.stringify({ query: v.query, limit: v.limit }),
-      });
-      return textResponse(result, true);
-    }
-    case "memory_sessions": {
-      const result = await handle.call(
-        `/agentmemory/sessions?limit=${v.limit}`,
-        { method: "GET" },
-      );
-      return textResponse(result, true);
-    }
-    case "memory_governance_delete": {
-      const result = await handle.call("/agentmemory/governance/memories", {
-        method: "POST",
-        body: JSON.stringify({ memoryIds: v.memoryIds, reason: v.reason }),
-      });
-      return textResponse(result);
-    }
-    case "memory_export": {
-      const result = await handle.call("/agentmemory/export", { method: "GET" });
-      return textResponse(result, true);
-    }
-    case "memory_audit": {
-      const result = await handle.call(
-        `/agentmemory/audit?limit=${v.limit}`,
-        { method: "GET" },
-      );
-      return textResponse(result, true);
-    }
-    default:
-      throw new Error(`Unknown tool: ${v.tool}`);
-  }
-}
-
 async function handleLocal(
   v: Validated,
   kvInstance: InMemoryKV,
@@ -298,12 +242,20 @@ export async function handleToolCall(
   args: Record<string, unknown>,
   kvInstance: InMemoryKV = kv,
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
-  const validated = validate(toolName, args);
   const handle = await resolveHandle();
   announceMode(handle);
+
   if (handle.mode === "proxy") {
     try {
-      return await handleProxy(validated, handle);
+      const result = await handle.call("/agentmemory/mcp/call", {
+        method: "POST",
+        body: JSON.stringify({ name: toolName, arguments: args }),
+      });
+      const content = (result as { content?: Array<{ type: string; text: string }> })?.content;
+      if (Array.isArray(content)) {
+        return { content };
+      }
+      return textResponse(result);
     } catch (err) {
       process.stderr.write(
         `[@agentmemory/mcp] proxy call failed for ${toolName}: ${err instanceof Error ? err.message : String(err)}; invalidating handle and falling back to local KV\n`,
@@ -311,6 +263,8 @@ export async function handleToolCall(
       invalidateHandle();
     }
   }
+
+  const validated = validate(toolName, args);
   return handleLocal(validated, kvInstance);
 }
 
@@ -329,10 +283,27 @@ const transport = createStdioTransport(async (method, params) => {
     case "notifications/initialized":
       return {};
 
-    case "tools/list":
+    case "tools/list": {
+      const handle = await resolveHandle();
+      announceMode(handle);
+      if (handle.mode === "proxy") {
+        try {
+          const result = await handle.call("/agentmemory/mcp/tools");
+          const tools = (result as { tools?: unknown[] })?.tools;
+          if (Array.isArray(tools)) return { tools };
+          process.stderr.write(
+            `[@agentmemory/mcp] tools/list proxy returned unexpected shape; falling back to local list\n`,
+          );
+        } catch (err) {
+          process.stderr.write(
+            `[@agentmemory/mcp] tools/list proxy failed: ${err instanceof Error ? err.message : String(err)}; falling back to local list\n`,
+          );
+        }
+      }
       return {
         tools: getVisibleTools().filter((t) => IMPLEMENTED_TOOLS.has(t.name)),
       };
+    }
 
     case "tools/call": {
       const toolName = params.name as string;

--- a/src/mcp/standalone.ts
+++ b/src/mcp/standalone.ts
@@ -257,10 +257,15 @@ export async function handleToolCall(
       }
       return textResponse(result);
     } catch (err) {
-      process.stderr.write(
-        `[@agentmemory/mcp] proxy call failed for ${toolName}: ${err instanceof Error ? err.message : String(err)}; invalidating handle and falling back to local KV\n`,
-      );
       invalidateHandle();
+      if (!IMPLEMENTED_TOOLS.has(toolName)) {
+        throw new Error(
+          `proxy call failed for ${toolName}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+      process.stderr.write(
+        `[@agentmemory/mcp] proxy call failed for ${toolName}: ${err instanceof Error ? err.message : String(err)}; falling back to local KV\n`,
+      );
     }
   }
 

--- a/test/mcp-standalone-proxy.test.ts
+++ b/test/mcp-standalone-proxy.test.ts
@@ -28,18 +28,22 @@ describe("@agentmemory/mcp standalone — server proxy (issue #159)", () => {
     resetHandleForTests();
     globalThis.fetch = originalFetch;
     delete process.env["AGENTMEMORY_URL"];
+    delete process.env["AGENTMEMORY_SECRET"];
   });
 
-  it("proxies memory_sessions to GET /agentmemory/sessions when server is up", async () => {
-    const calls: Array<{ url: string; method: string }> = [];
+  it("proxies any tool call to POST /agentmemory/mcp/call", async () => {
+    const calls: Array<{ url: string; method: string; body?: unknown }> = [];
     installFetch((url, init) => {
-      calls.push({ url, method: init?.method || "GET" });
+      const parsed = init?.body ? JSON.parse(init.body as string) : undefined;
+      calls.push({ url, method: init?.method || "GET", body: parsed });
       if (url.endsWith("/agentmemory/livez")) {
         return new Response("ok", { status: 200 });
       }
-      if (url.includes("/agentmemory/sessions")) {
+      if (url.endsWith("/agentmemory/mcp/call")) {
         return new Response(
-          JSON.stringify({ sessions: [{ id: "sess-1", observations: 69 }] }),
+          JSON.stringify({
+            content: [{ type: "text", text: JSON.stringify({ sessions: [{ id: "sess-1" }] }) }],
+          }),
           { status: 200, headers: { "content-type": "application/json" } },
         );
       }
@@ -50,59 +54,34 @@ describe("@agentmemory/mcp standalone — server proxy (issue #159)", () => {
     const body = JSON.parse(res.content[0].text);
     expect(body.sessions).toHaveLength(1);
     expect(body.sessions[0].id).toBe("sess-1");
-    expect(calls.find((c) => c.url.includes("/sessions"))).toBeDefined();
+
+    const mcpCall = calls.find((c) => c.url.endsWith("/agentmemory/mcp/call"));
+    expect(mcpCall).toBeDefined();
+    expect(mcpCall!.method).toBe("POST");
+    expect((mcpCall!.body as Record<string, unknown>).name).toBe("memory_sessions");
+    expect((mcpCall!.body as Record<string, unknown>).arguments).toEqual({ limit: 5 });
   });
 
-  it("proxies memory_smart_search to POST /agentmemory/smart-search", async () => {
+  it("proxies non-IMPLEMENTED_TOOLS tools to POST /agentmemory/mcp/call", async () => {
     installFetch((url, init) => {
       if (url.endsWith("/agentmemory/livez")) return new Response("ok", { status: 200 });
-      if (url.endsWith("/agentmemory/smart-search")) {
+      if (url.endsWith("/agentmemory/mcp/call")) {
         const body = JSON.parse((init?.body as string) || "{}");
         return new Response(
           JSON.stringify({
-            mode: "compact",
-            query: body.query,
-            results: [{ id: "m1", score: 0.9 }],
+            content: [{
+              type: "text",
+              text: JSON.stringify({ tool: body.name, query: body.arguments.query }),
+            }],
           }),
           { status: 200 },
         );
       }
       return new Response("", { status: 404 });
     });
-    const res = await handleToolCall("memory_smart_search", { query: "auth bug", limit: 5 });
+    const res = await handleToolCall("memory_crystallize", { actionIds: "a,b" });
     const body = JSON.parse(res.content[0].text);
-    expect(body.query).toBe("auth bug");
-    expect(body.results[0].id).toBe("m1");
-  });
-
-  it("local fallback returns the same shape as proxy for memory_smart_search", async () => {
-    installFetch(() => {
-      throw new Error("ECONNREFUSED");
-    });
-    const localKv = new InMemoryKV(undefined);
-    await handleToolCall("memory_save", { content: "shape-check entry" }, localKv);
-    const res = await handleToolCall("memory_smart_search", { query: "shape" }, localKv);
-    const body = JSON.parse(res.content[0].text);
-    expect(body).toHaveProperty("mode", "compact");
-    expect(Array.isArray(body.results)).toBe(true);
-    expect(body.results[0].content).toBe("shape-check entry");
-  });
-
-  it("attaches Bearer token on the proxied tool request, not just the probe", async () => {
-    process.env["AGENTMEMORY_SECRET"] = "s3cret";
-    const authByPath = new Map<string, string | undefined>();
-    installFetch((url, init) => {
-      const auth = (init?.headers as Record<string, string> | undefined)?.[
-        "authorization"
-      ];
-      const u = new URL(url);
-      authByPath.set(u.pathname, auth);
-      if (url.endsWith("/agentmemory/livez")) return new Response("ok", { status: 200 });
-      return new Response(JSON.stringify({ sessions: [] }), { status: 200 });
-    });
-    await handleToolCall("memory_sessions", {});
-    expect(authByPath.get("/agentmemory/livez")).toBe("Bearer s3cret");
-    expect(authByPath.get("/agentmemory/sessions")).toBe("Bearer s3cret");
+    expect(body.tool).toBe("memory_crystallize");
   });
 
   it("falls back to local InMemoryKV when server is unreachable", async () => {
@@ -121,7 +100,7 @@ describe("@agentmemory/mcp standalone — server proxy (issue #159)", () => {
   it("invalidates the handle on proxy failure, so the next call re-probes", async () => {
     let probeCount = 0;
     let serverUp = true;
-    installFetch((url) => {
+    installFetch((url, init) => {
       if (url.endsWith("/agentmemory/livez")) {
         probeCount++;
         return serverUp ? new Response("ok", { status: 200 }) : new Response("", { status: 500 });
@@ -136,18 +115,55 @@ describe("@agentmemory/mcp standalone — server proxy (issue #159)", () => {
     expect(probeCount).toBe(2);
   });
 
-  it("does not retry local after a validation error", async () => {
-    const fetchFn = installFetch((url) => {
+  it("attaches Bearer token on the proxied tool request and probe", async () => {
+    process.env["AGENTMEMORY_SECRET"] = "s3cret";
+    const authByPath = new Map<string, string | undefined>();
+    installFetch((url, init) => {
+      const auth = (init?.headers as Record<string, string> | undefined)?.[
+        "authorization"
+      ];
+      const u = new URL(url);
+      authByPath.set(u.pathname, auth);
       if (url.endsWith("/agentmemory/livez")) return new Response("ok", { status: 200 });
-      return new Response("{}", { status: 200 });
+      return new Response(
+        JSON.stringify({ content: [{ type: "text", text: "{}" }] }),
+        { status: 200 },
+      );
+    });
+    await handleToolCall("memory_sessions", {});
+    expect(authByPath.get("/agentmemory/livez")).toBe("Bearer s3cret");
+    expect(authByPath.get("/agentmemory/mcp/call")).toBe("Bearer s3cret");
+  });
+
+  it("in proxy mode, delegates validation to the server (no local validation error)", async () => {
+    installFetch((url, init) => {
+      if (url.endsWith("/agentmemory/livez")) return new Response("ok", { status: 200 });
+      if (url.endsWith("/agentmemory/mcp/call")) {
+        return new Response(
+          JSON.stringify({
+            content: [{ type: "text", text: JSON.stringify({ proxied: true }) }],
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response("", { status: 404 });
     });
     const localKv = new InMemoryKV(undefined);
-    await expect(
-      handleToolCall("memory_save", { content: "" }, localKv),
-    ).rejects.toThrow("content is required");
-    const remembersCalled = fetchFn.mock.calls.some(([url]) =>
-      String(url).endsWith("/agentmemory/remember"),
-    );
-    expect(remembersCalled).toBe(false);
+    const result = await handleToolCall("memory_save", { content: "" }, localKv);
+    const body = JSON.parse(result.content[0].text);
+    expect(body.proxied).toBe(true);
+  });
+
+  it("local fallback returns the same shape as expected for memory_smart_search", async () => {
+    installFetch(() => {
+      throw new Error("ECONNREFUSED");
+    });
+    const localKv = new InMemoryKV(undefined);
+    await handleToolCall("memory_save", { content: "shape-check entry" }, localKv);
+    const res = await handleToolCall("memory_smart_search", { query: "shape" }, localKv);
+    const body = JSON.parse(res.content[0].text);
+    expect(body).toHaveProperty("mode", "compact");
+    expect(Array.isArray(body.results)).toBe(true);
+    expect(body.results[0].content).toBe("shape-check entry");
   });
 });

--- a/test/mcp-standalone.test.ts
+++ b/test/mcp-standalone.test.ts
@@ -460,4 +460,18 @@ describe("handleToolCall", () => {
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed).toHaveProperty("sessions");
   });
+
+  it("in proxy mode, non-IMPLEMENTED_TOOLS tool proxy failure rethrows with proxy error", async () => {
+    const { resolveHandle } = await import("../src/mcp/rest-proxy.js");
+    vi.mocked(resolveHandle).mockResolvedValueOnce({
+      mode: "proxy",
+      baseUrl: "http://fake:9999",
+      call: vi.fn().mockRejectedValue(new Error("ECONNREFUSED")),
+    } as any);
+
+    const kv = new InMemoryKV();
+    await expect(
+      handleToolCall("memory_crystallize", { actionIds: "a,b" }, kv),
+    ).rejects.toThrow("proxy call failed for memory_crystallize: ECONNREFUSED");
+  });
 });

--- a/test/mcp-standalone.test.ts
+++ b/test/mcp-standalone.test.ts
@@ -19,6 +19,11 @@ vi.mock("../src/config.js", () => ({
   getStandalonePersistPath: vi.fn(() => "/tmp/test-standalone.json"),
 }));
 
+vi.mock("../src/mcp/rest-proxy.js", () => ({
+  resolveHandle: vi.fn(async () => ({ mode: "local" })),
+  invalidateHandle: vi.fn(),
+}));
+
 import {
   getAllTools,
   CORE_TOOLS,
@@ -403,5 +408,56 @@ describe("handleToolCall", () => {
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.deleted).toBe(1);
     expect(parsed.requested).toBe(2);
+  });
+
+  it("in proxy mode, tools outside IMPLEMENTED_TOOLS are forwarded to server", async () => {
+    const { resolveHandle } = await import("../src/mcp/rest-proxy.js");
+    vi.mocked(resolveHandle).mockResolvedValueOnce({
+      mode: "proxy",
+      baseUrl: "http://fake:9999",
+      call: vi.fn().mockResolvedValue({
+        content: [{ type: "text", text: '{"ok":true}' }],
+      }),
+    } as any);
+
+    const kv = new InMemoryKV();
+    const result = await handleToolCall("memory_crystallize", { actionIds: "a,b" }, kv);
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+  });
+
+  it("in proxy mode, tools/call sends correct name + arguments payload", async () => {
+    const { resolveHandle } = await import("../src/mcp/rest-proxy.js");
+    const callSpy = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: '{"done":true}' }],
+    });
+    vi.mocked(resolveHandle).mockResolvedValueOnce({
+      mode: "proxy",
+      baseUrl: "http://fake:9999",
+      call: callSpy,
+    } as any);
+
+    const kv = new InMemoryKV();
+    await handleToolCall("memory_reflect", { maxClusters: 5 }, kv);
+    expect(callSpy).toHaveBeenCalledWith("/agentmemory/mcp/call", expect.objectContaining({
+      method: "POST",
+    }));
+    const body = JSON.parse(callSpy.mock.calls[0][1].body);
+    expect(body.name).toBe("memory_reflect");
+    expect(body.arguments.maxClusters).toBe(5);
+  });
+
+  it("in local mode, tools outside IMPLEMENTED_TOOLS still throw", async () => {
+    const kv = new InMemoryKV();
+    await expect(
+      handleToolCall("memory_crystallize", { actionIds: "a,b" }, kv),
+    ).rejects.toThrow("Unknown tool: memory_crystallize");
+  });
+
+  it("in local mode, IMPLEMENTED_TOOLS tools still work", async () => {
+    const kv = new InMemoryKV();
+    const result = await handleToolCall("memory_sessions", { limit: 5 }, kv);
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed).toHaveProperty("sessions");
   });
 });


### PR DESCRIPTION
## Summary

Fixes #234 — `agentmemory mcp --tools all` now returns all 51 tools instead of silently filtering to 7.

## Root cause

`src/mcp/standalone.ts` had a hardcoded `IMPLEMENTED_TOOLS` set of 7 tool names. Both `tools/list` and `validate()` applied this filter **unconditionally**, even when the server was reachable in proxy mode. `getVisibleTools()` correctly returned all 51 tools when `AGENTMEMORY_TOOLS=all` was set, but the filter then cut them down to 7.

## Changes

### `src/mcp/standalone.ts`

1. **`tools/list` now proxy-aware**: When in proxy mode, fetches all tools from `GET /agentmemory/mcp/tools` (server returns unfiltered 51). Falls back to the local filtered list if the server is unreachable or returns an unexpected shape.

2. **`handleToolCall` proxies ALL tools**: Proxy resolution now happens *before* validation. In proxy mode, *any* tool call is forwarded to `POST /agentmemory/mcp/call` with `{ name, arguments }` payload — the server's `mcp::tools::call` endpoint already has handlers for all 51 tools.

3. **Removed `handleProxy()`**: The 7-tool switch that mapped each tool to a different REST endpoint is replaced by the generic `/agentmemory/mcp/call` endpoint. This eliminated ~54 lines of per-tool proxy code.

4. **Local mode preserved**: In local mode (no server), `IMPLEMENTED_TOOLS` filter and `validate()` are preserved — the `InMemoryKV` genuinely only supports 7 operations.

### `test/mcp-standalone.test.ts`
- Mocked `resolveHandle` to return local mode for all local tests (prevents server-probe side effects)
- Added 4 tests: proxy mode forwards non-IMPLEMENTED_TOOLS, sends correct payload, local mode still rejects unknown tools, local mode IMPLEMENTED_TOOLS still work

### `test/mcp-standalone-proxy.test.ts`
- Updated proxy tests to verify the new generic `/agentmemory/mcp/call` endpoint
- Verified proxy mode delegates validation to server (empty `content` arg passes through)
- Verified auth headers attach to probe AND `/agentmemory/mcp/call`

## Verification

```
# Before: only 7 tools
$ npx @agentmemory/agentmemory mcp --tools all
# tools/list returns 7 tools (memory_save, memory_recall, memory_smart_search,
#   memory_sessions, memory_export, memory_audit, memory_governance_delete)

# After: all 51 tools
$ npx @agentmemory/agentmemory mcp --tools all  
# tools/list returns 51 tools (all MCP tools including slot_list, lesson_save,
#   crystallize, reflect, signal_send, action_create, etc.)
```

Non-IMPLEMENTED_TOOLS calls now succeed:
```bash
$ curl -X POST http://localhost:3111/agentmemory/mcp/call \
  -d '{"name":"memory_lesson_save","arguments":{"content":"test"}}'
# Returns: {"content":[{"text":"{\n  \"action\": \"created\"..."}]}
# (memory_lesson_save was not in the 7-tool IMPLEMENTED_TOOLS set)
```

## Test results
- 35/35 tests pass (28 standalone + 7 proxy)
- Full suite: 810/818 pass (8 pre-existing failures unrelated to this change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified proxy-based tool invocation path that forwards tool requests to remote MCP proxies while falling back to local execution when needed.
  * Extended tools listing to optionally retrieve available tools from a remote proxy.

* **Bug Fixes**
  * Improved proxy failure handling and response-shape validation; ensures sensible fallback and clearer proxy-error reporting.
  * Ensures authentication token is forwarded with proxied requests.

* **Tests**
  * Expanded test coverage for proxy mode, delegation, auth forwarding, and failure/retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->