### PR TITLE
fix(fs-watcher): load agentmemory env file

### DIFF
--- a/integrations/filesystem-watcher/README.md
+++ b/integrations/filesystem-watcher/README.md
@@ -29,6 +29,12 @@ export AGENTMEMORY_SECRET=...   # only if the server requires auth
 agentmemory-fs-watcher
 ```
 
+The watcher also reads `~/.agentmemory/.env` and
+`$XDG_CONFIG_HOME/agentmemory/.env`, matching the main agentmemory service.
+Values exported in the process environment take precedence over the file. This
+is useful when the watcher runs in a container or process manager and should
+point at a shared server instead of the default `http://localhost:3111`.
+
 Every file change inside the watched roots becomes a `post_tool_use` observation whose `data.changeKind` is `file_change` or `file_delete`. The first 4 KB of each text file is included as `data.content` so retrieval can match by substring; larger files are truncated with `data.truncated: true`. Binary files are not read (set `AGENTMEMORY_FS_WATCH_ALLOW_BINARY=1` to override).
 
 Session id and project are required by the observe endpoint — set them via env, or the watcher generates a per-process `fs-watcher-<ts>-<rand>` session id and uses the first root's directory name as the project.

--- a/integrations/filesystem-watcher/README.md
+++ b/integrations/filesystem-watcher/README.md
@@ -29,11 +29,16 @@ export AGENTMEMORY_SECRET=...   # only if the server requires auth
 agentmemory-fs-watcher
 ```
 
-The watcher also reads `~/.agentmemory/.env` and
-`$XDG_CONFIG_HOME/agentmemory/.env`, matching the main agentmemory service.
-Values exported in the process environment take precedence over the file. This
-is useful when the watcher runs in a container or process manager and should
-point at a shared server instead of the default `http://localhost:3111`.
+The watcher also reads agentmemory env files, matching the main agentmemory
+service. Configuration is loaded in this order, with later sources overriding
+earlier ones:
+
+1. `~/.agentmemory/.env`
+2. `$XDG_CONFIG_HOME/agentmemory/.env`
+3. Process environment variables
+
+This is useful when the watcher runs in a container or process manager and
+should point at a shared server instead of the default `http://localhost:3111`.
 
 Every file change inside the watched roots becomes a `post_tool_use` observation whose `data.changeKind` is `file_change` or `file_delete`. The first 4 KB of each text file is included as `data.content` so retrieval can match by substring; larger files are truncated with `data.truncated: true`. Binary files are not read (set `AGENTMEMORY_FS_WATCH_ALLOW_BINARY=1` to override).
 

--- a/integrations/filesystem-watcher/watcher.mjs
+++ b/integrations/filesystem-watcher/watcher.mjs
@@ -1,4 +1,10 @@
-import { watch, promises as fsp, statSync } from "node:fs";
+import {
+  watch,
+  promises as fsp,
+  statSync,
+  existsSync,
+  readFileSync,
+} from "node:fs";
 import { resolve, relative, join, extname, sep, basename } from "node:path";
 import { randomBytes } from "node:crypto";
 
@@ -28,6 +34,50 @@ const DEFAULT_IGNORE = [
 
 const MAX_PREVIEW_BYTES = 4096;
 const DEBOUNCE_MS = 500;
+
+function parseEnvFile(content) {
+  const vars = {};
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eqIdx = trimmed.indexOf("=");
+    if (eqIdx === -1) continue;
+    const key = trimmed.slice(0, eqIdx).trim();
+    if (!key) continue;
+    let val = trimmed.slice(eqIdx + 1).trim();
+    const quoteChar = val[0] === '"' || val[0] === "'" ? val[0] : "";
+    if (quoteChar) {
+      const closeIdx = val.indexOf(quoteChar, 1);
+      val = closeIdx === -1 ? val.slice(1) : val.slice(1, closeIdx);
+    } else {
+      const hashIdx = val.indexOf(" #");
+      if (hashIdx !== -1) val = val.slice(0, hashIdx).trim();
+    }
+    vars[key] = val;
+  }
+  return vars;
+}
+
+function loadAgentMemoryEnv(env) {
+  const candidates = [];
+  const home = env.HOME || env.USERPROFILE;
+  if (home) candidates.push(join(home, ".agentmemory", ".env"));
+  if (env.XDG_CONFIG_HOME) {
+    candidates.push(join(env.XDG_CONFIG_HOME, "agentmemory", ".env"));
+  }
+
+  const fileEnv = {};
+  for (const path of candidates) {
+    try {
+      if (existsSync(path)) {
+        Object.assign(fileEnv, parseEnvFile(readFileSync(path, "utf-8")));
+      }
+    } catch {
+      // Keep watcher startup best-effort; explicit process env and defaults still apply.
+    }
+  }
+  return fileEnv;
+}
 
 export class FilesystemWatcher {
   constructor(config = {}) {
@@ -206,23 +256,24 @@ export class FilesystemWatcher {
 
 // Small helper used by tests and bin.mjs to parse env.
 export function configFromEnv(env = process.env) {
-  const roots = (env.AGENTMEMORY_FS_WATCH_DIRS || "")
+  const merged = { ...loadAgentMemoryEnv(env), ...env };
+  const roots = (merged.AGENTMEMORY_FS_WATCH_DIRS || "")
     .split(",")
     .map((s) => s.trim())
     .filter(Boolean);
-  const extraIgnore = (env.AGENTMEMORY_FS_WATCH_IGNORE || "")
+  const extraIgnore = (merged.AGENTMEMORY_FS_WATCH_IGNORE || "")
     .split(",")
     .map((s) => s.trim())
     .filter(Boolean)
     .map((s) => new RegExp(s));
   return {
     roots,
-    baseUrl: env.AGENTMEMORY_URL,
-    secret: env.AGENTMEMORY_SECRET,
-    project: env.AGENTMEMORY_PROJECT || null,
-    sessionId: env.AGENTMEMORY_SESSION_ID || null,
+    baseUrl: merged.AGENTMEMORY_URL,
+    secret: merged.AGENTMEMORY_SECRET,
+    project: merged.AGENTMEMORY_PROJECT || null,
+    sessionId: merged.AGENTMEMORY_SESSION_ID || null,
     ignorePatterns: extraIgnore,
-    allowBinary: env.AGENTMEMORY_FS_WATCH_ALLOW_BINARY === "1",
+    allowBinary: merged.AGENTMEMORY_FS_WATCH_ALLOW_BINARY === "1",
   };
 }
 

--- a/test/fs-watcher.test.ts
+++ b/test/fs-watcher.test.ts
@@ -191,4 +191,58 @@ describe("configFromEnv", () => {
     const cfg = configFromEnv({});
     expect(cfg.roots).toEqual([]);
   });
+
+  it("loads watcher settings from ~/.agentmemory/.env", () => {
+    const home = tempDir();
+    try {
+      mkdirSync(join(home, ".agentmemory"), { recursive: true });
+      writeFileSync(
+        join(home, ".agentmemory", ".env"),
+        [
+          "AGENTMEMORY_FS_WATCH_DIRS=/srv/project,/srv/notes",
+          "AGENTMEMORY_URL=http://agentmemory:3111",
+          "AGENTMEMORY_SECRET=from-file",
+          "AGENTMEMORY_PROJECT=central",
+          "AGENTMEMORY_FS_WATCH_ALLOW_BINARY=1",
+        ].join("\n"),
+      );
+
+      const cfg = configFromEnv({ HOME: home });
+
+      expect(cfg.roots).toEqual(["/srv/project", "/srv/notes"]);
+      expect(cfg.baseUrl).toBe("http://agentmemory:3111");
+      expect(cfg.secret).toBe("from-file");
+      expect(cfg.project).toBe("central");
+      expect(cfg.allowBinary).toBe(true);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("lets explicit env override ~/.agentmemory/.env", () => {
+    const home = tempDir();
+    try {
+      mkdirSync(join(home, ".agentmemory"), { recursive: true });
+      writeFileSync(
+        join(home, ".agentmemory", ".env"),
+        [
+          "AGENTMEMORY_FS_WATCH_DIRS=/srv/project",
+          "AGENTMEMORY_URL=http://agentmemory:3111",
+          "AGENTMEMORY_SECRET=from-file",
+        ].join("\n"),
+      );
+
+      const cfg = configFromEnv({
+        HOME: home,
+        AGENTMEMORY_URL: "http://override:3111",
+        AGENTMEMORY_SECRET: "from-env",
+      });
+
+      expect(cfg.roots).toEqual(["/srv/project"]);
+      expect(cfg.baseUrl).toBe("http://override:3111");
+      expect(cfg.secret).toBe("from-env");
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
 });

--- a/test/fs-watcher.test.ts
+++ b/test/fs-watcher.test.ts
@@ -219,6 +219,68 @@ describe("configFromEnv", () => {
     }
   });
 
+  it("parses env-file quoting, inline comments, open quotes, and empty values", () => {
+    const home = tempDir();
+    try {
+      mkdirSync(join(home, ".agentmemory"), { recursive: true });
+      writeFileSync(
+        join(home, ".agentmemory", ".env"),
+        [
+          'AGENTMEMORY_FS_WATCH_DIRS="/srv/incomplete',
+          "AGENTMEMORY_URL=http://agentmemory:3111 # shared server",
+          'AGENTMEMORY_PROJECT="central project"',
+          "AGENTMEMORY_SESSION_ID='watcher session'",
+          "AGENTMEMORY_SECRET=",
+          "MALFORMED_LINE_WITHOUT_EQUALS",
+        ].join("\n"),
+      );
+
+      const cfg = configFromEnv({ HOME: home });
+
+      expect(cfg.roots).toEqual(["/srv/incomplete"]);
+      expect(cfg.baseUrl).toBe("http://agentmemory:3111");
+      expect(cfg.project).toBe("central project");
+      expect(cfg.sessionId).toBe("watcher session");
+      expect(cfg.secret).toBe("");
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("lets XDG_CONFIG_HOME override ~/.agentmemory/.env", () => {
+    const home = tempDir();
+    const xdg = tempDir();
+    try {
+      mkdirSync(join(home, ".agentmemory"), { recursive: true });
+      mkdirSync(join(xdg, "agentmemory"), { recursive: true });
+      writeFileSync(
+        join(home, ".agentmemory", ".env"),
+        [
+          "AGENTMEMORY_FS_WATCH_DIRS=/home/project",
+          "AGENTMEMORY_URL=http://home:3111",
+          "AGENTMEMORY_SECRET=home-secret",
+        ].join("\n"),
+      );
+      writeFileSync(
+        join(xdg, "agentmemory", ".env"),
+        [
+          "AGENTMEMORY_FS_WATCH_DIRS=/xdg/project",
+          "AGENTMEMORY_URL=http://xdg:3111",
+          "AGENTMEMORY_SECRET=xdg-secret",
+        ].join("\n"),
+      );
+
+      const cfg = configFromEnv({ HOME: home, XDG_CONFIG_HOME: xdg });
+
+      expect(cfg.roots).toEqual(["/xdg/project"]);
+      expect(cfg.baseUrl).toBe("http://xdg:3111");
+      expect(cfg.secret).toBe("xdg-secret");
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+      rmSync(xdg, { recursive: true, force: true });
+    }
+  });
+
   it("lets explicit env override ~/.agentmemory/.env", () => {
     const home = tempDir();
     try {


### PR DESCRIPTION
## Summary
- load `~/.agentmemory/.env` and `$XDG_CONFIG_HOME/agentmemory/.env` in `@agentmemory/fs-watcher`
- keep explicit process environment values higher priority than file values
- document the fallback and add tests for file loading and env override behavior

This addresses the filesystem watcher part of #298, where a watcher running under a process manager/container could fall back to `localhost` even though the shared server URL lives in agentmemory's documented env file.

## Conflict check
- Current open PRs do not touch `integrations/filesystem-watcher/*` or `test/fs-watcher.test.ts`.

## Tests
- `npm test -- test/fs-watcher.test.ts`
- `node --check integrations/filesystem-watcher/watcher.mjs`
- `git diff --check`
- `npm run build`
- `npm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how configuration is loaded from .env files for the filesystem watcher.

* **New Features**
  * Filesystem watcher can load configuration from .env files in user config locations, with explicit process environment variables taking precedence.

* **Tests**
  * Added tests covering .env parsing, quoting/comments handling, XDG_HOME support, and environment-variable precedence.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/319)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->