### PR TITLE
fix(cli): authenticate apiFetch when AGENTMEMORY_SECRET is set

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -473,7 +473,13 @@ async function main() {
 
 async function apiFetch<T = unknown>(base: string, path: string, timeoutMs = 5000): Promise<T | null> {
   try {
-    const res = await fetch(`${base}/agentmemory/${path}`, { signal: AbortSignal.timeout(timeoutMs) });
+    const headers: Record<string, string> = {};
+    const secret = process.env["AGENTMEMORY_SECRET"];
+    if (secret) headers["Authorization"] = `Bearer ${secret}`;
+    const res = await fetch(`${base}/agentmemory/${path}`, {
+      signal: AbortSignal.timeout(timeoutMs),
+      headers,
+    });
     return (await res.json()) as T;
   } catch {
     return null;


### PR DESCRIPTION
The doctor and status commands call protected endpoints (config/flags, health) via apiFetch but never send the bearer header. Deployments that set AGENTMEMORY_SECRET get 401 responses, parsed as flags=null,  which the doctor renders as 'LLM provider: not set' and 'Embedding provider: not set' regardless of actual server-side config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API requests now support optional authentication when credentials are configured.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/380)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->