### PR TITLE
feat: configurable bind hosts for iii-engine and viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1091,6 +1091,15 @@ Create `~/.agentmemory/.env`:
 # Ports (defaults: 3111 API, 3113 viewer)
 # III_REST_PORT=3111
 
+# Bind hosts. Default 127.0.0.1; set to 0.0.0.0 to expose to other
+# hosts (containers, LAN). Pair with AGENTMEMORY_SECRET when exposing.
+# AGENTMEMORY_VIEWER_HOST=127.0.0.1   # viewer (:3113) bind
+# AGENTMEMORY_III_CONFIG=iii-config.yaml
+#   Override the iii-engine config file. Accepts a full path or a
+#   bare filename resolved against the bundled config dirs. Use
+#   `iii-config.docker.yaml` (ships in the package, host: 0.0.0.0)
+#   for container deployments.
+
 # Features
 # AGENTMEMORY_AUTO_COMPRESS=false  # OFF by default (#138). When on,
                                    # every PostToolUse hook calls your

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -150,9 +150,14 @@ Options:
 Environment:
   AGENTMEMORY_URL              Full REST base URL (e.g. http://localhost:3111).
                                Honored by status, doctor, and MCP shim commands.
+  AGENTMEMORY_VIEWER_HOST      Viewer bind host (default 127.0.0.1).
+                               Set to 0.0.0.0 to expose outside loopback.
   AGENTMEMORY_USE_DOCKER=1     Prefer the bundled docker-compose path over the
                                native iii-engine binary on first run.
   AGENTMEMORY_III_VERSION      Override pinned iii-engine version (default ${IIPINNED_VERSION}).
+  AGENTMEMORY_III_CONFIG       Override iii-engine config file. Accepts a full
+                               path or a bare filename resolved against the
+                               bundled config dirs (e.g. iii-config.docker.yaml).
 
 Quick start:
   npx @agentmemory/agentmemory          # start with local iii-engine or Docker
@@ -264,12 +269,12 @@ async function isAgentmemoryReady(): Promise<boolean> {
 }
 
 function findIiiConfig(): string {
-  const candidates = [
-    join(__dirname, "iii-config.yaml"),
-    join(__dirname, "..", "iii-config.yaml"),
-    join(process.cwd(), "iii-config.yaml"),
-  ];
-  for (const c of candidates) {
+  const override = process.env["AGENTMEMORY_III_CONFIG"];
+  if (override && existsSync(override)) return override;
+
+  const name = override || "iii-config.yaml";
+  for (const dir of [__dirname, join(__dirname, ".."), process.cwd()]) {
+    const c = join(dir, name);
     if (existsSync(c)) return c;
   }
   return "";

--- a/src/viewer/server.ts
+++ b/src/viewer/server.ts
@@ -115,19 +115,29 @@ export function startViewerServer(
     }
   });
 
+  const host = process.env["AGENTMEMORY_VIEWER_HOST"] || "127.0.0.1";
+  // Wildcard/loopback binds aren't directly navigable (0.0.0.0, ::) or
+  // unnecessarily verbose (127.0.0.1, ::1) — show "localhost" instead.
+  const isLocal =
+    host === "0.0.0.0" ||
+    host === "::" ||
+    host === "127.0.0.1" ||
+    host === "::1";
+  const displayHost = isLocal ? "localhost" : host;
+
   let attempt = 0;
   let currentPort = requestedPort;
 
   const tryListen = (): void => {
-    server.listen(currentPort, "127.0.0.1");
+    server.listen(currentPort, host);
   };
 
   server.on("listening", () => {
     if (currentPort === requestedPort) {
-      console.log(`[agentmemory] Viewer: http://localhost:${currentPort}`);
+      console.log(`[agentmemory] Viewer: http://${displayHost}:${currentPort}`);
     } else {
       console.log(
-        `[agentmemory] Viewer started on http://localhost:${currentPort} (fallback from ${requestedPort})`,
+        `[agentmemory] Viewer started on http://${displayHost}:${currentPort} (fallback from ${requestedPort})`,
       );
     }
   });

--- a/src/viewer/server.ts
+++ b/src/viewer/server.ts
@@ -176,7 +176,10 @@ async function proxyToRestApi(
     ? pathname
     : `/agentmemory${pathname.startsWith("/") ? pathname : "/" + pathname}`;
 
-  const upstreamUrl = `http://127.0.0.1:${restPort}${upstreamPath}${qs ? "?" + qs : ""}`;
+  const upstreamBase = (
+    process.env["AGENTMEMORY_URL"] || `http://127.0.0.1:${restPort}`
+  ).replace(/\/+$/, "");
+  const upstreamUrl = `${upstreamBase}${upstreamPath}${qs ? "?" + qs : ""}`;
 
   const headers: Record<string, string> = {};
   if (secret) {


### PR DESCRIPTION
Allow remove deployment by allowing custom bind host

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Viewer bind host configurable via AGENTMEMORY_VIEWER_HOST (default 127.0.0.1); startup logs display "localhost" for wildcard/loopback binds, otherwise the configured host.
  * iii-engine configuration path can be overridden with AGENTMEMORY_III_CONFIG, with automatic fallback discovery.

* **Documentation**
  * Help text and README updated to document the new environment variables and usage guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/376?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->