### PR TITLE
fix(openclaw): register memory capability for memory slot

### DIFF
--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -127,6 +127,7 @@ What the plugin does:
 
 - recalls relevant long-term memory before the agent starts
 - captures completed conversation turns after the agent finishes
+- registers a memory capability/runtime so `plugins.slots.memory = "agentmemory"` is accepted by current OpenClaw memory-slot builds
 - shares the same backend with Claude Code, Codex CLI, Gemini CLI, Hermes, pi, and other agents
 
 ## Troubleshooting
@@ -136,6 +137,10 @@ What the plugin does:
 **Connection refused on port 3111** — the agentmemory server is not running. Start it with `npx @agentmemory/agentmemory`.
 
 **No memories returned** — open `http://localhost:3113` and verify observations are being captured.
+
+**Memory slot shows unavailable even though the plugin loads** — your OpenClaw build may require an explicit memory capability/runtime registration for memory-slot plugins. This integration now registers that capability directly via the OpenClaw memory-core runtime API.
+
+**Docker startup fails before the server is ready** — some environments expose standalone `docker-compose` but not `docker compose`, and some do not have a reachable Docker daemon. In those cases, installing local `iii` 0.11.2 is a more reliable startup path than Docker.
 
 ## See also
 

--- a/integrations/openclaw/plugin.mjs
+++ b/integrations/openclaw/plugin.mjs
@@ -9,6 +9,8 @@
  * Start it with: npx @agentmemory/agentmemory
  */
 
+import { memoryRuntime } from "openclaw/extensions/memory-core/runtime-api";
+
 const DEFAULT_BASE_URL = "http://localhost:3111";
 const DEFAULT_TIMEOUT_MS = 5000;
 
@@ -104,6 +106,13 @@ function createClient(cfg, api) {
   return { postJson, baseUrl };
 }
 
+function buildPromptSection() {
+  return [
+    "Long-term memory provider: agentmemory.",
+    "Use recalled agentmemory context when it is relevant, but do not treat it as authoritative if it conflicts with newer workspace files or explicit user instructions."
+  ];
+}
+
 const plugin = {
   id: "agentmemory",
   name: "agentmemory",
@@ -119,6 +128,11 @@ const plugin = {
       timeout_ms: api.pluginConfig?.timeout_ms || DEFAULT_TIMEOUT_MS,
     };
     const client = createClient(cfg, api);
+
+    api.registerMemoryCapability({
+      promptBuilder: buildPromptSection,
+      runtime: memoryRuntime,
+    });
 
     api.on("before_agent_start", async (event) => {
       if (!cfg.enabled) return;


### PR DESCRIPTION
## What broke

On OpenClaw 2026.4.9, the `agentmemory` OpenClaw integration loaded as a plugin and its recall/capture hooks worked, but `plugins.slots.memory = "agentmemory"` still left memory in an `unavailable` state.

The root cause was that the plugin declared itself as a memory plugin, but did not register an actual memory capability/runtime for the current OpenClaw memory-slot contract.

## What this changes

- registers `api.registerMemoryCapability({ promptBuilder, runtime })`
- reuses OpenClaw's memory-core runtime API for the slot runtime adapter
- keeps the existing `before_agent_start` recall and `agent_end` capture hooks intact
- updates the OpenClaw README with the new slot-compatibility behavior
- documents the Docker startup caveat observed in the field

## Why this matters

Without this patch:
- plugin loads
- REST API works
- hook recall/capture exists
- but the OpenClaw memory slot still reports unavailable

With this patch:
- `plugins.slots.memory = "agentmemory"` is accepted by the tested OpenClaw build
- OpenClaw status reports `plugin agentmemory` instead of `unavailable`

## Extra note

While testing, Docker startup was also fragile in environments that expose standalone `docker-compose` instead of `docker compose`, or where the Docker daemon is unavailable. Installing local `iii` 0.11.2 was the reliable path in that setup, so I documented that too.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added memory capability support for OpenClaw integration, enabling `plugins.slots.memory = "agentmemory"` configuration.

* **Documentation**
  * Enhanced troubleshooting section with guidance on memory capability registration for specific builds.
  * Added Docker Compose compatibility troubleshooting and local startup path recommendations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/302)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->