### PR TITLE
feat(providers): add openai provider with custom base_url support

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -59,6 +59,16 @@ function detectProvider(env: Record<string, string>): ProviderConfig {
     };
   }
 
+  // OpenAI-compatible: uses OpenRouterProvider with custom base URL
+  if (hasRealValue(env["OPENAI_API_KEY"])) {
+    return {
+      provider: "openai",
+      model: env["OPENAI_MODEL"] || "gpt-4o-mini",
+      maxTokens,
+      baseURL: env["OPENAI_BASE_URL"] || "https://api.openai.com/v1/chat/completions",
+    };
+  }
+
   if (hasRealValue(env["ANTHROPIC_API_KEY"])) {
     return {
       provider: "anthropic",
@@ -92,7 +102,7 @@ function detectProvider(env: Record<string, string>): ProviderConfig {
   if (!allowAgentSdk) {
     process.stderr.write(
       "[agentmemory] No LLM provider key found " +
-        "(ANTHROPIC_API_KEY, GEMINI_API_KEY, OPENROUTER_API_KEY, MINIMAX_API_KEY). " +
+        "(ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY, OPENROUTER_API_KEY, MINIMAX_API_KEY). " +
         "LLM-backed compression and summarization are DISABLED — using no-op provider. " +
         "This is the safe default: the agent-sdk fallback used to spawn Claude Agent SDK " +
         "child sessions which inherit Claude Code's plugin hooks and cause infinite Stop-hook " +
@@ -153,6 +163,7 @@ export function detectLlmProviderKind(): "llm" | "noop" {
   const env = getMergedEnv();
   if (
     hasRealValue(env["ANTHROPIC_API_KEY"]) ||
+    hasRealValue(env["OPENAI_API_KEY"]) ||
     hasRealValue(env["GEMINI_API_KEY"]) ||
     hasRealValue(env["GOOGLE_API_KEY"]) ||
     hasRealValue(env["OPENROUTER_API_KEY"]) ||
@@ -288,6 +299,7 @@ export function getStandalonePersistPath(): string {
 
 const VALID_PROVIDERS = new Set([
   "anthropic",
+  "openai",
   "gemini",
   "openrouter",
   "agent-sdk",

--- a/src/functions/summarize.ts
+++ b/src/functions/summarize.ts
@@ -80,7 +80,7 @@ export function registerSummarizeFunction(
           success: false,
           error: "no_provider",
           reason:
-            "No LLM provider key set; Summarize is a no-op. Set ANTHROPIC_API_KEY (or GEMINI/OPENROUTER/MINIMAX) in ~/.agentmemory/.env to enable.",
+            "No LLM provider key set; Summarize is a no-op. Set ANTHROPIC_API_KEY (or OPENAI/GEMINI/OPENROUTER/MINIMAX) in ~/.agentmemory/.env to enable.",
         };
       }
 

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -65,6 +65,18 @@ function createBaseProvider(config: ProviderConfig): MemoryProvider {
         config.model,
         config.maxTokens,
       );
+    case "openai": {
+      const openaiKey = requireEnvVar("OPENAI_API_KEY");
+      const openaiBase =
+        getEnvVar("OPENAI_BASE_URL") ||
+        "https://api.openai.com/v1/chat/completions";
+      return new OpenRouterProvider(
+        openaiKey,
+        config.model,
+        config.maxTokens,
+        openaiBase,
+      );
+    }
     case "anthropic":
       return new AnthropicProvider(
         requireEnvVar("ANTHROPIC_API_KEY"),

--- a/src/providers/openrouter.ts
+++ b/src/providers/openrouter.ts
@@ -17,7 +17,11 @@ export class OpenRouterProvider implements MemoryProvider {
     this.model = model;
     this.maxTokens = maxTokens;
     this.baseUrl = baseUrl;
-    this.name = baseUrl.includes("openrouter") ? "openrouter" : "gemini";
+    this.name = baseUrl.includes("openrouter")
+      ? "openrouter"
+      : baseUrl.includes("generativelanguage")
+        ? "gemini"
+        : "openai";
   }
 
   async compress(systemPrompt: string, userPrompt: string): Promise<string> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -129,7 +129,7 @@ export interface ProviderConfig {
   baseURL?: string;
 }
 
-export type ProviderType = "agent-sdk" | "anthropic" | "gemini" | "openrouter" | "minimax" | "noop";
+export type ProviderType = "agent-sdk" | "anthropic" | "gemini" | "openai" | "openrouter" | "minimax" | "noop";
 
 export interface MemoryProvider {
   name: string;


### PR DESCRIPTION
## Problem

agentmemory currently does not support  as a summary/compression LLM provider. Users who want to use OpenAI-compatible endpoints (including self-hosted proxies like Ollama, vLLM, etc.) have no way to configure a custom base URL for the summary LLM.

The embedding provider already supports  — but the summary LLM provider does not.

## Solution

Add  as a first-class provider type that reuses the existing  implementation (which already handles OpenAI-compatible chat completions API).

### Environment Variables

| Variable | Required | Default |
|---|---|---|
| `OPENAI_API_KEY` | Yes | — |
| `OPENAI_BASE_URL` | No | `https://api.openai.com/v1/chat/completions` |
| `OPENAI_MODEL` | No | `gpt-4o-mini` |

### Files Changed

- **src/types.ts** — add `'openai'` to `ProviderType` union
- **src/config.ts** — `detectProvider()` openai branch + `detectLlmProviderKind()` + `VALID_PROVIDERS`
- **src/providers/index.ts** — `createBaseProvider()` `case 'openai'`
- **src/providers/openrouter.ts** — name detection from ternary to multi-branch (openrouter/gemini/openai)
- **src/functions/summarize.ts** — error message includes OPENAI

### Testing

- All existing tests pass (82/84 test files — 2 failures are pre-existing upstream issues unrelated to this change)
- No new test failures introduced by this PR

### Usage Example

```bash
# Use official OpenAI
export OPENAI_API_KEY="sk-..."

# Use custom endpoint (e.g. local proxy)
export OPENAI_API_KEY="your-key"
export OPENAI_BASE_URL="http://localhost:8080/v1/chat/completions"
export OPENAI_MODEL="qwen2.5-72b"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenAI is now supported as an LLM provider option. Configure it using the `OPENAI_API_KEY` environment variable. You can optionally customize the API endpoint with `OPENAI_BASE_URL`; if not set, it defaults to OpenAI's official Chat Completions endpoint. System error messages have been updated to list OpenAI among available LLM provider options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/385)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->