### PR TITLE
docs(readme): clarify MCP shim vs full server tool count (#233 gap 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ codex plugin install agentmemory
 
 The Codex plugin ships from the same `plugin/` directory as the Claude Code plugin. It registers:
 
-- `@agentmemory/mcp` as an MCP server (all 51 tools when `AGENTMEMORY_TOOLS=all`)
+- `@agentmemory/mcp` as an MCP server (proxies all 51 tools when `AGENTMEMORY_URL` points at a running agentmemory server; falls back to 7 tools locally when no server is reachable)
 - 6 lifecycle hooks: `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `PreCompact`, `Stop`
 - 4 skills: `/recall`, `/remember`, `/session-history`, `/forget`
 
@@ -730,6 +730,8 @@ npm install @xenova/transformers
 <h2 id="mcp-server"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/section-mcp.svg"><img src="assets/tags/section-mcp.svg" alt="MCP Server" height="32" /></picture></h2>
 
 51 tools, 6 resources, 3 prompts, and 4 skills — the most comprehensive MCP memory toolkit for any agent.
+
+> **MCP shim vs full server:** the published `@agentmemory/mcp` package is a thin shim. It exposes the full 51-tool surface **only when it can reach a running agentmemory server** via `AGENTMEMORY_URL` (proxy mode). With no server reachable, the shim falls back to a 7-tool local set (`memory_save`, `memory_recall`, `memory_smart_search`, `memory_sessions`, `memory_export`, `memory_audit`, `memory_governance_delete`). The `AGENTMEMORY_TOOLS=core|all` env var is a *server-side* flag — setting it in the shim's `env` block has no effect. If you see only 7 tools in Cursor / OpenCode / Gemini CLI, start `npx @agentmemory/agentmemory` (or the Docker stack) and set `AGENTMEMORY_URL=http://localhost:3111`.
 
 ### 50 Tools
 


### PR DESCRIPTION
## Summary

Addresses gap #1 from [#233](https://github.com/rohitg00/agentmemory/issues/233): users following the Cursor / OpenCode / Gemini CLI setup only see 7 tools and assume they misconfigured something.

The README implied the `@agentmemory/mcp` shim exposes _"all 51 tools when `AGENTMEMORY_TOOLS=all`"_. In reality:

- `AGENTMEMORY_TOOLS` is a **server-side** flag (read by iii-engine), not by the shim — setting it in the shim's MCP `env` block does nothing.
- The shim has two modes:
  - **Proxy** — `AGENTMEMORY_URL` reaches a running agentmemory server → all 51 tools forwarded.
  - **Local fallback** — no server reachable → 7 hardcoded tools from `src/mcp/standalone.ts` (`memory_save`, `memory_recall`, `memory_smart_search`, `memory_sessions`, `memory_export`, `memory_audit`, `memory_governance_delete`).

## Changes (README.md only)

1. **Codex plugin bullet (L371):** replace the misleading `AGENTMEMORY_TOOLS=all` qualifier with an accurate proxy/local mode description.
2. **MCP Server section header (L733):** new callout that enumerates the 7-tool local fallback set and explains how to unlock the full 51.

## Verification

- Diff is 1 file / 3 insertions / 1 deletion.
- 7-tool list mirrors `IMPLEMENTED_TOOLS` in `src/mcp/standalone.ts:16-23` verbatim.
- No code changes — pure documentation.

## Note on scope

#233 documents 6 doc gaps in total. This PR addresses only **gap 1** to keep the change focused and easy to review. The other gaps (stdio→HTTP MCP bridge docs, `AGENTMEMORY_URL` env-table entry, end-to-end self-hosted Ollama guide, Windows `env_file` gotcha, npm v11 + onnx-proto workaround) are independent and worth separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified MCP shim tool availability behavior: the full 51-tool set is exposed when connected to an agentmemory server, with automatic fallback to a 7-tool local set when the server is unreachable.
  * Updated Codex integration documentation to reflect these tool availability changes and clarified server-side configuration behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/391)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->