### PR TITLE
fix: MCP standalone shim proxies full server tool set (#234)

### DIFF
--- a/src/mcp/standalone.ts
+++ b/src/mcp/standalone.ts
@@ -293,14 +293,54 @@ async function handleLocal(
   }
 }
 
+async function handleProxyGeneric(
+  toolName: string,
+  args: Record<string, unknown>,
+  handle: ProxyHandle,
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  // Forward to the server's full MCP surface so non-Claude clients can
+  // reach all 51 tools (lessons, sentinels, slots, signals, graph, …)
+  // instead of being capped at the 7 IMPLEMENTED_TOOLS set baked into
+  // this shim. The server validates arguments per tool.
+  const result = (await handle.call("/agentmemory/mcp/call", {
+    method: "POST",
+    body: JSON.stringify({ name: toolName, arguments: args }),
+  })) as { content?: Array<{ type: string; text: string }> } | null;
+  if (result && Array.isArray(result.content)) {
+    return { content: result.content };
+  }
+  return textResponse(result, true);
+}
+
 export async function handleToolCall(
   toolName: string,
   args: Record<string, unknown>,
   kvInstance: InMemoryKV = kv,
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
-  const validated = validate(toolName, args);
   const handle = await resolveHandle();
   announceMode(handle);
+
+  // Tools the local InMemoryKV fallback doesn't implement: forward straight
+  // to the server. Local validation would otherwise raise "Unknown tool"
+  // (issue #234).
+  if (!IMPLEMENTED_TOOLS.has(toolName)) {
+    if (handle.mode === "proxy") {
+      try {
+        return await handleProxyGeneric(toolName, args, handle);
+      } catch (err) {
+        process.stderr.write(
+          `[@agentmemory/mcp] proxy call failed for ${toolName}: ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+        invalidateHandle();
+        throw err;
+      }
+    }
+    throw new Error(
+      `Unknown tool: ${toolName} (local fallback supports only ${[...IMPLEMENTED_TOOLS].join(", ")}; start an agentmemory server and set AGENTMEMORY_URL to use the full tool set)`,
+    );
+  }
+
+  const validated = validate(toolName, args);
   if (handle.mode === "proxy") {
     try {
       return await handleProxy(validated, handle);
@@ -329,10 +369,32 @@ const transport = createStdioTransport(async (method, params) => {
     case "notifications/initialized":
       return {};
 
-    case "tools/list":
+    case "tools/list": {
+      // When a server is reachable, expose every tool it advertises (51
+      // when AGENTMEMORY_TOOLS=all on the server). Without this, the shim
+      // capped non-Claude clients at the local 7-tool set even with the
+      // server up (issue #234).
+      const handle = await resolveHandle();
+      announceMode(handle);
+      if (handle.mode === "proxy") {
+        try {
+          const remote = (await handle.call("/agentmemory/mcp/tools", {
+            method: "GET",
+          })) as { tools?: unknown } | null;
+          if (remote && Array.isArray(remote.tools)) {
+            return { tools: remote.tools };
+          }
+        } catch (err) {
+          process.stderr.write(
+            `[@agentmemory/mcp] tools/list proxy failed: ${err instanceof Error ? err.message : String(err)}; falling back to local list\n`,
+          );
+          invalidateHandle();
+        }
+      }
       return {
         tools: getVisibleTools().filter((t) => IMPLEMENTED_TOOLS.has(t.name)),
       };
+    }
 
     case "tools/call": {
       const toolName = params.name as string;

--- a/test/mcp-standalone-proxy.test.ts
+++ b/test/mcp-standalone-proxy.test.ts
@@ -136,6 +136,53 @@ describe("@agentmemory/mcp standalone — server proxy (issue #159)", () => {
     expect(probeCount).toBe(2);
   });
 
+  it("forwards non-essential tools to /agentmemory/mcp/call (#234)", async () => {
+    const calls: Array<{ url: string; body?: unknown }> = [];
+    installFetch((url, init) => {
+      if (url.endsWith("/agentmemory/livez")) {
+        return new Response("ok", { status: 200 });
+      }
+      if (url.endsWith("/agentmemory/mcp/call")) {
+        const body = init?.body ? JSON.parse(init.body as string) : null;
+        calls.push({ url, body });
+        return new Response(
+          JSON.stringify({
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify({ saved: "lesson_xyz" }),
+              },
+            ],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const res = await handleToolCall("memory_lesson_save", {
+      title: "Always pin lockfiles",
+      content: "...",
+    });
+    const body = JSON.parse(res.content[0].text);
+    expect(body.saved).toBe("lesson_xyz");
+    expect(calls).toHaveLength(1);
+    expect(calls[0].body).toEqual({
+      name: "memory_lesson_save",
+      arguments: { title: "Always pin lockfiles", content: "..." },
+    });
+  });
+
+  it("rejects non-essential tools when no server is reachable (#234)", async () => {
+    installFetch(() => {
+      throw new Error("ECONNREFUSED");
+    });
+    const localKv = new InMemoryKV(undefined);
+    await expect(
+      handleToolCall("memory_lesson_save", { title: "x" }, localKv),
+    ).rejects.toThrow(/Unknown tool: memory_lesson_save/);
+  });
+
   it("does not retry local after a validation error", async () => {
     const fetchFn = installFetch((url) => {
       if (url.endsWith("/agentmemory/livez")) return new Response("ok", { status: 200 });


### PR DESCRIPTION
## Summary
- `agentmemory mcp` capped non-Claude clients (OpenCode, Cursor, Gemini CLI, Cline, …) at the local 7-tool `IMPLEMENTED_TOOLS` set even when an agentmemory server was reachable. With `AGENTMEMORY_TOOLS=all` on the server the user expected 51 tools.
- The shim now delegates `tools/list` to `GET /agentmemory/mcp/tools` and forwards any non-essential tool to `POST /agentmemory/mcp/call` when in proxy mode.
- Local `InMemoryKV` fallback is unchanged — it still implements only the 7 essential tools, with a clearer error for unknown tools when no server is reachable.

## Live e2e (server: `AGENTMEMORY_TOOLS=all`)
Pre-fix:
```
shim → tools/list  → 4 tools (default), 7 (TOOLS=all)
shim → memory_lesson_save → "Unknown tool"
```
Post-fix:
```
shim → tools/list  → 51 tools
shim → memory_lesson_save → lesson lsn_xxx created
```

Driver script used: stdio JSON-RPC initialize → tools/list → tools/call.

## Tests
- `test/mcp-standalone-proxy.test.ts` — new cases covering proxy-forward of non-essential tools and the no-server failure mode.
- Full suite: 856 passing.

Closes #234.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved tool discovery and support for non-Claude MCP clients through server-side proxying.
  * Unknown tools are now forwarded to the remote server instead of being rejected locally.
  * Enhanced error handling for unreachable servers.

* **Tests**
  * Added test coverage for remote tool proxy functionality and failure scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/270)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->