### PR TITLE
fix(hermes): accept passthrough kwargs in memory provider hooks (closes #249)

### DIFF
--- a/integrations/hermes/__init__.py
+++ b/integrations/hermes/__init__.py
@@ -38,13 +38,13 @@ except ImportError:
         def get_config_schema(self) -> list[dict]: return []
         def save_config(self, values: dict, hermes_home: str) -> None: pass
         def system_prompt_block(self) -> str: return ""
-        def prefetch(self, query: str) -> str: return ""
-        def queue_prefetch(self, query: str) -> None: pass
-        def sync_turn(self, user: str, assistant: str) -> None: pass
-        def on_session_end(self, messages: list) -> None: pass
-        def on_pre_compress(self, messages: list) -> None: pass
-        def on_memory_write(self, action: str, target: str, content: str) -> None: pass
-        def shutdown(self) -> None: pass
+        def prefetch(self, query: str, **kwargs: Any) -> str: return ""
+        def queue_prefetch(self, query: str, **kwargs: Any) -> None: pass
+        def sync_turn(self, user: str, assistant: str, **kwargs: Any) -> None: pass
+        def on_session_end(self, messages: list, **kwargs: Any) -> None: pass
+        def on_pre_compress(self, messages: list, **kwargs: Any) -> None: pass
+        def on_memory_write(self, action: str, target: str, content: str, **kwargs: Any) -> None: pass
+        def shutdown(self, **kwargs: Any) -> None: pass
 
 
 DEFAULT_BASE_URL = "http://localhost:3111"
@@ -138,7 +138,7 @@ class AgentMemoryProvider(MemoryProvider):
             return result["context"]
         return ""
 
-    def prefetch(self, query: str) -> str:
+    def prefetch(self, query: str, **kwargs: Any) -> str:
         result = _api(self._base, "smart-search", {
             "query": query,
             "limit": 5,
@@ -155,7 +155,7 @@ class AgentMemoryProvider(MemoryProvider):
                 lines.append(f"- {title}: {narrative[:200]}")
         return "\n".join(lines) if lines else ""
 
-    def queue_prefetch(self, query: str) -> None:
+    def queue_prefetch(self, query: str, **kwargs: Any) -> None:
         _api_bg(self._base, "smart-search", {"query": query, "limit": 3})
 
     def get_tool_schemas(self) -> list[dict]:
@@ -248,10 +248,10 @@ class AgentMemoryProvider(MemoryProvider):
 
         return {"error": f"Unknown tool: {name}"}
 
-    def sync_turn(self, user: str, assistant: str) -> None:
+    def sync_turn(self, user: str, assistant: str, **kwargs: Any) -> None:
         _api_bg(self._base, "observe", {
             "hookType": "post_tool_use",
-            "sessionId": self._session_id,
+            "sessionId": kwargs.get("session_id", self._session_id),
             "project": self._project,
             "cwd": self._project,
             "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
@@ -262,14 +262,14 @@ class AgentMemoryProvider(MemoryProvider):
             },
         })
 
-    def on_session_end(self, messages: list) -> None:
+    def on_session_end(self, messages: list, **kwargs: Any) -> None:
         _api(self._base, "session/end", {
-            "sessionId": self._session_id,
+            "sessionId": kwargs.get("session_id", self._session_id),
         })
 
-    def on_pre_compress(self, messages: list) -> None:
+    def on_pre_compress(self, messages: list, **kwargs: Any) -> None:
         result = _api(self._base, "context", {
-            "sessionId": self._session_id,
+            "sessionId": kwargs.get("session_id", self._session_id),
             "project": self._project,
         })
         if result and result.get("context"):
@@ -278,14 +278,14 @@ class AgentMemoryProvider(MemoryProvider):
                 "content": f"[agentmemory context before compaction]\n{result['context']}",
             })
 
-    def on_memory_write(self, action: str, target: str, content: str) -> None:
+    def on_memory_write(self, action: str, target: str, content: str, **kwargs: Any) -> None:
         if action in ("add", "update") and content:
             _api_bg(self._base, "remember", {
                 "content": content,
                 "type": "fact",
             })
 
-    def shutdown(self) -> None:
+    def shutdown(self, **kwargs: Any) -> None:
         pass
 
 


### PR DESCRIPTION
Closes #249.

## What

Hermes calls memory provider hooks with extra context kwargs (e.g. `session_id`) that the existing strict signatures rejected with:

```
Memory provider 'agentmemory' sync_turn failed: AgentMemoryProvider.sync_turn() got an unexpected keyword argument 'session_id'
```

This kept the plugin "alive" but silently broke per-turn memory sync — every `sync_turn` invocation hit an exception and got skipped, so conversation observations were lost.

## Fix

Add `**kwargs: Any` to every memory-provider hook so extra context fields are tolerated:

- `sync_turn`
- `on_session_end`
- `on_pre_compress`
- `on_memory_write`
- `prefetch`
- `queue_prefetch`
- `shutdown`

Mirror the same change on the abstract `MemoryProvider` fallback used when `agent.memory_provider` is unavailable at import time, so the contract stays consistent across both paths.

Where Hermes passes `session_id` in kwargs, prefer it over the cached `self._session_id` so per-turn observations land on the correct session when Hermes routes a hook through a different conversation than the one the provider was initialized with. Same pattern applied to `on_session_end` and `on_pre_compress`.

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('integrations/hermes/__init__.py').read())"` — syntax clean.
- [x] Reproduce per @OptionalCoin's repro: install plugin, run normal CLI conversation turn, check `~/.hermes/logs/agent.log` — no more `unexpected keyword argument 'session_id'` warnings, and `sync_turn` actually fires the observe POST.
- [ ] @OptionalCoin reported they ran their local-patched version through a Hermes CLI smoke run and the warning disappeared. Asking them to confirm against this branch as well.

Credit to @OptionalCoin for the root-cause analysis and the local patch verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated memory provider interface signatures to support additional context parameters across core operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/252)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->