### PR TITLE
fix(hermes): wrong JSON keys in sync_turn cause empty auto-compressed observations

### DIFF
--- a/integrations/hermes/__init__.py
+++ b/integrations/hermes/__init__.py
@@ -344,8 +344,8 @@ class AgentMemoryProvider(MemoryProvider):
             "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
             "data": {
                 "tool_name": "conversation",
-                "input": user[:500],
-                "output": assistant[:2000],
+                "tool_input": user[:500],
+                "tool_output": assistant[:2000],
             },
         })
 


### PR DESCRIPTION
## Problem

The Hermes plugin's `sync_turn()` sends conversation observations to the `/agentmemory/observe` endpoint with keys `"input"` and `"output"`:

```python
# integrations/hermes/__init__.py:345-348
"data": {
    "tool_name": "conversation",
    "input": user[:500],
    "output": assistant[:2000],
},
```

However, the server's `mem::observe` handler (in `src/functions/observe.ts`) extracts observation data using `"tool_input"` and `"tool_output"`:

```typescript
raw.toolName = d["tool_name"];
raw.toolInput = d["tool_input"];    // ← expects "tool_input"
raw.toolOutput = d["tool_output"];  // ← expects "tool_output"
```

This is consistent with how the Claude Code hooks (`dist/hooks/post-tool-use.mjs`) send data:

```javascript
data: {
    tool_name: data.tool_name,
    tool_input: data.tool_input,
    tool_output: truncate(cleanOutput, 8e3),
}
```

## Impact

Since `raw.toolInput` and `raw.toolOutput` are always `undefined`, the compression prompt built by `buildCompressionPrompt()` (in `src/prompts/compression.ts`) contains only the timestamp, hookType, and `toolName="conversation"`. The LLM receives no actual content and produces generic, useless observations:

```
title: "Agent initiated conversation"
narrative: "No specific content was provided"
importance: 1
facts: []
concepts: []
```

Every conversation turn produces identical garbage, polluting the memory store and making injected context useless (the `mem::context` function serves these empty observations back into the agent's prompt).

## Fix

Rename the keys to match what the server expects:

```python
"data": {
    "tool_name": "conversation",
    "tool_input": user[:500],
    "tool_output": assistant[:2000],
},
```

## Verification

Tested locally with agentmemory v0.9.12 + DeepSeek `deepseek-v4-flash` as the compression LLM. After the fix, the same observation payload produces:

```
type: discovery
title: "Verified fix for agentmemory plugin key naming"
subtitle: "Renamed input/output to tool_input/tool_output"
importance: 6
narrative: "The conversation confirms that the agentmemory plugin fix has been applied..."
facts: ["The fix in __init__.py lines 415-416 replaces ..."]
concepts: ["agentmemory plugin", "tool_input/tool_output key renaming"]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated payload field names in the Hermes integration for improved clarity and consistency in tool interaction handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/384)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->