### PR TITLE
fix(cli): include project + cwd in demo seeder observe payload (closes #229)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -789,6 +789,8 @@ async function seedDemoSession(
     const payload = {
       hookType: "post_tool_use",
       sessionId: session.id,
+      project,
+      cwd: project,
       timestamp: new Date().toISOString(),
       data: {
         tool_name: obs.toolName,


### PR DESCRIPTION
Closes #229.

## What

`npx @agentmemory/agentmemory demo` was silently seeding **0** observations because the per-observation POST to `/agentmemory/observe` omitted the `project` and `cwd` fields that `api::observe` requires.

```
▲  observe failed for Write: 400 Bad Request — {"error":"hookType, sessionId, project, cwd, and timestamp are required strings"}
... (one per observation)
◇  Seeded 0 observations across 3 sessions
```

The three smart-search queries that follow then returned 0 hits, defeating the point of the demo.

## Fix

Two-line addition to `src/cli.ts::seedDemoSession`. `project` was already a function parameter, so no plumbing was needed. `cwd` is set equal to `project` for the demo (matches what `session/start` and `session/end` already do in the same function).

## Test plan

- [x] Run `npx -y @agentmemory/agentmemory` in one terminal.
- [x] Run `npx -y @agentmemory/agentmemory demo` in another. Should see `Seeded 9 observations across 3 sessions` (3 sessions × 3 obs each).
- [x] Re-run the smart-search queries the demo prints; should now return real hits.

Credit to @seishonagon for the precise root-cause analysis in #229.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced demo session data capture to include additional project context information, improving the completeness of session recordings.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/251)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->