### PR TITLE
docs(readme): add Trendshift badge + star history graph + tagline fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,7 @@
   <a href="https://trendshift.io/repositories/25123" target="_blank"><img src="https://trendshift.io/api/badge/repositories/25123" alt="rohitg00/agentmemory | Trendshift" width="250" height="55"/></a>
 </p>
 
-<p align="center">
-  <a href="https://star-history.com/#rohitg00/agentmemory&Date"><img src="https://api.star-history.com/svg?repos=rohitg00/agentmemory&type=Date" alt="Stargazers over time" width="720" /></a>
-</p>
+[![Stargazers over time](https://api.star-history.com/svg?repos=rohitg00/agentmemory&type=Date)](https://star-history.com/#rohitg00/agentmemory&Date)
 
 <p align="center">
   <a href="https://gist.github.com/rohitg00/2067ab416f7bbe447c1977edaaa681e2"><img src="https://img.shields.io/badge/Viral%20GitHub%20Gist-1200%20stars%20%2F%20172%20forks-FF6B35?style=for-the-badge&logo=github&logoColor=white&labelColor=1a1a1a" alt="Design doc: 1200 stars / 172 forks on the gist" /></a>

--- a/README.md
+++ b/README.md
@@ -15,13 +15,7 @@
 </p>
 
 <p align="center">
-  <a href="https://star-history.com/#rohitg00/agentmemory&Date">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=rohitg00/agentmemory&type=Date&theme=dark" />
-      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=rohitg00/agentmemory&type=Date" />
-      <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=rohitg00/agentmemory&type=Date" width="720" />
-    </picture>
-  </a>
+  <a href="https://star-history.com/#rohitg00/agentmemory&Date"><img src="https://api.star-history.com/svg?repos=rohitg00/agentmemory&type=Date" alt="Stargazers over time" width="720" /></a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -6,8 +6,22 @@
   <strong>
     Your coding agent remembers everything. No more re-explaining.
     Built on <a href="https://github.com/iii-hq/iii">iii engine</a>
-  </strong></br>
-  Persistent memory for Claude Code, Cursor, Gemini CLI, Codex CLI, pi, OpenCode, and any MCP client.
+  </strong><br/>
+  Persistent memory for Claude Code, Cursor, Gemini CLI, Codex CLI, Hermes, OpenClaw, pi, OpenCode, and any MCP client.
+</p>
+
+<p align="center">
+  <a href="https://trendshift.io/repositories/25123" target="_blank"><img src="https://trendshift.io/api/badge/repositories/25123" alt="rohitg00/agentmemory | Trendshift" width="250" height="55"/></a>
+</p>
+
+<p align="center">
+  <a href="https://star-history.com/#rohitg00/agentmemory&Date">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=rohitg00/agentmemory&type=Date&theme=dark" />
+      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=rohitg00/agentmemory&type=Date" />
+      <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=rohitg00/agentmemory&type=Date" width="720" />
+    </picture>
+  </a>
 </p>
 
 <p align="center">
@@ -15,7 +29,7 @@
 </p>
 
 <p align="center">
-  <strong>The gist extends Karpathy's LLM Wiki pattern with confidence scoring, lifecycle, knowledge graphs, and hybrid search.<br/> agentmemory is the implementation.</strong>
+  <em>The gist extends Karpathy's LLM Wiki pattern with confidence scoring, lifecycle, knowledge graphs, and hybrid search — agentmemory is the implementation.</em>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -14,7 +14,15 @@
   <a href="https://trendshift.io/repositories/25123" target="_blank"><img src="https://trendshift.io/api/badge/repositories/25123" alt="rohitg00/agentmemory | Trendshift" width="250" height="55"/></a>
 </p>
 
-[![Stargazers over time](https://api.star-history.com/svg?repos=rohitg00/agentmemory&type=Date)](https://star-history.com/#rohitg00/agentmemory&Date)
+<p align="center">
+  <a href="https://www.star-history.com/?repos=rohitg00%2Fagentmemory&type=date&legend=top-left">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=rohitg00/agentmemory&type=date&theme=dark&legend=top-left" />
+      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=rohitg00/agentmemory&type=date&legend=top-left" />
+      <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=rohitg00/agentmemory&type=date&legend=top-left" />
+    </picture>
+  </a>
+</p>
 
 <p align="center">
   <a href="https://gist.github.com/rohitg00/2067ab416f7bbe447c1977edaaa681e2"><img src="https://img.shields.io/badge/Viral%20GitHub%20Gist-1200%20stars%20%2F%20172%20forks-FF6B35?style=for-the-badge&logo=github&logoColor=white&labelColor=1a1a1a" alt="Design doc: 1200 stars / 172 forks on the gist" /></a>

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@
 </p>
 
 <p align="center">
-  <a href="https://gist.github.com/rohitg00/2067ab416f7bbe447c1977edaaa681e2"><img src="https://img.shields.io/badge/Viral%20GitHub%20Gist-1050%20stars%20%2F%20150%20forks-FF6B35?style=for-the-badge&logo=github&logoColor=white&labelColor=1a1a1a" alt="Design doc: 1050 stars / 150 forks on the gist" /></a>
+  <a href="https://gist.github.com/rohitg00/2067ab416f7bbe447c1977edaaa681e2"><img src="https://img.shields.io/badge/Viral%20GitHub%20Gist-1200%20stars%20%2F%20172%20forks-FF6B35?style=for-the-badge&logo=github&logoColor=white&labelColor=1a1a1a" alt="Design doc: 1200 stars / 172 forks on the gist" /></a>
 </p>
 
 <p align="center">
-  <em>The gist extends Karpathy's LLM Wiki pattern with confidence scoring, lifecycle, knowledge graphs, and hybrid search — agentmemory is the implementation.</em>
+  <em>The gist extends Karpathy's LLM Wiki pattern with confidence scoring, lifecycle, knowledge graphs, and hybrid search: agentmemory is the implementation.</em>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

Four small README polishes flagged on the live README screenshot:

1. **Trendshift badge** (repo #25123) under the tagline so the trending signal sits at eye level with the banner.
2. **Star history graph** under the badge via `star-history.com` — uses `<picture>` with dark/light `prefers-color-scheme` variants matching the rest of the README's pattern.
3. **Tagline** missed two first-party integrations that already ship plugin folders in this repo (`integrations/hermes`, `integrations/openclaw`); added **Hermes + OpenClaw** to the agent list.
4. **Karpathy-gist sentence** reflows onto a single italic line. The previous `<strong>` + `<br/>` shape wrapped awkwardly on narrower viewports.

## Not in this PR (deferred)

- Stat-tag row redesign flagged on the same screenshot ("make them minimal beautiful" arrow at the row of recall %, fewer tokens, MCP tools, hooks, deps, tests). Needs new SVG assets in `assets/tags/` and is worth doing as a separate visual pass rather than a quick edit.

## Test plan

- [x] `git diff --stat README.md` — 17 insertions, 3 deletions, no code touched.
- [ ] Visual check on the rendered README after merge — Trendshift badge + star history graph should render on both light and dark GitHub themes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved README hero/header formatting for clearer hierarchy and visual presentation.
  * Separated headline and tagline for better emphasis and readability.
  * Updated “Viral GitHub Gist” badge counts and rephrased the descriptive line into emphasized italic text for clearer presentation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/305)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->