### PR TITLE
fix(viewer): stabilize tab-bar height when switching tabs

### DIFF
--- a/src/viewer/index.html
+++ b/src/viewer/index.html
@@ -147,6 +147,8 @@
 
     .tab-bar {
       display: flex;
+      height: 48px;
+      flex-shrink: 0;
       border-bottom: 1px solid var(--border-light);
       background: var(--bg);
       overflow-x: auto;


### PR DESCRIPTION
Add explicit height: 48px and flex-shrink: 0 to .tab-bar to prevent dimension shifts caused by overflow-x scroll state changes on tab switch.

Closes #324

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined viewer tab bar presentation with fixed sizing to ensure consistent layout and prevent unintended visual changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/325)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->