### PR TITLE
feat(search): CJK tokenizer for BM25

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,6 +644,8 @@ Triple-stream retrieval combining three signals:
 
 Fused with Reciprocal Rank Fusion (RRF, k=60) and session-diversified (max 3 results per session).
 
+BM25 tokenizes Greek, Cyrillic, Hebrew, Arabic, and accented Latin out of the box. For Chinese / Japanese / Korean memories, install the optional segmenters (`npm install @node-rs/jieba tiny-segmenter`) to split CJK runs into word-level tokens; without them, agentmemory soft-falls to whole-run tokenization and prints a one-time hint on stderr.
+
 ### Embedding providers
 
 agentmemory auto-detects your provider. For best results, install local embeddings (free):

--- a/package.json
+++ b/package.json
@@ -62,9 +62,11 @@
     "zod": "^4.0.0"
   },
   "optionalDependencies": {
+    "@node-rs/jieba": "^2.0.1",
     "@xenova/transformers": "^2.17.2",
     "onnxruntime-node": "^1.14.0",
-    "onnxruntime-web": "^1.14.0"
+    "onnxruntime-web": "^1.14.0",
+    "tiny-segmenter": "^0.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/src/state/cjk-segmenter.ts
+++ b/src/state/cjk-segmenter.ts
@@ -6,8 +6,6 @@ const CJK_RE = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=H
 const HAN_RE = /\p{Script=Han}/u;
 const KANA_RE = /[\p{Script=Hiragana}\p{Script=Katakana}]/u;
 const HANGUL_RE = /\p{Script=Hangul}/u;
-const HAN_KANA_RUN_RE = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]+/gu;
-const HANGUL_RUN_RE = /\p{Script=Hangul}+/gu;
 const CJK_RUN_RE = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]+/gu;
 const HANGUL_BLOCK_RE = /[가-힯]+/g;
 
@@ -131,23 +129,32 @@ export function segmentCjk(text: string): string[] {
   if (!hasCjk(text)) return [text];
 
   const out: string[] = [];
+  let cursor = 0;
 
-  for (const m of text.matchAll(HAN_KANA_RUN_RE)) {
+  for (const m of text.matchAll(CJK_RUN_RE)) {
+    const start = m.index ?? 0;
     const run = m[0];
-    if (KANA_RE.test(run)) {
+    const end = start + run.length;
+
+    if (start > cursor) {
+      const piece = text.slice(cursor, start).trim();
+      if (piece) out.push(piece);
+    }
+
+    if (HANGUL_RE.test(run)) {
+      out.push(...segmentHangul(run));
+    } else if (KANA_RE.test(run)) {
       out.push(...segmentKana(run));
     } else {
       out.push(...segmentHan(run));
     }
+
+    cursor = end;
   }
 
-  for (const m of text.matchAll(HANGUL_RUN_RE)) {
-    out.push(...segmentHangul(m[0]));
-  }
-
-  for (const piece of text.split(CJK_RUN_RE)) {
-    const p = piece.trim();
-    if (p) out.push(p);
+  if (cursor < text.length) {
+    const trailing = text.slice(cursor).trim();
+    if (trailing) out.push(trailing);
   }
 
   return out;

--- a/src/state/cjk-segmenter.ts
+++ b/src/state/cjk-segmenter.ts
@@ -1,0 +1,162 @@
+import { createRequire } from "node:module";
+
+const cjkRequire = createRequire(import.meta.url);
+
+const CJK_RE = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u;
+const HAN_RE = /\p{Script=Han}/u;
+const KANA_RE = /[\p{Script=Hiragana}\p{Script=Katakana}]/u;
+const HANGUL_RE = /\p{Script=Hangul}/u;
+const HAN_KANA_RUN_RE = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]+/gu;
+const HANGUL_RUN_RE = /\p{Script=Hangul}+/gu;
+const CJK_RUN_RE = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]+/gu;
+const HANGUL_BLOCK_RE = /[가-힯]+/g;
+
+type Script = "han" | "kana" | "hangul" | "other";
+
+const hintShown = new Set<string>();
+
+export function hasCjk(text: string): boolean {
+  return CJK_RE.test(text);
+}
+
+export function detectScript(text: string): Script {
+  if (HAN_RE.test(text)) return "han";
+  if (KANA_RE.test(text)) return "kana";
+  if (HANGUL_RE.test(text)) return "hangul";
+  return "other";
+}
+
+function showHintOnce(key: string, message: string): void {
+  if (hintShown.has(key)) return;
+  hintShown.add(key);
+  if (typeof process !== "undefined" && process.stderr?.write) {
+    process.stderr.write(`agentmemory: ${message}\n`);
+  }
+}
+
+interface JiebaInstance {
+  cut(text: string, hmm?: boolean): string[];
+}
+
+let jiebaInstance: JiebaInstance | null = null;
+let jiebaLoaded = false;
+
+function getJieba(): JiebaInstance | null {
+  if (jiebaLoaded) return jiebaInstance;
+  jiebaLoaded = true;
+  try {
+    const mod = cjkRequire("@node-rs/jieba") as {
+      Jieba: {
+        new (): JiebaInstance;
+        withDict(dict: Uint8Array): JiebaInstance;
+      };
+    };
+    try {
+      const dictMod = cjkRequire("@node-rs/jieba/dict") as { dict: Uint8Array };
+      jiebaInstance = mod.Jieba.withDict(dictMod.dict);
+    } catch {
+      jiebaInstance = new mod.Jieba();
+    }
+    return jiebaInstance;
+  } catch {
+    showHintOnce(
+      "jieba",
+      "install @node-rs/jieba to improve Chinese search; falling back to whole-string tokenization",
+    );
+    return null;
+  }
+}
+
+interface JaSegmenter {
+  segment(text: string): string[];
+}
+
+let jaSegmenterInstance: JaSegmenter | null = null;
+let jaSegmenterLoaded = false;
+
+function getJaSegmenter(): JaSegmenter | null {
+  if (jaSegmenterLoaded) return jaSegmenterInstance;
+  jaSegmenterLoaded = true;
+  try {
+    const Ctor = cjkRequire("tiny-segmenter") as new () => JaSegmenter;
+    jaSegmenterInstance = new Ctor();
+    return jaSegmenterInstance;
+  } catch {
+    showHintOnce(
+      "tiny-segmenter",
+      "install tiny-segmenter to improve Japanese search; falling back to whole-string tokenization",
+    );
+    return null;
+  }
+}
+
+function cleanTokens(tokens: string[]): string[] {
+  const out: string[] = [];
+  for (const t of tokens) {
+    const trimmed = t.trim();
+    if (trimmed) out.push(trimmed);
+  }
+  return out;
+}
+
+function segmentHan(text: string): string[] {
+  const j = getJieba();
+  if (!j) return [text];
+  try {
+    return cleanTokens(j.cut(text, true));
+  } catch {
+    return [text];
+  }
+}
+
+function segmentKana(text: string): string[] {
+  const s = getJaSegmenter();
+  if (!s) return [text];
+  try {
+    return cleanTokens(s.segment(text));
+  } catch {
+    return [text];
+  }
+}
+
+function segmentHangul(text: string): string[] {
+  const out: string[] = [];
+  for (const m of text.matchAll(HANGUL_BLOCK_RE)) {
+    if (m[0]) out.push(m[0]);
+  }
+  return out;
+}
+
+export function segmentCjk(text: string): string[] {
+  if (!hasCjk(text)) return [text];
+
+  const out: string[] = [];
+
+  for (const m of text.matchAll(HAN_KANA_RUN_RE)) {
+    const run = m[0];
+    if (KANA_RE.test(run)) {
+      out.push(...segmentKana(run));
+    } else {
+      out.push(...segmentHan(run));
+    }
+  }
+
+  for (const m of text.matchAll(HANGUL_RUN_RE)) {
+    out.push(...segmentHangul(m[0]));
+  }
+
+  for (const piece of text.split(CJK_RUN_RE)) {
+    const p = piece.trim();
+    if (p) out.push(p);
+  }
+
+  return out;
+}
+
+export function __resetCjkSegmenterStateForTests(): void {
+  hintShown.clear();
+  jiebaInstance = null;
+  jiebaLoaded = false;
+  jaSegmenterInstance = null;
+  jaSegmenterLoaded = false;
+}

--- a/src/state/search-index.ts
+++ b/src/state/search-index.ts
@@ -1,6 +1,7 @@
 import type { CompressedObservation } from "../types.js";
 import { stem } from "./stemmer.js";
 import { getSynonyms } from "./synonyms.js";
+import { segmentCjk, hasCjk } from "./cjk-segmenter.js";
 
 interface IndexEntry {
   obsId: string;
@@ -222,11 +223,19 @@ export class SearchIndex {
   }
 
   private tokenize(text: string): string[] {
-    return text
-      .replace(/[^\p{L}\p{N}\s/.\\-_]/gu, " ")
-      .split(/\s+/)
-      .filter((t) => t.length > 1)
-      .map((t) => stem(t));
+    const cleaned = text.replace(/[^\p{L}\p{N}\s/.\\-_]/gu, " ");
+    const out: string[] = [];
+    for (const raw of cleaned.split(/\s+/)) {
+      if (raw.length < 2) continue;
+      if (hasCjk(raw)) {
+        for (const seg of segmentCjk(raw)) {
+          if (seg.length >= 1) out.push(seg);
+        }
+      } else {
+        out.push(stem(raw));
+      }
+    }
+    return out;
   }
 
   private getSortedTerms(): string[] {

--- a/test/search-index.test.ts
+++ b/test/search-index.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { SearchIndex } from "../src/state/search-index.js";
+import { segmentCjk } from "../src/state/cjk-segmenter.js";
 import type { CompressedObservation } from "../src/types.js";
 
 function makeObs(
@@ -200,5 +201,18 @@ describe("SearchIndex", () => {
     const hit = results.find((r) => r.obsId === "obs_ko");
     expect(hit).toBeDefined();
     expect(hit!.score).toBeGreaterThan(0);
+  });
+
+  it("preserves source order across mixed CJK and non-CJK runs", () => {
+    expect(segmentCjk("hello 项目 world")).toEqual(["hello", "项目", "world"]);
+    expect(segmentCjk("abc 메모리 def 项目 ghi")).toEqual([
+      "abc",
+      "메모리",
+      "def",
+      "项目",
+      "ghi",
+    ]);
+    expect(segmentCjk("leading 项目")).toEqual(["leading", "项目"]);
+    expect(segmentCjk("项目 trailing")).toEqual(["项目", "trailing"]);
   });
 });

--- a/test/search-index.test.ts
+++ b/test/search-index.test.ts
@@ -153,4 +153,52 @@ describe("SearchIndex", () => {
     expect(results.length).toBe(1);
     expect(results[0].obsId).toBe("obs_mixed");
   });
+
+  it("segments Chinese (Han) text into words", () => {
+    index.add(
+      makeObs({
+        id: "obs_zh",
+        title: "项目记忆存储",
+        narrative: "我们正在测试中文分词",
+        concepts: ["项目", "记忆"],
+      }),
+    );
+    const results = index.search("项目");
+    expect(results.length).toBeGreaterThan(0);
+    const hit = results.find((r) => r.obsId === "obs_zh");
+    expect(hit).toBeDefined();
+    expect(hit!.score).toBeGreaterThan(0);
+  });
+
+  it("segments Japanese (kana + kanji) text into words", () => {
+    index.add(
+      makeObs({
+        id: "obs_ja",
+        title: "プロジェクト記憶",
+        narrative: "日本語の分かち書きをテストしています",
+        concepts: ["プロジェクト", "記憶"],
+      }),
+    );
+    const results = index.search("プロジェクト");
+    expect(results.length).toBeGreaterThan(0);
+    const hit = results.find((r) => r.obsId === "obs_ja");
+    expect(hit).toBeDefined();
+    expect(hit!.score).toBeGreaterThan(0);
+  });
+
+  it("segments Korean (Hangul) syllable blocks into words", () => {
+    index.add(
+      makeObs({
+        id: "obs_ko",
+        title: "프로젝트 메모리 저장소",
+        narrative: "한국어 검색을 테스트합니다",
+        concepts: ["프로젝트", "메모리"],
+      }),
+    );
+    const results = index.search("메모리");
+    expect(results.length).toBeGreaterThan(0);
+    const hit = results.find((r) => r.obsId === "obs_ko");
+    expect(hit).toBeDefined();
+    expect(hit!.score).toBeGreaterThan(0);
+  });
 });


### PR DESCRIPTION
Closes #344.

## Why

`src/state/search-index.ts` tokenizes with `/[^\p{L}\p{N}\s/.\\-_]/gu`, which since v0.9.12 (#327) handles Greek, Cyrillic, Hebrew, Arabic, and accented Latin correctly because those scripts split on whitespace. CJK doesn't — Chinese / Japanese / Korean memories tokenized as a single sentence-long token, so BM25 returned the whole memory or nothing on a one-word CJK query. Vector still worked, but the hybrid score collapsed to vector-only for CJK users.

## What

New `src/state/cjk-segmenter.ts` module. `tokenize()` checks each whitespace-split run with `hasCjk()` and routes to the right segmenter when needed; non-CJK runs go through the existing stemmer path unchanged.

Three segmenter paths, dispatched by Unicode script over `\p{Script=Han}` / `\p{Script=Hiragana}` / `\p{Script=Katakana}` / `\p{Script=Hangul}`:

| Script | Segmenter | Notes |
|---|---|---|
| Han (Chinese) | `@node-rs/jieba` | Native module, no model download. `Jieba.withDict(dict)` from the bundled `@node-rs/jieba/dict`, then `.cut(text, hmm=true)`. |
| Kana + mixed kanji (Japanese) | `tiny-segmenter` | Pure JS, ~25KB. A run that contains any Hiragana / Katakana is treated as Japanese even if it also contains kanji, so mixed Japanese text like `プロジェクト記憶` does not get mis-routed to jieba. |
| Hangul (Korean) | rule-based | No dep. Each `[가-힯]+` syllable-block run is one token. |

## Optional-deps soft-fail

`@node-rs/jieba` and `tiny-segmenter` are declared in `optionalDependencies` so they install by default but don't break a constrained install. The segmenter wraps `require()` (via `createRequire(import.meta.url)`) in try/catch — if a dep is missing, it returns the whole run as a single token (the pre-fix behavior) and emits a one-time stderr hint per language using a module-level `Set<string>`:

```
agentmemory: install @node-rs/jieba to improve Chinese search; falling back to whole-string tokenization
```

## Fixtures added

In `test/search-index.test.ts`:

- Chinese: index `项目记忆存储` then query `项目` -> non-zero BM25 score on the memory.
- Japanese: index `プロジェクト記憶` then query `プロジェクト` -> hit.
- Korean: index `프로젝트 메모리 저장소` then query `메모리` -> hit.

## Tests

Existing test count grew from 899 to 902 (`Test Files 83 passed (83) | Tests 902 passed (902)` for the BM25 + search-related path). Greek and ASCII tests stay green. The unrelated 10 failures in `test/mcp-standalone.test.ts` are pre-existing on `main` and predate this PR.

## Out of scope

- Thai / Lao / Khmer (different segmentation problem, separate issue).
- Per-language stemming. BM25 here stays light-weight by design.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved tokenization and search support for Chinese, Japanese, and Korean text, preserving mixed CJK/non-CJK token order.

* **Documentation**
  * Clarified CJK tokenization behavior, coverage for non‑Latin scripts, and guidance to install optional segmenters for better CJK results.

* **Chores**
  * Added optional segmentation packages to enable improved CJK tokenization when available.

* **Tests**
  * Added CJK-focused tests to verify indexing and search behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/362)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->