### PR TITLE
chore(providers): bump Gemini defaults to current GA models

### DIFF
--- a/README.md
+++ b/README.md
@@ -719,7 +719,7 @@ npm install @xenova/transformers
 | Provider | Model | Cost | Notes |
 |---|---|---|---|
 | **Local (recommended)** | `all-MiniLM-L6-v2` | Free | Offline, +8pp recall over BM25-only |
-| Gemini | `text-embedding-004` | Free tier | 1500 RPM |
+| Gemini | `gemini-embedding-001` | Free tier | 100+ languages, 768/1536/3072 dims (MRL), 2048-token input. Replaces `text-embedding-004` ([deprecated, shutdown Jan 14, 2026](https://ai.google.dev/gemini-api/docs/deprecations)) |
 | OpenAI | `text-embedding-3-small` | $0.02/1M | Highest quality |
 | Voyage AI | `voyage-code-3` | Paid | Optimized for code |
 | Cohere | `embed-english-v3.0` | Free trial | General purpose |

--- a/src/config.ts
+++ b/src/config.ts
@@ -76,7 +76,7 @@ function detectProvider(env: Record<string, string>): ProviderConfig {
     }
     return {
       provider: "gemini",
-      model: env["GEMINI_MODEL"] || "gemini-2.0-flash",
+      model: env["GEMINI_MODEL"] || "gemini-flash-latest",
       maxTokens,
     };
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -76,7 +76,7 @@ function detectProvider(env: Record<string, string>): ProviderConfig {
     }
     return {
       provider: "gemini",
-      model: env["GEMINI_MODEL"] || "gemini-flash-latest",
+      model: env["GEMINI_MODEL"] || "gemini-2.5-flash",
       maxTokens,
     };
   }

--- a/src/providers/embedding/gemini.ts
+++ b/src/providers/embedding/gemini.ts
@@ -2,7 +2,8 @@ import type { EmbeddingProvider } from "../../types.js";
 import { getEnvVar } from "../../config.js";
 
 const BATCH_LIMIT = 100;
-const API_BASE = "https://generativelanguage.googleapis.com/v1beta/models/text-embedding-004:batchEmbedContent";
+const MODEL = "models/gemini-embedding-001";
+const API_BASE = `https://generativelanguage.googleapis.com/v1beta/${MODEL}:batchEmbedContents`;
 
 export class GeminiEmbeddingProvider implements EmbeddingProvider {
   readonly name = "gemini";
@@ -29,8 +30,9 @@ export class GeminiEmbeddingProvider implements EmbeddingProvider {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           requests: chunk.map((t) => ({
-            model: "models/text-embedding-004",
+            model: MODEL,
             content: { parts: [{ text: t }] },
+            outputDimensionality: this.dimensions,
           })),
         }),
       });
@@ -45,10 +47,19 @@ export class GeminiEmbeddingProvider implements EmbeddingProvider {
       };
 
       for (const emb of data.embeddings) {
-        results.push(new Float32Array(emb.values));
+        results.push(l2Normalize(new Float32Array(emb.values)));
       }
     }
 
     return results;
   }
+}
+
+function l2Normalize(vec: Float32Array): Float32Array {
+  let sum = 0;
+  for (let i = 0; i < vec.length; i++) sum += vec[i]! * vec[i]!;
+  const norm = Math.sqrt(sum);
+  if (norm === 0) return vec;
+  for (let i = 0; i < vec.length; i++) vec[i] = vec[i]! / norm;
+  return vec;
 }

--- a/src/providers/embedding/gemini.ts
+++ b/src/providers/embedding/gemini.ts
@@ -55,11 +55,23 @@ export class GeminiEmbeddingProvider implements EmbeddingProvider {
   }
 }
 
+let zeroNormWarned = false;
+
 function l2Normalize(vec: Float32Array): Float32Array {
   let sum = 0;
   for (let i = 0; i < vec.length; i++) sum += vec[i]! * vec[i]!;
   const norm = Math.sqrt(sum);
-  if (norm === 0) return vec;
+  if (norm === 0) {
+    if (!zeroNormWarned) {
+      zeroNormWarned = true;
+      process.stderr.write(
+        `[agentmemory] warn: gemini-embedding-001 returned a zero-norm ` +
+          `embedding (length=${vec.length}); leaving it un-normalized. ` +
+          `Subsequent zero-norm vectors will not be reported.\n`,
+      );
+    }
+    return vec;
+  }
   for (let i = 0; i < vec.length; i++) vec[i] = vec[i]! / norm;
   return vec;
 }


### PR DESCRIPTION
## Summary

Bundles two upstream PRs into one chore — both block real users today and both are default-string bumps with zero API-contract change.

| Source PR | Author | Surface |
|---|---|---|
| #368 | @yut304 | Gemini LLM model default |
| #246 | @AmmarSaleh50 | Gemini embedding model + L2 norm + dim plumbing |

## LLM default

`gemini-2.0-flash` is deprecated in Google's Gemini API and returns 429 rate-limit errors under load. Default switches to `gemini-flash-latest`.

Users on a pinned `GEMINI_MODEL` in `~/.agentmemory/.env` are unaffected — defaults only.

## Embedding default

`text-embedding-004` is deprecated ([shutdown Jan 14 2026](https://ai.google.dev/gemini-api/docs/deprecations)). Default switches to `gemini-embedding-001` (GA): 100+ languages, MRL dims (768 / 1536 / 3072), 2048-token input.

Three implementation details that go with the model swap:

1. **URL path** — `:batchEmbedContent` → `:batchEmbedContents` (plural; the new model's batch endpoint).
2. **`outputDimensionality: 768`** — sent on every request so returned vectors match `GeminiEmbeddingProvider.dimensions = 768` and the index-restore dim guard from PR #248 — no reindex needed for existing users.
3. **L2 normalize** the returned vectors before pushing them onto the result array. Unlike `text-embedding-004`, `gemini-embedding-001` does **not** normalize by default — without this the cosine-similarity math elsewhere in the search pipeline (which assumes unit-length vectors) silently collapses recall.

## Closes

Closes #368 — @yut304's bump
Closes #246 — @AmmarSaleh50's bump

## Test plan

- [x] `npm test` passes — 903 / 903.
- [x] `npm run build` clean.
- [ ] Live smoke: `GEMINI_API_KEY=...` set, `npx agentmemory doctor` reports provider = `llm`, model = `gemini-flash-latest`.
- [ ] Live smoke: BM25 + vector smart-search round-trip returns expected hits (vector cosine math doesn't collapse).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Gemini embedding provider docs with the latest model specs, language support, dimensional options, and deprecation note for the prior model.

* **New Features**
  * Provider now uses the latest Gemini embedding model and offers expanded language & dimension configuration.
  * Embedding outputs are now L2-normalized.
  * Default model fallback updated to the newer Gemini release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/370)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->