### PR TITLE
fix(types): remove duplicate source field in RetentionScore (closes #277)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -839,7 +839,6 @@ export interface RetentionScore {
   reinforcementBoost: number;
   lastAccessed: string;
   accessCount: number;
-  source?: "episodic" | "semantic";
 }
 
 export interface DecayConfig {


### PR DESCRIPTION
## Verified bug

`src/types.ts:835` and `:842` both declared `source?: "episodic" | "semantic"` on `RetentionScore`. TypeScript silently accepts duplicate property declarations when types are identical — but the documented JSDoc on the first declaration (referencing #124 / pre-0.8.10 row back-compat) was effectively shadowed.

```ts
// before
export interface RetentionScore {
  memoryId: string;
  // ... see #124 back-compat note ...
  source?: "episodic" | "semantic";
  score: number;
  salience: number;
  temporalDecay: number;
  reinforcementBoost: number;
  lastAccessed: string;
  accessCount: number;
  source?: "episodic" | "semantic";  // ← dup
}
```

## Verified safe to remove

`grep -rn "\.source\s*=\|source:" src/ | grep -i retention` returned zero writers setting `source` on `RetentionScore`. No path could plausibly write to both shadowed declarations. Single source of truth restored, JSDoc back-compat note preserved.

## Test plan

- [x] `npm test` — **877 / 877**.
- [x] `npm run build` — tsdown clean.

Closes [#277](https://github.com/rohitg00/agentmemory/issues/277). Thanks @cl0ckt0wer for the precise file:line trace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated retention tracking data structure to support enhanced metrics including reinforcement scoring, access timing, and usage frequency monitoring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/326)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->