### PR TITLE
fix(openclaw): claim plugins.slots.memory via registerMemoryCapability

### DIFF
--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -125,13 +125,20 @@ Then enable it in `~/.openclaw/openclaw.json`:
 
 What the plugin does:
 
-- recalls relevant long-term memory before the agent starts
-- captures completed conversation turns after the agent finishes
+- claims the `plugins.slots.memory = "agentmemory"` slot via `api.registerMemoryCapability({ promptBuilder })` so OpenClaw recognises it as the active memory plugin
+- recalls relevant long-term memory before the agent starts (via the `before_agent_start` hook)
+- captures completed conversation turns after the agent finishes (via the `agent_end` hook)
 - shares the same backend with Claude Code, Codex CLI, Gemini CLI, Hermes, pi, and other agents
+
+### Memory runtime (current scope)
+
+The plugin currently registers a `promptBuilder` only — not a full `MemoryPluginRuntime` adapter. OpenClaw's `MemoryRuntimeBackendConfig` type today is `{ backend: "builtin" }` or `{ backend: "qmd" }`; both are openclaw-internal backends that don't fit agentmemory's external REST shape. The hook-driven recall + capture flow above is the working integration path. If you need OpenClaw's in-process memory-runtime APIs (e.g. `getMemorySearchManager`) backed by agentmemory, file an upstream request against `openclaw` for an `"external"` backend type and we'll wire `runtime` here once the contract supports it.
 
 ## Troubleshooting
 
 **Plugin validates but does not load** — make sure the folder contains `package.json`, `openclaw.plugin.json`, and `plugin.mjs`, and that `plugins.slots.memory` is set to `agentmemory`.
+
+**`plugins.slots.memory = "agentmemory"` reports `unavailable`** — upgrade to v0.9.11+. Older versions of this plugin registered hooks but never called `api.registerMemoryCapability(...)`, so the memory-slot machinery did not consider the slot claimed. The current plugin registers a memory capability (prompt builder) at startup, which is the documented OpenClaw API for occupying the slot.
 
 **Connection refused on port 3111** — the agentmemory server is not running. Start it with `npx @agentmemory/agentmemory`.
 

--- a/integrations/openclaw/plugin.mjs
+++ b/integrations/openclaw/plugin.mjs
@@ -123,7 +123,10 @@ const plugin = {
 
     if (typeof api.registerMemoryCapability === "function") {
       api.registerMemoryCapability({
-        promptBuilder: () => [
+        // OpenClaw passes { availableTools: Set<string>, citationsMode? }. We
+        // don't currently branch on tool availability, but accept the params
+        // object so the signature matches MemoryPromptSectionBuilder exactly.
+        promptBuilder: (_params) => [
           "Long-term memory provider: agentmemory (external REST service on " +
             client.baseUrl +
             ").",

--- a/integrations/openclaw/plugin.mjs
+++ b/integrations/openclaw/plugin.mjs
@@ -2,8 +2,9 @@
  * agentmemory plugin for OpenClaw
  *
  * Deeper integration than raw MCP:
- * - recalls relevant memories before the agent starts
- * - captures completed conversation turns after the agent finishes
+ * - claims the plugins.slots.memory slot via api.registerMemoryCapability({ promptBuilder })
+ * - recalls relevant memories before the agent starts (before_agent_start hook)
+ * - captures completed conversation turns after the agent finishes (agent_end hook)
  *
  * Requires the agentmemory server on localhost:3111.
  * Start it with: npx @agentmemory/agentmemory
@@ -119,6 +120,18 @@ const plugin = {
       timeout_ms: api.pluginConfig?.timeout_ms || DEFAULT_TIMEOUT_MS,
     };
     const client = createClient(cfg, api);
+
+    if (typeof api.registerMemoryCapability === "function") {
+      api.registerMemoryCapability({
+        promptBuilder: () => [
+          "Long-term memory provider: agentmemory (external REST service on " +
+            client.baseUrl +
+            ").",
+          "agentmemory recalls relevant prior observations before each turn via the before_agent_start hook and captures completed turns via agent_end.",
+          "Treat recalled context as background, not authoritative — prefer current workspace state and explicit user instructions when they conflict.",
+        ],
+      });
+    }
 
     api.on("before_agent_start", async (event) => {
       if (!cfg.enabled) return;

--- a/test/openclaw-plugin.test.ts
+++ b/test/openclaw-plugin.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+
+type Capability = {
+  promptBuilder?: (params: {
+    availableTools: Set<string>;
+  }) => string[] | undefined;
+};
+
+type RegisterFn = (capability: Capability) => void;
+
+interface FakeApi {
+  registerMemoryCapability: RegisterFn;
+  on: ReturnType<typeof vi.fn>;
+  pluginConfig: Record<string, unknown>;
+  logger: { warn: ReturnType<typeof vi.fn> };
+}
+
+function makeApi(overrides: Partial<FakeApi> = {}): FakeApi {
+  return {
+    registerMemoryCapability: vi.fn(),
+    on: vi.fn(),
+    pluginConfig: { base_url: "http://localhost:3111" },
+    logger: { warn: vi.fn() },
+    ...overrides,
+  };
+}
+
+describe("openclaw plugin — memory capability registration (closes #286 follow-up)", () => {
+  it("calls api.registerMemoryCapability with a promptBuilder when the host supports it", async () => {
+    const mod = await import("../integrations/openclaw/plugin.mjs");
+    const plugin = (mod as unknown as { default: { register(api: FakeApi): void } }).default;
+    const api = makeApi();
+    plugin.register(api);
+    expect(api.registerMemoryCapability).toHaveBeenCalledTimes(1);
+    const capability = (api.registerMemoryCapability as ReturnType<typeof vi.fn>).mock.calls[0][0] as Capability;
+    expect(typeof capability.promptBuilder).toBe("function");
+    const lines = capability.promptBuilder?.({ availableTools: new Set() });
+    expect(Array.isArray(lines)).toBe(true);
+    expect((lines as string[]).join(" ")).toMatch(/agentmemory/i);
+  });
+
+  it("still registers hooks and tolerates older OpenClaw builds without registerMemoryCapability", async () => {
+    const mod = await import("../integrations/openclaw/plugin.mjs");
+    const plugin = (mod as unknown as { default: { register(api: FakeApi): void } }).default;
+    const api = makeApi({ registerMemoryCapability: undefined as unknown as RegisterFn });
+    expect(() => plugin.register(api)).not.toThrow();
+    expect(api.on).toHaveBeenCalled();
+    const events = (api.on as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0]);
+    expect(events).toContain("before_agent_start");
+    expect(events).toContain("agent_end");
+  });
+
+  it("promptBuilder returns lines that mention the configured base_url", async () => {
+    const mod = await import("../integrations/openclaw/plugin.mjs");
+    const plugin = (mod as unknown as { default: { register(api: FakeApi): void } }).default;
+    const api = makeApi({ pluginConfig: { base_url: "http://memory.internal:9999" } });
+    plugin.register(api);
+    const capability = (api.registerMemoryCapability as ReturnType<typeof vi.fn>).mock.calls[0][0] as Capability;
+    const lines = capability.promptBuilder?.({ availableTools: new Set() }) ?? [];
+    expect(lines.join("\n")).toMatch(/memory\.internal:9999/);
+  });
+});


### PR DESCRIPTION
## Problem

The OpenClaw integration declared `"kind": "memory"` in its manifest and wired `before_agent_start` / `agent_end` hooks, but **never called `api.registerMemoryCapability(...)`**. On OpenClaw `2026.4.9+`, `plugins.slots.memory = "agentmemory"` reported `unavailable` despite hooks running end-to-end and the REST API being healthy.

## Verified API contract

Pulled `openclaw@2026.5.7` and read the type declarations directly:

```ts
// plugin-sdk/src/plugins/types.d.ts:2028
registerMemoryCapability: (capability: MemoryPluginCapability) => void;

// plugin-sdk/src/plugins/memory-state.d.ts
export type MemoryPluginCapability = {
  promptBuilder?: MemoryPromptSectionBuilder;
  flushPlanResolver?: MemoryFlushPlanResolver;
  runtime?: MemoryPluginRuntime;
  publicArtifacts?: MemoryPluginPublicArtifactsProvider;
};

export type MemoryPromptSectionBuilder = (params: {
  availableTools: Set<string>;
  citationsMode?: MemoryCitationsMode;
}) => string[];
```

All capability fields are optional. `promptBuilder` alone is enough to claim the slot.

## Changes

### `integrations/openclaw/plugin.mjs`

```js
if (typeof api.registerMemoryCapability === "function") {
  api.registerMemoryCapability({
    promptBuilder: () => [
      "Long-term memory provider: agentmemory (external REST service on " +
        client.baseUrl + ").",
      "agentmemory recalls relevant prior observations before each turn via " +
        "the before_agent_start hook and captures completed turns via agent_end.",
      "Treat recalled context as background, not authoritative — prefer " +
        "current workspace state and explicit user instructions when they conflict.",
    ],
  });
}
```

- Guards on `typeof api.registerMemoryCapability === "function"` so older OpenClaw builds (pre-capability API) still load via the existing hook-only path. Net behaviour on older hosts unchanged.
- Returns the configured `base_url` in the prompt so the agent knows where recall is coming from.

### `integrations/openclaw/README.md`

Adds an explicit troubleshooting entry for `plugins.slots.memory = "agentmemory" reports unavailable`, points at this fix. Documents the runtime-adapter scope decision so users running deep host integrations aren't surprised.

### `test/openclaw-plugin.test.ts` (new, 3 cases)

1. `registerMemoryCapability` is called with a `promptBuilder` when the host supports it.
2. Plugin still registers hooks and does not throw on older hosts that don't expose `registerMemoryCapability`.
3. `promptBuilder` respects the configured `base_url`.

## What this PR does NOT do

**Does not register a `runtime` adapter.** OpenClaw's current `MemoryRuntimeBackendConfig` type is:

```ts
type MemoryRuntimeBackendConfig =
  | { backend: "builtin" }
  | { backend: "qmd"; qmd?: { command?: string } };
```

Both variants are in-process backends. There's no `"external"` option that fits agentmemory's REST shape. The hook-driven recall + capture flow remains the working integration path; full runtime registration is documented as a follow-up gated on an upstream OpenClaw change to add an `"external"` backend variant.

## Why a fresh PR, not #302

The closed PR #302 attempted the same end goal but:

1. Imported `memoryRuntime` from `openclaw/extensions/memory-core/runtime-api` — a path **not in the package's `exports` map**. Would have failed with `ERR_PACKAGE_PATH_NOT_EXPORTED` at load time.
2. Referenced a `memoryRuntime` symbol that **does not exist** anywhere in `openclaw@2026.5.7`.

This PR uses only `api.registerMemoryCapability(...)` directly off the api object the plugin init receives — no openclaw imports needed.

## Test plan

- [x] `npm test` — **871 / 871** (868 baseline + 3 new tests).
- [x] `npm run build` — tsdown clean.
- [ ] Smoke test on a real OpenClaw `2026.4.9+` install: `plugins.slots.memory = "agentmemory"` should now show as available; the prompt-section builder lines should appear in the assembled system prompt.
- [ ] If `unavailable` still reports after this lands, file follow-up with the exact OpenClaw build's slot-status check (might need additional optional capability fields).

Closes the bug premise originally reported in PR #302 (without picking up that PR's broken implementation).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenClaw plugin now registers memory capability when available, enabling automatic recall before interactions and capture after turns.
  * Prompt generation now reflects the configured external memory service, including its base URL.

* **Documentation**
  * Expanded README with detailed memory runtime behavior and troubleshooting guidance, including upgrade advice for registration issues.

* **Tests**
  * Added tests verifying memory capability registration, hook behavior, and prompt content.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/310)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->