### PR TITLE
docs(readme): move OpenHuman after pi in agents grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,6 @@ agentmemory works with any agent that supports hooks, MCP, or REST API. All agen
 <sub>native plugin + 6 hooks + MCP</sub>
 </td>
 <td align="center" width="12.5%">
-<a href="https://github.com/tinyhumansai/openhuman"><img src="https://raw.githubusercontent.com/tinyhumansai/openhuman/main/app/src-tauri/icons/128x128.png" alt="OpenHuman" width="48" height="48" /></a><br/>
-<strong>OpenHuman</strong><br/>
-<sub>native Memory trait backend</sub>
-</td>
-<td align="center" width="12.5%">
 <a href="integrations/openclaw/"><img src="https://github.com/openclaw.png?size=120" alt="OpenClaw" width="48" height="48" /></a><br/>
 <strong>OpenClaw</strong><br/>
 <sub>native plugin + MCP</sub>
@@ -103,6 +98,11 @@ agentmemory works with any agent that supports hooks, MCP, or REST API. All agen
 <a href="integrations/pi/"><img src="assets/agents/pi.svg" alt="pi" width="48" height="48" /></a><br/>
 <strong>pi</strong><br/>
 <sub>native plugin + MCP</sub>
+</td>
+<td align="center" width="12.5%">
+<a href="https://github.com/tinyhumansai/openhuman"><img src="https://raw.githubusercontent.com/tinyhumansai/openhuman/main/app/src-tauri/icons/128x128.png" alt="OpenHuman" width="48" height="48" /></a><br/>
+<strong>OpenHuman</strong><br/>
+<sub>native Memory trait backend</sub>
 </td>
 <td align="center" width="12.5%">
 <a href="https://cursor.com"><img src="https://www.freelogovectors.net/wp-content/uploads/2025/06/cursor-logo-freelogovectors.net_.png" alt="Cursor" width="48" height="48" /></a><br/>


### PR DESCRIPTION
Reorder row 1 of the agents grid so OpenHuman sits in slot 6 (after pi) instead of slot 3.

New row 1 order: Claude Code → Codex CLI → OpenClaw → Hermes → pi → OpenHuman → Cursor → Gemini CLI.

## Test plan
- [x] Rendered preview verified locally — row 1 layout matches request
- [x] Counter (`15 integrations`) unchanged; no agent added/removed
- [x] No anchor or link changed; only sibling `<td>` order


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized the integration grid layout in the documentation, repositioning the OpenHuman integration tile within the same row.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/397)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->