### PR TITLE
fix(providers/minimax): use shared env loader + bump default base URL (#285)

### DIFF
--- a/src/providers/minimax.ts
+++ b/src/providers/minimax.ts
@@ -1,4 +1,5 @@
 import type { MemoryProvider } from '../types.js'
+import { getEnvVar } from '../config.js'
 
 /**
  * MiniMax provider using raw fetch to call MiniMax's Anthropic-compatible API.
@@ -6,13 +7,13 @@ import type { MemoryProvider } from '../types.js'
  * The Anthropic SDK automatically injects `x-stainless-*` headers that MiniMax
  * rejects with 403. This provider bypasses the SDK and calls the API directly.
  *
- * Required env vars:
+ * Required env vars (loaded from ~/.agentmemory/.env or process.env):
  *   MINIMAX_API_KEY  — your MiniMax API key
  *   MINIMAX_MODEL    — model name (default: MiniMax-M2.7)
  *   MAX_TOKENS       — max output tokens (default: 800; MiniMax-M2.7 needs ≤800)
  *
  * Optional:
- *   MINIMAX_BASE_URL — base URL without path (default: https://api.minimaxi.com/anthropic)
+ *   MINIMAX_BASE_URL — base URL without path (default: https://api.minimax.io/anthropic)
  */
 export class MinimaxProvider implements MemoryProvider {
   name = 'minimax'
@@ -26,7 +27,7 @@ export class MinimaxProvider implements MemoryProvider {
     this.model = model
     this.maxTokens = maxTokens
     this.baseUrl =
-      process.env['MINIMAX_BASE_URL'] || 'https://api.minimaxi.com/anthropic'
+      getEnvVar('MINIMAX_BASE_URL') || 'https://api.minimax.io/anthropic'
   }
 
   async compress(systemPrompt: string, userPrompt: string): Promise<string> {

--- a/test/minimax-provider.test.ts
+++ b/test/minimax-provider.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, afterEach } from "vitest";
+import { MinimaxProvider } from "../src/providers/minimax.js";
+
+describe("MinimaxProvider — base URL resolution (#285)", () => {
+  const originalEnv = process.env["MINIMAX_BASE_URL"];
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env["MINIMAX_BASE_URL"];
+    } else {
+      process.env["MINIMAX_BASE_URL"] = originalEnv;
+    }
+  });
+
+  it("defaults to https://api.minimax.io/anthropic (not the legacy minimaxi.com host)", () => {
+    delete process.env["MINIMAX_BASE_URL"];
+    const provider = new MinimaxProvider("test-key", "MiniMax-M2.7", 800);
+    expect((provider as unknown as { baseUrl: string }).baseUrl).toBe(
+      "https://api.minimax.io/anthropic",
+    );
+  });
+
+  it("honors MINIMAX_BASE_URL via getEnvVar (merged ~/.agentmemory/.env + process.env)", () => {
+    process.env["MINIMAX_BASE_URL"] = "https://custom.example.com/anthropic";
+    const provider = new MinimaxProvider("test-key", "MiniMax-M2.7", 800);
+    expect((provider as unknown as { baseUrl: string }).baseUrl).toBe(
+      "https://custom.example.com/anthropic",
+    );
+  });
+});


### PR DESCRIPTION
## Reproduction

[@rager306](https://github.com/rager306) on [#285](https://github.com/rohitg00/agentmemory/issues/285):

- agentmemory **v0.9.8** with `MINIMAX_API_KEY` + `MINIMAX_BASE_URL=https://api.minimax.io/anthropic` in `~/.agentmemory/.env` (not exported into the shell).
- Compression fails with `MiniMax API error 401: invalid api key` against a verified-good key.
- Direct `curl https://api.minimax.io/anthropic/v1/messages` with the same key → **200 OK**.
- Control `curl https://api.minimaxi.com/anthropic/v1/messages` with the same key → **401**.

The 401 was the *stale fallback host* answering, not the key.

## Root cause: split-brain env source

`src/config.ts` (provider detection + API-key load) reads `~/.agentmemory/.env` through `getMergedEnv()`. `src/providers/minimax.ts` read `MINIMAX_BASE_URL` straight off `process.env`:

```ts
// before
this.baseUrl =
  process.env['MINIMAX_BASE_URL'] || 'https://api.minimaxi.com/anthropic'
```

Deployments that put MiniMax config in `~/.agentmemory/.env` only (systemd / launchd / Docker `--env-file` not loaded into the worker shell) got `MINIMAX_API_KEY` loaded fine, but `MINIMAX_BASE_URL` fell through to the stale `api.minimaxi.com` default → 401 against a healthy key.

MiniMax's current Anthropic-compatible endpoint per [their docs](https://platform.minimax.io/docs/api-reference/text-anthropic-api) is `api.minimax.io/anthropic/v1/messages`.

## Fix

```ts
// after
this.baseUrl =
  getEnvVar('MINIMAX_BASE_URL') || 'https://api.minimax.io/anthropic'
```

- Switch base-URL resolution to the shared `getEnvVar()` (merged `~/.agentmemory/.env` + `process.env`), matching how every other agentmemory config knob is loaded.
- Bump the default host from `api.minimaxi.com` → `api.minimax.io`.
- Update the inline JSDoc to mention `~/.agentmemory/.env` as a source so the env contract is discoverable from the file.
- New `test/minimax-provider.test.ts` asserts the default is the current host and `MINIMAX_BASE_URL` is honored.

## Verification

- [x] `npm test` — **862 / 862** (860 baseline + 2 new tests).
- [x] @rager306 already verified end-to-end that the same change fixed his `/agentmemory/observe` + compression flow live.

## Next

Cut **v0.9.9** after this lands so deployments hitting the stale `api.minimaxi.com` host don't need to manually set `MINIMAX_BASE_URL` to recover.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected the default Minimax API endpoint URL to point to the proper service

* **New Features**
  * Added support for customizing the Minimax API base URL through environment configuration

* **Tests**
  * Added tests for base URL resolution behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/289)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->