### PR TITLE
fix: pass plugin mcp env overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,8 @@ Implementation details live in `src/cli.ts` (see `runUpgrade` around the `src/cl
 Install agentmemory: run `npx @agentmemory/agentmemory` in a separate terminal to start the memory server. Then run `/plugin marketplace add rohitg00/agentmemory` and `/plugin install agentmemory` — the plugin registers all 12 hooks, 4 skills, AND auto-wires the `@agentmemory/mcp` stdio server via its `.mcp.json`, so you get 51 MCP tools (memory_smart_search, memory_save, memory_sessions, memory_governance_delete, etc.) without any extra config step. Verify with `curl http://localhost:3111/agentmemory/health`. The real-time viewer is at http://localhost:3113.
 ```
 
+For remote or protected deployments, launch Claude Code with `AGENTMEMORY_URL` and `AGENTMEMORY_SECRET` set. The plugin passes both values through to its bundled MCP server, with `http://localhost:3111` as the default URL.
+
 ### Codex CLI (Codex plugin platform)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ Implementation details live in `src/cli.ts` (see `runUpgrade` around the `src/cl
 Install agentmemory: run `npx @agentmemory/agentmemory` in a separate terminal to start the memory server. Then run `/plugin marketplace add rohitg00/agentmemory` and `/plugin install agentmemory` — the plugin registers all 12 hooks, 4 skills, AND auto-wires the `@agentmemory/mcp` stdio server via its `.mcp.json`, so you get 51 MCP tools (memory_smart_search, memory_save, memory_sessions, memory_governance_delete, etc.) without any extra config step. Verify with `curl http://localhost:3111/agentmemory/health`. The real-time viewer is at http://localhost:3113.
 ```
 
-For remote or protected deployments, launch Claude Code with `AGENTMEMORY_URL` and `AGENTMEMORY_SECRET` set. The plugin passes both values through to its bundled MCP server, with `http://localhost:3111` as the default URL.
+For remote or protected deployments, launch Claude Code with `AGENTMEMORY_URL` and `AGENTMEMORY_SECRET` set. The plugin passes both values through to its bundled MCP server; when `AGENTMEMORY_URL` is empty, the MCP shim uses `http://localhost:3111`.
 
 ### Codex CLI (Codex plugin platform)
 

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -2,7 +2,11 @@
   "mcpServers": {
     "agentmemory": {
       "command": "npx",
-      "args": ["-y", "@agentmemory/mcp"]
+      "args": ["-y", "@agentmemory/mcp"],
+      "env": {
+        "AGENTMEMORY_URL": "${AGENTMEMORY_URL:-http://localhost:3111}",
+        "AGENTMEMORY_SECRET": "${AGENTMEMORY_SECRET:-}"
+      }
     }
   }
 }

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -4,8 +4,8 @@
       "command": "npx",
       "args": ["-y", "@agentmemory/mcp"],
       "env": {
-        "AGENTMEMORY_URL": "${AGENTMEMORY_URL:-http://localhost:3111}",
-        "AGENTMEMORY_SECRET": "${AGENTMEMORY_SECRET:-}"
+        "AGENTMEMORY_URL": "${AGENTMEMORY_URL}",
+        "AGENTMEMORY_SECRET": "${AGENTMEMORY_SECRET}"
       }
     }
   }

--- a/test/codex-plugin.test.ts
+++ b/test/codex-plugin.test.ts
@@ -59,8 +59,8 @@ describe("Codex plugin manifest (developers.openai.com/codex/plugins)", () => {
     }>(join(pluginRoot, ".mcp.json"));
 
     expect(mcp.mcpServers.agentmemory?.env).toMatchObject({
-      AGENTMEMORY_URL: "${AGENTMEMORY_URL:-http://localhost:3111}",
-      AGENTMEMORY_SECRET: "${AGENTMEMORY_SECRET:-}",
+      AGENTMEMORY_URL: "${AGENTMEMORY_URL}",
+      AGENTMEMORY_SECRET: "${AGENTMEMORY_SECRET}",
     });
   });
 

--- a/test/codex-plugin.test.ts
+++ b/test/codex-plugin.test.ts
@@ -46,6 +46,24 @@ describe("Codex plugin manifest (developers.openai.com/codex/plugins)", () => {
     expect(existsSync(join(pluginRoot, manifest.hooks))).toBe(true);
   });
 
+  it("plugin MCP server inherits remote agentmemory environment overrides", () => {
+    const mcp = readJson<{
+      mcpServers: Record<
+        string,
+        {
+          command: string;
+          args: string[];
+          env?: Record<string, string>;
+        }
+      >;
+    }>(join(pluginRoot, ".mcp.json"));
+
+    expect(mcp.mcpServers.agentmemory?.env).toMatchObject({
+      AGENTMEMORY_URL: "${AGENTMEMORY_URL:-http://localhost:3111}",
+      AGENTMEMORY_SECRET: "${AGENTMEMORY_SECRET:-}",
+    });
+  });
+
   it("hooks.codex.json contains only events Codex supports (no Subagent / SessionEnd / Notification / TaskCompleted / PostToolUseFailure)", () => {
     const hooksPath = join(pluginRoot, "hooks/hooks.codex.json");
     const hooks = readJson<{ hooks: Record<string, unknown> }>(hooksPath);


### PR DESCRIPTION
## Summary
- Pass `AGENTMEMORY_URL` and `AGENTMEMORY_SECRET` through the bundled plugin MCP server config.
- Keep `http://localhost:3111` as the default MCP server target when `AGENTMEMORY_URL` is unset.
- Add regression coverage for the plugin MCP env block.
- Document the remote/protected Claude Code launch path.

Fixes #375

## Test plan
- `npm test -- --run test/codex-plugin.test.ts`
- `npx tsdown`
- `git diff --check`

## Notes
- `npm run build` reaches the tsdown compile step on Windows, then the shell copy tail exits on `true` because the script uses Unix shell syntax.
- `npm test` on Windows reports path-sensitive failures in `test/obsidian-export.test.ts` and `test/compress-file.test.ts`; 894 tests pass, including `test/codex-plugin.test.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified installation snippet on how to run agentmemory in remote/protected deployments by setting AGENTMEMORY_URL and AGENTMEMORY_SECRET; notes these values are forwarded to the bundled MCP server (default URL shown).
* **Tests**
  * Added an automated test to verify the environment variable entries for agentmemory are present and correctly passed through.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/386?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->