### PR TITLE
fix(embedding): migrate Gemini provider to gemini-embedding-001

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,7 +596,7 @@ npm install @xenova/transformers
 | Provider | Model | Cost | Notes |
 |---|---|---|---|
 | **Local (recommended)** | `all-MiniLM-L6-v2` | Free | Offline, +8pp recall over BM25-only |
-| Gemini | `text-embedding-004` | Free tier | 1500 RPM |
+| Gemini | `gemini-embedding-001` | Free tier | 100+ langs, 768/1536/3072 dims (MRL), 2048-token input. Replaces `text-embedding-004` ([shutdown Jan 14, 2026](https://ai.google.dev/gemini-api/docs/deprecations)) |
 | OpenAI | `text-embedding-3-small` | $0.02/1M | Highest quality |
 | Voyage AI | `voyage-code-3` | Paid | Optimized for code |
 | Cohere | `embed-english-v3.0` | Free trial | General purpose |

--- a/src/providers/embedding/gemini.ts
+++ b/src/providers/embedding/gemini.ts
@@ -2,7 +2,8 @@ import type { EmbeddingProvider } from "../../types.js";
 import { getEnvVar } from "../../config.js";
 
 const BATCH_LIMIT = 100;
-const API_BASE = "https://generativelanguage.googleapis.com/v1beta/models/text-embedding-004:batchEmbedContent";
+const MODEL = "models/gemini-embedding-001";
+const API_BASE = `https://generativelanguage.googleapis.com/v1beta/${MODEL}:batchEmbedContents`;
 
 export class GeminiEmbeddingProvider implements EmbeddingProvider {
   readonly name = "gemini";
@@ -29,8 +30,9 @@ export class GeminiEmbeddingProvider implements EmbeddingProvider {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           requests: chunk.map((t) => ({
-            model: "models/text-embedding-004",
+            model: MODEL,
             content: { parts: [{ text: t }] },
+            outputDimensionality: this.dimensions,
           })),
         }),
       });
@@ -45,10 +47,19 @@ export class GeminiEmbeddingProvider implements EmbeddingProvider {
       };
 
       for (const emb of data.embeddings) {
-        results.push(new Float32Array(emb.values));
+        results.push(l2Normalize(new Float32Array(emb.values)));
       }
     }
 
     return results;
   }
+}
+
+function l2Normalize(vec: Float32Array): Float32Array {
+  let sum = 0;
+  for (let i = 0; i < vec.length; i++) sum += vec[i]! * vec[i]!;
+  const norm = Math.sqrt(sum);
+  if (norm === 0) return vec;
+  for (let i = 0; i < vec.length; i++) vec[i] = vec[i]! / norm;
+  return vec;
 }


### PR DESCRIPTION
## What

Migrates the Gemini embedding provider from `text-embedding-004` to `gemini-embedding-001`.

## Why

Google deprecated `text-embedding-004` with a shutdown date of **January 14, 2026** on both Google AI and Vertex AI. The recommended replacement is `gemini-embedding-001` (now GA in the Gemini API).

- [Gemini deprecations](https://ai.google.dev/gemini-api/docs/deprecations)
- [Announcement: Gemini Embedding GA](https://developers.googleblog.com/gemini-embedding-available-gemini-api/)

No tracking issue existed for this — opening the PR direct.

## Changes

**`src/providers/embedding/gemini.ts`**
- Switch model + API URL to `gemini-embedding-001`.
- Fix endpoint typo: `batchEmbedContent` → `batchEmbedContents` (documented v1beta name; the singular form was a pre-existing bug).
- Pass `outputDimensionality: 768` so existing 768-dim vector indexes remain compatible. `gemini-embedding-001` defaults to 3072 dims, so without this the embedding spaces would be incompatible and require a full reindex for current users.
- Add L2 normalization. Google's docs require manual normalization whenever `outputDimensionality` is reduced from the native 3072.

**`README.md`**
- Update the Gemini row in the embedding-providers table with the new model name and a note linking to the deprecations page.

## How to verify

1. Set ` + '`' + `GEMINI_API_KEY` + '`' + ` and run any flow that exercises the Gemini embedding provider (e.g. ` + '`' + `EMBEDDING_PROVIDER=gemini` + '`' + `).
2. Confirm requests now hit ` + '`' + `https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-001:batchEmbedContents` + '`' + `.
3. Confirm returned vectors are length 768 and L2-normalized (‖v‖ ≈ 1).
4. Existing 768-dim indexes should keep working since dimensions are preserved — though note that since the model itself is different, embedding-space drift is expected. Recall on existing memories should still be fine for most use cases; reindex if you see noticeable degradation.

## Notes

- Single signed-off commit per CONTRIBUTING.
- No CHANGELOG touch (per CONTRIBUTING: that lives in release PRs only).
- No new dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Gemini embedding provider documentation with new model information, dimensionality details, and deprecation notice for the previous model version (shutdown Jan 14, 2026)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->