### PR TITLE
feat(website): add Star on GitHub button to hero CTA row

### DIFF
--- a/website/components/GitHubStarButton.module.css
+++ b/website/components/GitHubStarButton.module.css
@@ -1,0 +1,30 @@
+.starBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.icon {
+  display: inline-block;
+  flex: 0 0 auto;
+  margin-top: -2px;
+}
+
+.label {
+  letter-spacing: 0.08em;
+}
+
+.count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.5ch;
+  padding: 0 6px;
+  margin-left: 4px;
+  border-radius: 3px;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--mist, #cfd2d1);
+  font-variant-numeric: tabular-nums;
+  font-size: 0.85em;
+  letter-spacing: 0.04em;
+}

--- a/website/components/GitHubStarButton.tsx
+++ b/website/components/GitHubStarButton.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import styles from "./GitHubStarButton.module.css";
+
+interface Props {
+  repo: string;
+}
+
+function formatStars(n: number): string {
+  if (n >= 1000) {
+    const k = n / 1000;
+    return k >= 10 ? `${Math.round(k)}k` : `${k.toFixed(1).replace(/\.0$/, "")}k`;
+  }
+  return String(n);
+}
+
+export function GitHubStarButton({ repo }: Props) {
+  const [stars, setStars] = useState<number | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const cacheKey = `gh-stars:${repo}`;
+    const cached = typeof window !== "undefined" ? window.localStorage.getItem(cacheKey) : null;
+    if (cached) {
+      try {
+        const parsed = JSON.parse(cached) as { value: number; at: number };
+        if (Date.now() - parsed.at < 30 * 60 * 1000) {
+          setStars(parsed.value);
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+    (async () => {
+      try {
+        const res = await fetch(`https://api.github.com/repos/${repo}`, {
+          headers: { Accept: "application/vnd.github+json" },
+        });
+        if (!res.ok) return;
+        const data = (await res.json()) as { stargazers_count?: number };
+        if (cancelled) return;
+        if (typeof data.stargazers_count === "number") {
+          setStars(data.stargazers_count);
+          try {
+            window.localStorage.setItem(
+              cacheKey,
+              JSON.stringify({ value: data.stargazers_count, at: Date.now() }),
+            );
+          } catch {
+            /* ignore */
+          }
+        }
+      } catch {
+        /* offline / blocked — keep cached or null */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [repo]);
+
+  return (
+    <a
+      href={`https://github.com/${repo}`}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={`btn btn--ghost ${styles.starBtn}`}
+      aria-label={`Star ${repo} on GitHub`}
+    >
+      <svg
+        aria-hidden
+        viewBox="0 0 16 16"
+        width="18"
+        height="18"
+        className={styles.icon}
+        fill="currentColor"
+      >
+        <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z" />
+      </svg>
+      <span className={styles.label}>STAR</span>
+      {stars !== null && <span className={styles.count}>{formatStars(stars)}</span>}
+    </a>
+  );
+}

--- a/website/components/Hero.tsx
+++ b/website/components/Hero.tsx
@@ -1,4 +1,5 @@
 import { MemoryGraph } from "./MemoryGraph";
+import { GitHubStarButton } from "./GitHubStarButton";
 import { getProjectMeta } from "@/lib/meta";
 import styles from "./Hero.module.css";
 
@@ -27,6 +28,7 @@ export function Hero() {
           <a href="#live" className="btn btn--ghost">
             SEE IT MOVE
           </a>
+          <GitHubStarButton repo="rohitg00/agentmemory" />
         </div>
       </div>
     </section>

--- a/website/lib/generated-meta.json
+++ b/website/lib/generated-meta.json
@@ -1,8 +1,8 @@
 {
-  "version": "0.9.7",
+  "version": "0.9.10",
   "mcpTools": 51,
   "hooks": 12,
   "restEndpoints": 121,
-  "testsPassing": 880,
-  "generatedAt": "2026-05-11T13:23:24.696Z"
+  "testsPassing": 898,
+  "generatedAt": "2026-05-12T22:49:51.241Z"
 }


### PR DESCRIPTION
## Why

Hero CTA row had **START IN 60 SECONDS** + **SEE IT MOVE** but no GitHub star path. Visitors landing from X / Reddit / HN have nowhere obvious to bookmark before they leave to install.

## What

Adds `GitHubStarButton` next to the existing ghost button.

- Ghost-style button matching the existing visual register — no new design surface
- Inline SVG star icon (currentColor, matches button text)
- **STAR** label + live star count
- Count fetches once on mount from `api.github.com/repos/rohitg00/agentmemory` (unauthenticated, 60 req/h per IP — plenty for a marketing page)
- 30-minute `localStorage` cache keyed by repo so repeat visits don't re-hit the API
- Graceful degradation: if fetch fails (offline, rate-limited, blocked), button still renders without the count

`"use client"` because the count is live. No deps added.

## Files

- `website/components/GitHubStarButton.tsx` — new
- `website/components/GitHubStarButton.module.css` — new
- `website/components/Hero.tsx` — adds `<GitHubStarButton repo="rohitg00/agentmemory" />` after `SEE IT MOVE`

## Test plan

- [x] `cd website && npm run build` — Next 16 static export clean, no type errors.
- [ ] Visual check on Vercel preview deploy: third button appears in hero CTA row, star count shows current stargazer count, button links to `https://github.com/rohitg00/agentmemory` in new tab.
- [ ] Throttle network in DevTools, reload — button renders without count, no console errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a GitHub star button to the hero section displaying the live star count
* **Chores**
  * Version bumped from 0.9.7 to 0.9.10
  * Enhanced test coverage (898 tests passing)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/316)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->