### PR TITLE
fix: validate sentinel regex patterns

### DIFF
--- a/src/functions/sentinels.ts
+++ b/src/functions/sentinels.ts
@@ -14,6 +14,85 @@ const VALID_TYPES: Sentinel["type"][] = [
   "custom",
 ];
 
+const MAX_PATTERN_LENGTH = 512;
+const BACKREFERENCE_PATTERN = /\\[1-9]/;
+
+type CompiledPattern =
+  | { regex: RegExp }
+  | { error: string };
+
+function readUnboundedQuantifier(source: string, index: number): number | null {
+  const current = source[index];
+  if (current === "*" || current === "+") return index + 1;
+  if (current !== "{") return null;
+
+  const match = source.slice(index).match(/^\{\d+,\}/);
+  return match ? index + match[0].length : null;
+}
+
+function hasNestedUnboundedQuantifier(pattern: string): boolean {
+  const maskedPattern = pattern.replace(/\\.|\[(?:\\.|[^\]\\])*\]/g, "_");
+  const groupHasUnboundedQuantifier = [false];
+
+  for (let i = 0; i < maskedPattern.length; i++) {
+    const current = maskedPattern[i];
+    if (current === "(") {
+      groupHasUnboundedQuantifier.push(false);
+      continue;
+    }
+
+    if (current === ")") {
+      const groupHasInner = groupHasUnboundedQuantifier.pop() ?? false;
+      const quantifierEnd = readUnboundedQuantifier(maskedPattern, i + 1);
+      if (quantifierEnd !== null) {
+        if (groupHasInner) return true;
+        groupHasUnboundedQuantifier[groupHasUnboundedQuantifier.length - 1] =
+          true;
+        i = quantifierEnd - 1;
+        continue;
+      }
+      if (groupHasInner) {
+        groupHasUnboundedQuantifier[groupHasUnboundedQuantifier.length - 1] =
+          true;
+      }
+      continue;
+    }
+
+    const quantifierEnd = readUnboundedQuantifier(maskedPattern, i);
+    if (quantifierEnd !== null) {
+      groupHasUnboundedQuantifier[groupHasUnboundedQuantifier.length - 1] =
+        true;
+      i = quantifierEnd - 1;
+    }
+  }
+
+  return false;
+}
+
+function compileSentinelPattern(pattern: string): CompiledPattern {
+  if (pattern.length > MAX_PATTERN_LENGTH) {
+    return {
+      error: `pattern config must be ${MAX_PATTERN_LENGTH} characters or less`,
+    };
+  }
+
+  let regex: RegExp;
+  try {
+    regex = new RegExp(pattern, "i");
+  } catch {
+    return { error: "pattern config requires a valid regex" };
+  }
+
+  if (
+    BACKREFERENCE_PATTERN.test(pattern) ||
+    hasNestedUnboundedQuantifier(pattern)
+  ) {
+    return { error: "pattern config contains an unsafe regex" };
+  }
+
+  return { regex };
+}
+
 export function registerSentinelsFunction(sdk: ISdk, kv: StateKV): void {
   sdk.registerFunction("mem::sentinel-create", 
     async (data: {
@@ -58,6 +137,10 @@ export function registerSentinelsFunction(sdk: ISdk, kv: StateKV): void {
             success: false,
             error: "pattern config requires a pattern string",
           };
+        }
+        const compiled = compileSentinelPattern(cfg.pattern);
+        if ("error" in compiled) {
+          return { success: false, error: compiled.error };
         }
       }
 
@@ -261,7 +344,10 @@ export function registerSentinelsFunction(sdk: ISdk, kv: StateKV): void {
 
         if (sentinel.type === "pattern") {
           const cfg = sentinel.config as { pattern: string };
-          const regex = new RegExp(cfg.pattern, "i");
+          if (typeof cfg.pattern !== "string") continue;
+          const compiled = compileSentinelPattern(cfg.pattern);
+          if ("error" in compiled) continue;
+          const regex = compiled.regex;
           const sessions = await kv.list<Session>(KV.sessions);
           let matchedObs: CompressedObservation | null = null;
 

--- a/test/sentinels.test.ts
+++ b/test/sentinels.test.ts
@@ -217,6 +217,28 @@ describe("Sentinels Functions", () => {
       expect(result.error).toContain("pattern config requires");
     });
 
+    it("returns error for pattern config with invalid regex syntax", async () => {
+      const result = (await sdk.trigger("mem::sentinel-create", {
+        name: "bad-regex",
+        type: "pattern",
+        config: { pattern: "(" },
+      })) as { success: boolean; error: string };
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("valid regex");
+    });
+
+    it("returns error for pattern config with nested quantifiers", async () => {
+      const result = (await sdk.trigger("mem::sentinel-create", {
+        name: "redos-pattern",
+        type: "pattern",
+        config: { pattern: "(a+)+$" },
+      })) as { success: boolean; error: string };
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("unsafe regex");
+    });
+
     it("returns error for webhook config missing path", async () => {
       const result = (await sdk.trigger("mem::sentinel-create", {
         name: "bad-webhook",
@@ -622,6 +644,28 @@ describe("Sentinels Functions", () => {
       expect(result.success).toBe(true);
       expect(result.triggered).toEqual([]);
       expect(result.checkedCount).toBe(0);
+    });
+
+    it("skips legacy pattern sentinels with invalid regex syntax", async () => {
+      await kv.set("mem:sentinels", "snl_legacy_invalid", {
+        id: "snl_legacy_invalid",
+        name: "legacy-invalid",
+        type: "pattern",
+        status: "watching",
+        config: { pattern: "(" },
+        createdAt: new Date().toISOString(),
+        linkedActionIds: [],
+      });
+
+      const result = (await sdk.trigger("mem::sentinel-check", {})) as {
+        success: boolean;
+        triggered: string[];
+        checkedCount: number;
+      };
+
+      expect(result.success).toBe(true);
+      expect(result.triggered).toEqual([]);
+      expect(result.checkedCount).toBe(1);
     });
   });
 });


### PR DESCRIPTION
Fixes #263.

## Summary
- validate pattern sentinel regexes before storing them
- reject invalid syntax, backreferences, overly long patterns, and common nested unbounded quantifiers
- reuse the same guard in `mem::sentinel-check` so old persisted bad patterns do not crash the check loop

## Verification
- `npm test -- --run test/sentinels.test.ts`
- `npx tsdown src/functions/sentinels.ts --dts false --format esm --target node20 --out-dir .tmp-sentinel-build`
- `git diff --check HEAD~1..HEAD`

## Local notes
- Full `npm test` is blocked on this Windows checkout by existing path/symlink-sensitive failures in `test/obsidian-export.test.ts` and `test/compress-file.test.ts`.
- `npm run build` reaches the tsdown build, then fails on the POSIX post-build copy chain (`cp ... || true`) under PowerShell.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for pattern sentinels to prevent unsafe regex configurations.
  * Patterns now have a maximum length limit and are checked for dangerous constructs.
  * Invalid patterns are rejected with clear error messages during creation.
  * Legacy invalid patterns are gracefully skipped during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->