### PR TITLE
fix(graph): report trigger failures separately

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -224,6 +224,10 @@ async function main() {
   if (isGraphExtractionEnabled()) {
     registerGraphFunction(sdk, kv, provider);
     console.log(`[agentmemory] Knowledge graph: extraction enabled`);
+  } else {
+    console.log(
+      `[agentmemory] Knowledge graph: disabled (set GRAPH_EXTRACTION_ENABLED=true in the agentmemory host environment or ~/.agentmemory/.env, then restart)`,
+    );
   }
 
   registerConsolidationPipelineFunction(sdk, kv, provider);

--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -77,6 +77,18 @@ function graphDisabledResponse(): Response {
   });
 }
 
+function graphRequestFailedResponse(functionId: string, err: unknown): Response {
+  const message = err instanceof Error ? err.message : String(err);
+  return {
+    status_code: 500,
+    body: {
+      error: "Knowledge graph request failed",
+      functionId,
+      message,
+    },
+  };
+}
+
 function consolidationDisabledResponse(): Response {
   return flagDisabledResponse({
     error: "Consolidation pipeline not enabled",
@@ -1060,11 +1072,13 @@ export function registerApiTriggers(
     ): Promise<Response> => {
       const authErr = checkAuth(req, secret);
       if (authErr) return authErr;
+      if (!isGraphExtractionEnabled()) return graphDisabledResponse();
+      const functionId = "mem::graph-query";
       try {
-        const result = await sdk.trigger({ function_id: "mem::graph-query", payload: req.body || {} });
+        const result = await sdk.trigger({ function_id: functionId, payload: req.body || {} });
         return { status_code: 200, body: result };
-      } catch {
-        return graphDisabledResponse();
+      } catch (err) {
+        return graphRequestFailedResponse(functionId, err);
       }
     },
   );
@@ -1078,11 +1092,13 @@ export function registerApiTriggers(
     async (req: ApiRequest): Promise<Response> => {
       const authErr = checkAuth(req, secret);
       if (authErr) return authErr;
+      if (!isGraphExtractionEnabled()) return graphDisabledResponse();
+      const functionId = "mem::graph-stats";
       try {
-        const result = await sdk.trigger({ function_id: "mem::graph-stats", payload: {} });
+        const result = await sdk.trigger({ function_id: functionId, payload: {} });
         return { status_code: 200, body: result };
-      } catch {
-        return graphDisabledResponse();
+      } catch (err) {
+        return graphRequestFailedResponse(functionId, err);
       }
     },
   );
@@ -1096,6 +1112,7 @@ export function registerApiTriggers(
     async (req: ApiRequest<{ observations: unknown[] }>): Promise<Response> => {
       const authErr = checkAuth(req, secret);
       if (authErr) return authErr;
+      if (!isGraphExtractionEnabled()) return graphDisabledResponse();
       if (
         !Array.isArray(req.body?.observations) ||
         req.body.observations.length === 0
@@ -1105,11 +1122,12 @@ export function registerApiTriggers(
           body: { error: "observations array is required" },
         };
       }
+      const functionId = "mem::graph-extract";
       try {
-        const result = await sdk.trigger({ function_id: "mem::graph-extract", payload: req.body });
+        const result = await sdk.trigger({ function_id: functionId, payload: req.body });
         return { status_code: 200, body: result };
-      } catch {
-        return graphDisabledResponse();
+      } catch (err) {
+        return graphRequestFailedResponse(functionId, err);
       }
     },
   );

--- a/test/api-graph.test.ts
+++ b/test/api-graph.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { registerApiTriggers } from "../src/triggers/api.js";
+
+type ApiResponse = {
+  status_code: number;
+  body: unknown;
+};
+
+type ApiHandler = (req: {
+  body?: unknown;
+  headers?: Record<string, string>;
+}) => Promise<ApiResponse>;
+
+function createSdk(
+  triggerImpl: (input: { function_id: string; payload: unknown }) => Promise<unknown>,
+) {
+  const functions = new Map<string, ApiHandler>();
+  const sdk = {
+    registerFunction: vi.fn((id: string, handler: ApiHandler) => {
+      functions.set(id, handler);
+    }),
+    registerTrigger: vi.fn(),
+    trigger: vi.fn(triggerImpl),
+  };
+
+  return { sdk, functions };
+}
+
+describe("graph REST endpoints", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it.each([
+    { apiFunction: "api::graph-query", request: { headers: {} } },
+    { apiFunction: "api::graph-stats", request: { headers: {} } },
+    { apiFunction: "api::graph-extract", request: { headers: {} } },
+  ])("returns disabled response for $apiFunction when graph extraction is off", async ({
+    apiFunction,
+    request,
+  }) => {
+    vi.stubEnv("GRAPH_EXTRACTION_ENABLED", "false");
+    const { sdk, functions } = createSdk(async () => ({ ok: true }));
+
+    registerApiTriggers(sdk as never, {} as never);
+    const response = await functions.get(apiFunction)!(request);
+
+    expect(response.status_code).toBe(503);
+    expect(response.body).toMatchObject({
+      error: "Knowledge graph not enabled",
+      flag: "GRAPH_EXTRACTION_ENABLED",
+    });
+    expect(sdk.trigger).not.toHaveBeenCalled();
+  });
+
+  it("returns graph stats when graph extraction is on", async () => {
+    vi.stubEnv("GRAPH_EXTRACTION_ENABLED", "true");
+    const stats = { success: true, nodes: 2, edges: 1 };
+    const { sdk, functions } = createSdk(async () => stats);
+
+    registerApiTriggers(sdk as never, {} as never);
+    const response = await functions.get("api::graph-stats")!({ headers: {} });
+
+    expect(response).toEqual({ status_code: 200, body: stats });
+    expect(sdk.trigger).toHaveBeenCalledWith({
+      function_id: "mem::graph-stats",
+      payload: {},
+    });
+  });
+
+  it.each([
+    {
+      apiFunction: "api::graph-query",
+      memFunction: "mem::graph-query",
+      request: { headers: {}, body: { query: "index" } },
+    },
+    {
+      apiFunction: "api::graph-stats",
+      memFunction: "mem::graph-stats",
+      request: { headers: {} },
+    },
+    {
+      apiFunction: "api::graph-extract",
+      memFunction: "mem::graph-extract",
+      request: { headers: {}, body: { observations: [{ id: "obs-1" }] } },
+    },
+  ])("reports $memFunction trigger failures separately from disabled graph extraction", async ({
+    apiFunction,
+    memFunction,
+    request,
+  }) => {
+    vi.stubEnv("GRAPH_EXTRACTION_ENABLED", "true");
+    const { sdk, functions } = createSdk(async () => {
+      throw new Error(`iii::engine Function not found: ${memFunction}`);
+    });
+
+    registerApiTriggers(sdk as never, {} as never);
+    const response = await functions.get(apiFunction)!(request);
+
+    expect(response.status_code).toBe(500);
+    expect(response.body).toMatchObject({
+      error: "Knowledge graph request failed",
+      functionId: memFunction,
+      message: `iii::engine Function not found: ${memFunction}`,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Refs #338.

The graph REST endpoints were treating every graph trigger failure as if graph extraction was disabled. That made a real backend error, for example `iii::engine Function not found: mem::graph-stats`, show up as `503 Knowledge graph not enabled`.

This keeps the disabled-flag response, but only uses it when `GRAPH_EXTRACTION_ENABLED` is actually off. If the flag is on and the underlying graph function fails, the REST endpoint now returns a 500 with the function id and the original error message. That should make reports like #338 much easier to diagnose.

I also added a startup log when graph extraction is off. The log calls out that `GRAPH_EXTRACTION_ENABLED=true` has to be set in the process running agentmemory, or in `~/.agentmemory/.env`; setting it only inside the iii Docker container will not enable graph registration for the host worker.

#308 looks related from the user's point of view because graph extraction is skipped there too, but it is a different problem: SessionEnd is unreliable, so the extraction path may never run. This PR only fixes the misleading REST error handling around #338.

## Tests

```bash
npm test -- test/api-graph.test.ts --reporter=dot
npm run build
```

Both pass locally.

I also ran `git diff --check`.

Note: the full suite still has existing failures in `test/mcp-standalone.test.ts` in this workspace. Those failures are on the standalone MCP/proxy path and are unrelated to the graph REST changes here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for knowledge graph operations, clearly distinguishing between disabled extraction and actual request failures.
  * Improved user guidance when knowledge graph extraction is not enabled with clearer activation instructions.

* **Tests**
  * Added comprehensive test coverage for knowledge graph REST endpoints to ensure reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/341)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->