### PR TITLE
Add Ollama embedding provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -885,6 +885,10 @@ Create `~/.agentmemory/.env`:
 
 # Embedding provider (auto-detected, or override)
 # EMBEDDING_PROVIDER=local
+# EMBEDDING_PROVIDER=ollama
+# OLLAMA_BASE_URL=http://localhost:11434
+# OLLAMA_EMBEDDING_MODEL=nomic-embed-text:latest
+# OLLAMA_EMBEDDING_DIMENSIONS=768          # nomic-embed-text=768, mxbai-embed-large=1024
 # VOYAGE_API_KEY=...
 # OPENAI_API_KEY=sk-...
 # OPENAI_BASE_URL=https://api.openai.com   # Override for Azure / vLLM / LM Studio / proxies

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "agentmemory": "dist/cli.mjs"
   },
   "scripts": {
-    "build": "tsdown && (cp iii-config.yaml dist/ 2>/dev/null || true) && (cp iii-config.docker.yaml dist/ 2>/dev/null || true) && (cp docker-compose.yml dist/ 2>/dev/null || true) && mkdir -p dist/viewer && cp src/viewer/index.html dist/viewer/",
+    "build": "tsdown && node scripts/copy-build-assets.mjs",
     "dev": "tsx src/index.ts",
     "start": "node dist/cli.mjs",
     "migrate": "node dist/functions/migrate.js",

--- a/scripts/copy-build-assets.mjs
+++ b/scripts/copy-build-assets.mjs
@@ -1,0 +1,29 @@
+import { access, copyFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+
+const root = process.cwd();
+
+async function copyIfPresent(from, to) {
+  try {
+    await access(from);
+  } catch {
+    return;
+  }
+  await copyFile(from, to);
+}
+
+await mkdir(join(root, "dist"), { recursive: true });
+await Promise.all([
+  copyIfPresent(join(root, "iii-config.yaml"), join(root, "dist", "iii-config.yaml")),
+  copyIfPresent(
+    join(root, "iii-config.docker.yaml"),
+    join(root, "dist", "iii-config.docker.yaml"),
+  ),
+  copyIfPresent(join(root, "docker-compose.yml"), join(root, "dist", "docker-compose.yml")),
+]);
+
+await mkdir(join(root, "dist", "viewer"), { recursive: true });
+await copyFile(
+  join(root, "src", "viewer", "index.html"),
+  join(root, "dist", "viewer", "index.html"),
+);

--- a/src/config.ts
+++ b/src/config.ts
@@ -185,6 +185,13 @@ export function detectEmbeddingProvider(
   const forced = source["EMBEDDING_PROVIDER"];
   if (forced) return forced;
 
+  if (
+    hasRealValue(source["OLLAMA_BASE_URL"]) ||
+    hasRealValue(source["OLLAMA_EMBEDDING_MODEL"]) ||
+    hasRealValue(source["OLLAMA_EMBEDDING_DIMENSIONS"])
+  ) {
+    return "ollama";
+  }
   if (source["GEMINI_API_KEY"]) return "gemini";
   if (source["OPENAI_API_KEY"]) return "openai";
   if (source["VOYAGE_API_KEY"]) return "voyage";

--- a/src/functions/remember.ts
+++ b/src/functions/remember.ts
@@ -1,32 +1,13 @@
 import { TriggerAction, type ISdk } from "iii-sdk";
-import type { CompressedObservation, Memory } from "../types.js";
+import type { Memory } from "../types.js";
 import { KV, generateId, jaccardSimilarity } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
 import { withKeyedLock } from "../state/keyed-mutex.js";
 import { deleteAccessLog } from "./access-tracker.js";
 import { recordAudit } from "./audit.js";
 import { getSearchIndex } from "./search.js";
+import { memoryAsIndexable } from "../state/search-documents.js";
 import { logger } from "../logger.js";
-
-// SearchIndex is built around CompressedObservation. Memories carry the
-// same searchable text (title + content + concepts + files) so we wrap
-// them in the observation shape before indexing. Type is normalized to
-// "decision" so memories are still distinguishable in result metadata
-// without colliding with observation enums (file_read, command_run, etc).
-function memoryAsIndexable(memory: Memory): CompressedObservation {
-  return {
-    id: memory.id,
-    sessionId: memory.sessionIds[0] ?? "memory",
-    timestamp: memory.createdAt,
-    type: "decision",
-    title: memory.title,
-    facts: [memory.content],
-    narrative: memory.content,
-    concepts: memory.concepts,
-    files: memory.files,
-    importance: memory.strength,
-  };
-}
 
 export function registerRememberFunction(sdk: ISdk, kv: StateKV): void {
   sdk.registerFunction("mem::remember", 

--- a/src/functions/search.ts
+++ b/src/functions/search.ts
@@ -3,29 +3,9 @@ import type { CompactSearchResult, CompressedObservation, Memory, SearchResult, 
 import { KV } from '../state/schema.js'
 import { StateKV } from '../state/kv.js'
 import { SearchIndex } from '../state/search-index.js'
+import { memoryAsIndexable, resolveIndexedObservation } from '../state/search-documents.js'
 import { recordAccessBatch } from './access-tracker.js'
 import { logger } from "../logger.js";
-
-// Memories share the same searchable fields as observations (title +
-// content + concepts + files), so we wrap them in the observation shape
-// before indexing. Type is normalized to "decision" to keep memories
-// distinguishable in result metadata. Mirrors the helper in
-// functions/remember.ts; kept inline here to avoid a circular import
-// (remember.ts imports from this file).
-function memoryAsIndexable(memory: Memory): CompressedObservation {
-  return {
-    id: memory.id,
-    sessionId: memory.sessionIds[0] ?? "memory",
-    timestamp: memory.createdAt,
-    type: "decision",
-    title: memory.title,
-    facts: [memory.content],
-    narrative: memory.content,
-    concepts: memory.concepts,
-    files: memory.files,
-    importance: memory.strength,
-  };
-}
 
 let index: SearchIndex | null = null
 
@@ -167,7 +147,7 @@ export function registerSearchFunction(sdk: ISdk, kv: StateKV): void {
       // Second pass: load observations in parallel.
       const obsResults = await Promise.all(
         candidates.map((r) =>
-          kv.get<CompressedObservation>(KV.observations(r.sessionId), r.obsId)
+          resolveIndexedObservation(kv, r.sessionId, r.obsId)
         )
       )
       const enriched: SearchResult[] = []

--- a/src/functions/smart-search.ts
+++ b/src/functions/smart-search.ts
@@ -6,6 +6,7 @@ import type {
 } from "../types.js";
 import { KV } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
+import { resolveIndexedObservation } from "../state/search-documents.js";
 import { recordAccessBatch } from "./access-tracker.js";
 import { logger } from "../logger.js";
 
@@ -99,11 +100,12 @@ async function findObservation(
   sessionIdHint?: string,
 ): Promise<CompressedObservation | null> {
   if (sessionIdHint) {
-    const obs = await kv
-      .get<CompressedObservation>(KV.observations(sessionIdHint), obsId)
-      .catch(() => null);
+    const obs = await resolveIndexedObservation(kv, sessionIdHint, obsId);
     if (obs) return obs;
   }
+
+  const memory = await resolveIndexedObservation(kv, "memory", obsId);
+  if (memory) return memory;
 
   const sessions = await kv.list<{ id: string }>(KV.sessions);
   for (let i = 0; i < sessions.length; i += 5) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import {
 } from "./providers/index.js";
 import { StateKV } from "./state/kv.js";
 import { KV } from "./state/schema.js";
+import { memoryAsIndexable } from "./state/search-documents.js";
 import { VectorIndex } from "./state/vector-index.js";
 import { HybridSearch } from "./state/hybrid-search.js";
 import { IndexPersistence } from "./state/index-persistence.js";
@@ -419,18 +420,7 @@ async function main() {
         if (memory.isLatest === false) continue;
         if (!memory.title || !memory.content) continue;
         if (bm25Index.has(memory.id)) continue;
-        bm25Index.add({
-          id: memory.id,
-          sessionId: memory.sessionIds[0] ?? "memory",
-          timestamp: memory.createdAt,
-          type: "decision",
-          title: memory.title,
-          facts: [memory.content],
-          narrative: memory.content,
-          concepts: memory.concepts,
-          files: memory.files,
-          importance: memory.strength,
-        });
+        bm25Index.add(memoryAsIndexable(memory));
         backfilled++;
       }
       if (backfilled > 0) {

--- a/src/providers/embedding/index.ts
+++ b/src/providers/embedding/index.ts
@@ -2,6 +2,7 @@ import type { EmbeddingProvider } from "../../types.js";
 import { detectEmbeddingProvider, getEnvVar } from "../../config.js";
 import { GeminiEmbeddingProvider } from "./gemini.js";
 import { OpenAIEmbeddingProvider } from "./openai.js";
+import { OllamaEmbeddingProvider } from "./ollama.js";
 import { VoyageEmbeddingProvider } from "./voyage.js";
 import { CohereEmbeddingProvider } from "./cohere.js";
 import { OpenRouterEmbeddingProvider } from "./openrouter.js";
@@ -11,6 +12,7 @@ import { ClipEmbeddingProvider } from "./clip.js";
 export {
   GeminiEmbeddingProvider,
   OpenAIEmbeddingProvider,
+  OllamaEmbeddingProvider,
   VoyageEmbeddingProvider,
   CohereEmbeddingProvider,
   OpenRouterEmbeddingProvider,
@@ -36,6 +38,8 @@ export function createEmbeddingProvider(): EmbeddingProvider | null {
       return withDimensionGuard(new GeminiEmbeddingProvider(getEnvVar("GEMINI_API_KEY")!));
     case "openai":
       return withDimensionGuard(new OpenAIEmbeddingProvider(getEnvVar("OPENAI_API_KEY")!));
+    case "ollama":
+      return withDimensionGuard(new OllamaEmbeddingProvider());
     case "voyage":
       return withDimensionGuard(new VoyageEmbeddingProvider(getEnvVar("VOYAGE_API_KEY")!));
     case "cohere":

--- a/src/providers/embedding/ollama.ts
+++ b/src/providers/embedding/ollama.ts
@@ -1,0 +1,73 @@
+import type { EmbeddingProvider } from "../../types.js";
+import { getEnvVar } from "../../config.js";
+
+const DEFAULT_BASE_URL = "http://localhost:11434";
+const DEFAULT_MODEL = "nomic-embed-text:latest";
+
+const MODEL_DIMENSIONS: Record<string, number> = {
+  "nomic-embed-text": 768,
+  "nomic-embed-text:latest": 768,
+  "mxbai-embed-large": 1024,
+  "mxbai-embed-large:latest": 1024,
+};
+
+function resolveDimensions(model: string, override: string | undefined): number {
+  if (override !== undefined && override.trim().length > 0) {
+    const parsed = parseInt(override, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      throw new Error(
+        `OLLAMA_EMBEDDING_DIMENSIONS must be a positive integer, got: ${override}`,
+      );
+    }
+    return parsed;
+  }
+  return MODEL_DIMENSIONS[model] ?? MODEL_DIMENSIONS[DEFAULT_MODEL] ?? 768;
+}
+
+export class OllamaEmbeddingProvider implements EmbeddingProvider {
+  readonly name = "ollama";
+  readonly dimensions: number;
+  private baseUrl: string;
+  private model: string;
+
+  constructor() {
+    this.baseUrl = (
+      getEnvVar("OLLAMA_BASE_URL") || DEFAULT_BASE_URL
+    ).replace(/\/+$/, "");
+    this.model = getEnvVar("OLLAMA_EMBEDDING_MODEL") || DEFAULT_MODEL;
+    this.dimensions = resolveDimensions(
+      this.model,
+      getEnvVar("OLLAMA_EMBEDDING_DIMENSIONS"),
+    );
+  }
+
+  async embed(text: string): Promise<Float32Array> {
+    const [result] = await this.embedBatch([text]);
+    return result;
+  }
+
+  async embedBatch(texts: string[]): Promise<Float32Array[]> {
+    const response = await fetch(`${this.baseUrl}/api/embed`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: this.model,
+        input: texts,
+      }),
+    });
+
+    if (!response.ok) {
+      const err = await response.text();
+      throw new Error(`Ollama embedding failed (${response.status}): ${err}`);
+    }
+
+    const data = (await response.json()) as {
+      embeddings?: number[][];
+    };
+    if (!Array.isArray(data.embeddings)) {
+      throw new Error("Ollama embedding response did not include embeddings");
+    }
+
+    return data.embeddings.map((embedding) => new Float32Array(embedding));
+  }
+}

--- a/src/state/hybrid-search.ts
+++ b/src/state/hybrid-search.ts
@@ -3,11 +3,10 @@ import { VectorIndex } from "./vector-index.js";
 import type {
   EmbeddingProvider,
   HybridSearchResult,
-  CompressedObservation,
   QueryExpansion,
 } from "../types.js";
 import type { StateKV } from "./kv.js";
-import { KV } from "./schema.js";
+import { resolveIndexedObservation } from "./search-documents.js";
 import {
   GraphRetrieval,
   type GraphRetrievalResult,
@@ -288,9 +287,7 @@ export class HybridSearch {
     const sliced = results.slice(0, limit);
     const observations = await Promise.all(
       sliced.map((r) =>
-        this.kv
-          .get<CompressedObservation>(KV.observations(r.sessionId), r.obsId)
-          .catch(() => null),
+        resolveIndexedObservation(this.kv, r.sessionId, r.obsId),
       ),
     );
     const enriched: HybridSearchResult[] = [];

--- a/src/state/search-documents.ts
+++ b/src/state/search-documents.ts
@@ -1,0 +1,33 @@
+import type { CompressedObservation, Memory } from "../types.js";
+import type { StateKV } from "./kv.js";
+import { KV } from "./schema.js";
+
+export function memoryAsIndexable(memory: Memory): CompressedObservation {
+  return {
+    id: memory.id,
+    sessionId: memory.sessionIds[0] ?? "memory",
+    timestamp: memory.createdAt,
+    type: "decision",
+    title: memory.title,
+    facts: [memory.content],
+    narrative: memory.content,
+    concepts: memory.concepts,
+    files: memory.files,
+    importance: memory.strength,
+  };
+}
+
+export async function resolveIndexedObservation(
+  kv: StateKV,
+  sessionId: string,
+  obsId: string,
+): Promise<CompressedObservation | null> {
+  const observation = await kv
+    .get<CompressedObservation>(KV.observations(sessionId), obsId)
+    .catch(() => null);
+  if (observation) return observation;
+
+  const memory = await kv.get<Memory>(KV.memories, obsId).catch(() => null);
+  if (!memory || memory.isLatest === false) return null;
+  return memoryAsIndexable(memory);
+}

--- a/test/compress-file.test.ts
+++ b/test/compress-file.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolve } from "node:path";
 
 vi.mock("../src/logger.js", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
@@ -44,6 +45,10 @@ vi.mock("node:fs/promises", () => ({
 }));
 
 import { registerCompressFileFunction } from "../src/functions/compress-file.js";
+
+function abs(path: string): string {
+  return resolve(path);
+}
 
 function mockKV() {
   const store = new Map<string, Map<string, unknown>>();
@@ -107,7 +112,7 @@ describe("mem::compress-file", () => {
   });
 
   it("rejects symlinks", async () => {
-    symlinkPaths.add("/tmp/notes.md");
+    symlinkPaths.add(abs("/tmp/notes.md"));
     const result = (await sdk.trigger("mem::compress-file", {
       filePath: "/tmp/notes.md",
     })) as { success: boolean; error: string };
@@ -120,13 +125,13 @@ describe("mem::compress-file", () => {
   it("rejects TOCTOU symlink swap at write time via O_NOFOLLOW", async () => {
     const path = "/tmp/notes.md";
     fileStore.set(
-      path,
+      abs(path),
       "# Title\n\nVisit https://example.com\n\n```ts\nconst x = 1;\n```\n\nContent.",
     );
     summarize.mockResolvedValue(
       "# Title\n\nVisit https://example.com\n\n```ts\nconst x = 1;\n```\n\nShort.",
     );
-    openEloopPaths.add(path);
+    openEloopPaths.add(abs(path));
 
     const result = (await sdk.trigger("mem::compress-file", {
       filePath: path,
@@ -154,7 +159,7 @@ describe("mem::compress-file", () => {
   it("compresses markdown and writes .original.md backup", async () => {
     const path = "/tmp/notes.md";
     fileStore.set(
-      path,
+      abs(path),
       "# Title\n\nVisit https://example.com\n\n```ts\nconst x = 1;\n```\n\nSome long explanation.",
     );
 
@@ -172,15 +177,15 @@ describe("mem::compress-file", () => {
     };
 
     expect(result.success).toBe(true);
-    expect(result.backupPath).toBe("/tmp/notes.original.md");
-    expect(fileStore.get("/tmp/notes.original.md")).toContain("Some long explanation.");
-    expect(fileStore.get(path)).toContain("Short explanation.");
+    expect(result.backupPath).toBe(abs("/tmp/notes.original.md"));
+    expect(fileStore.get(abs("/tmp/notes.original.md"))).toContain("Some long explanation.");
+    expect(fileStore.get(abs(path))).toContain("Short explanation.");
     expect(result.compressedChars).toBeLessThan(result.originalChars);
   });
 
   it("fails validation when URLs change", async () => {
     const path = "/tmp/guide.md";
-    fileStore.set(path, "# Guide\n\nhttps://example.com\n");
+    fileStore.set(abs(path), "# Guide\n\nhttps://example.com\n");
     summarize.mockResolvedValue("# Guide\n\nhttps://different.example.com\n");
 
     const result = (await sdk.trigger("mem::compress-file", {
@@ -190,12 +195,12 @@ describe("mem::compress-file", () => {
     expect(result.success).toBe(false);
     expect(result.error).toContain("validation");
     expect(result.details.some((d) => d.includes("url"))).toBe(true);
-    expect(fileStore.get("/tmp/guide.original.md")).toBeUndefined();
+    expect(fileStore.get(abs("/tmp/guide.original.md"))).toBeUndefined();
   });
 
   it("uses a distinct backup path for *.original.md inputs", async () => {
     const path = "/tmp/notes.original.md";
-    fileStore.set(path, "# Title\n\nLong original body.");
+    fileStore.set(abs(path), "# Title\n\nLong original body.");
     summarize.mockResolvedValue("# Title\n\nShort body.");
 
     const result = (await sdk.trigger("mem::compress-file", {
@@ -203,10 +208,10 @@ describe("mem::compress-file", () => {
     })) as { success: boolean; backupPath: string };
 
     expect(result.success).toBe(true);
-    expect(result.backupPath).toBe("/tmp/notes.original.backup.md");
-    expect(fileStore.get("/tmp/notes.original.backup.md")).toBe(
+    expect(result.backupPath).toBe(abs("/tmp/notes.original.backup.md"));
+    expect(fileStore.get(abs("/tmp/notes.original.backup.md"))).toBe(
       "# Title\n\nLong original body.",
     );
-    expect(fileStore.get(path)).toBe("# Title\n\nShort body.");
+    expect(fileStore.get(abs(path))).toBe("# Title\n\nShort body.");
   });
 });

--- a/test/embedding-provider.test.ts
+++ b/test/embedding-provider.test.ts
@@ -5,19 +5,27 @@ import {
 } from "../src/providers/embedding/index.js";
 import { GeminiEmbeddingProvider } from "../src/providers/embedding/gemini.js";
 import { OpenAIEmbeddingProvider } from "../src/providers/embedding/openai.js";
+import { OllamaEmbeddingProvider } from "../src/providers/embedding/ollama.js";
 import type { EmbeddingProvider } from "../src/types.js";
+
+function clearEnv(key: string): void {
+  process.env[key] = "";
+}
 
 describe("createEmbeddingProvider", () => {
   const originalEnv = { ...process.env };
 
   beforeEach(() => {
     process.env = { ...originalEnv };
-    delete process.env["GEMINI_API_KEY"];
-    delete process.env["OPENAI_API_KEY"];
-    delete process.env["VOYAGE_API_KEY"];
-    delete process.env["COHERE_API_KEY"];
-    delete process.env["OPENROUTER_API_KEY"];
-    delete process.env["EMBEDDING_PROVIDER"];
+    clearEnv("GEMINI_API_KEY");
+    clearEnv("OPENAI_API_KEY");
+    clearEnv("VOYAGE_API_KEY");
+    clearEnv("COHERE_API_KEY");
+    clearEnv("OPENROUTER_API_KEY");
+    clearEnv("EMBEDDING_PROVIDER");
+    clearEnv("OLLAMA_BASE_URL");
+    clearEnv("OLLAMA_EMBEDDING_MODEL");
+    clearEnv("OLLAMA_EMBEDDING_DIMENSIONS");
   });
 
   afterEach(() => {
@@ -50,6 +58,26 @@ describe("createEmbeddingProvider", () => {
     const provider = createEmbeddingProvider();
     expect(provider).toBeInstanceOf(OpenAIEmbeddingProvider);
   });
+
+  it("returns OllamaEmbeddingProvider when EMBEDDING_PROVIDER is ollama", () => {
+    process.env["EMBEDDING_PROVIDER"] = "ollama";
+    const provider = createEmbeddingProvider();
+    expect(provider).toBeInstanceOf(OllamaEmbeddingProvider);
+    expect(provider!.name).toBe("ollama");
+  });
+
+  it("auto-detects Ollama when Ollama embedding env vars are set", () => {
+    process.env["OLLAMA_EMBEDDING_MODEL"] = "nomic-embed-text:latest";
+    const provider = createEmbeddingProvider();
+    expect(provider).toBeInstanceOf(OllamaEmbeddingProvider);
+  });
+
+  it("allows Ollama embeddings to override Gemini key auto-detection", () => {
+    process.env["GEMINI_API_KEY"] = "test-key-123";
+    process.env["EMBEDDING_PROVIDER"] = "ollama";
+    const provider = createEmbeddingProvider();
+    expect(provider).toBeInstanceOf(OllamaEmbeddingProvider);
+  });
 });
 
 describe("OpenAIEmbeddingProvider", () => {
@@ -57,9 +85,9 @@ describe("OpenAIEmbeddingProvider", () => {
 
   beforeEach(() => {
     process.env = { ...originalEnv };
-    delete process.env["OPENAI_BASE_URL"];
-    delete process.env["OPENAI_EMBEDDING_MODEL"];
-    delete process.env["OPENAI_EMBEDDING_DIMENSIONS"];
+    clearEnv("OPENAI_BASE_URL");
+    clearEnv("OPENAI_EMBEDDING_MODEL");
+    clearEnv("OPENAI_EMBEDDING_DIMENSIONS");
   });
 
   afterEach(() => {
@@ -73,7 +101,7 @@ describe("OpenAIEmbeddingProvider", () => {
   });
 
   it("throws when no API key is provided", () => {
-    delete process.env["OPENAI_API_KEY"];
+    clearEnv("OPENAI_API_KEY");
     expect(() => new OpenAIEmbeddingProvider()).toThrow("OPENAI_API_KEY is required");
   });
 
@@ -150,6 +178,93 @@ describe("OpenAIEmbeddingProvider", () => {
     process.env["OPENAI_EMBEDDING_DIMENSIONS"] = "0";
     expect(() => new OpenAIEmbeddingProvider("test-key")).toThrow(
       /OPENAI_EMBEDDING_DIMENSIONS must be a positive integer/,
+    );
+  });
+});
+
+describe("OllamaEmbeddingProvider", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    clearEnv("OLLAMA_BASE_URL");
+    clearEnv("OLLAMA_EMBEDDING_MODEL");
+    clearEnv("OLLAMA_EMBEDDING_DIMENSIONS");
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("uses local Ollama defaults", () => {
+    const provider = new OllamaEmbeddingProvider();
+    expect(provider.name).toBe("ollama");
+    expect(provider.dimensions).toBe(768);
+  });
+
+  it("posts embeddings to the native Ollama endpoint", async () => {
+    process.env["OLLAMA_BASE_URL"] = "http://ollama.local:11434";
+    const provider = new OllamaEmbeddingProvider();
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ embeddings: [[0.1, 0.2, 0.3]] }), { status: 200 }),
+    );
+
+    await provider.embed("hello");
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "http://ollama.local:11434/api/embed",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const body = JSON.parse((fetchSpy.mock.calls[0][1] as RequestInit).body as string);
+    expect(body).toEqual({
+      model: "nomic-embed-text:latest",
+      input: ["hello"],
+    });
+
+    fetchSpy.mockRestore();
+  });
+
+  it("respects OLLAMA_EMBEDDING_MODEL env var", async () => {
+    process.env["OLLAMA_EMBEDDING_MODEL"] = "mxbai-embed-large:latest";
+    const provider = new OllamaEmbeddingProvider();
+    expect(provider.dimensions).toBe(1024);
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ embeddings: [[0.1, 0.2, 0.3]] }), { status: 200 }),
+    );
+
+    await provider.embed("hello");
+    const body = JSON.parse((fetchSpy.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.model).toBe("mxbai-embed-large:latest");
+
+    fetchSpy.mockRestore();
+  });
+
+  it("OLLAMA_EMBEDDING_DIMENSIONS overrides the model-derived dimensions", () => {
+    process.env["OLLAMA_EMBEDDING_MODEL"] = "mxbai-embed-large:latest";
+    process.env["OLLAMA_EMBEDDING_DIMENSIONS"] = "768";
+    const provider = new OllamaEmbeddingProvider();
+    expect(provider.dimensions).toBe(768);
+  });
+
+  it("rejects invalid OLLAMA_EMBEDDING_DIMENSIONS values", () => {
+    process.env["OLLAMA_EMBEDDING_DIMENSIONS"] = "not-a-number";
+    expect(() => new OllamaEmbeddingProvider()).toThrow(
+      /OLLAMA_EMBEDDING_DIMENSIONS must be a positive integer/,
+    );
+
+    process.env["OLLAMA_EMBEDDING_DIMENSIONS"] = "-5";
+    expect(() => new OllamaEmbeddingProvider()).toThrow(
+      /OLLAMA_EMBEDDING_DIMENSIONS must be a positive integer/,
+    );
+
+    process.env["OLLAMA_EMBEDDING_DIMENSIONS"] = "0";
+    expect(() => new OllamaEmbeddingProvider()).toThrow(
+      /OLLAMA_EMBEDDING_DIMENSIONS must be a positive integer/,
     );
   });
 });

--- a/test/mcp-memory-save-search.test.ts
+++ b/test/mcp-memory-save-search.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { registerRememberFunction } from "../src/functions/remember.js";
+import { getSearchIndex, registerSearchFunction } from "../src/functions/search.js";
+import { registerSmartSearchFunction } from "../src/functions/smart-search.js";
+import { registerMcpEndpoints } from "../src/mcp/server.js";
+import { HybridSearch } from "../src/state/hybrid-search.js";
+
+function mockKV() {
+  const store = new Map<string, Map<string, unknown>>();
+  return {
+    get: async <T>(scope: string, key: string): Promise<T | null> => {
+      return (store.get(scope)?.get(key) as T) ?? null;
+    },
+    set: async <T>(scope: string, key: string, data: T): Promise<T> => {
+      if (!store.has(scope)) store.set(scope, new Map());
+      store.get(scope)!.set(key, data);
+      return data;
+    },
+    delete: async (scope: string, key: string): Promise<void> => {
+      store.get(scope)?.delete(key);
+    },
+    list: async <T>(scope: string): Promise<T[]> => {
+      const entries = store.get(scope);
+      return entries ? (Array.from(entries.values()) as T[]) : [];
+    },
+  };
+}
+
+function mockSdk() {
+  const functions = new Map<string, Function>();
+  return {
+    registerFunction: (idOrOpts: string | { id: string }, handler: Function) => {
+      const id = typeof idOrOpts === "string" ? idOrOpts : idOrOpts.id;
+      functions.set(id, handler);
+    },
+    registerTrigger: () => {},
+    trigger: async (
+      idOrInput: string | { function_id: string; payload: unknown },
+      data?: unknown,
+    ) => {
+      const id = typeof idOrInput === "string" ? idOrInput : idOrInput.function_id;
+      const payload = typeof idOrInput === "string" ? data : idOrInput.payload;
+      const fn = functions.get(id);
+      if (!fn) throw new Error(`No function: ${id}`);
+      return fn(payload);
+    },
+    getFunction: (id: string) => functions.get(id),
+  };
+}
+
+function makeReq(body?: unknown) {
+  return {
+    body,
+    headers: {},
+    query_params: {},
+  };
+}
+
+describe("MCP saved standalone memories", () => {
+  let sdk: ReturnType<typeof mockSdk>;
+
+  beforeEach(() => {
+    getSearchIndex().clear();
+    sdk = mockSdk();
+    const kv = mockKV();
+    const bm25 = getSearchIndex();
+    const hybridSearch = new HybridSearch(bm25, null, null, kv as never);
+
+    registerRememberFunction(sdk as never, kv as never);
+    registerSearchFunction(sdk as never, kv as never);
+    registerSmartSearchFunction(sdk as never, kv as never, (query, limit) =>
+      hybridSearch.search(query, limit),
+    );
+    registerMcpEndpoints(sdk as never, kv as never);
+  });
+
+  it("makes memory_save facts immediately retrievable through memory_recall", async () => {
+    const call = sdk.getFunction("mcp::tools::call")!;
+    const saved = (await call(makeReq({
+      name: "memory_save",
+      arguments: { content: "silver tractor violin" },
+    }))) as { status_code: number; body: { content: Array<{ text: string }> } };
+    const savedBody = JSON.parse(saved.body.content[0].text) as {
+      success: boolean;
+      memory: { id: string; content: string };
+    };
+
+    const recalled = (await call(makeReq({
+      name: "memory_recall",
+      arguments: { query: "silver tractor violin" },
+    }))) as { status_code: number; body: { content: Array<{ text: string }> } };
+    const recallBody = JSON.parse(recalled.body.content[0].text) as {
+      results: Array<{ observation: { id: string; narrative: string } }>;
+    };
+
+    expect(saved.status_code).toBe(200);
+    expect(savedBody.memory.content).toBe("silver tractor violin");
+    expect(recalled.status_code).toBe(200);
+    expect(recallBody.results[0]?.observation.id).toBe(savedBody.memory.id);
+    expect(recallBody.results[0]?.observation.narrative).toBe(
+      "silver tractor violin",
+    );
+  });
+
+  it("makes memory_save facts immediately retrievable through memory_smart_search in BM25-only mode", async () => {
+    const call = sdk.getFunction("mcp::tools::call")!;
+    const saved = (await call(makeReq({
+      name: "memory_save",
+      arguments: { content: "silver tractor violin" },
+    }))) as { body: { content: Array<{ text: string }> } };
+    const savedBody = JSON.parse(saved.body.content[0].text) as {
+      memory: { id: string; content: string };
+    };
+
+    const searched = (await call(makeReq({
+      name: "memory_smart_search",
+      arguments: { query: "silver tractor violin" },
+    }))) as { status_code: number; body: { content: Array<{ text: string }> } };
+    const searchBody = JSON.parse(searched.body.content[0].text) as {
+      mode: string;
+      results: Array<{ obsId: string; title: string }>;
+    };
+
+    expect(searched.status_code).toBe(200);
+    expect(searchBody.mode).toBe("compact");
+    expect(searchBody.results[0]?.obsId).toBe(savedBody.memory.id);
+    expect(searchBody.results[0]?.title).toBe(savedBody.memory.content);
+
+    const expanded = (await call(makeReq({
+      name: "memory_smart_search",
+      arguments: {
+        query: "silver tractor violin",
+        expandIds: savedBody.memory.id,
+      },
+    }))) as { status_code: number; body: { content: Array<{ text: string }> } };
+    const expandedBody = JSON.parse(expanded.body.content[0].text) as {
+      mode: string;
+      results: Array<{ observation: { id: string; narrative: string } }>;
+    };
+
+    expect(expanded.status_code).toBe(200);
+    expect(expandedBody.mode).toBe("expanded");
+    expect(expandedBody.results[0]?.observation.id).toBe(savedBody.memory.id);
+    expect(expandedBody.results[0]?.observation.narrative).toBe(
+      savedBody.memory.content,
+    );
+  });
+});

--- a/test/mcp-standalone.test.ts
+++ b/test/mcp-standalone.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
 vi.mock("../src/logger.js", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
@@ -26,6 +26,7 @@ import {
 } from "../src/mcp/tools-registry.js";
 import { InMemoryKV } from "../src/mcp/in-memory-kv.js";
 import { handleToolCall } from "../src/mcp/standalone.js";
+import { resetHandleForTests } from "../src/mcp/rest-proxy.js";
 import { writeFileSync } from "node:fs";
 
 describe("Tools Registry", () => {
@@ -120,8 +121,19 @@ describe("InMemoryKV", () => {
 });
 
 describe("handleToolCall", () => {
+  const originalFetch = globalThis.fetch;
+
   beforeEach(() => {
+    resetHandleForTests();
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
     vi.mocked(writeFileSync).mockClear();
+  });
+
+  afterEach(() => {
+    resetHandleForTests();
+    globalThis.fetch = originalFetch;
   });
 
   it("memory_save persists to disk immediately after saving", async () => {

--- a/test/obsidian-export.test.ts
+++ b/test/obsidian-export.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { join, resolve } from "node:path";
 
 vi.mock("../src/logger.js", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
@@ -18,6 +19,10 @@ vi.mock("node:fs/promises", () => ({
 
 import { registerObsidianExportFunction } from "../src/functions/obsidian-export.js";
 import type { Memory, Lesson, Crystal, Session } from "../src/types.js";
+
+function pathEndsWith(path: string, ...segments: string[]): boolean {
+  return path.endsWith(join(...segments));
+}
 
 function mockKV() {
   const store = new Map<string, Map<string, unknown>>();
@@ -121,7 +126,8 @@ function makeSession(id: string): Session {
 describe("Obsidian Export", () => {
   let sdk: ReturnType<typeof mockSdk>;
   let kv: ReturnType<typeof mockKV>;
-  const exportRoot = "/tmp/agentmemory-export-root";
+  const exportRoot = resolve("/tmp/agentmemory-export-root");
+  const originalExportRoot = process.env.AGENTMEMORY_EXPORT_ROOT;
 
   beforeEach(() => {
     process.env.AGENTMEMORY_EXPORT_ROOT = exportRoot;
@@ -130,6 +136,14 @@ describe("Obsidian Export", () => {
     writtenFiles.clear();
     createdDirs.clear();
     registerObsidianExportFunction(sdk as never, kv as never);
+  });
+
+  afterEach(() => {
+    if (originalExportRoot === undefined) {
+      delete process.env.AGENTMEMORY_EXPORT_ROOT;
+    } else {
+      process.env.AGENTMEMORY_EXPORT_ROOT = originalExportRoot;
+    }
   });
 
   it("creates directories and MOC.md with empty data", async () => {
@@ -164,7 +178,7 @@ describe("Obsidian Export", () => {
     expect(result.exported.memories).toBe(1);
 
     const memFile = [...writtenFiles.entries()].find(([k]) =>
-      k.includes("memories/mem_001.md"),
+      pathEndsWith(k, "memories", "mem_001.md"),
     );
     expect(memFile).toBeDefined();
     const content = memFile![1];
@@ -186,7 +200,7 @@ describe("Obsidian Export", () => {
     expect(result.exported.lessons).toBe(1);
 
     const lsnFile = [...writtenFiles.entries()].find(([k]) =>
-      k.includes("lessons/lsn_001.md"),
+      pathEndsWith(k, "lessons", "lsn_001.md"),
     );
     expect(lsnFile).toBeDefined();
     const content = lsnFile![1];
@@ -202,7 +216,7 @@ describe("Obsidian Export", () => {
     await sdk.trigger("mem::obsidian-export", {});
 
     const crysFile = [...writtenFiles.entries()].find(([k]) =>
-      k.includes("crystals/crys_001.md"),
+      pathEndsWith(k, "crystals", "crys_001.md"),
     );
     expect(crysFile).toBeDefined();
     expect(crysFile![1]).toContain("[[act_1]]");
@@ -223,18 +237,18 @@ describe("Obsidian Export", () => {
 
   it("respects custom vaultDir", async () => {
     await sdk.trigger("mem::obsidian-export", {
-      vaultDir: "/tmp/agentmemory-export-root/test-vault",
+      vaultDir: join(exportRoot, "test-vault"),
     });
 
     const hasCustomPath = [...createdDirs].some((d) =>
-      d.startsWith("/tmp/agentmemory-export-root/test-vault"),
+      d.startsWith(join(exportRoot, "test-vault")),
     );
     expect(hasCustomPath).toBe(true);
   });
 
   it("rejects vaultDir outside the export root", async () => {
     const result = (await sdk.trigger("mem::obsidian-export", {
-      vaultDir: "/tmp/outside-root",
+      vaultDir: resolve("/tmp/outside-root"),
     })) as { success: boolean; error: string };
 
     expect(result.success).toBe(false);


### PR DESCRIPTION
## Summary

Adds native Ollama embedding support so agentmemory can use locally downloaded Ollama embedding models without routing through the OpenAI-compatible provider. The default local embedding model is `nomic-embed-text:latest`, with known dimensions for both `nomic-embed-text` and `mxbai-embed-large`.

This also fixes the Windows-specific build script failure by replacing the POSIX shell copy tail with a small Node asset-copy script. While validating the full suite on Windows, three unrelated-looking failure clusters were traced to test portability and isolation assumptions, so this branch fixes those as part of making the suite merge-ready.

## Root Cause And Fix

The embedding provider factory had no first-class Ollama provider, so local Ollama embeddings required pretending the endpoint was OpenAI-compatible. The new provider calls Ollama's native `/api/embed` endpoint, resolves dimensions from the configured model or explicit override, and stays behind the existing dimension guard.

The full test suite failures were not caused by the Ollama provider. `compress-file` and `obsidian-export` used POSIX path expectations in tests while production code resolves paths through Node on Windows. Those tests now compare resolved and joined paths instead of hard-coded separators. `mcp-standalone` unit tests could accidentally proxy to a live server on localhost, so they now force local fallback while the dedicated proxy test file continues to cover proxy behavior.

The package build script used `cp`, `mkdir -p`, POSIX redirection, and `true`, which fails under Windows shells after `tsdown` completes. The build now runs `tsdown && node scripts/copy-build-assets.mjs`.

## Validation

- `npm test -- test/compress-file.test.ts` passed, 7 tests.
- `npm test -- test/obsidian-export.test.ts` passed, 11 tests.
- `npm test -- test/mcp-standalone.test.ts` passed, 24 tests.
- `npm test -- test/mcp-standalone-proxy.test.ts` passed, 7 tests.
- `npm test -- test/embedding-provider.test.ts` passed, 25 tests.
- `npm run test:integration` passed, 17 tests.
- `npm run build` passed on Windows.
- `npm test` passed, 78 files and 862 tests.