### PR TITLE
fix(hermes): preload ~/.agentmemory/.env so status reflects service env (closes #250)

### DIFF
--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -106,6 +106,8 @@ The plugin auto-detects the running server and hooks into the Hermes agent loop.
 | `AGENTMEMORY_URL` | `http://localhost:3111` | agentmemory server URL |
 | `AGENTMEMORY_SECRET` | (none) | Auth token for protected instances |
 
+The plugin reads `~/.agentmemory/.env` (or `$XDG_CONFIG_HOME/agentmemory/.env`) at import time and populates any missing values into the process environment via `os.environ.setdefault`. Anything you set in the shell takes precedence; the file is only used to fill gaps. This means `hermes memory status` reports the plugin as available even when the agentmemory service is launched by systemd or another process manager that loads `~/.agentmemory/.env` directly without exporting it to the Hermes CLI shell (#250).
+
 ## What Hermes gets
 
 - 95.2% retrieval accuracy (LongMemEval-S, ICLR 2025)

--- a/integrations/hermes/__init__.py
+++ b/integrations/hermes/__init__.py
@@ -50,6 +50,46 @@ except ImportError:
 DEFAULT_BASE_URL = "http://localhost:3111"
 TIMEOUT = 5
 
+# agentmemory's documented runtime config lives at ~/.agentmemory/.env.
+# When agentmemory is launched as a systemd user service (or any other
+# process manager that loads that file directly), those values never
+# reach an interactive shell. `hermes memory status` then reads
+# os.environ in the Hermes CLI process, finds AGENTMEMORY_URL /
+# AGENTMEMORY_SECRET unset, and reports the plugin as "Missing" even
+# though the service is healthy and live sessions can use it (#250).
+#
+# Preload the file at plugin-import time using os.environ.setdefault so
+# we never override anything the user explicitly set in the shell. The
+# preload is best-effort and silent on any failure (file absent,
+# unreadable, malformed) — the plugin falls back to its existing default
+# (http://localhost:3111) and Hermes status reflects that.
+def _preload_agentmemory_dotenv() -> None:
+    candidates: list[Path] = []
+    home = os.environ.get("HOME")
+    if home:
+        candidates.append(Path(home) / ".agentmemory" / ".env")
+    xdg_config = os.environ.get("XDG_CONFIG_HOME")
+    if xdg_config:
+        candidates.append(Path(xdg_config) / "agentmemory" / ".env")
+    for path in candidates:
+        try:
+            if not path.is_file():
+                continue
+            for raw in path.read_text(encoding="utf-8").splitlines():
+                line = raw.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, _, value = line.partition("=")
+                key = key.strip()
+                value = value.strip().strip('"').strip("'")
+                if key:
+                    os.environ.setdefault(key, value)
+        except (OSError, UnicodeDecodeError):
+            continue
+
+
+_preload_agentmemory_dotenv()
+
 
 def _validate_url(base: str) -> bool:
     from urllib.parse import urlparse


### PR DESCRIPTION
Closes #250.

## What

When a user manages agentmemory's runtime config in `~/.agentmemory/.env` (the file agentmemory's own README documents) and starts the service via systemd / launchd / docker compose, those values never reach Hermes. Hermes' canonical env source is `~/.hermes/.env` ([per the Configuration page](https://hermes-agent.nousresearch.com/docs/user-guide/configuration)):

> `~/.hermes/.env` — fallback for env vars; **required** for secrets (API keys, tokens, passwords)

The "happy path" Hermes expects is `hermes plugin configure agentmemory` → user enters URL + secret → Hermes writes them to `~/.hermes/.env`. But users running agentmemory as an external service skip that step, and `hermes memory status` then reports the plugin as "not available" + "Missing AGENTMEMORY_URL / AGENTMEMORY_SECRET" — even though the service is healthy and live conversations can use it.

## Fix

Preload `~/.agentmemory/.env` (the agentmemory-side config) at plugin-import time using `os.environ.setdefault`. This bridges the two source-of-truths cleanly:

- **Hermes-side priority preserved.** `~/.hermes/.env` and any explicitly-exported shell vars take precedence — `setdefault` only fills gaps.
- **agentmemory-side fallback honored.** Users who manage config in agentmemory's documented file get correct status without re-typing values into `hermes plugin configure agentmemory`.
- **Best-effort.** Absent / unreadable / malformed `.env` is silently skipped; the plugin falls back to its existing defaults.
- **Two paths checked.** `~/.agentmemory/.env` (primary) and `$XDG_CONFIG_HOME/agentmemory/.env` (XDG fallback).

The parser is intentionally tiny — `KEY=VALUE` lines, `#` comments, blank lines, trim matching `'`/`"` quotes. No `python-dotenv` dependency; the rest of `integrations/hermes/` is zero-dep too.

## Why fix from the plugin side

The cleaner long-term fix would be Hermes' `memory status` command consulting the provider's `is_available()` rather than treating env-var presence as a proxy. That's an upstream change. This PR closes the symptom from our side without waiting on it, mirroring the defensive pattern in #252 (`**kwargs` everywhere because Hermes' runtime contract drifts from its docs).

## Test plan

- [x] Unit: with a fake `HOME` containing `.agentmemory/.env`, importing the plugin populates `os.environ`.
- [x] Precedence: shell-set `AGENTMEMORY_URL` is preserved through plugin import; only missing keys are filled from the file.
- [x] Failure modes: nonexistent file, unreadable file, malformed lines all skip silently.
- [x] Verified against Hermes' [Configuration docs](https://hermes-agent.nousresearch.com/docs/user-guide/configuration) and the documented [MemoryProvider interface](https://hermes-agent.nousresearch.com/docs/developer-guide/memory-provider-plugin) — fix doesn't conflict with either, and respects the documented Hermes-side env precedence.

Credit to @OptionalCoin for the precise repro.