### PR TITLE
fix(types): remove duplicate source property in RetentionScore interface

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -839,7 +839,6 @@ export interface RetentionScore {
   reinforcementBoost: number;
   lastAccessed: string;
   accessCount: number;
-  source?: "episodic" | "semantic";
 }
 
 export interface DecayConfig {


### PR DESCRIPTION
## Summary

Duplicate `source` property in `RetentionScore` interface (src/types.ts):

```typescript
export interface RetentionScore {
  memoryId: string;
  source?: "episodic" | "semantic";  // line 835 — original
  ...
  source?: "episodic" | "semantic";  // line 842 — duplicate (shadowing)
}
```

TypeScript silently accepts duplicate property declarations, but the later declaration shadows the earlier one. Any code reading `retentionScore.source` gets unpredictable behavior depending on object creation order.

**Fix:** Remove the duplicate on line 842.

## Testing

```bash
npm run typecheck  # should pass, no duplicate property warning
```

## Issue

Fixes #277

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal data tracking structures to capture additional metrics on data access patterns, including access frequency and timing information.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/287)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->