### PR TITLE
Fix viewer nav overlap and mobile shell layout

### DIFF
--- a/src/viewer/index.html
+++ b/src/viewer/index.html
@@ -200,13 +200,15 @@
       background: var(--bg);
     }
     .app-main {
+      display: flex;
+      flex-direction: column;
       flex: 1 1 auto;
       min-height: 0;
       overflow: hidden;
       position: relative;
       z-index: 1;
     }
-    .view { display: none; height: 100%; min-height: 0; overflow-y: auto; padding: 24px; position: relative; z-index: 1; }
+    .view { display: none; flex: 1 1 auto; min-height: 0; overflow-y: auto; padding: 24px; position: relative; z-index: 1; }
     .view.active { display: block; }
     #view-sessions,
     #view-lessons,
@@ -709,6 +711,7 @@
       display: flex; align-items: center; gap: 10px;
       font-family: var(--font-ui); font-size: 11px;
       color: var(--ink-faint); letter-spacing: 0.05em;
+      flex: 0 0 auto;
     }
     .viewer-footer a { color: var(--ink-muted); text-decoration: none; }
     .viewer-footer a:hover { color: var(--ink); text-decoration: underline; }

--- a/src/viewer/index.html
+++ b/src/viewer/index.html
@@ -88,6 +88,7 @@
       height: 100vh;
       display: flex;
       flex-direction: column;
+      isolation: isolate;
       background-image: radial-gradient(circle, #D4D4CF 0.5px, transparent 0.5px);
       background-size: 16px 16px;
     }
@@ -102,12 +103,18 @@
       display: flex;
       align-items: center;
       justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
       background: var(--bg);
+      position: relative;
+      z-index: 40;
     }
     .app-header .brand {
       display: flex;
       align-items: baseline;
       gap: 10px;
+      min-width: 0;
+      flex-wrap: wrap;
     }
     .app-header .brand h1 {
       font-size: 22px;
@@ -128,6 +135,9 @@
       display: flex;
       align-items: center;
       gap: 12px;
+      min-width: 0;
+      flex-wrap: wrap;
+      justify-content: flex-end;
     }
     .ws-status {
       font-size: 10px;
@@ -157,6 +167,10 @@
       border-bottom: 1px solid var(--border-light);
       background: var(--bg);
       overflow-x: auto;
+      align-items: stretch;
+      scrollbar-width: thin;
+      position: relative;
+      z-index: 39;
     }
     .tab-bar button {
       background: none;
@@ -179,8 +193,44 @@
       border-bottom-color: var(--accent);
     }
 
-    .view { display: none; flex: 1 1 auto; min-height: 0; overflow-y: auto; padding: 24px; }
+    .app-shell {
+      flex: 0 0 auto;
+      position: relative;
+      z-index: 40;
+      background: var(--bg);
+    }
+    .app-main {
+      flex: 1 1 auto;
+      min-height: 0;
+      overflow: hidden;
+      position: relative;
+      z-index: 1;
+    }
+    .view { display: none; height: 100%; min-height: 0; overflow-y: auto; padding: 24px; position: relative; z-index: 1; }
     .view.active { display: block; }
+    #view-sessions,
+    #view-lessons,
+    #view-actions,
+    #view-crystals,
+    #view-audit,
+    #view-activity,
+    #view-profile,
+    #view-replay {
+      isolation: isolate;
+      contain: layout paint;
+      z-index: 0;
+    }
+    #view-sessions > *,
+    #view-lessons > *,
+    #view-actions > *,
+    #view-crystals > *,
+    #view-audit > *,
+    #view-activity > *,
+    #view-profile > *,
+    #view-replay > * {
+      position: relative;
+      z-index: 0;
+    }
 
     .stats-grid {
       display: grid;
@@ -599,6 +649,7 @@
 
     /* Feature flag banner system — compact collapsed by default */
     .flag-banners { padding: 0 0 10px 0; }
+    .flag-banners { position: relative; z-index: 38; background: var(--bg); }
     button.flag-summary {
       display: flex; align-items: center; gap: 12px;
       padding: 8px 14px; border-radius: 4px;
@@ -729,6 +780,32 @@
     @media (max-width: 1100px) { .three-col { grid-template-columns: 1fr 1fr; } }
     @media (max-width: 768px) { .three-col { grid-template-columns: 1fr; } }
 
+    @media (max-width: 980px) {
+      .app-header {
+        padding: 12px 16px;
+        align-items: flex-start;
+      }
+      .header-right {
+        width: 100%;
+        justify-content: flex-start;
+        gap: 8px;
+      }
+      .tab-bar {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+        overflow-x: visible;
+      }
+      .tab-bar button {
+        padding: 10px 12px;
+        border-right: 1px solid var(--border-light);
+        border-bottom: 1px solid var(--border-light);
+      }
+      .tab-bar button.active {
+        border-bottom-color: var(--border-light);
+        box-shadow: inset 0 -2px 0 var(--accent);
+      }
+    }
+
     .pagination {
       display: flex;
       justify-content: center;
@@ -792,7 +869,26 @@
     }
     @media (max-width: 768px) {
       .two-col { grid-template-columns: 1fr; }
-      .graph-sidebar { width: 200px; }
+      .view { padding: 16px; }
+      .dateline { display: none; }
+      .tab-bar { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      .tab-bar button {
+        min-height: 42px;
+        font-size: 10px;
+        letter-spacing: 0.08em;
+      }
+      .graph-container {
+        height: auto;
+        min-height: calc(100vh - 220px);
+        flex-direction: column;
+        margin: -16px;
+      }
+      .graph-sidebar {
+        width: 100%;
+        max-height: 36vh;
+        border-left: none;
+        border-top: 2px solid var(--border);
+      }
       .stats-grid { grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); }
     }
 
@@ -873,61 +969,65 @@
   </style>
 </head>
 <body>
-  <div class="app-header">
-    <div class="brand">
-      <h1>agentmemory</h1>
-      <span class="version">v__AGENTMEMORY_VERSION__</span>
+  <div class="app-shell">
+    <div class="app-header">
+      <div class="brand">
+        <h1>agentmemory</h1>
+        <span class="version">v__AGENTMEMORY_VERSION__</span>
+      </div>
+      <div class="header-right">
+        <span class="dateline" id="dateline"></span>
+        <button id="theme-toggle" class="btn" style="font-size:9px;padding:3px 10px;letter-spacing:0.1em;margin-right:8px;" data-action="toggle-theme">DARK</button>
+        <span id="ws-status" class="ws-status disconnected">live updates off</span>
+      </div>
     </div>
-    <div class="header-right">
-      <span class="dateline" id="dateline"></span>
-      <button id="theme-toggle" class="btn" style="font-size:9px;padding:3px 10px;letter-spacing:0.1em;margin-right:8px;" data-action="toggle-theme">DARK</button>
-      <span id="ws-status" class="ws-status disconnected">live updates off</span>
+
+    <div class="tab-bar" id="tab-bar">
+      <button class="active" data-tab="dashboard">Dashboard</button>
+      <button data-tab="graph">Graph</button>
+      <button data-tab="memories">Memories</button>
+      <button data-tab="timeline">Timeline</button>
+      <button data-tab="sessions">Sessions</button>
+      <button data-tab="lessons">Lessons</button>
+      <button data-tab="actions">Actions</button>
+      <button data-tab="crystals">Crystals</button>
+      <button data-tab="audit">Audit</button>
+      <button data-tab="activity">Activity</button>
+      <button data-tab="profile">Profile</button>
+      <button data-tab="replay">Replay</button>
     </div>
+
+    <div id="flag-banners" class="flag-banners"></div>
   </div>
 
-  <div class="tab-bar" id="tab-bar">
-    <button class="active" data-tab="dashboard">Dashboard</button>
-    <button data-tab="graph">Graph</button>
-    <button data-tab="memories">Memories</button>
-    <button data-tab="timeline">Timeline</button>
-    <button data-tab="sessions">Sessions</button>
-    <button data-tab="lessons">Lessons</button>
-    <button data-tab="actions">Actions</button>
-    <button data-tab="crystals">Crystals</button>
-    <button data-tab="audit">Audit</button>
-    <button data-tab="activity">Activity</button>
-    <button data-tab="profile">Profile</button>
-    <button data-tab="replay">Replay</button>
-  </div>
+  <main class="app-main">
+    <div id="view-dashboard" class="view active"></div>
+    <div id="view-graph" class="view"></div>
+    <div id="view-memories" class="view"></div>
+    <div id="view-lessons" class="view"></div>
+    <div id="view-actions" class="view"></div>
+    <div id="view-crystals" class="view"></div>
+    <div id="view-timeline" class="view"></div>
+    <div id="view-sessions" class="view"></div>
+    <div id="view-audit" class="view"></div>
+    <div id="view-activity" class="view"></div>
+    <div id="view-profile" class="view"></div>
+    <div id="view-replay" class="view"></div>
 
-  <div id="flag-banners" class="flag-banners"></div>
-
-  <div id="view-dashboard" class="view active"></div>
-  <div id="view-graph" class="view"></div>
-  <div id="view-memories" class="view"></div>
-  <div id="view-lessons" class="view"></div>
-  <div id="view-actions" class="view"></div>
-  <div id="view-crystals" class="view"></div>
-  <div id="view-timeline" class="view"></div>
-  <div id="view-sessions" class="view"></div>
-  <div id="view-audit" class="view"></div>
-  <div id="view-activity" class="view"></div>
-  <div id="view-profile" class="view"></div>
-  <div id="view-replay" class="view"></div>
+    <footer id="viewer-footer" class="viewer-footer">
+      <span>agentmemory viewer · <span id="footer-version">loading...</span></span>
+      <span class="footer-sep">·</span>
+      <a href="https://github.com/rohitg00/agentmemory" target="_blank" rel="noopener">github</a>
+      <span class="footer-sep">·</span>
+      <a href="https://github.com/rohitg00/agentmemory#readme" target="_blank" rel="noopener">docs</a>
+      <span class="footer-sep">·</span>
+      <a id="footer-feedback" href="#" target="_blank" rel="noopener">report issue &rarr;</a>
+    </footer>
+  </main>
 
   <div id="modal-overlay" class="modal-overlay">
     <div class="modal" id="modal"></div>
   </div>
-
-  <footer id="viewer-footer" class="viewer-footer">
-    <span>agentmemory viewer · <span id="footer-version">loading...</span></span>
-    <span class="footer-sep">·</span>
-    <a href="https://github.com/rohitg00/agentmemory" target="_blank" rel="noopener">github</a>
-    <span class="footer-sep">·</span>
-    <a href="https://github.com/rohitg00/agentmemory#readme" target="_blank" rel="noopener">docs</a>
-    <span class="footer-sep">·</span>
-    <a id="footer-feedback" href="#" target="_blank" rel="noopener">report issue &rarr;</a>
-  </footer>
 
   <script nonce="__AGENTMEMORY_VIEWER_NONCE__">
     var params = new URLSearchParams(window.location.search);


### PR DESCRIPTION
## Summary
- separate the viewer chrome from scrollable tab content so tab bodies cannot visually overrun the header/nav shell
- add stacking isolation for the later tabs that were reproducing the overlap most often
- make the viewer header and tab bar wrap cleanly on narrower viewports instead of collapsing into a single overflowing row
- improve mobile graph/layout behavior so the shell stays usable on small screens

## Why
On the viewer, tabs from roughly Sessions onward could render over the navigation area: the nav became invisible while still remaining clickable underneath. The shell also behaved poorly on narrower widths because the header/tab row had no real responsive fallback.

## Notes
- change is limited to 
- this is based on reproducing the overlap in the installed viewer and moving the shell into its own non-scrolling container
- I did not add automated tests because this viewer is a single-file HTML/CSS/JS surface and the fix is structural/layout-only


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Reworked overall app layout and stacking to improve visual layering and scrolling.
  * Enhanced header, tab bar, and footer alignment, spacing, and active/tab behaviour across breakpoints.
  * Improved responsive and mobile experiences with adjusted padding, grid behavior, and content reflow.

* **Refactor**
  * Reorganized top-level structure so shell and main content are separated for clearer layout management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/369)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->