### PR TITLE
fix(embedding): guard provider responses against dimension mismatches

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -338,29 +338,44 @@ async function main() {
   if (loaded?.vector && vectorIndex && loaded.vector.size > 0) {
     // Persisted vectors carry whatever dimension the provider had when
     // they were written. If the active provider declares a different
-    // dimension (model swap, provider switch, model upgrade), restoring
-    // the old vectors would silently mix dimensions: cosineSimilarity
-    // returns 0 on cross-dim pairs, so the old observations stop matching
-    // anything and recall degrades without an error. Refuse to load.
-    // Same defense the live-write path got from #248.
-    const persistedDim = loaded.vector.firstDimensions();
+    // dimension — or if the on-disk index contains a mix of dimensions
+    // (legacy indexes written before the live-API guard in this PR) —
+    // restoring would silently corrupt search: cosineSimilarity returns
+    // 0 on cross-dim pairs, so affected observations stop matching
+    // anything and recall degrades without an error. Walk every stored
+    // vector instead of trusting the first; refuse to load if anything
+    // is off.
     const activeDim = embeddingProvider?.dimensions ?? 0;
-    if (persistedDim > 0 && activeDim > 0 && persistedDim !== activeDim) {
+    const { mismatches, seenDimensions } =
+      activeDim > 0
+        ? loaded.vector.validateDimensions(activeDim)
+        : { mismatches: [], seenDimensions: new Set<number>() };
+
+    if (mismatches.length > 0) {
+      const sample = mismatches
+        .slice(0, 5)
+        .map((m) => `${m.obsId} (dim=${m.dim})`)
+        .join(", ");
+      const distinct = Array.from(seenDimensions).sort((a, b) => a - b).join(", ");
       const dropStale =
         process.env["AGENTMEMORY_DROP_STALE_INDEX"] === "true";
       if (dropStale) {
         console.warn(
-          `[agentmemory] Persisted vector index has dimension ${persistedDim} but ` +
-            `active provider (${embeddingProvider?.name}) declares ${activeDim}. ` +
+          `[agentmemory] Persisted vector index has ${mismatches.length} of ` +
+            `${loaded.vector.size} vectors with the wrong dimension. Active ` +
+            `provider (${embeddingProvider?.name}) declares ${activeDim}; ` +
+            `dimensions seen on disk: ${distinct}. ` +
             `AGENTMEMORY_DROP_STALE_INDEX=true is set — discarding the persisted ` +
             `vectors. Live observations will rebuild the index over time.`,
         );
       } else {
         throw new Error(
-          `[agentmemory] Refusing to start: persisted vector index has dimension ` +
-            `${persistedDim}, but the active provider (${embeddingProvider?.name}) ` +
-            `declares ${activeDim}. Loading would silently corrupt search ` +
-            `(cross-dimension cosine returns 0). Choose one:\n` +
+          `[agentmemory] Refusing to start: persisted vector index has ` +
+            `${mismatches.length} of ${loaded.vector.size} vectors with the ` +
+            `wrong dimension. Active provider (${embeddingProvider?.name}) ` +
+            `declares ${activeDim}; dimensions seen on disk: ${distinct}. ` +
+            `First mismatched obsIds: ${sample}. Loading would silently corrupt ` +
+            `search (cross-dimension cosine returns 0). Choose one:\n` +
             `  - Re-embed the existing index against the new provider, then start.\n` +
             `  - Set AGENTMEMORY_DROP_STALE_INDEX=true to discard the persisted ` +
             `vectors and rebuild from live observations.\n` +

--- a/src/index.ts
+++ b/src/index.ts
@@ -336,10 +336,43 @@ async function main() {
     );
   }
   if (loaded?.vector && vectorIndex && loaded.vector.size > 0) {
-    vectorIndex.restoreFrom(loaded.vector);
-    console.log(
-      `[agentmemory] Loaded persisted vector index (${vectorIndex.size} vectors)`,
-    );
+    // Persisted vectors carry whatever dimension the provider had when
+    // they were written. If the active provider declares a different
+    // dimension (model swap, provider switch, model upgrade), restoring
+    // the old vectors would silently mix dimensions: cosineSimilarity
+    // returns 0 on cross-dim pairs, so the old observations stop matching
+    // anything and recall degrades without an error. Refuse to load.
+    // Same defense the live-write path got from #248.
+    const persistedDim = loaded.vector.firstDimensions();
+    const activeDim = embeddingProvider?.dimensions ?? 0;
+    if (persistedDim > 0 && activeDim > 0 && persistedDim !== activeDim) {
+      const dropStale =
+        process.env["AGENTMEMORY_DROP_STALE_INDEX"] === "true";
+      if (dropStale) {
+        console.warn(
+          `[agentmemory] Persisted vector index has dimension ${persistedDim} but ` +
+            `active provider (${embeddingProvider?.name}) declares ${activeDim}. ` +
+            `AGENTMEMORY_DROP_STALE_INDEX=true is set — discarding the persisted ` +
+            `vectors. Live observations will rebuild the index over time.`,
+        );
+      } else {
+        throw new Error(
+          `[agentmemory] Refusing to start: persisted vector index has dimension ` +
+            `${persistedDim}, but the active provider (${embeddingProvider?.name}) ` +
+            `declares ${activeDim}. Loading would silently corrupt search ` +
+            `(cross-dimension cosine returns 0). Choose one:\n` +
+            `  - Re-embed the existing index against the new provider, then start.\n` +
+            `  - Set AGENTMEMORY_DROP_STALE_INDEX=true to discard the persisted ` +
+            `vectors and rebuild from live observations.\n` +
+            `  - Switch the embedding provider back to the one that wrote the index.`,
+        );
+      }
+    } else {
+      vectorIndex.restoreFrom(loaded.vector);
+      console.log(
+        `[agentmemory] Loaded persisted vector index (${vectorIndex.size} vectors)`,
+      );
+    }
   }
 
   const needsRebuild = bm25Index.size === 0;

--- a/src/providers/embedding/index.ts
+++ b/src/providers/embedding/index.ts
@@ -23,7 +23,7 @@ let imageEmbeddingProvider: EmbeddingProvider | null = null;
 export function createImageEmbeddingProvider(): EmbeddingProvider | null {
   if (process.env["AGENTMEMORY_IMAGE_EMBEDDINGS"] !== "true") return null;
   if (imageEmbeddingProvider) return imageEmbeddingProvider;
-  imageEmbeddingProvider = new ClipEmbeddingProvider();
+  imageEmbeddingProvider = withDimensionGuard(new ClipEmbeddingProvider());
   return imageEmbeddingProvider;
 }
 
@@ -33,18 +33,49 @@ export function createEmbeddingProvider(): EmbeddingProvider | null {
 
   switch (detected) {
     case "gemini":
-      return new GeminiEmbeddingProvider(getEnvVar("GEMINI_API_KEY")!);
+      return withDimensionGuard(new GeminiEmbeddingProvider(getEnvVar("GEMINI_API_KEY")!));
     case "openai":
-      return new OpenAIEmbeddingProvider(getEnvVar("OPENAI_API_KEY")!);
+      return withDimensionGuard(new OpenAIEmbeddingProvider(getEnvVar("OPENAI_API_KEY")!));
     case "voyage":
-      return new VoyageEmbeddingProvider(getEnvVar("VOYAGE_API_KEY")!);
+      return withDimensionGuard(new VoyageEmbeddingProvider(getEnvVar("VOYAGE_API_KEY")!));
     case "cohere":
-      return new CohereEmbeddingProvider(getEnvVar("COHERE_API_KEY")!);
+      return withDimensionGuard(new CohereEmbeddingProvider(getEnvVar("COHERE_API_KEY")!));
     case "openrouter":
-      return new OpenRouterEmbeddingProvider(getEnvVar("OPENROUTER_API_KEY")!);
+      return withDimensionGuard(new OpenRouterEmbeddingProvider(getEnvVar("OPENROUTER_API_KEY")!));
     case "local":
-      return new LocalEmbeddingProvider();
+      return withDimensionGuard(new LocalEmbeddingProvider());
     default:
       return null;
   }
+}
+
+// Wrong-dimension vectors corrupt the index silently: vector-index.ts
+// returns 0 from cosineSimilarity on length mismatch instead of throwing,
+// so a bad vector is stored, never matches anything, and the memory
+// becomes invisible without an error. Catch it at the boundary.
+export function withDimensionGuard(provider: EmbeddingProvider): EmbeddingProvider {
+  const expected = provider.dimensions;
+  const check = (v: Float32Array, where: string): Float32Array => {
+    if (v.length !== expected) {
+      throw new Error(
+        `Embedding dimension mismatch in ${provider.name}.${where}: expected ${expected}, got ${v.length}`,
+      );
+    }
+    return v;
+  };
+  const wrapped: EmbeddingProvider = {
+    name: provider.name,
+    dimensions: provider.dimensions,
+    embed: async (t) => check(await provider.embed(t), "embed"),
+    embedBatch: async (ts) => {
+      const out = await provider.embedBatch(ts);
+      out.forEach((v, i) => check(v, `embedBatch[${i}]`));
+      return out;
+    },
+  };
+  if (provider.embedImage) {
+    wrapped.embedImage = async (s: string) =>
+      check(await provider.embedImage!(s), "embedImage");
+  }
+  return wrapped;
 }

--- a/src/providers/embedding/index.ts
+++ b/src/providers/embedding/index.ts
@@ -63,15 +63,14 @@ export function withDimensionGuard(provider: EmbeddingProvider): EmbeddingProvid
     }
     return v;
   };
-  const wrapped: EmbeddingProvider = {
-    name: provider.name,
-    dimensions: provider.dimensions,
-    embed: async (t) => check(await provider.embed(t), "embed"),
-    embedBatch: async (ts) => {
-      const out = await provider.embedBatch(ts);
-      out.forEach((v, i) => check(v, `embedBatch[${i}]`));
-      return out;
-    },
+  // Preserve the provider's prototype chain so `instanceof` checks
+  // against concrete classes (e.g. GeminiEmbeddingProvider) keep working.
+  const wrapped = Object.create(provider) as EmbeddingProvider;
+  wrapped.embed = async (t) => check(await provider.embed(t), "embed");
+  wrapped.embedBatch = async (ts) => {
+    const out = await provider.embedBatch(ts);
+    out.forEach((v, i) => check(v, `embedBatch[${i}]`));
+    return out;
   };
   if (provider.embedImage) {
     wrapped.embedImage = async (s: string) =>

--- a/src/state/vector-index.ts
+++ b/src/state/vector-index.ts
@@ -66,6 +66,17 @@ export class VectorIndex {
     return this.vectors.size;
   }
 
+  // Dimension of any stored vector, or 0 if the index is empty. All vectors
+  // in a single index are expected to share the same dimension; the first
+  // entry is representative because the live-write path is gated by the
+  // dimension guard in src/providers/embedding/index.ts.
+  firstDimensions(): number {
+    for (const entry of this.vectors.values()) {
+      return entry.embedding.length;
+    }
+    return 0;
+  }
+
   clear(): void {
     this.vectors.clear();
   }

--- a/src/state/vector-index.ts
+++ b/src/state/vector-index.ts
@@ -66,15 +66,27 @@ export class VectorIndex {
     return this.vectors.size;
   }
 
-  // Dimension of any stored vector, or 0 if the index is empty. All vectors
-  // in a single index are expected to share the same dimension; the first
-  // entry is representative because the live-write path is gated by the
-  // dimension guard in src/providers/embedding/index.ts.
-  firstDimensions(): number {
-    for (const entry of this.vectors.values()) {
-      return entry.embedding.length;
+  // Walks every stored vector and returns the obsIds whose dimension
+  // doesn't match `expected`, plus the set of distinct dimensions seen.
+  // Used by the persistence-restore guard in src/index.ts to refuse
+  // loading any index containing wrong-dimension vectors — including
+  // legacy on-disk indexes written before the live-API dimension guard
+  // existed (where a mid-session provider swap could mix dimensions
+  // inside a single index). Empty `mismatches` plus a single-entry
+  // `seenDimensions` matching `expected` is the only clean state.
+  validateDimensions(
+    expected: number,
+  ): { mismatches: Array<{ obsId: string; dim: number }>; seenDimensions: Set<number> } {
+    const mismatches: Array<{ obsId: string; dim: number }> = [];
+    const seenDimensions = new Set<number>();
+    for (const [obsId, entry] of this.vectors) {
+      const dim = entry.embedding.length;
+      seenDimensions.add(dim);
+      if (dim !== expected) {
+        mismatches.push({ obsId, dim });
+      }
     }
-    return 0;
+    return { mismatches, seenDimensions };
   }
 
   clear(): void {

--- a/test/embedding-provider.test.ts
+++ b/test/embedding-provider.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { createEmbeddingProvider } from "../src/providers/embedding/index.js";
+import {
+  createEmbeddingProvider,
+  withDimensionGuard,
+} from "../src/providers/embedding/index.js";
 import { GeminiEmbeddingProvider } from "../src/providers/embedding/gemini.js";
 import { OpenAIEmbeddingProvider } from "../src/providers/embedding/openai.js";
+import type { EmbeddingProvider } from "../src/types.js";
 
 describe("createEmbeddingProvider", () => {
   const originalEnv = { ...process.env };
@@ -147,5 +151,82 @@ describe("OpenAIEmbeddingProvider", () => {
     expect(() => new OpenAIEmbeddingProvider("test-key")).toThrow(
       /OPENAI_EMBEDDING_DIMENSIONS must be a positive integer/,
     );
+  });
+});
+
+describe("withDimensionGuard", () => {
+  function fakeProvider(opts: {
+    dimensions: number;
+    embed: () => Float32Array;
+    batch?: () => Float32Array[];
+    image?: () => Float32Array;
+  }): EmbeddingProvider {
+    const provider: EmbeddingProvider = {
+      name: "fake",
+      dimensions: opts.dimensions,
+      embed: async () => opts.embed(),
+      embedBatch: async () => opts.batch?.() ?? [opts.embed()],
+    };
+    if (opts.image) provider.embedImage = async () => opts.image!();
+    return provider;
+  }
+
+  it("passes through vectors that match the declared dimensions", async () => {
+    const guarded = withDimensionGuard(
+      fakeProvider({
+        dimensions: 4,
+        embed: () => new Float32Array([1, 2, 3, 4]),
+        batch: () => [new Float32Array([1, 2, 3, 4]), new Float32Array([5, 6, 7, 8])],
+      }),
+    );
+    await expect(guarded.embed("x")).resolves.toEqual(new Float32Array([1, 2, 3, 4]));
+    await expect(guarded.embedBatch(["a", "b"])).resolves.toHaveLength(2);
+  });
+
+  it("throws when embed() returns the wrong dimension", async () => {
+    const guarded = withDimensionGuard(
+      fakeProvider({
+        dimensions: 4,
+        embed: () => new Float32Array([1, 2, 3]),
+      }),
+    );
+    await expect(guarded.embed("x")).rejects.toThrow(
+      /dimension mismatch in fake\.embed: expected 4, got 3/,
+    );
+  });
+
+  it("throws when any vector in embedBatch() returns the wrong dimension", async () => {
+    const guarded = withDimensionGuard(
+      fakeProvider({
+        dimensions: 4,
+        embed: () => new Float32Array([1, 2, 3, 4]),
+        batch: () => [new Float32Array([1, 2, 3, 4]), new Float32Array([1, 2])],
+      }),
+    );
+    await expect(guarded.embedBatch(["a", "b"])).rejects.toThrow(
+      /dimension mismatch in fake\.embedBatch\[1\]: expected 4, got 2/,
+    );
+  });
+
+  it("guards embedImage when present and omits it when absent", async () => {
+    const withImage = withDimensionGuard(
+      fakeProvider({
+        dimensions: 4,
+        embed: () => new Float32Array([1, 2, 3, 4]),
+        image: () => new Float32Array([1, 2]),
+      }),
+    );
+    expect(withImage.embedImage).toBeDefined();
+    await expect(withImage.embedImage!("/tmp/x")).rejects.toThrow(
+      /dimension mismatch in fake\.embedImage: expected 4, got 2/,
+    );
+
+    const withoutImage = withDimensionGuard(
+      fakeProvider({
+        dimensions: 4,
+        embed: () => new Float32Array([1, 2, 3, 4]),
+      }),
+    );
+    expect(withoutImage.embedImage).toBeUndefined();
   });
 });

--- a/test/embedding-provider.test.ts
+++ b/test/embedding-provider.test.ts
@@ -171,6 +171,23 @@ describe("withDimensionGuard", () => {
     return provider;
   }
 
+  it("preserves the wrapped provider's prototype so instanceof keeps working", async () => {
+    class FakeProvider implements EmbeddingProvider {
+      readonly name = "fake-class";
+      readonly dimensions = 4;
+      async embed(): Promise<Float32Array> {
+        return new Float32Array([1, 2, 3, 4]);
+      }
+      async embedBatch(): Promise<Float32Array[]> {
+        return [new Float32Array([1, 2, 3, 4])];
+      }
+    }
+    const guarded = withDimensionGuard(new FakeProvider());
+    expect(guarded).toBeInstanceOf(FakeProvider);
+    expect(guarded.name).toBe("fake-class");
+    expect(guarded.dimensions).toBe(4);
+  });
+
   it("passes through vectors that match the declared dimensions", async () => {
     const guarded = withDimensionGuard(
       fakeProvider({

--- a/test/vector-index-dimensions.test.ts
+++ b/test/vector-index-dimensions.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { VectorIndex } from "../src/state/vector-index.js";
+
+describe("VectorIndex.firstDimensions", () => {
+  it("returns 0 when empty", () => {
+    expect(new VectorIndex().firstDimensions()).toBe(0);
+  });
+  it("returns the dimension of the first stored vector", () => {
+    const idx = new VectorIndex();
+    idx.add("o1", "s1", new Float32Array([1, 2, 3, 4]));
+    expect(idx.firstDimensions()).toBe(4);
+  });
+  it("works for high-dim providers", () => {
+    const idx = new VectorIndex();
+    idx.add("o1", "s1", new Float32Array(1536));
+    expect(idx.firstDimensions()).toBe(1536);
+  });
+});

--- a/test/vector-index-dimensions.test.ts
+++ b/test/vector-index-dimensions.test.ts
@@ -1,18 +1,42 @@
 import { describe, it, expect } from "vitest";
 import { VectorIndex } from "../src/state/vector-index.js";
 
-describe("VectorIndex.firstDimensions", () => {
-  it("returns 0 when empty", () => {
-    expect(new VectorIndex().firstDimensions()).toBe(0);
+describe("VectorIndex.validateDimensions", () => {
+  it("reports no mismatches and an empty dim set on an empty index", () => {
+    const result = new VectorIndex().validateDimensions(384);
+    expect(result.mismatches).toEqual([]);
+    expect(Array.from(result.seenDimensions)).toEqual([]);
   });
-  it("returns the dimension of the first stored vector", () => {
+
+  it("reports no mismatches when every vector matches the expected dimension", () => {
     const idx = new VectorIndex();
-    idx.add("o1", "s1", new Float32Array([1, 2, 3, 4]));
-    expect(idx.firstDimensions()).toBe(4);
+    idx.add("o1", "s1", new Float32Array(384));
+    idx.add("o2", "s1", new Float32Array(384));
+    const result = idx.validateDimensions(384);
+    expect(result.mismatches).toEqual([]);
+    expect(Array.from(result.seenDimensions)).toEqual([384]);
   });
-  it("works for high-dim providers", () => {
+
+  it("reports every wrong-dimension vector, not just the first", () => {
     const idx = new VectorIndex();
-    idx.add("o1", "s1", new Float32Array(1536));
-    expect(idx.firstDimensions()).toBe(1536);
+    idx.add("good1", "s1", new Float32Array(384));
+    idx.add("bad1", "s1", new Float32Array(1536));
+    idx.add("good2", "s1", new Float32Array(384));
+    idx.add("bad2", "s1", new Float32Array(768));
+    const result = idx.validateDimensions(384);
+    expect(result.mismatches).toHaveLength(2);
+    expect(result.mismatches.map((m) => m.obsId).sort()).toEqual(["bad1", "bad2"]);
+    expect(Array.from(result.seenDimensions).sort((a, b) => a - b)).toEqual([
+      384, 768, 1536,
+    ]);
+  });
+
+  it("flags every entry when the entire index has the wrong dimension", () => {
+    const idx = new VectorIndex();
+    idx.add("o1", "s1", new Float32Array(384));
+    idx.add("o2", "s1", new Float32Array(384));
+    const result = idx.validateDimensions(1536);
+    expect(result.mismatches).toHaveLength(2);
+    expect(Array.from(result.seenDimensions)).toEqual([384]);
   });
 });


### PR DESCRIPTION
Closes #247.

## What

Adds a dimension-check wrapper at the `EmbeddingProvider` boundary in `src/providers/embedding/index.ts`. `createEmbeddingProvider()` and `createImageEmbeddingProvider()` now wrap every provider so that any returned `Float32Array` whose length differs from `provider.dimensions` throws a descriptive error.

## Why

Embedding providers in `src/providers/embedding/` (gemini, openai, voyage, cohere, openrouter, local, clip) trust that the API returns vectors matching their declared dimensions. None of them validate `result.length === this.dimensions`. When the assumption breaks, the failure is **silent**:

- `src/state/vector-index.ts:10` returns `0` from `cosineSimilarity` on length mismatch instead of throwing.
- A wrong-size vector gets stored, never matches anything in search, and the affected memory becomes effectively invisible — no error, no log line.

This came up during review of #246 (gemini deprecation), where CodeRabbit flagged the gap on a single provider. Per-provider guards would be 7× duplication and easy to miss for new providers, so the fix lives at the factory boundary instead.

## Changes

**`src/providers/embedding/index.ts`**
- New `withDimensionGuard(provider)` that returns a wrapper checking `embed`, `embedBatch`, and (when present) `embedImage` results.
- `createEmbeddingProvider()` and `createImageEmbeddingProvider()` apply the wrapper to every constructed provider.
- Errors name the provider, call site (`embed` / `embedBatch[i]` / `embedImage`), expected dimension, and actual dimension.

**`test/embedding-provider.test.ts`**
- Happy path passes through correct-dimension vectors.
- Mismatch on `embed` throws.
- Mismatch on any item in `embedBatch` throws with the index.
- `embedImage` is guarded when present and absent when not.

## How to verify

```bash
npm install
npm test -- test/embedding-provider.test.ts
```

The four new tests under `describe(\"withDimensionGuard\")` should pass alongside the existing suite.

## Notes

- Single signed-off commit per CONTRIBUTING.
- No CHANGELOG touch (release PRs only).
- No new dependencies.
- No existing test breakage expected — the existing tests construct providers directly via `new GeminiEmbeddingProvider(...)`, which is unwrapped, while only the factory entry points apply the guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Embedding providers now validate returned vector dimensions and surface clear errors (expected vs actual, including failing batch index).
  * Loading persisted vector indexes now verifies dimensionality and will either drop stale vectors with a warning (configurable) or refuse startup with guidance to re-embed or switch providers.
  * Indexes can report all observed stored vector dimensions.

* **Tests**
  * Added tests covering provider dimension guards and index dimension validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/248)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->