### PR TITLE
fix(mcp): local fallback exposes all 7 IMPLEMENTED_TOOLS, not 4 (#234)

### DIFF
--- a/src/mcp/standalone.ts
+++ b/src/mcp/standalone.ts
@@ -2,7 +2,7 @@
 
 import { InMemoryKV } from "./in-memory-kv.js";
 import { createStdioTransport } from "./transport.js";
-import { getVisibleTools } from "./tools-registry.js";
+import { getAllTools } from "./tools-registry.js";
 import { getStandalonePersistPath } from "../config.js";
 import { VERSION } from "../version.js";
 import { generateId } from "../state/schema.js";
@@ -354,6 +354,57 @@ export async function handleToolCall(
   return handleLocal(validated, kvInstance);
 }
 
+export async function handleToolsList(): Promise<{ tools: unknown[] }> {
+  const debug = process.env["AGENTMEMORY_DEBUG"] === "1" || process.env["AGENTMEMORY_DEBUG"] === "true";
+  const handle = await resolveHandle();
+  announceMode(handle);
+  if (debug) {
+    process.stderr.write(
+      `[@agentmemory/mcp] tools/list: handle.mode=${handle.mode}${handle.mode === "proxy" ? ` baseUrl=${handle.baseUrl}` : ""}\n`,
+    );
+  }
+  if (handle.mode === "proxy") {
+    try {
+      const remote = (await handle.call("/agentmemory/mcp/tools", {
+        method: "GET",
+      })) as { tools?: unknown } | null;
+      if (debug) {
+        const shape = remote === null
+          ? "null"
+          : typeof remote !== "object"
+            ? typeof remote
+            : `keys=${Object.keys(remote as object).join(",")} toolsType=${Array.isArray((remote as { tools?: unknown }).tools) ? `array(len=${((remote as { tools: unknown[] }).tools).length})` : typeof (remote as { tools?: unknown }).tools}`;
+        process.stderr.write(
+          `[@agentmemory/mcp] tools/list: remote response shape: ${shape}\n`,
+        );
+      }
+      if (remote && Array.isArray(remote.tools)) {
+        if (debug) {
+          process.stderr.write(
+            `[@agentmemory/mcp] tools/list: returning ${remote.tools.length} tools from server\n`,
+          );
+        }
+        return { tools: remote.tools };
+      }
+      process.stderr.write(
+        `[@agentmemory/mcp] tools/list: server returned unexpected shape (no .tools array); falling back to local IMPLEMENTED_TOOLS list. Set AGENTMEMORY_DEBUG=1 to inspect response.\n`,
+      );
+    } catch (err) {
+      process.stderr.write(
+        `[@agentmemory/mcp] tools/list proxy failed: ${err instanceof Error ? err.message : String(err)}; falling back to local list\n`,
+      );
+      invalidateHandle();
+    }
+  }
+  const fallback = getAllTools().filter((t) => IMPLEMENTED_TOOLS.has(t.name));
+  if (debug) {
+    process.stderr.write(
+      `[@agentmemory/mcp] tools/list: returning ${fallback.length} local fallback tools (${fallback.map((t) => t.name).join(",")})\n`,
+    );
+  }
+  return { tools: fallback };
+}
+
 const transport = createStdioTransport(async (method, params) => {
   switch (method) {
     case "initialize":
@@ -369,56 +420,8 @@ const transport = createStdioTransport(async (method, params) => {
     case "notifications/initialized":
       return {};
 
-    case "tools/list": {
-      const debug = process.env["AGENTMEMORY_DEBUG"] === "1" || process.env["AGENTMEMORY_DEBUG"] === "true";
-      const handle = await resolveHandle();
-      announceMode(handle);
-      if (debug) {
-        process.stderr.write(
-          `[@agentmemory/mcp] tools/list: handle.mode=${handle.mode}${handle.mode === "proxy" ? ` baseUrl=${handle.baseUrl}` : ""}\n`,
-        );
-      }
-      if (handle.mode === "proxy") {
-        try {
-          const remote = (await handle.call("/agentmemory/mcp/tools", {
-            method: "GET",
-          })) as { tools?: unknown } | null;
-          if (debug) {
-            const shape = remote === null
-              ? "null"
-              : typeof remote !== "object"
-                ? typeof remote
-                : `keys=${Object.keys(remote as object).join(",")} toolsType=${Array.isArray((remote as { tools?: unknown }).tools) ? `array(len=${((remote as { tools: unknown[] }).tools).length})` : typeof (remote as { tools?: unknown }).tools}`;
-            process.stderr.write(
-              `[@agentmemory/mcp] tools/list: remote response shape: ${shape}\n`,
-            );
-          }
-          if (remote && Array.isArray(remote.tools)) {
-            if (debug) {
-              process.stderr.write(
-                `[@agentmemory/mcp] tools/list: returning ${remote.tools.length} tools from server\n`,
-              );
-            }
-            return { tools: remote.tools };
-          }
-          process.stderr.write(
-            `[@agentmemory/mcp] tools/list: server returned unexpected shape (no .tools array); falling back to local IMPLEMENTED_TOOLS list. Set AGENTMEMORY_DEBUG=1 to inspect response.\n`,
-          );
-        } catch (err) {
-          process.stderr.write(
-            `[@agentmemory/mcp] tools/list proxy failed: ${err instanceof Error ? err.message : String(err)}; falling back to local list\n`,
-          );
-          invalidateHandle();
-        }
-      }
-      const fallback = getVisibleTools().filter((t) => IMPLEMENTED_TOOLS.has(t.name));
-      if (debug) {
-        process.stderr.write(
-          `[@agentmemory/mcp] tools/list: returning ${fallback.length} local fallback tools (${fallback.map((t) => t.name).join(",")})\n`,
-        );
-      }
-      return { tools: fallback };
-    }
+    case "tools/list":
+      return handleToolsList();
 
     case "tools/call": {
       const toolName = params.name as string;

--- a/test/mcp-standalone-proxy.test.ts
+++ b/test/mcp-standalone-proxy.test.ts
@@ -247,6 +247,32 @@ describe("@agentmemory/mcp standalone — server proxy (issue #159)", () => {
     expect(joined).toMatch(/AGENTMEMORY_FORCE_PROXY/);
   });
 
+  it("local fallback tools/list returns all 7 IMPLEMENTED_TOOLS regardless of AGENTMEMORY_TOOLS env (#234)", async () => {
+    const { handleToolsList } = await import("../src/mcp/standalone.js");
+    installFetch(() => {
+      throw new Error("ECONNREFUSED");
+    });
+    delete process.env["AGENTMEMORY_TOOLS"];
+    const before = await handleToolsList();
+    const beforeTools = before.tools as Array<{ name: string }>;
+    expect(beforeTools.map((t) => t.name).sort()).toEqual([
+      "memory_audit",
+      "memory_export",
+      "memory_governance_delete",
+      "memory_recall",
+      "memory_save",
+      "memory_sessions",
+      "memory_smart_search",
+    ]);
+    expect(beforeTools).toHaveLength(7);
+
+    resetHandleForTests();
+    process.env["AGENTMEMORY_TOOLS"] = "core";
+    const core = await handleToolsList();
+    expect((core.tools as unknown[]).length).toBe(7);
+    delete process.env["AGENTMEMORY_TOOLS"];
+  });
+
   it("AGENTMEMORY_PROBE_TIMEOUT_MS overrides the default probe timeout", async () => {
     process.env["AGENTMEMORY_PROBE_TIMEOUT_MS"] = "50";
     let probeStarted = 0;


### PR DESCRIPTION
## Reproduction

When no agentmemory server is reachable on `localhost:3111`, the `@agentmemory/mcp` shim showed exactly **4 tools** in MCP clients (Cursor, Roo Code, etc.):

```
memory_recall, memory_save, memory_sessions, memory_smart_search
```

Should be **7** — those four plus `memory_export`, `memory_audit`, `memory_governance_delete`. The InMemoryKV that backs local mode implements all seven operations; only four were advertised.

Reproduced live via stdio against a downed server before this PR:

```
$ {
    printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{...}}'
    printf '%s\n' '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}'
    printf '%s\n' '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
    sleep 1
  } | node dist/standalone.mjs 2>/dev/null | grep -o '"name":"memory_[^"]*"' | sort -u
"name":"memory_recall"
"name":"memory_save"
"name":"memory_sessions"
"name":"memory_smart_search"
```

Same four tools showing in @rohitghumare's Cursor against a downed server, matching the bug @jcalfee originally reported in #234.

## Root cause

The local-fallback branch of `tools/list` in `src/mcp/standalone.ts` intersected the shim's `IMPLEMENTED_TOOLS` (7) with `getVisibleTools()`:

```ts
const fallback = getVisibleTools().filter((t) => IMPLEMENTED_TOOLS.has(t.name));
```

`getVisibleTools()` honors the *shim process's* `AGENTMEMORY_TOOLS` env var. Default unset → returns 8 `ESSENTIAL_TOOLS` (the server's default "core" tier). Intersection:

```
ESSENTIAL_TOOLS (8):
  memory_save, memory_recall, memory_consolidate, memory_smart_search,
  memory_sessions, memory_diagnose, memory_lesson_save, memory_reflect

IMPLEMENTED_TOOLS (7):
  memory_save, memory_recall, memory_smart_search, memory_sessions,
  memory_export, memory_audit, memory_governance_delete

ESSENTIAL_TOOLS ∩ IMPLEMENTED_TOOLS = 4:
  memory_save, memory_recall, memory_smart_search, memory_sessions
```

Exactly the four tools that showed up.

The intersection was meaningless from the start: the shim dispatches by `IMPLEMENTED_TOOLS`, not by `ESSENTIAL_TOOLS`. The shim's local-mode capabilities are fixed by its in-memory KV, not by an env knob that's only meant to filter the server's catalog.

## Fix

Switch the filter source from `getVisibleTools()` to `getAllTools()`:

```ts
const fallback = getAllTools().filter((t) => IMPLEMENTED_TOOLS.has(t.name));
```

`IMPLEMENTED_TOOLS.has(t.name)` still picks the right 7 names, but now from the unfiltered universe instead of an env-filtered subset.

Also refactored the `tools/list` handler out of the inline `createStdioTransport` callback into an exported `handleToolsList()` for direct testability. Added a regression test asserting the local-fallback path returns exactly the 7 `IMPLEMENTED_TOOLS` regardless of `AGENTMEMORY_TOOLS=core` or unset.

## Verified

- [x] Live stdio repro post-fix: returns all 7 names (`memory_save`, `memory_recall`, `memory_smart_search`, `memory_sessions`, `memory_export`, `memory_audit`, `memory_governance_delete`).
- [x] `npm test` — 860 / 860 (859 baseline + 1 regression test).
- [x] `npm run build` — tsdown clean.

## Next

Cut **v0.9.8** after this lands and publish. v0.9.7's local-mode count was wrong; v0.9.8 restores the documented 7-tool local fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool listing reliability with better fallback support when remote services are unreachable.

* **Tests**
  * Added test coverage for tool listing in offline scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/283)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->