### PR TITLE
fix(install): pin iii-engine to v0.11.2 across all install paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,12 +413,15 @@ npm install && npm run build && npm start
 
 This starts agentmemory with a local `iii-engine` if `iii` is already installed, or falls back to Docker Compose if Docker is available. REST, streams, and the viewer bind to `127.0.0.1` by default.
 
-Install `iii-engine` manually:
+Install `iii-engine` manually. **agentmemory currently pins `iii-engine` to `v0.11.2`** â€” `v0.11.6` ships a regression where engine-internal cron/http triggers fail validation and the agentmemory worker drops into an EPIPE reconnect loop. Override with `AGENTMEMORY_III_VERSION=<version>` once compat is verified manually.
 
-- **macOS / Linux:** `curl -fsSL https://install.iii.dev/iii/main/install.sh | sh`
-- **Windows:** download `iii-x86_64-pc-windows-msvc.zip` from [iii-hq/iii releases](https://github.com/iii-hq/iii/releases/latest), extract `iii.exe`, add to PATH
+- **macOS arm64:** `curl -fsSL https://github.com/iii-hq/iii/releases/download/iii/v0.11.2/iii-aarch64-apple-darwin.tar.gz | tar -xz -C ~/.local/bin && chmod +x ~/.local/bin/iii`
+- **macOS x64:** swap `aarch64-apple-darwin` for `x86_64-apple-darwin`
+- **Linux x64:** swap for `x86_64-unknown-linux-gnu`
+- **Linux arm64:** swap for `aarch64-unknown-linux-gnu`
+- **Windows:** download `iii-x86_64-pc-windows-msvc.zip` from [iii-hq/iii releases v0.11.2](https://github.com/iii-hq/iii/releases/tag/iii%2Fv0.11.2), extract `iii.exe`, add to PATH
 
-Or use Docker (the bundled `docker-compose.yml` pulls `iiidev/iii:latest`). Full docs: [iii.dev/docs](https://iii.dev/docs).
+Or use Docker (the bundled `docker-compose.yml` pulls `iiidev/iii:0.11.2`). Full docs: [iii.dev/docs](https://iii.dev/docs).
 
 ### Windows
 
@@ -427,7 +430,8 @@ agentmemory runs on Windows 10/11, but the Node.js package alone isn't enough â€
 **Option A â€” Prebuilt Windows binary (recommended):**
 
 ```powershell
-# 1. Open https://github.com/iii-hq/iii/releases/latest in your browser
+# 1. Open https://github.com/iii-hq/iii/releases/tag/iii%2Fv0.11.2 in your browser
+#    (we pin to v0.11.2 â€” v0.11.6 has a regression that breaks agentmemory)
 # 2. Download iii-x86_64-pc-windows-msvc.zip
 #    (or iii-aarch64-pc-windows-msvc.zip if you're on an ARM machine)
 # 3. Extract iii.exe somewhere on PATH, or place it at:
@@ -435,6 +439,7 @@ agentmemory runs on Windows 10/11, but the Node.js package alone isn't enough â€
 #    (agentmemory checks that location automatically)
 # 4. Verify:
 iii --version
+# Should print: 0.11.2
 
 # 5. Then run agentmemory as usual:
 npx -y @agentmemory/agentmemory

--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ This starts agentmemory with a local `iii-engine` if `iii` is already installed,
 
 Install `iii-engine` manually. **agentmemory currently pins `iii-engine` to `v0.11.2`** — `v0.11.6` ships a regression where engine-internal cron/http triggers fail validation and the agentmemory worker drops into an EPIPE reconnect loop. Override with `AGENTMEMORY_III_VERSION=<version>` once compat is verified manually.
 
-- **macOS arm64:** `curl -fsSL https://github.com/iii-hq/iii/releases/download/iii/v0.11.2/iii-aarch64-apple-darwin.tar.gz | tar -xz -C ~/.local/bin && chmod +x ~/.local/bin/iii`
+- **macOS arm64:** `mkdir -p ~/.local/bin && curl -fsSL https://github.com/iii-hq/iii/releases/download/iii/v0.11.2/iii-aarch64-apple-darwin.tar.gz | tar -xz -C ~/.local/bin && chmod +x ~/.local/bin/iii`
 - **macOS x64:** swap `aarch64-apple-darwin` for `x86_64-apple-darwin`
 - **Linux x64:** swap for `x86_64-unknown-linux-gnu`
 - **Linux arm64:** swap for `aarch64-unknown-linux-gnu`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,11 @@
 services:
   iii-engine:
-    image: iiidev/iii:latest
+    # Pinned to v0.11.2. v0.11.6 has a regression where engine-internal
+    # cron/http trigger registrations fail validation, causing the
+    # agentmemory worker to drop into an EPIPE reconnect loop and BM25
+    # search to return empty after save. Bump only after compat is
+    # verified end-to-end against a fresh agentmemory install.
+    image: iiidev/iii:0.11.2
     ports:
       - "127.0.0.1:49134:49134"
       - "127.0.0.1:3111:3111"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,10 @@ services:
     # agentmemory worker to drop into an EPIPE reconnect loop and BM25
     # search to return empty after save. Bump only after compat is
     # verified end-to-end against a fresh agentmemory install.
-    image: iiidev/iii:0.11.2
+    #
+    # Override per-shell or via .env file:
+    #   AGENTMEMORY_III_VERSION=0.11.7 docker compose up
+    image: iiidev/iii:${AGENTMEMORY_III_VERSION:-0.11.2}
     ports:
       - "127.0.0.1:49134:49134"
       - "127.0.0.1:3111:3111"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -356,7 +356,7 @@ function installInstructions(): string[] {
     ];
   }
   const linuxInstall = releaseUrl
-    ? `  A) curl -fsSL "${releaseUrl}" | tar -xz -C ~/.local/bin && chmod +x ~/.local/bin/iii`
+    ? `  A) mkdir -p ~/.local/bin && curl -fsSL "${releaseUrl}" | tar -xz -C ~/.local/bin && chmod +x ~/.local/bin/iii`
     : `  A) Manual download from https://github.com/iii-hq/iii/releases/tag/iii%2Fv${IIPINNED_VERSION}`;
   return [
     `agentmemory requires the \`iii-engine\` runtime, pinned to v${IIPINNED_VERSION}. Pick one:`,
@@ -1042,9 +1042,22 @@ async function runUpgrade() {
     }
     if (upgradeEngine === true) {
       const releaseUrl = iiiReleaseUrl();
+      const asset = iiiReleaseAsset();
+      const isZipAsset = asset?.endsWith(".zip") === true;
       if (!releaseUrl) {
         p.log.warn(
           `iii-engine binary not available for ${platform()}/${process.arch}. Use Docker (\`docker pull iiidev/iii:${IIPINNED_VERSION}\`) or download manually from https://github.com/iii-hq/iii/releases/tag/iii%2Fv${IIPINNED_VERSION}.`,
+        );
+      } else if (IS_WINDOWS || isZipAsset) {
+        // Windows ships a .zip, not a tarball, and the rest of this
+        // branch assumes sh + tar -xz + chmod. Skip the auto-installer
+        // there and point at the manual flow / Docker fallback. Same
+        // guidance as installInstructions().
+        p.log.info(
+          `Skipping auto-install on ${platform()} — the ${asset} asset isn't tar-compatible. Install manually:\n` +
+            `  1. Download ${releaseUrl}\n` +
+            `  2. Extract iii.exe and place it on PATH (e.g. %USERPROFILE%\\.local\\bin)\n` +
+            `Or use Docker: docker pull iiidev/iii:${IIPINNED_VERSION}`,
         );
       } else {
         // Pinned to IIPINNED_VERSION rather than `install.iii.dev/iii/main`,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,47 @@ const args = process.argv.slice(2);
 const IS_WINDOWS = platform() === "win32";
 const IS_VERBOSE = args.includes("--verbose") || args.includes("-v");
 
+// Pinned iii-engine version. The unpinned `install.iii.dev/iii/main/install.sh`
+// script tracks `latest`, which made every fresh agentmemory install pull
+// engine 0.11.6 — and 0.11.6 has a regression where its internal cron/http
+// trigger registrations fail validation, the worker drops into an EPIPE
+// reconnect loop, and BM25 search returns empty after save (visible to users
+// as "demo can't reach worker" and recall always-empty). Override env var
+// AGENTMEMORY_III_VERSION lets early adopters move forward when a fixed
+// engine ships, without us cutting another agentmemory release.
+const IIPINNED_VERSION =
+  process.env["AGENTMEMORY_III_VERSION"] || "0.11.2";
+
+// Map Node platform/arch → the asset name iii-hq/iii ships under
+// https://github.com/iii-hq/iii/releases/download/iii/v<version>/<asset>
+function iiiReleaseAsset(): string | null {
+  const p = platform();
+  const a = process.arch;
+  if (p === "darwin" && a === "arm64")
+    return "iii-aarch64-apple-darwin.tar.gz";
+  if (p === "darwin" && a === "x64")
+    return "iii-x86_64-apple-darwin.tar.gz";
+  if (p === "linux" && a === "x64")
+    return "iii-x86_64-unknown-linux-gnu.tar.gz";
+  if (p === "linux" && a === "arm64")
+    return "iii-aarch64-unknown-linux-gnu.tar.gz";
+  if (p === "linux" && a === "arm")
+    return "iii-armv7-unknown-linux-gnueabihf.tar.gz";
+  if (p === "win32" && a === "x64")
+    return "iii-x86_64-pc-windows-msvc.zip";
+  if (p === "win32" && a === "arm64")
+    return "iii-aarch64-pc-windows-msvc.zip";
+  return null;
+}
+
+function iiiReleaseUrl(): string | null {
+  const asset = iiiReleaseAsset();
+  if (!asset) return null;
+  // Tag name is monorepo-prefixed: `iii/v0.11.2`. Slash is URL-encoded
+  // by GitHub when serving the download path, hence `iii/v...` not `iii%2Fv...`.
+  return `https://github.com/iii-hq/iii/releases/download/iii/v${IIPINNED_VERSION}/${asset}`;
+}
+
 function vlog(msg: string): void {
   if (IS_VERBOSE) p.log.info(`[verbose] ${msg}`);
 }
@@ -291,13 +332,14 @@ async function waitForEngine(timeoutMs: number): Promise<boolean> {
 }
 
 function installInstructions(): string[] {
+  const releaseUrl = iiiReleaseUrl();
   if (IS_WINDOWS) {
     return [
-      "agentmemory requires the `iii-engine` runtime. Pick one:",
+      `agentmemory requires the \`iii-engine\` runtime, pinned to v${IIPINNED_VERSION}. Pick one:`,
       "",
       "  A) Download the prebuilt Windows binary:",
-      "     1. Open https://github.com/iii-hq/iii/releases/latest",
-      "     2. Download iii-x86_64-pc-windows-msvc.zip",
+      `     1. Open https://github.com/iii-hq/iii/releases/tag/iii%2Fv${IIPINNED_VERSION}`,
+      `     2. Download iii-x86_64-pc-windows-msvc.zip`,
       "        (or iii-aarch64-pc-windows-msvc.zip on ARM)",
       "     3. Extract iii.exe and either add its folder to PATH",
       "        or move it to %USERPROFILE%\\.local\\bin\\iii.exe",
@@ -305,25 +347,31 @@ function installInstructions(): string[] {
       "",
       "  B) Docker Desktop:",
       "     1. Install Docker Desktop for Windows",
-      "     2. Start Docker Desktop (engine must be running)",
-      "     3. Re-run: npx @agentmemory/agentmemory",
+      `     2. docker pull iiidev/iii:${IIPINNED_VERSION}`,
+      "     3. Start Docker Desktop (engine must be running)",
+      "     4. Re-run: npx @agentmemory/agentmemory",
       "",
       "Or skip the engine entirely for standalone MCP:",
       "  npx @agentmemory/agentmemory mcp",
     ];
   }
+  const linuxInstall = releaseUrl
+    ? `  A) curl -fsSL "${releaseUrl}" | tar -xz -C ~/.local/bin && chmod +x ~/.local/bin/iii`
+    : `  A) Manual download from https://github.com/iii-hq/iii/releases/tag/iii%2Fv${IIPINNED_VERSION}`;
   return [
-    "agentmemory requires the `iii-engine` runtime. Pick one:",
+    `agentmemory requires the \`iii-engine\` runtime, pinned to v${IIPINNED_VERSION}. Pick one:`,
     "",
-    "  A) curl -fsSL https://install.iii.dev/iii/main/install.sh | sh",
-    "     (installs the prebuilt iii binary into ~/.local/bin/iii)",
+    linuxInstall,
+    `     (installs iii v${IIPINNED_VERSION} into ~/.local/bin/iii)`,
     "",
-    "  B) Docker: install Docker Desktop or docker-ce, then re-run",
+    `  B) Docker: \`docker pull iiidev/iii:${IIPINNED_VERSION}\``,
     "",
     "Or skip the engine entirely for standalone MCP:",
     "  npx @agentmemory/agentmemory mcp",
     "",
     "Docs: https://iii.dev/docs",
+    `Why pinned: agentmemory hits a regression in iii v0.11.6. Override with`,
+    `AGENTMEMORY_III_VERSION=<version> if you've verified compat manually.`,
   ];
 }
 
@@ -993,15 +1041,30 @@ async function runUpgrade() {
       return process.exit(0);
     }
     if (upgradeEngine === true) {
-      const installerOk = runCommand(
-        shBin,
-        ["-c", "curl -fsSL https://install.iii.dev/iii/main/install.sh | sh"],
-        { label: "Upgrading iii-engine via installer", optional: true },
-      );
-      if (!installerOk) {
+      const releaseUrl = iiiReleaseUrl();
+      if (!releaseUrl) {
         p.log.warn(
-          "iii-engine installer failed. Fallbacks: Docker (`docker pull iiidev/iii:latest`) or releases at https://github.com/iii-hq/iii/releases/latest.",
+          `iii-engine binary not available for ${platform()}/${process.arch}. Use Docker (\`docker pull iiidev/iii:${IIPINNED_VERSION}\`) or download manually from https://github.com/iii-hq/iii/releases/tag/iii%2Fv${IIPINNED_VERSION}.`,
         );
+      } else {
+        // Pinned to IIPINNED_VERSION rather than `install.iii.dev/iii/main`,
+        // which would track `latest` and re-pull the broken 0.11.6 build.
+        const homeDir = homedir();
+        const binDir = join(homeDir, ".local", "bin");
+        const installCmd = [
+          `mkdir -p "${binDir}"`,
+          `curl -fsSL "${releaseUrl}" | tar -xz -C "${binDir}"`,
+          `chmod +x "${binDir}/iii"`,
+        ].join(" && ");
+        const installerOk = runCommand(shBin, ["-c", installCmd], {
+          label: `Installing iii-engine v${IIPINNED_VERSION} (pinned)`,
+          optional: true,
+        });
+        if (!installerOk) {
+          p.log.warn(
+            `iii-engine installer failed. Fallbacks: Docker (\`docker pull iiidev/iii:${IIPINNED_VERSION}\`) or download manually from https://github.com/iii-hq/iii/releases/tag/iii%2Fv${IIPINNED_VERSION}.`,
+          );
+        }
       }
     } else {
       p.log.info("Skipped iii-engine installer.");
@@ -1011,8 +1074,8 @@ async function runUpgrade() {
   }
 
   if (dockerBin) {
-    runCommand(dockerBin, ["pull", "iiidev/iii:latest"], {
-      label: "Pulling latest iii Docker image",
+    runCommand(dockerBin, ["pull", `iiidev/iii:${IIPINNED_VERSION}`], {
+      label: `Pulling iii Docker image v${IIPINNED_VERSION} (pinned)`,
       optional: true,
     });
   } else {


### PR DESCRIPTION
## Why

`iii-engine` v0.11.6 ships a regression where its internal cron/http trigger registrations fail the engine's own new validators at boot. Result for end users: every fresh agentmemory install pulls v0.11.6 (because all paths resolve `latest` / `main`), and the worker drops into an EPIPE reconnect loop. `memory_save` returns 200 with a memory ID, but `memory_smart_search` and `memory_recall` always return empty

Reproducer (verified locally on macOS arm64 with iii v0.11.6):

```bash
$ curl -X POST :3111/agentmemory/remember -d '{"content":"alpha bravo","type":"fact"}'
{"success":true,"memory":{"id":"mem_..."}}

$ curl -X POST :3111/agentmemory/search -d '{"query":"alpha bravo"}'
{"format":"full","results":[],"tokens_used":0}     # broken
```

Engine boot log:

```
[ERROR] iii::workers::cron::cron Cron expression is not set for trigger 2e5afd82-...
[ERROR] iii::trigger Error registering trigger — error: Cron expression is required
[ERROR] iii::trigger Error registering trigger — error: api_path is required for http triggers
[ERROR] agentmemory [iii] Failed to send message: write EPIPE   # ~10/sec, indefinitely
```

The trigger UUIDs are stable across fresh state dirs — these are the engine's own internal registrations failing its own new validation, not anything agentmemory registers.

## What changes

Until the engine fix lands upstream, every agentmemory install path now resolves to **v0.11.2** (last known-good engine version):

| Path | Before | After |
|---|---|---|
| `src/cli.ts` auto-installer | `curl install.iii.dev/iii/main/install.sh \| sh` (tracks `latest`) | `curl github.com/iii-hq/iii/releases/download/iii/v0.11.2/iii-<arch>.tar.gz \| tar -xz -C ~/.local/bin` |
| `src/cli.ts` Docker fallback | `docker pull iiidev/iii:latest` | `docker pull iiidev/iii:0.11.2` |
| `src/cli.ts` install instructions | linked `releases/latest` | link `releases/tag/iii%2Fv0.11.2` |
| `docker-compose.yml` | `image: iiidev/iii:latest` | `image: iiidev/iii:0.11.2` |
| `README.md` install section | one-liner curl pipe | per-arch tarball commands + pin rationale |

## Escape hatch

```bash
AGENTMEMORY_III_VERSION=0.11.7 npx @agentmemory/agentmemory upgrade
```

Lets early adopters pull a newer engine when one ships, without us cutting another agentmemory release. Default stays pinned.

## What's NOT in this PR

- No engine version bump path automation. When the engine fix ships (likely v0.11.7), bump `IIPINNED_VERSION` in `src/cli.ts`, the README, and `docker-compose.yml` and ship a follow-up.
- No iii-sdk pin change. The npm SDK doesn't break — the engine binary does.

## Test plan

- [x] Type-check clean (`npx tsc --noEmit` — no new errors from changed files).
- [x] Build clean (`npm run build`).
- [x] Verified the pinned tarball URL resolves and extracts a working binary:
  ```
  $ /tmp/iii --version
  0.11.2
  ```
- [x] dist contains only pinned URLs — grep finds no leftover `iiidev/iii:latest` or `install.iii.dev/iii/main/install.sh`.
- [ ] CI on this PR (Vercel preview deploy will fail with the usual "Authorization required" — known limitation on forks, ignore).

## Follow-up

File against `iii-hq/iii` for the engine-internal trigger validation regression. Smoking gun: engine rejects its own cron triggers at UUIDs `2e5afd82-...` and `00c616c5-...` that are stable across fresh state — these are hardcoded in the engine, not user-registered. Worth flagging upstream so the fix lands and we can unpin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved installation instructions with platform-specific download steps and explicit verification of the pinned runtime (v0.11.2).
  * Documented a v0.11.6 regression and how to override the pinned version via an environment variable.

* **New Features**
  * CLI now installs/upgrades using the pinned runtime release and reports fallbacks when pinned assets aren’t available.

* **Chores**
  * Container configuration and install guidance updated to use the pinned engine version.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/260)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->