### PR TITLE
fix(cli): silent killers — viewer port auto-bump, engine version-match warning, adopt-on-attach, stop --force, npx PATH hint

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -239,6 +239,21 @@ function iiiBinVersion(binPath: string): string | null {
   }
 }
 
+let warnedVersionMismatch = false;
+function warnIfEngineVersionMismatch(iiiBinPath: string | null | undefined): void {
+  if (!iiiBinPath || warnedVersionMismatch) return;
+  const detected = iiiBinVersion(iiiBinPath);
+  if (!detected || detected === IIPINNED_VERSION) return;
+  warnedVersionMismatch = true;
+  const asset = iiiReleaseAsset();
+  const downloadHint = asset
+    ? `curl -fsSL https://github.com/iii-hq/iii/releases/download/iii/v${IIPINNED_VERSION}/${asset} | tar -xz -C ~/.local/bin`
+    : `download v${IIPINNED_VERSION} from https://github.com/iii-hq/iii/releases/tag/iii%2Fv${IIPINNED_VERSION}`;
+  p.log.warn(
+    `iii-engine on PATH is v${detected} but agentmemory v0.9.14+ pins v${IIPINNED_VERSION}. Set AGENTMEMORY_III_VERSION=${detected} to silence, or downgrade with: \`${downloadHint}\``,
+  );
+}
+
 function enginePidfilePath(): string {
   return join(homedir(), ".agentmemory", "iii.pid");
 }
@@ -427,6 +442,7 @@ function spawnEngineBackground(
 }
 
 function startIiiBin(iiiBin: string, configPath: string): boolean {
+  warnIfEngineVersionMismatch(iiiBin);
   const s = p.spinner();
   s.start(`Starting iii-engine: ${iiiBin}`);
   writeEngineState({ kind: "native", configPath });
@@ -622,6 +638,9 @@ async function main() {
 
   if (await isEngineRunning()) {
     p.log.success("iii-engine is running");
+    const attachedBin =
+      whichBinary("iii") ?? fallbackIiiPaths().find((p) => existsSync(p)) ?? null;
+    warnIfEngineVersionMismatch(attachedBin);
     await import("./index.js");
     return;
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -333,6 +333,35 @@ function discoverComposeFile(): string | null {
   return candidates.find((c) => existsSync(c)) ?? null;
 }
 
+function isInvokedViaNpx(): boolean {
+  if (process.env["npm_lifecycle_event"] === "npx") return true;
+  const argv1 = process.argv[1] ?? "";
+  if (argv1.includes("_npx")) return true;
+  const ua = process.env["npm_config_user_agent"] ?? "";
+  if (ua.startsWith("npm/") || ua.includes(" npm/")) return true;
+  return false;
+}
+
+function shouldSkipNpxHint(): boolean {
+  try {
+    const prefsPath = join(homedir(), ".agentmemory", "preferences.json");
+    if (!existsSync(prefsPath)) return false;
+    const raw = readFileSync(prefsPath, "utf-8");
+    const prefs = JSON.parse(raw) as { skipNpxHint?: boolean };
+    return prefs?.skipNpxHint === true;
+  } catch {
+    return false;
+  }
+}
+
+function maybeEmitNpxHint(): void {
+  if (!isInvokedViaNpx()) return;
+  if (shouldSkipNpxHint()) return;
+  p.log.info(
+    "Tip: install globally for the bare `agentmemory` command:\n  npm install -g @agentmemory/agentmemory",
+  );
+}
+
 function adoptRunningEngine(): void {
   try {
     const existingState = readEngineState();
@@ -671,6 +700,7 @@ async function main() {
       whichBinary("iii") ?? fallbackIiiPaths().find((p) => existsSync(p)) ?? null;
     warnIfEngineVersionMismatch(attachedBin);
     adoptRunningEngine();
+    maybeEmitNpxHint();
     await import("./index.js");
     return;
   }
@@ -739,6 +769,7 @@ async function main() {
   }
 
   s.stop("iii-engine is ready");
+  maybeEmitNpxHint();
   await import("./index.js");
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -266,7 +266,7 @@ function engineStatePath(): string {
 }
 
 type EngineState =
-  | { kind: "native"; configPath: string }
+  | { kind: "native"; configPath: string; attached?: boolean }
   | { kind: "docker"; composeFile: string };
 
 function writeEnginePidfile(pid: number): void {
@@ -331,6 +331,32 @@ function discoverComposeFile(): string | null {
     join(process.cwd(), "docker-compose.yml"),
   ];
   return candidates.find((c) => existsSync(c)) ?? null;
+}
+
+function adoptRunningEngine(): void {
+  try {
+    const existingState = readEngineState();
+    const existingPid = readEnginePidfile();
+    if (existingState && existingPid) return;
+
+    const pids = findEnginePidsByPort(getRestPort());
+    const enginePid = pids[0];
+    if (enginePid && !existingPid) {
+      writeEnginePidfile(enginePid);
+    }
+    if (!existingState) {
+      writeEngineState({
+        kind: "native",
+        configPath: findIiiConfig() || "",
+        attached: true,
+      });
+    }
+    if (enginePid && !existingPid) {
+      p.log.info(`Attached to existing iii-engine (pid ${enginePid})`);
+    }
+  } catch (err) {
+    vlog(`adoptRunningEngine: ${err instanceof Error ? err.message : String(err)}`);
+  }
 }
 
 async function runIiiInstaller(): Promise<{ ok: boolean; binPath: string | null }> {
@@ -644,6 +670,7 @@ async function main() {
     const attachedBin =
       whichBinary("iii") ?? fallbackIiiPaths().find((p) => existsSync(p)) ?? null;
     warnIfEngineVersionMismatch(attachedBin);
+    adoptRunningEngine();
     await import("./index.js");
     return;
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -87,7 +87,10 @@ Commands:
   doctor             Run diagnostic checks (server, flags, graph, providers)
   demo               Seed sample sessions and show recall in action
   upgrade            Upgrade local deps + iii runtime (best effort)
-  stop               Stop the running iii-engine started by this CLI
+  stop [--force]     Stop the running iii-engine started by this CLI.
+                     --force bypasses the Docker-heuristic guard and signals
+                     whatever pidfile+lsof report on the REST port (use when
+                     the engine was started natively but state file is missing).
   mcp                Start standalone MCP server (no engine required)
   import-jsonl [p]   Import Claude Code JSONL transcripts (default: ~/.claude/projects)
                      --max-files <N> | --max-files=<N>: override scan cap (default 200, max 1000;
@@ -1480,6 +1483,7 @@ async function runStop(): Promise<void> {
   const port = getRestPort();
   const state = readEngineState();
   const running = await isEngineRunning();
+  const force = args.includes("--force");
 
   if (state?.kind === "docker") {
     if (!running) {
@@ -1517,10 +1521,16 @@ async function runStop(): Promise<void> {
   if (!state) {
     const compose = discoverComposeFile();
     if (compose && pidfilePid === null) {
-      p.log.error(
-        `Engine is running on :${port} but no pidfile or state file is present. It may have been started via Docker compose by a different shell. Refusing to signal host PIDs.\n\nStop it with:\n  docker compose -f ${compose} down\n\nOr re-run with AGENTMEMORY_USE_DOCKER=1 to record state next time.`,
-      );
-      process.exit(1);
+      if (force) {
+        p.log.warn(
+          `--force: bypassing Docker-heuristic guard. Falling back to native pidfile + lsof on :${port}.`,
+        );
+      } else {
+        p.log.error(
+          `Engine is running on :${port} but no pidfile or state file is present. It may have been started via Docker compose by a different shell. Refusing to signal host PIDs.\n\nStop it with:\n  docker compose -f ${compose} down\n\nOr re-run with --force to signal whatever lsof finds on :${port}, or AGENTMEMORY_USE_DOCKER=1 to record state next time.`,
+        );
+        process.exit(1);
+      }
     }
   }
 

--- a/src/viewer/server.ts
+++ b/src/viewer/server.ts
@@ -58,6 +58,8 @@ function readBody(req: IncomingMessage): Promise<string> {
   });
 }
 
+const MAX_VIEWER_PORT_RETRIES = 10;
+
 export function startViewerServer(
   port: number,
   _kv: unknown,
@@ -66,6 +68,7 @@ export function startViewerServer(
   restPort?: number,
 ): Server {
   const resolvedRestPort = restPort ?? port - 2;
+  const requestedPort = port;
 
   const server = createServer(async (req, res) => {
     const raw = req.url || "/";
@@ -112,17 +115,40 @@ export function startViewerServer(
     }
   });
 
+  let attempt = 0;
+  let currentPort = requestedPort;
+
+  const tryListen = (): void => {
+    server.listen(currentPort, "127.0.0.1");
+  };
+
+  server.on("listening", () => {
+    if (currentPort === requestedPort) {
+      console.log(`[agentmemory] Viewer: http://localhost:${currentPort}`);
+    } else {
+      console.log(
+        `[agentmemory] Viewer started on http://localhost:${currentPort} (fallback from ${requestedPort})`,
+      );
+    }
+  });
+
   server.on("error", (err: NodeJS.ErrnoException) => {
+    if (err.code === "EADDRINUSE" && attempt < MAX_VIEWER_PORT_RETRIES) {
+      attempt++;
+      currentPort = requestedPort + attempt;
+      setImmediate(tryListen);
+      return;
+    }
     if (err.code === "EADDRINUSE") {
-      console.warn(`[agentmemory] Viewer port ${port} already in use, skipping viewer.`);
+      console.warn(
+        `[agentmemory] Viewer ports ${requestedPort}-${requestedPort + MAX_VIEWER_PORT_RETRIES} all in use, skipping viewer.`,
+      );
     } else {
       console.error(`[agentmemory] Viewer error:`, err.message);
     }
   });
 
-  server.listen(port, "127.0.0.1", () => {
-    console.log(`[agentmemory] Viewer: http://localhost:${port}`);
-  });
+  tryListen();
 
   return server;
 }


### PR DESCRIPTION
Five small DevEx fixes surfaced during v0.9.14 local testing. Each one closes a path where the CLI silently fails or refuses to act with no escape hatch.

## Fixes

1. **Viewer port auto-bump** — `src/viewer/server.ts:61-148`
   Used to log `Viewer port 3113 already in use, skipping viewer.` and silently exit. Now retries up to 10 increments (3113 -> 3122) before giving up. On fallback, logs `Viewer started on http://localhost:3114 (fallback from 3113)`. Only fail-loud after all retries.

2. **Engine version-match warning** — `src/cli.ts:245-258` (helper) + wired at `src/cli.ts:503` (`startIiiBin`) and `src/cli.ts:699-702` (`main()` attach path).
   New helper `warnIfEngineVersionMismatch(iiiBinPath)` calls `iiiBinVersion()` and prints a `p.log.warn` line when the version differs from `IIPINNED_VERSION` (currently `0.11.2`). The message tells the operator how to silence it (`AGENTMEMORY_III_VERSION`) and how to downgrade (curl | tar). Fires once per process.

3. **`stop --force`** — `src/cli.ts:1544` (flag parse) + `src/cli.ts:1583-1592` (guard bypass) + `src/cli.ts:90-93` (`--help`).
   `runStop()` parses `--force`. When true AND the Docker-heuristic guard would have fired (state missing + compose discoverable), bypasses the guard and proceeds with native pidfile + lsof. Documented in `--help`. The non-force path remains the default and still refuses.

4. **Adopt-on-attach** — `src/cli.ts:365-389` (helper) + `src/cli.ts:702` (wire-in).
   When `main()` finds `isEngineRunning()` already true, new `adoptRunningEngine()` writes the engine PID (from `findEnginePidsByPort`) to `~/.agentmemory/iii.pid` and writes `{kind:'native', configPath, attached:true}` to `~/.agentmemory/engine-state.json`. Idempotent — never clobbers existing files. Logs `Attached to existing iii-engine (pid 12345)`. This lets a subsequent `agentmemory stop` actually find the process without `--force`.

5. **npx PATH hint** — `src/cli.ts:336-364` (helpers) + `src/cli.ts:703,772` (wire-in).
   After engine is ready, detects npx via `npm_lifecycle_event`, `_npx` in `process.argv[1]`, or `npm_config_user_agent` starting with `npm/`. Emits one line:
   \`\`\`
   Tip: install globally for the bare \`agentmemory\` command:
     npm install -g @agentmemory/agentmemory
   \`\`\`
   Suppressed when `~/.agentmemory/preferences.json` has `skipNpxHint: true`.

## Verification
- `npm run build` clean
- `npm test`: 11 failed | 892 passed (baseline unchanged — all 11 pre-existing failures in `test/mcp-standalone.test.ts`)
- No new dependencies
- Only `src/cli.ts` and `src/viewer/server.ts` touched
- No `CHANGELOG.md` / version bump

## Test plan
- [ ] `agentmemory stop` on an engine started by a previous shell (without state file) -> still refuses
- [ ] `agentmemory stop --force` on the same -> proceeds with native pidfile + lsof
- [ ] Start agentmemory while another process holds :3113 -> viewer comes up on :3114 with fallback message
- [ ] Install `iii v0.11.6` on PATH, run `agentmemory` -> see version mismatch warning
- [ ] Run `npx @agentmemory/agentmemory` -> see one-line install-globally tip after engine ready
- [ ] Start engine in shell A, run `agentmemory` in shell B -> pidfile + state file written, attach message logged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `stop --force` mode to force engine stop while bypassing engine state protection checks
  * Engine version mismatch detection automatically warns users with helpful download guidance
  * Npx invocation detection offers users an optional prompt to install the tool globally
  * Viewer server automatically retries alternate ports when the primary port is unavailable or in use

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/405)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->