### PR TITLE
fix(hermes): serialize handle_tool_call returns to JSON string (closes #254)

### DIFF
--- a/integrations/hermes/__init__.py
+++ b/integrations/hermes/__init__.py
@@ -34,7 +34,7 @@ except ImportError:
         @abstractmethod
         def get_tool_schemas(self) -> list[dict]: ...
         @abstractmethod
-        def handle_tool_call(self, name: str, args: dict) -> Any: ...
+        def handle_tool_call(self, name: str, args: dict) -> str: ...
         def get_config_schema(self) -> list[dict]: return []
         def save_config(self, values: dict, hermes_home: str) -> None: pass
         def system_prompt_block(self) -> str: return ""
@@ -242,14 +242,19 @@ class AgentMemoryProvider(MemoryProvider):
             },
         ]
 
-    def handle_tool_call(self, name: str, args: dict) -> Any:
+    def handle_tool_call(self, name: str, args: dict) -> str:
+        # Hermes stores the return value as the tool result `content` in the
+        # session history. Anthropic-protocol providers reject non-string
+        # content with a 400 on the next request, so always serialize to a
+        # JSON string here — matches what agentmemory's main MCP server does
+        # in src/mcp/standalone.ts (`{ type: "text", text: JSON.stringify(...) }`).
         if name == "memory_recall":
             result = _api(self._base, "search", {
                 "query": args["query"],
                 "limit": args.get("limit", 10),
             })
             if not result:
-                return {"results": []}
+                return json.dumps({"results": []})
             items = []
             for r in result.get("results", []):
                 obs = r.get("observation", r)
@@ -260,14 +265,14 @@ class AgentMemoryProvider(MemoryProvider):
                     "importance": obs.get("importance", 0),
                     "timestamp": obs.get("timestamp", ""),
                 })
-            return {"results": items}
+            return json.dumps({"results": items})
 
         if name == "memory_save":
             result = _api(self._base, "remember", {
                 "content": args["content"],
                 "type": args.get("type", "fact"),
             })
-            return result or {"success": False}
+            return json.dumps(result or {"success": False})
 
         if name == "memory_search":
             result = _api(self._base, "smart-search", {
@@ -275,7 +280,7 @@ class AgentMemoryProvider(MemoryProvider):
                 "limit": args.get("limit", 5),
             })
             if not result:
-                return {"results": []}
+                return json.dumps({"results": []})
             items = []
             for r in result.get("results", []):
                 obs = r.get("observation", r)
@@ -284,9 +289,9 @@ class AgentMemoryProvider(MemoryProvider):
                     "narrative": obs.get("narrative", "")[:300],
                     "score": r.get("combinedScore", r.get("score", 0)),
                 })
-            return {"results": items}
+            return json.dumps({"results": items})
 
-        return {"error": f"Unknown tool: {name}"}
+        return json.dumps({"error": f"Unknown tool: {name}"})
 
     def sync_turn(self, user: str, assistant: str, **kwargs: Any) -> None:
         _api_bg(self._base, "observe", {


### PR DESCRIPTION
Closes #254.

## What

Hermes stores `handle_tool_call`'s return value verbatim as the tool result `content` in the session history. When Hermes is configured with an Anthropic-protocol LLM backend (`provider: anthropic`, plus any Anthropic-compatible proxy), the API rejects non-string `content` with a 400 on the next request:

```
Failed to deserialize the JSON body into the target type:
messages[N]: content should be a string or a list at line 1 column XXXXX
```

Once that happens, every subsequent request in the affected session 400s until the session JSON is hand-cleaned — a real cliff.

## Fix

Wrap all four return paths in `json.dumps`:
- `memory_recall` (empty + populated branches)
- `memory_save`
- `memory_search` (empty + populated branches)
- unknown-tool fallback

Tighten the return-type annotation on both the abstract base and the concrete class from `Any` → `str` so a future regression surfaces at type-check time.

## Why this is the right contract

agentmemory's own MCP server already returns JSON strings — see `src/mcp/standalone.ts`:

```ts
{ type: "text", text: JSON.stringify(payload, null, pretty ? 2 : 0) }
```

The Hermes integration is the outlier here, not the rule. After this PR, every agentmemory tool surface (REST, MCP, OpenClaw plugin, OpenCode plugin once #237 lands, Hermes plugin) hands back a string.

## Test plan

- [x] Unit smoke test against an unreachable backend — every `handle_tool_call` path returns a `str` that round-trips through `json.loads`.
- [x] Verified against agentmemory's existing MCP server contract (`src/mcp/standalone.ts`) so the Hermes plugin is now consistent with native MCP behavior.
- [ ] Real-world: trigger `memory_recall` in a Hermes session with `provider: anthropic`, continue conversation past the tool turn, no 400.

Credit to @KyoMio for the precise root-cause analysis (4 dict returns flagged with before/after diffs) and the Anthropic-protocol-specific repro that pinpointed why the bug is invisible on OpenAI-protocol backends.

## Note re: KyoMio's secondary point about `session_id` in hook signatures

KyoMio also flagged that `prefetch` / `queue_prefetch` / `sync_turn` were missing `*, session_id: str = ""` for gateway multi-session contexts. That's already addressed by #252 (merged this morning) which added `**kwargs: Any` to all those hooks plus `on_session_end` / `on_pre_compress` / `on_memory_write` / `shutdown`. `**kwargs` is a strict superset of the keyword-only `session_id` proposal — accepts that key plus any other future Hermes-passed context kwargs without further patches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced consistency in how memory tool results are stored and managed within session history.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/255)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->