### PR TITLE
fix: redact filesystem watcher previews before transport

### DIFF
--- a/integrations/filesystem-watcher/watcher.mjs
+++ b/integrations/filesystem-watcher/watcher.mjs
@@ -28,6 +28,43 @@ const DEFAULT_IGNORE = [
 
 const MAX_PREVIEW_BYTES = 4096;
 const DEBOUNCE_MS = 500;
+const REDACTED = "[REDACTED]";
+
+function isDotEnvPath(path) {
+  const name = basename(path).toLowerCase();
+  return name === ".env" || name.startsWith(".env.");
+}
+
+function isSensitiveKey(key) {
+  const normalized = key.replace(/[^a-z0-9]/gi, "").toLowerCase();
+  return [
+    "apikey",
+    "accesstoken",
+    "accesskey",
+    "authorization",
+    "bearer",
+    "clientsecret",
+    "password",
+    "passwd",
+    "privatekey",
+    "pwd",
+    "secret",
+    "token",
+  ].some((needle) => normalized.includes(needle));
+}
+
+function redactSensitiveLine(line) {
+  const assignment = line.match(/^(\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_.-]*)\s*([=:])\s*)(.*)$/);
+  if (assignment && isSensitiveKey(assignment[2])) {
+    const bearer = assignment[3] === ":" ? assignment[4].match(/^(Bearer\s+).+/i) : null;
+    return `${assignment[1]}${bearer ? bearer[1] : ""}${REDACTED}`;
+  }
+  return line.replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{8,}\b/gi, `$1${REDACTED}`);
+}
+
+function redactSensitivePreview(preview) {
+  return preview.split("\n").map(redactSensitiveLine).join("\n");
+}
 
 export class FilesystemWatcher {
   constructor(config = {}) {
@@ -54,7 +91,7 @@ export class FilesystemWatcher {
   isTextFile(path) {
     if (this.allowBinary) return true;
     const ext = extname(path).toLowerCase();
-    return TEXT_EXTENSIONS.has(ext);
+    return TEXT_EXTENSIONS.has(ext) || isDotEnvPath(path);
   }
 
   async readPreview(path) {
@@ -121,6 +158,7 @@ export class FilesystemWatcher {
     let preview = null;
     if (exists && this.isTextFile(absPath)) {
       preview = await this.readPreview(absPath);
+      if (preview !== null) preview = redactSensitivePreview(preview);
     }
     const truncated = exists && size > MAX_PREVIEW_BYTES;
     const payload = {

--- a/integrations/filesystem-watcher/watcher.mjs
+++ b/integrations/filesystem-watcher/watcher.mjs
@@ -54,7 +54,9 @@ function isSensitiveKey(key) {
 }
 
 function redactSensitiveLine(line) {
-  const assignment = line.match(/^(\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_.-]*)\s*([=:])\s*)(.*)$/);
+  const assignment = line.match(
+    /^(\s*(?:export\s+)?["']?([A-Za-z_][A-Za-z0-9_.-]*)["']?\s*([=:])\s*)(.*)$/,
+  );
   if (assignment && isSensitiveKey(assignment[2])) {
     const bearer = assignment[3] === ":" ? assignment[4].match(/^(Bearer\s+).+/i) : null;
     return `${assignment[1]}${bearer ? bearer[1] : ""}${REDACTED}`;

--- a/test/fs-watcher.test.ts
+++ b/test/fs-watcher.test.ts
@@ -171,6 +171,31 @@ describe("FilesystemWatcher", () => {
     expect(content).not.toContain("live-token-value");
   });
 
+  it("redacts quoted JSON-style sensitive keys before sending observations", async () => {
+    writeFileSync(
+      join(root, "settings.json"),
+      [
+        '{',
+        '  "api_key": "json-preview-secret",',
+        '  "public_flag": "enabled"',
+        '}',
+      ].join("\n"),
+    );
+    const w = new FilesystemWatcher({
+      roots: [root],
+      baseUrl: "http://localhost:3111",
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    await w.flush(root, "settings.json");
+
+    expect(captured).toHaveLength(1);
+    const content = (captured[0].body as { data: { content: string } }).data.content;
+    expect(content).toContain('"api_key": [REDACTED]');
+    expect(content).toContain('"public_flag": "enabled"');
+    expect(content).not.toContain("json-preview-secret");
+  });
+
   it("redacts bearer tokens from regular text previews before sending observations", async () => {
     writeFileSync(join(root, "request.txt"), "Authorization: Bearer plaintext-token-value\n");
     const w = new FilesystemWatcher({

--- a/test/fs-watcher.test.ts
+++ b/test/fs-watcher.test.ts
@@ -145,6 +145,48 @@ describe("FilesystemWatcher", () => {
     }
   });
 
+  it("redacts sensitive dotenv preview values before sending observations", async () => {
+    writeFileSync(
+      join(root, ".env"),
+      [
+        "OPENAI_API_KEY=sk-test-secret-value",
+        "PUBLIC_FLAG=enabled",
+        "AUTHORIZATION=Bearer live-token-value",
+      ].join("\n"),
+    );
+    const w = new FilesystemWatcher({
+      roots: [root],
+      baseUrl: "http://localhost:3111",
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    await w.flush(root, ".env");
+
+    expect(captured).toHaveLength(1);
+    const content = (captured[0].body as { data: { content: string } }).data.content;
+    expect(content).toContain("OPENAI_API_KEY=[REDACTED]");
+    expect(content).toContain("PUBLIC_FLAG=enabled");
+    expect(content).toContain("AUTHORIZATION=[REDACTED]");
+    expect(content).not.toContain("sk-test-secret-value");
+    expect(content).not.toContain("live-token-value");
+  });
+
+  it("redacts bearer tokens from regular text previews before sending observations", async () => {
+    writeFileSync(join(root, "request.txt"), "Authorization: Bearer plaintext-token-value\n");
+    const w = new FilesystemWatcher({
+      roots: [root],
+      baseUrl: "http://localhost:3111",
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    await w.flush(root, "request.txt");
+
+    expect(captured).toHaveLength(1);
+    const content = (captured[0].body as { data: { content: string } }).data.content;
+    expect(content).toContain("Authorization: Bearer [REDACTED]");
+    expect(content).not.toContain("plaintext-token-value");
+  });
+
   it("debounces rapid writes to a single observation", async () => {
     const w = new FilesystemWatcher({
       roots: [root],


### PR DESCRIPTION
## Summary
- Redact sensitive filesystem-watcher preview lines before the observation payload is serialized and sent to `/agentmemory/observe`
- Treat dotenv filenames (`.env`, `.env.*`) as intentional text previews so they go through the same client-side redaction path instead of depending on `extname()` behavior
- Add regression coverage proving fake dotenv values, bearer-token preview values, and quoted JSON-style sensitive keys do not appear in the captured fetch body

## Why
`mem::observe` already has server-side redaction paths, but the fs-watcher sends preview content over the configured transport first. For remote/plain HTTP setups, preview redaction needs to happen in the watcher before `fetch()`.

## Conflict / duplicate check
- Open PR #319 also edits `integrations/filesystem-watcher/watcher.mjs` and `test/fs-watcher.test.ts`, but it is about loading watcher config from agentmemory env files.
- This PR is a narrower preview-payload hardening change; it may need a mechanical rebase if #319 lands first, but it does not duplicate #319’s behavior.

## Test Plan
- RED check before implementation: `PATH=/opt/homebrew/bin:$PATH npm test -- test/fs-watcher.test.ts --reporter=basic` failed on the two new redaction tests
- `PATH=/opt/homebrew/bin:$PATH npm test -- test/fs-watcher.test.ts -t "redacts" --reporter=basic`
- `PATH=/opt/homebrew/bin:$PATH npm test -- --reporter=basic` → `81 passed`, `880 passed`
- `PATH=/opt/homebrew/bin:$PATH npm run build`
- `PATH=/opt/homebrew/bin:$PATH node --check integrations/filesystem-watcher/watcher.mjs`
- `git diff --check`

Note: the initial build attempt exposed a local missing optional `rolldown` native binding; reinstalling `node_modules` with the same npm version restored the optional dependency, after which build passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File monitoring now redacts sensitive information in previews (secret keys, API tokens, bearer tokens) and recognizes environment-style files to ensure their contents are masked in emitted events.
* **Tests**
  * Added tests validating redaction behavior across dotenv-style files, JSON-style keys, and inline bearer tokens to prevent accidental exposure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/332)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
