### PR TITLE
fix: preserve session start metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1026,7 +1026,7 @@ Create `~/.agentmemory/.env`:
 | Method | Path | Description |
 |--------|------|-------------|
 | `GET` | `/agentmemory/health` | Health check (always public) |
-| `POST` | `/agentmemory/session/start` | Start session + get context |
+| `POST` | `/agentmemory/session/start` | Start session + get context; accepts optional `title`, `summary`, and `firstPrompt` labels |
 | `POST` | `/agentmemory/session/end` | End session |
 | `POST` | `/agentmemory/observe` | Capture observation |
 | `POST` | `/agentmemory/smart-search` | Hybrid search |

--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -92,6 +92,11 @@ function asNonEmptyString(value: unknown): string | null {
   return trimmed ? trimmed : null;
 }
 
+function asSessionPreview(value: unknown, maxLength: number): string | null {
+  const text = asNonEmptyString(value);
+  return text ? text.replace(/\s+/g, " ").slice(0, maxLength) : null;
+}
+
 function parseOptionalFiniteNumber(value: unknown): number | undefined | null {
   if (value === undefined || value === null) return undefined;
   if (typeof value === "number") return Number.isFinite(value) ? value : null;
@@ -517,7 +522,14 @@ export function registerApiTriggers(
 
   sdk.registerFunction("api::session::start",
     async (
-      req: ApiRequest<{ sessionId: string; project: string; cwd: string }>,
+      req: ApiRequest<{
+        sessionId: string;
+        project: string;
+        cwd: string;
+        title?: string;
+        summary?: string;
+        firstPrompt?: string;
+      }>,
     ): Promise<Response> => {
       const body = (req.body ?? {}) as Record<string, unknown>;
       const sessionId = asNonEmptyString(body.sessionId);
@@ -531,6 +543,9 @@ export function registerApiTriggers(
           },
         };
       }
+      const title = asSessionPreview(body.title, 200);
+      const summary = asSessionPreview(body.summary, 300) ?? title;
+      const firstPrompt = asSessionPreview(body.firstPrompt, 200) ?? title;
       const session: Session = {
         id: sessionId,
         project,
@@ -539,6 +554,8 @@ export function registerApiTriggers(
         status: "active",
         observationCount: 0,
       };
+      if (summary) session.summary = summary;
+      if (firstPrompt) session.firstPrompt = firstPrompt;
       await kv.set(KV.sessions, sessionId, session);
       const contextResult = await sdk.trigger<
         { sessionId: string; project: string },

--- a/test/api-session-start.test.ts
+++ b/test/api-session-start.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { registerApiTriggers } from "../src/triggers/api.js";
+import { KV } from "../src/state/schema.js";
+import type { Session } from "../src/types.js";
+import { mockKV, mockSdk } from "./helpers/mocks.js";
+
+function setupApi() {
+  const sdk = mockSdk();
+  const kv = mockKV();
+  sdk.registerFunction("mem::context", async () => ({ context: "" }));
+  registerApiTriggers(sdk as never, kv as never);
+  return { sdk, kv };
+}
+
+describe("api::session::start", () => {
+  it("uses title as summary and firstPrompt fallback", async () => {
+    const { sdk, kv } = setupApi();
+
+    await sdk.trigger("api::session::start", {
+      body: {
+        sessionId: "ses_title",
+        project: "/tmp/project",
+        cwd: "/tmp/project",
+        title: "Add OpenCode memory integration",
+      },
+    });
+
+    const session = await kv.get<Session>(KV.sessions, "ses_title");
+    expect(session?.summary).toBe("Add OpenCode memory integration");
+    expect(session?.firstPrompt).toBe("Add OpenCode memory integration");
+  });
+
+  it("keeps explicit summary and firstPrompt distinct", async () => {
+    const { sdk, kv } = setupApi();
+
+    const res = (await sdk.trigger("api::session::start", {
+      body: {
+        sessionId: "ses_prompt",
+        project: "/tmp/project",
+        cwd: "/tmp/project",
+        title: "OpenCode follow-up",
+        summary: "Investigate OpenCode session names",
+        firstPrompt: "Why do OpenCode sessions show raw IDs?",
+      },
+    })) as { status_code: number; body: { session: Session } };
+
+    const session = await kv.get<Session>(KV.sessions, "ses_prompt");
+    expect(res.status_code).toBe(200);
+    expect(res.body.session.summary).toBe("Investigate OpenCode session names");
+    expect(res.body.session.firstPrompt).toBe(
+      "Why do OpenCode sessions show raw IDs?",
+    );
+    expect(session?.summary).toBe("Investigate OpenCode session names");
+    expect(session?.firstPrompt).toBe("Why do OpenCode sessions show raw IDs?");
+  });
+});


### PR DESCRIPTION
## Summary
- accept optional `title`, `summary`, and `firstPrompt` in `POST /agentmemory/session/start`
- use `title` as the fallback session label/first prompt so OpenCode-created sessions do not surface as raw IDs when prompt submission races session creation
- keep explicit `summary` and `firstPrompt` values distinct when clients provide both
- document the optional session labels in the API table

Fixes #244

## Related
- This is intentionally scoped to #244. #306 touches the same endpoint for #259 agent/session attribution metadata, but does not handle the OpenCode `title` -> `summary`/`firstPrompt` path. Happy to rebase if #306 lands first.

## Tests
- `npm run build`
- `npm test`
- `npm test -- test/api-session-start.test.ts`
