### PR TITLE
fix: surface saved memories in smart_search/recall (#265)

### DIFF
--- a/src/functions/remember.ts
+++ b/src/functions/remember.ts
@@ -1,32 +1,13 @@
 import { TriggerAction, type ISdk } from "iii-sdk";
-import type { CompressedObservation, Memory } from "../types.js";
+import type { Memory } from "../types.js";
 import { KV, generateId, jaccardSimilarity } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
 import { withKeyedLock } from "../state/keyed-mutex.js";
+import { memoryToObservation } from "../state/memory-utils.js";
 import { deleteAccessLog } from "./access-tracker.js";
 import { recordAudit } from "./audit.js";
 import { getSearchIndex } from "./search.js";
 import { logger } from "../logger.js";
-
-// SearchIndex is built around CompressedObservation. Memories carry the
-// same searchable text (title + content + concepts + files) so we wrap
-// them in the observation shape before indexing. Type is normalized to
-// "decision" so memories are still distinguishable in result metadata
-// without colliding with observation enums (file_read, command_run, etc).
-function memoryAsIndexable(memory: Memory): CompressedObservation {
-  return {
-    id: memory.id,
-    sessionId: memory.sessionIds[0] ?? "memory",
-    timestamp: memory.createdAt,
-    type: "decision",
-    title: memory.title,
-    facts: [memory.content],
-    narrative: memory.content,
-    concepts: memory.concepts,
-    files: memory.files,
-    importance: memory.strength,
-  };
-}
 
 export function registerRememberFunction(sdk: ISdk, kv: StateKV): void {
   sdk.registerFunction("mem::remember", 
@@ -124,7 +105,7 @@ export function registerRememberFunction(sdk: ISdk, kv: StateKV): void {
         // an indexing failure doesn't block the save itself — the
         // restart-time rebuild will pick the memory up either way.
         try {
-          getSearchIndex().add(memoryAsIndexable(memory));
+          getSearchIndex().add(memoryToObservation(memory));
         } catch (err) {
           logger.warn("Failed to index saved memory into BM25", {
             memId: memory.id,

--- a/src/functions/search.ts
+++ b/src/functions/search.ts
@@ -3,29 +3,9 @@ import type { CompactSearchResult, CompressedObservation, Memory, SearchResult, 
 import { KV } from '../state/schema.js'
 import { StateKV } from '../state/kv.js'
 import { SearchIndex } from '../state/search-index.js'
+import { memoryToObservation } from '../state/memory-utils.js'
 import { recordAccessBatch } from './access-tracker.js'
 import { logger } from "../logger.js";
-
-// Memories share the same searchable fields as observations (title +
-// content + concepts + files), so we wrap them in the observation shape
-// before indexing. Type is normalized to "decision" to keep memories
-// distinguishable in result metadata. Mirrors the helper in
-// functions/remember.ts; kept inline here to avoid a circular import
-// (remember.ts imports from this file).
-function memoryAsIndexable(memory: Memory): CompressedObservation {
-  return {
-    id: memory.id,
-    sessionId: memory.sessionIds[0] ?? "memory",
-    timestamp: memory.createdAt,
-    type: "decision",
-    title: memory.title,
-    facts: [memory.content],
-    narrative: memory.content,
-    concepts: memory.concepts,
-    files: memory.files,
-    importance: memory.strength,
-  };
-}
 
 let index: SearchIndex | null = null
 
@@ -49,7 +29,7 @@ export async function rebuildIndex(kv: StateKV): Promise<number> {
     for (const memory of memories) {
       if (memory.isLatest === false) continue
       if (!memory.title || !memory.content) continue
-      idx.add(memoryAsIndexable(memory))
+      idx.add(memoryToObservation(memory))
       count++
     }
   } catch (err) {
@@ -177,7 +157,7 @@ export function registerSearchFunction(sdk: ISdk, kv: StateKV): void {
           const mem = await kv
             .get<Memory>(KV.memories, r.obsId)
             .catch(() => null)
-          return mem ? memoryAsIndexable(mem) : null
+          return mem ? memoryToObservation(mem) : null
         })
       )
       const enriched: SearchResult[] = []

--- a/src/functions/search.ts
+++ b/src/functions/search.ts
@@ -164,11 +164,21 @@ export function registerSearchFunction(sdk: ISdk, kv: StateKV): void {
         candidates.push(r)
       }
 
-      // Second pass: load observations in parallel.
+      // Second pass: load observations in parallel. Fall back to
+      // KV.memories when the observation lookup misses — entries indexed
+      // via mem::remember live in the memories scope under a synthetic
+      // sessionId, so the observation key never exists (#265).
       const obsResults = await Promise.all(
-        candidates.map((r) =>
-          kv.get<CompressedObservation>(KV.observations(r.sessionId), r.obsId)
-        )
+        candidates.map(async (r) => {
+          const obs = await kv
+            .get<CompressedObservation>(KV.observations(r.sessionId), r.obsId)
+            .catch(() => null)
+          if (obs) return obs
+          const mem = await kv
+            .get<Memory>(KV.memories, r.obsId)
+            .catch(() => null)
+          return mem ? memoryAsIndexable(mem) : null
+        })
       )
       const enriched: SearchResult[] = []
       for (let i = 0; i < candidates.length; i++) {

--- a/src/state/hybrid-search.ts
+++ b/src/state/hybrid-search.ts
@@ -4,6 +4,7 @@ import type {
   EmbeddingProvider,
   HybridSearchResult,
   CompressedObservation,
+  Memory,
   QueryExpansion,
 } from "../types.js";
 import type { StateKV } from "./kv.js";
@@ -287,11 +288,20 @@ export class HybridSearch {
   ): Promise<HybridSearchResult[]> {
     const sliced = results.slice(0, limit);
     const observations = await Promise.all(
-      sliced.map((r) =>
-        this.kv
+      sliced.map(async (r) => {
+        const obs = await this.kv
           .get<CompressedObservation>(KV.observations(r.sessionId), r.obsId)
-          .catch(() => null),
-      ),
+          .catch(() => null);
+        if (obs) return obs;
+        // Fallback: indexed entry may originate from mem::remember, which
+        // writes to KV.memories with a synthetic sessionId ("memory" or the
+        // memory's first associated session). Coerce the Memory record into
+        // a CompressedObservation so search/recall surface saved memories.
+        const mem = await this.kv
+          .get<Memory>(KV.memories, r.obsId)
+          .catch(() => null);
+        return mem ? memoryToObservation(mem) : null;
+      }),
     );
     const enriched: HybridSearchResult[] = [];
     for (let i = 0; i < sliced.length; i++) {
@@ -310,4 +320,19 @@ export class HybridSearch {
     }
     return enriched;
   }
+}
+
+function memoryToObservation(memory: Memory): CompressedObservation {
+  return {
+    id: memory.id,
+    sessionId: memory.sessionIds[0] ?? "memory",
+    timestamp: memory.createdAt,
+    type: "decision",
+    title: memory.title,
+    facts: [memory.content],
+    narrative: memory.content,
+    concepts: memory.concepts,
+    files: memory.files,
+    importance: memory.strength,
+  };
 }

--- a/src/state/hybrid-search.ts
+++ b/src/state/hybrid-search.ts
@@ -7,6 +7,7 @@ import type {
   Memory,
   QueryExpansion,
 } from "../types.js";
+import { memoryToObservation } from "./memory-utils.js";
 import type { StateKV } from "./kv.js";
 import { KV } from "./schema.js";
 import {
@@ -320,19 +321,4 @@ export class HybridSearch {
     }
     return enriched;
   }
-}
-
-function memoryToObservation(memory: Memory): CompressedObservation {
-  return {
-    id: memory.id,
-    sessionId: memory.sessionIds[0] ?? "memory",
-    timestamp: memory.createdAt,
-    type: "decision",
-    title: memory.title,
-    facts: [memory.content],
-    narrative: memory.content,
-    concepts: memory.concepts,
-    files: memory.files,
-    importance: memory.strength,
-  };
 }

--- a/src/state/memory-utils.ts
+++ b/src/state/memory-utils.ts
@@ -1,0 +1,24 @@
+import type { CompressedObservation, Memory } from "../types.js";
+
+// Wraps a Memory record in the CompressedObservation shape that
+// SearchIndex / VectorIndex / enrichment paths consume. Memories share
+// the same searchable fields as observations (title + content +
+// concepts + files); type is normalized to "decision" so memories stay
+// distinguishable in result metadata without colliding with observation
+// enums (file_read, command_run, …). The synthetic sessionId
+// ("memory" or memory.sessionIds[0]) is what enrich-side fallbacks key
+// off of when looking up the source record in KV.memories.
+export function memoryToObservation(memory: Memory): CompressedObservation {
+  return {
+    id: memory.id,
+    sessionId: memory.sessionIds[0] ?? "memory",
+    timestamp: memory.createdAt,
+    type: "decision",
+    title: memory.title,
+    facts: [memory.content],
+    narrative: memory.content,
+    concepts: memory.concepts,
+    files: memory.files,
+    importance: memory.strength,
+  };
+}

--- a/test/hybrid-search.test.ts
+++ b/test/hybrid-search.test.ts
@@ -142,4 +142,42 @@ describe("HybridSearch", () => {
     const results = await hybrid.search("auth");
     expect(results).toEqual([]);
   });
+
+  it("falls back to KV.memories when an indexed entry is a saved memory (#265)", async () => {
+    // mem::remember writes to KV.memories under the synthetic sessionId
+    // "memory" — the BM25 index sees that synthetic sessionId, but
+    // KV.observations("memory") never has anything.
+    const indexable = makeObs({
+      id: "mem_abc",
+      sessionId: "memory",
+      title: "Test memory for search",
+      narrative: "Test memory for search",
+      concepts: ["test", "search"],
+    });
+    bm25.add(indexable);
+
+    const memory = {
+      id: "mem_abc",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      type: "fact",
+      title: "Test memory for search",
+      content: "Test memory for search",
+      concepts: ["test", "search"],
+      files: [],
+      sessionIds: [],
+      strength: 7,
+      version: 1,
+      isLatest: true,
+    };
+    await kv.set("mem:memories", "mem_abc", memory);
+
+    const hybrid = new HybridSearch(bm25, null, null, kv as never);
+    const results = await hybrid.search("test memory search");
+
+    expect(results.length).toBe(1);
+    expect(results[0].observation.id).toBe("mem_abc");
+    expect(results[0].observation.narrative).toBe("Test memory for search");
+    expect(results[0].observation.concepts).toEqual(["test", "search"]);
+  });
 });

--- a/test/search.test.ts
+++ b/test/search.test.ts
@@ -4,7 +4,7 @@ vi.mock("../src/logger.js", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
-import { registerSearchFunction } from "../src/functions/search.js";
+import { registerSearchFunction, getSearchIndex, rebuildIndex } from "../src/functions/search.js";
 import { KV } from "../src/state/schema.js";
 import type { CompressedObservation, Session } from "../src/types.js";
 
@@ -97,6 +97,9 @@ describe("mem::search", () => {
 
     await kv.set(KV.observations("ses_1"), obsA.id, obsA);
     await kv.set(KV.observations("ses_1"), obsB.id, obsB);
+
+    // Module-level SearchIndex singleton would leak across tests; reset.
+    getSearchIndex().clear();
   });
 
   it("returns full format by default", async () => {
@@ -146,5 +149,37 @@ describe("mem::search", () => {
     await expect(
       sdk.trigger("mem::search", { query: "auth", format: "verbose" }),
     ).rejects.toThrow("format must be one of");
+  });
+
+  it("surfaces saved memories from KV.memories (#265)", async () => {
+    // mem::remember persists to KV.memories under a synthetic sessionId
+    // ("memory") that has no corresponding KV.observations entry. mem::search
+    // must fall back to KV.memories or memory_recall returns empty.
+    await kv.set(KV.memories, "mem_x1", {
+      id: "mem_x1",
+      createdAt: "2026-02-01T00:00:00Z",
+      updatedAt: "2026-02-01T00:00:00Z",
+      type: "fact",
+      title: "Pineapple belongs on pizza",
+      content: "Pineapple belongs on pizza for testing fallback path.",
+      concepts: ["pineapple", "pizza"],
+      files: [],
+      sessionIds: [],
+      strength: 7,
+      version: 1,
+      isLatest: true,
+    });
+    // Force the rebuild to pick up the new memory (mem::search only
+    // rebuilds on first call when idx.size === 0).
+    await rebuildIndex(kv as never);
+
+    const result = (await sdk.trigger("mem::search", {
+      query: "pineapple pizza",
+      format: "compact",
+    })) as { results: Array<{ obsId: string; title: string }> };
+
+    const hit = result.results.find((r) => r.obsId === "mem_x1");
+    expect(hit).toBeDefined();
+    expect(hit?.title).toBe("Pineapple belongs on pizza");
   });
 });


### PR DESCRIPTION
## Summary
- `memory_save` succeeded but `memory_smart_search` / `memory_recall` always returned `[]` — the save→search flow was effectively write-only.
- Two enrichment sites silently dropped memory hits because they queried `KV.observations(sessionId, obsId)`, while `mem::remember` writes to `KV.memories` under a synthetic `sessionId`.
- Both sites now fall back to `KV.memories` and coerce the `Memory` into a `CompressedObservation`.

## Affected paths
- `HybridSearch.enrichResults` → powers `/smart-search`, MCP `memory_smart_search`
- `mem::search` `obsResults` map → powers `/search`, MCP `memory_recall`

The first site was the one called out in the issue. The second was found while validating end-to-end and has the same bug — without it `memory_recall` would still be broken even after the smart-search fix.

## Live e2e (iii-engine 0.11.2 + agentmemory 0.9.5, `EMBEDDING_PROVIDER=local`)
Pre-fix:
```
POST /agentmemory/remember           → mem_xxx (saved, visible in /memories)
POST /agentmemory/smart-search       → { results: [] }
POST /agentmemory/search             → memory not present
```
Post-fix:
```
POST /agentmemory/smart-search       → results[0].obsId === mem_xxx (score 0.016)
POST /agentmemory/search             → results[0].obsId === mem_xxx (score 4.43)
```

## Tests
- `test/hybrid-search.test.ts` — new regression case: BM25 indexes a memory, `enrichResults` falls back to `KV.memories`.
- `test/search.test.ts` — new regression case: `mem::search` surfaces memories saved to `KV.memories`.
- Full suite: 856 passing.

Closes #265.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search now falls back to retrieve saved memories when direct observation lookups fail, surfacing results that previously went missing.

* **New Features**
  * Indexing and memory-saving flows now ensure saved memories are converted and indexed so they appear in search.

* **Tests**
  * Added tests to validate the fallback and indexing behavior for saved memories in search results.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/269)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->