### PR TITLE
fix(slots): wire pinned slot injection into mem::context

### DIFF
--- a/src/functions/context.ts
+++ b/src/functions/context.ts
@@ -10,6 +10,11 @@ import { KV } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
 import { recordAccessBatch } from "./access-tracker.js";
 import { logger } from "../logger.js";
+import {
+  isSlotsEnabled,
+  listPinnedSlots,
+  renderPinnedContext,
+} from "./slots.js";
 
 function estimateTokens(text: string): number {
   return Math.ceil(text.length / 3);
@@ -32,6 +37,19 @@ export function registerContextFunction(
     async (data: { sessionId: string; project: string; budget?: number }) => {
       const budget = data.budget || tokenBudget;
       const blocks: ContextBlock[] = [];
+
+      if (isSlotsEnabled()) {
+        const pinned = await listPinnedSlots(kv).catch(() => []);
+        const slotContent = renderPinnedContext(pinned);
+        if (slotContent) {
+          blocks.push({
+            type: "memory",
+            content: slotContent,
+            tokens: estimateTokens(slotContent),
+            recency: Date.now(),
+          });
+        }
+      }
 
       const profile = await kv
         .get<ProjectProfile>(KV.profiles, data.project)

--- a/src/functions/context.ts
+++ b/src/functions/context.ts
@@ -5,6 +5,7 @@ import type {
   SessionSummary,
   ContextBlock,
   ProjectProfile,
+  MemorySlot,
 } from "../types.js";
 import { KV } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
@@ -38,22 +39,24 @@ export function registerContextFunction(
       const budget = data.budget || tokenBudget;
       const blocks: ContextBlock[] = [];
 
-      if (isSlotsEnabled()) {
-        const pinned = await listPinnedSlots(kv).catch(() => []);
-        const slotContent = renderPinnedContext(pinned);
-        if (slotContent) {
-          blocks.push({
-            type: "memory",
-            content: slotContent,
-            tokens: estimateTokens(slotContent),
-            recency: Date.now(),
-          });
-        }
-      }
+      const [pinnedSlots, profile] = await Promise.all([
+        isSlotsEnabled()
+          ? listPinnedSlots(kv).catch(() => [] as MemorySlot[])
+          : Promise.resolve([] as MemorySlot[]),
+        kv
+          .get<ProjectProfile>(KV.profiles, data.project)
+          .catch(() => null),
+      ]);
 
-      const profile = await kv
-        .get<ProjectProfile>(KV.profiles, data.project)
-        .catch(() => null);
+      const slotContent = renderPinnedContext(pinnedSlots);
+      if (slotContent) {
+        blocks.push({
+          type: "memory",
+          content: slotContent,
+          tokens: estimateTokens(slotContent),
+          recency: Date.now(),
+        });
+      }
       if (profile) {
         const profileParts = [];
         if (profile.topConcepts.length > 0) {

--- a/test/context-slots.test.ts
+++ b/test/context-slots.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { registerContextFunction } from "../src/functions/context.js";
+import { KV } from "../src/state/schema.js";
+
+function mockKV() {
+  const store = new Map<string, Map<string, unknown>>();
+  return {
+    get: async <T>(scope: string, key: string): Promise<T | null> => {
+      return (store.get(scope)?.get(key) as T) ?? null;
+    },
+    set: async <T>(scope: string, key: string, data: T): Promise<T> => {
+      if (!store.has(scope)) store.set(scope, new Map());
+      store.get(scope)!.set(key, data);
+      return data;
+    },
+    delete: async (scope: string, key: string): Promise<void> => {
+      store.get(scope)?.delete(key);
+    },
+    list: async <T>(scope: string): Promise<T[]> => {
+      if (!store.has(scope)) return [];
+      return Array.from(store.get(scope)!.values()) as T[];
+    },
+  };
+}
+
+type ContextHandler = (data: {
+  sessionId: string;
+  project: string;
+  budget?: number;
+}) => Promise<{ context: string; blocks: number; tokens: number }>;
+
+function wireContext(kv: ReturnType<typeof mockKV>) {
+  let handler: ContextHandler | undefined;
+  const sdk = {
+    registerFunction: vi.fn((id: string, cb: ContextHandler) => {
+      if (id === "mem::context") handler = cb;
+    }),
+  } as unknown as import("iii-sdk").ISdk;
+  registerContextFunction(sdk, kv as never, 2000);
+  if (!handler) throw new Error("mem::context not registered");
+  return handler;
+}
+
+async function seedPinnedSlot(
+  kv: ReturnType<typeof mockKV>,
+  label: string,
+  content: string,
+  scope: "project" | "global" = "global",
+) {
+  const target = scope === "global" ? KV.globalSlots : KV.slots;
+  await kv.set(target, label, {
+    label,
+    content,
+    description: "",
+    sizeLimit: 2000,
+    pinned: true,
+    readOnly: false,
+    scope,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  });
+}
+
+describe("mem::context — pinned slot injection", () => {
+  const ORIGINAL_SLOTS_ENV = process.env["AGENTMEMORY_SLOTS"];
+
+  afterEach(() => {
+    if (ORIGINAL_SLOTS_ENV === undefined) {
+      delete process.env["AGENTMEMORY_SLOTS"];
+    } else {
+      process.env["AGENTMEMORY_SLOTS"] = ORIGINAL_SLOTS_ENV;
+    }
+  });
+
+  describe("when AGENTMEMORY_SLOTS=true", () => {
+    let kv: ReturnType<typeof mockKV>;
+    let handler: ContextHandler;
+
+    beforeEach(() => {
+      process.env["AGENTMEMORY_SLOTS"] = "true";
+      kv = mockKV();
+      handler = wireContext(kv);
+    });
+
+    it("includes pinned global slot content in returned context", async () => {
+      await seedPinnedSlot(kv, "tool_guidelines", "rule-alpha", "global");
+
+      const result = await handler({
+        sessionId: "ses_a",
+        project: "/tmp/proj",
+      });
+
+      expect(result.context).toContain("tool_guidelines");
+      expect(result.context).toContain("rule-alpha");
+      expect(result.blocks).toBeGreaterThan(0);
+    });
+
+    it("renders multiple pinned slots, sorted by label", async () => {
+      await seedPinnedSlot(kv, "user_preferences", "pref-alpha", "global");
+      await seedPinnedSlot(kv, "tool_guidelines", "rule-alpha", "global");
+
+      const result = await handler({
+        sessionId: "ses_b",
+        project: "/tmp/proj",
+      });
+
+      const guidelinesIdx = result.context.indexOf("tool_guidelines");
+      const prefsIdx = result.context.indexOf("user_preferences");
+      expect(guidelinesIdx).toBeGreaterThan(-1);
+      expect(prefsIdx).toBeGreaterThan(-1);
+      expect(guidelinesIdx).toBeLessThan(prefsIdx);
+    });
+
+    it("skips unpinned slots even when they have content", async () => {
+      await kv.set(KV.globalSlots, "self_notes", {
+        label: "self_notes",
+        content: "unpinned-content-alpha",
+        description: "",
+        sizeLimit: 1500,
+        pinned: false,
+        readOnly: false,
+        scope: "global",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      });
+
+      const result = await handler({
+        sessionId: "ses_c",
+        project: "/tmp/proj",
+      });
+
+      expect(result.context).not.toContain("unpinned-content-alpha");
+    });
+
+    it("skips empty pinned slots (the seeded defaults)", async () => {
+      await seedPinnedSlot(kv, "persona", "", "global");
+
+      const result = await handler({
+        sessionId: "ses_d",
+        project: "/tmp/proj",
+      });
+
+      expect(result.context).not.toContain("persona");
+    });
+
+    it("project-scoped slot shadows global slot with the same label", async () => {
+      await seedPinnedSlot(kv, "tool_guidelines", "global-value", "global");
+      await seedPinnedSlot(kv, "tool_guidelines", "project-value", "project");
+
+      const result = await handler({
+        sessionId: "ses_e",
+        project: "/tmp/proj",
+      });
+
+      expect(result.context).toContain("project-value");
+      expect(result.context).not.toContain("global-value");
+    });
+  });
+
+  describe("when AGENTMEMORY_SLOTS is off", () => {
+    it("does not include any slot content", async () => {
+      delete process.env["AGENTMEMORY_SLOTS"];
+      const kv = mockKV();
+      const handler = wireContext(kv);
+
+      await seedPinnedSlot(kv, "tool_guidelines", "rule-alpha", "global");
+
+      const result = await handler({
+        sessionId: "ses_f",
+        project: "/tmp/proj",
+      });
+
+      expect(result.context).not.toContain("tool_guidelines");
+      expect(result.context).not.toContain("rule-alpha");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #286. `renderPinnedContext` and `listPinnedSlots` were introduced in #182 and tested in `test/slots.test.ts`, but no code path actually invokes them. `mem::context` — the function `/agentmemory/session/start` calls and that `session-start.mjs` reads back into Claude Code — reads profile / sessions / observations but never reads slots, so pinned content stays in KV and never reaches the conversation.

#182's description hedged with "pinned slots **can be** injected into SessionStart context" and "pinned slots are **candidates for** SessionStart injection". The helpers and unit tests landed; the wiring didn't.

## Fix

Add the `listPinnedSlots` → `renderPinnedContext` call at the top of `mem::context`, gated by `isSlotsEnabled()`:

```ts
if (isSlotsEnabled()) {
  const slotContent = renderPinnedContext(
    await listPinnedSlots(kv).catch(() => []),
  );
  if (slotContent) {
    blocks.push({
      type: "memory",
      content: slotContent,
      tokens: estimateTokens(slotContent),
      recency: Date.now(),
    });
  }
}
```

`recency: Date.now()` so the pinned block sorts to the top of the budget-bounded selection. Mirrors how `isGraphExtractionEnabled()` guards `mem::graph-extract` after #215.

`AGENTMEMORY_SLOTS=false` (the default) and `AGENTMEMORY_INJECT_CONTEXT=false` (also the default) both keep the existing behaviour untouched — the gate composition matches the established opt-in convention (#138, #143, #160, #179).

## On cross-project visibility

This PR uses the same `listPinnedSlots(kv)` reader as the existing `mem::slot-list` / `memory_slot_list` / `memory_slot_get` APIs and the `mem::slot-reflect` writer. Project-scoped slot storage (`KV.slots = "mem:slots"`) is keyed by label without a project prefix today, so cross-project visibility already exists via the slot list/get tools and via reflect. This PR doesn't change the underlying isolation model; if tighter per-project keying is wanted, that's an orthogonal concern in the slot storage layer.

## Verify

```bash
# server: AGENTMEMORY_SLOTS=true AGENTMEMORY_INJECT_CONTEXT=true
curl -X POST localhost:3111/agentmemory/slot/replace \
  -H 'Content-Type: application/json' \
  -d '{"label":"tool_guidelines","content":"rule-alpha"}'

curl -X POST localhost:3111/agentmemory/session/start \
  -H 'Content-Type: application/json' \
  -d '{"sessionId":"s1","project":"/tmp","cwd":"/tmp"}'
```

Before: `"context": ""` (0 chars).
After: `context` contains the `tool_guidelines` slot wrapped in `<agentmemory-context>`.

## Tests

6 cases in `test/context-slots.test.ts`:

- pinned global slot lands in returned context
- multiple pinned slots render in label-sorted order
- unpinned slots are excluded even with content
- empty pinned slots (the seeded defaults) are excluded
- project-scoped slot shadows global slot with the same label
- `AGENTMEMORY_SLOTS=off` path emits nothing

`npm test` for the file: 6/6 pass. Pre-existing failures in `test/mcp-standalone.test.ts` and `test/fs-watcher.test.ts` are unaffected by this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Support for pinned slots in context memory: when enabled, pinned slot content is injected into memory blocks, sorted by label, with project-scoped slots overriding global ones. If disabled, no pinned content is included.

* **Tests**
  * Added tests verifying pinned slot injection behavior across configurations and precedence rules.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/288)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
