### PR TITLE
fix: cap session-start/subagent-start hook latency (#221)

### DIFF
--- a/plugin/scripts/session-start.mjs
+++ b/plugin/scripts/session-start.mjs
@@ -8,6 +8,8 @@ function isSdkChildContext(payload) {
 const INJECT_CONTEXT = process.env["AGENTMEMORY_INJECT_CONTEXT"] === "true";
 const REST_URL = process.env["AGENTMEMORY_URL"] || "http://localhost:3111";
 const SECRET = process.env["AGENTMEMORY_SECRET"] || "";
+const INJECT_TIMEOUT_MS = 1500;
+const REGISTER_TIMEOUT_MS = 800;
 function authHeaders() {
 	const h = { "Content-Type": "application/json" };
 	if (SECRET) h["Authorization"] = `Bearer ${SECRET}`;
@@ -25,18 +27,29 @@ async function main() {
 	if (isSdkChildContext(data)) return;
 	const sessionId = data.session_id || `ses_${Date.now().toString(36)}`;
 	const project = data.cwd || process.cwd();
+	const url = `${REST_URL}/agentmemory/session/start`;
+	const init = {
+		method: "POST",
+		headers: authHeaders(),
+		body: JSON.stringify({
+			sessionId,
+			project,
+			cwd: project
+		})
+	};
+	if (!INJECT_CONTEXT) {
+		fetch(url, {
+			...init,
+			signal: AbortSignal.timeout(REGISTER_TIMEOUT_MS)
+		}).catch(() => {});
+		return;
+	}
 	try {
-		const res = await fetch(`${REST_URL}/agentmemory/session/start`, {
-			method: "POST",
-			headers: authHeaders(),
-			body: JSON.stringify({
-				sessionId,
-				project,
-				cwd: project
-			}),
-			signal: AbortSignal.timeout(5e3)
+		const res = await fetch(url, {
+			...init,
+			signal: AbortSignal.timeout(INJECT_TIMEOUT_MS)
 		});
-		if (INJECT_CONTEXT && res.ok) {
+		if (res.ok) {
 			const result = await res.json();
 			if (result.context) process.stdout.write(result.context);
 		}

--- a/plugin/scripts/subagent-start.mjs
+++ b/plugin/scripts/subagent-start.mjs
@@ -7,6 +7,7 @@ function isSdkChildContext(payload) {
 }
 const REST_URL = process.env["AGENTMEMORY_URL"] || "http://localhost:3111";
 const SECRET = process.env["AGENTMEMORY_SECRET"] || "";
+const TIMEOUT_MS = 800;
 function authHeaders() {
 	const h = { "Content-Type": "application/json" };
 	if (SECRET) h["Authorization"] = `Bearer ${SECRET}`;
@@ -23,24 +24,22 @@ async function main() {
 	}
 	if (isSdkChildContext(data)) return;
 	const sessionId = data.session_id || "unknown";
-	try {
-		await fetch(`${REST_URL}/agentmemory/observe`, {
-			method: "POST",
-			headers: authHeaders(),
-			body: JSON.stringify({
-				hookType: "subagent_start",
-				sessionId,
-				project: data.cwd || process.cwd(),
-				cwd: data.cwd || process.cwd(),
-				timestamp: (/* @__PURE__ */ new Date()).toISOString(),
-				data: {
-					agent_id: data.agent_id,
-					agent_type: data.agent_type
-				}
-			}),
-			signal: AbortSignal.timeout(2e3)
-		});
-	} catch {}
+	fetch(`${REST_URL}/agentmemory/observe`, {
+		method: "POST",
+		headers: authHeaders(),
+		body: JSON.stringify({
+			hookType: "subagent_start",
+			sessionId,
+			project: data.cwd || process.cwd(),
+			cwd: data.cwd || process.cwd(),
+			timestamp: (/* @__PURE__ */ new Date()).toISOString(),
+			data: {
+				agent_id: data.agent_id,
+				agent_type: data.agent_type
+			}
+		}),
+		signal: AbortSignal.timeout(TIMEOUT_MS)
+	}).catch(() => {});
 }
 main();
 

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+// Inlined from ./sdk-guard so each hook bundles to a single self-contained
+// .mjs (matches the pattern used by every other hook entry in tsdown.config).
 function isSdkChildContext(payload: unknown): boolean {
   if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
   if (!payload || typeof payload !== "object") return false;
@@ -17,6 +19,13 @@ const INJECT_CONTEXT = process.env["AGENTMEMORY_INJECT_CONTEXT"] === "true";
 
 const REST_URL = process.env["AGENTMEMORY_URL"] || "http://localhost:3111";
 const SECRET = process.env["AGENTMEMORY_SECRET"] || "";
+
+// When the server is unreachable a 5s timeout multiplies hard under
+// concurrent fan-out (Slack bots, multi-agent harnesses) and becomes a
+// positive feedback loop that OOM-kills iii-engine (#221). Cap tight on
+// both paths and skip the await entirely when the response is unused.
+const INJECT_TIMEOUT_MS = 1500;
+const REGISTER_TIMEOUT_MS = 800;
 
 function authHeaders(): Record<string, string> {
   const h: Record<string, string> = { "Content-Type": "application/json" };
@@ -43,18 +52,30 @@ async function main() {
     (data.session_id as string) || `ses_${Date.now().toString(36)}`;
   const project = (data.cwd as string) || process.cwd();
 
-  try {
-    const res = await fetch(`${REST_URL}/agentmemory/session/start`, {
-      method: "POST",
-      headers: authHeaders(),
-      body: JSON.stringify({ sessionId, project, cwd: project }),
-      signal: AbortSignal.timeout(5000),
-    });
+  const url = `${REST_URL}/agentmemory/session/start`;
+  const init: RequestInit = {
+    method: "POST",
+    headers: authHeaders(),
+    body: JSON.stringify({ sessionId, project, cwd: project }),
+  };
 
-    // Only write context to stdout when the user has explicitly opted
-    // into injection. Registering the session is cheap and doesn't touch
-    // Claude Code's input token window.
-    if (INJECT_CONTEXT && res.ok) {
+  if (!INJECT_CONTEXT) {
+    // Pure telemetry path: caller never reads the response, so don't
+    // block on it. AbortSignal.timeout caps the wait the event loop
+    // gives the pending socket before exit.
+    fetch(url, {
+      ...init,
+      signal: AbortSignal.timeout(REGISTER_TIMEOUT_MS),
+    }).catch(() => {});
+    return;
+  }
+
+  try {
+    const res = await fetch(url, {
+      ...init,
+      signal: AbortSignal.timeout(INJECT_TIMEOUT_MS),
+    });
+    if (res.ok) {
       const result = (await res.json()) as { context?: string };
       if (result.context) {
         process.stdout.write(result.context);

--- a/src/hooks/subagent-start.ts
+++ b/src/hooks/subagent-start.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+// Inlined from ./sdk-guard so each hook bundles to a single self-contained
+// .mjs (matches the pattern used by every other hook entry in tsdown.config).
 function isSdkChildContext(payload: unknown): boolean {
   if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
   if (!payload || typeof payload !== "object") return false;
@@ -8,6 +10,12 @@ function isSdkChildContext(payload: unknown): boolean {
 
 const REST_URL = process.env["AGENTMEMORY_URL"] || "http://localhost:3111";
 const SECRET = process.env["AGENTMEMORY_SECRET"] || "";
+
+// Passive telemetry only — nothing reads the response, so the previous
+// `await` was pure latency. Tightened from 2000ms to a defensive cap so a
+// slow/unreachable server can't stack onto every concurrent subagent
+// startup (#221).
+const TIMEOUT_MS = 800;
 
 function authHeaders(): Record<string, string> {
   const h: Record<string, string> = { "Content-Type": "application/json" };
@@ -32,26 +40,22 @@ async function main() {
 
   const sessionId = (data.session_id as string) || "unknown";
 
-  try {
-    await fetch(`${REST_URL}/agentmemory/observe`, {
-      method: "POST",
-      headers: authHeaders(),
-      body: JSON.stringify({
-        hookType: "subagent_start",
-        sessionId,
-        project: data.cwd || process.cwd(),
-        cwd: data.cwd || process.cwd(),
-        timestamp: new Date().toISOString(),
-        data: {
-          agent_id: data.agent_id,
-          agent_type: data.agent_type,
-        },
-      }),
-      signal: AbortSignal.timeout(2000),
-    });
-  } catch {
-    // fire and forget
-  }
+  fetch(`${REST_URL}/agentmemory/observe`, {
+    method: "POST",
+    headers: authHeaders(),
+    body: JSON.stringify({
+      hookType: "subagent_start",
+      sessionId,
+      project: data.cwd || process.cwd(),
+      cwd: data.cwd || process.cwd(),
+      timestamp: new Date().toISOString(),
+      data: {
+        agent_id: data.agent_id,
+        agent_type: data.agent_type,
+      },
+    }),
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  }).catch(() => {});
 }
 
 main();


### PR DESCRIPTION
## Summary
- `session-start.ts` awaited a 5000ms POST and discarded the response whenever `AGENTMEMORY_INJECT_CONTEXT=false` (the default since 0.8.10) — pure blocking latency on every Claude Code session start.
- `subagent-start.ts` had a `// fire and forget` comment but the code awaited a 2000ms POST.
- Under concurrent fan-out (Slack-bot orchestrators, multi-agent harnesses, fanned `claude -p` jobs) the awaited timeouts stack and create the positive feedback loop the reporter described — leading to iii-engine OOM-kill.

## Fix
- `session-start` — fire-and-forget on the telemetry path. Cap the inject path at **1500ms** (down from 5000ms) so a slow server can't block the agent indefinitely when stdout is consumed.
- `subagent-start` — actually fire-and-forget, matching the existing comment. Cap at **800ms**.

## Live e2e (black-hole TCP listener: accepts, never replies)
| hook | before | after |
|---|---|---|
| `session-start` (no inject) | 5.05s | **0.85s** |
| `session-start` (inject=true) | 5.05s | **1.55s** |
| `subagent-start` | 2.05s | **0.87s** |

## Notes
- Bundled artifacts in `plugin/scripts/` regenerated via `npx tsdown`.
- The shared `isSdkChildContext` guard is intentionally inlined in each hook source (matches the established pattern: every `tsdown` hook entry compiles to a single self-contained `.mjs`).
- Full suite: 856 passing.

Closes #221.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized timeout handling for startup operations with separate thresholds for telemetry versus response-dependent requests.
  * Improved startup responsiveness by making telemetry requests non-blocking.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/271)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->