### PR TITLE
feat(cli): onboarding wires selected agents inline + memory-share callout

### DIFF
--- a/src/cli/connect/index.ts
+++ b/src/cli/connect/index.ts
@@ -49,7 +49,7 @@ function parseFlags(args: string[]): {
   return { dryRun, force, all, positional };
 }
 
-async function runAdapter(
+export async function runAdapter(
   adapter: ConnectAdapter,
   opts: ConnectOptions,
 ): Promise<ConnectResult> {

--- a/src/cli/onboarding.ts
+++ b/src/cli/onboarding.ts
@@ -26,6 +26,8 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import * as p from "@clack/prompts";
 import { writePrefs } from "./preferences.js";
+import { resolveAdapter, runAdapter } from "./connect/index.js";
+import type { ConnectResult } from "./connect/types.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -158,6 +160,18 @@ export async function runOnboarding(): Promise<OnboardingResult> {
     process.exit(0);
   }
 
+  const pickedAgentsList = (agentsPicked as string[]) ?? [];
+  if (pickedAgentsList.length > 0) {
+    p.note(
+      [
+        "━ how this works ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
+        "All selected agents share the same memory at :3111.",
+        "A memory saved by Claude Code is visible to Codex + Cursor instantly.",
+        "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
+      ].join("\n"),
+    );
+  }
+
   const providerPicked = await p.select<string>({
     message: "Which LLM provider should agentmemory use for compress/consolidate?",
     options: PROVIDERS.map(({ value, label }) => ({ value, label })),
@@ -198,5 +212,77 @@ export async function runOnboarding(): Promise<OnboardingResult> {
   }
   p.note(lines.join("\n"), "ready");
 
+  if (agents.length > 0) {
+    await wireSelectedAgents(agents);
+  }
+
   return { agents, provider };
+}
+
+async function wireSelectedAgents(agents: string[]): Promise<void> {
+  p.note("Wire selected agents now?", "next step");
+  const confirmed = await p.confirm({
+    message: "Run `agentmemory connect <agent>` for each selected agent now? [Y/n]",
+    initialValue: true,
+  });
+
+  if (p.isCancel(confirmed) || confirmed === false) {
+    const cmds = agents.map((a) => `  agentmemory connect ${a}`);
+    p.note(["Wire later with:", ...cmds].join("\n"), "later");
+    return;
+  }
+
+  const wired: string[] = [];
+  const manual: { name: string; docs?: string }[] = [];
+  const failed: { name: string; reason: string }[] = [];
+
+  for (const name of agents) {
+    const adapter = resolveAdapter(name);
+    if (!adapter) {
+      failed.push({ name, reason: "no adapter available" });
+      p.log.warn(`Wiring ${name}… no adapter available (skipped).`);
+      continue;
+    }
+    p.log.step(`Wiring ${name}...`);
+    let result: ConnectResult;
+    try {
+      result = await runAdapter(adapter, { dryRun: false, force: false });
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      failed.push({ name, reason });
+      p.log.error(`${name}: ${reason}`);
+      continue;
+    }
+    switch (result.kind) {
+      case "installed":
+      case "already-wired":
+        wired.push(name);
+        break;
+      case "stub":
+        manual.push({ name, docs: adapter.docs });
+        break;
+      case "skipped":
+        failed.push({ name, reason: result.reason });
+        break;
+    }
+  }
+
+  const summary: string[] = [];
+  if (wired.length > 0) {
+    summary.push(`Wired: ${wired.join(", ")}.`);
+  }
+  if (manual.length > 0 || failed.length > 0) {
+    const parts: string[] = [];
+    for (const m of manual) {
+      parts.push(`${m.name} (manual install required${m.docs ? ` — see ${m.docs}` : ""})`);
+    }
+    for (const f of failed) {
+      parts.push(`${f.name} (${f.reason})`);
+    }
+    summary.push(`Skipped/failed: ${parts.join(", ")}.`);
+  }
+  if (summary.length === 0) {
+    summary.push("No agents were wired.");
+  }
+  p.note(summary.join("\n"), "wire summary");
 }


### PR DESCRIPTION
## Summary

Today the first-run wizard stores the multi-select in `~/.agentmemory/preferences.json` and exits. Users then have to re-run `agentmemory connect <agent>` per agent by hand. This PR closes that loop.

Two changes, one PR:

1. **Memory-share callout.** After the agents multi-select (only when >=1 agent selected, before provider select), print a callout explaining that all picked agents share the same memory at :3111 — a save by Claude Code is visible to Codex + Cursor instantly.

2. **Wire selected agents inline.** After provider selection + `.env` write, ask "Run `agentmemory connect <agent>` for each selected agent now? [Y/n]". On yes, dispatch each through the existing `runAdapter` (same code path the standalone `agentmemory connect <agent>` command uses today), collect per-agent results, and summarize `Wired: ... / Skipped/failed: ...`. On no/cancel, print the exact commands to run later.

Edge cases handled:
- Stubbed adapters (hermes / pi / openhuman) print their manual-install hint and are bucketed as "manual install required — see <docs>"; not a failure.
- Per-adapter errors are caught + logged; the loop keeps going for remaining agents.
- Zero-agents case (user hit enter on empty multi-select / chose skip) bypasses both the callout and the wire prompt entirely.

Scope-limited to `src/cli/onboarding.ts` (callout + wire flow) and `src/cli/connect/index.ts` (export `runAdapter`).

## Sample first-run flow

```
┌── first-run setup ──
Welcome to agentmemory.

Persistent memory for your AI coding agents. We'll pick which
agents to wire up and which provider (if any) handles compression
and consolidation. Either step can be changed later in ~/.agentmemory/.env.

? Which agents will use agentmemory? (space to toggle, enter to confirm)
  [x] ⟁ Claude Code
  [x] ◎ Codex
  [x] ◫ Cursor
  [x] ◇ Hermes
  ...

━ how this works ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
All selected agents share the same memory at :3111.
A memory saved by Claude Code is visible to Codex + Cursor instantly.
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

? Which LLM provider should agentmemory use for compress/consolidate?
  > Skip — BM25-only mode (no LLM key)

┌── ready ──
✓ Saved preferences to ~/.agentmemory/preferences.json
✓ Wrote ~/.agentmemory/.env (edit to add your API key)
  No provider chosen — agentmemory will run in BM25-only mode.

┌── next step ──
Wire selected agents now?

? Run `agentmemory connect <agent>` for each selected agent now? [Y/n] › y

▶ Wiring claude-code...
▶ Wiring codex...
▶ Wiring cursor...
▶ Wiring hermes...

┌── wire summary ──
Wired: claude-code, codex, cursor.
Skipped/failed: hermes (manual install required — see https://github.com/rohitg00/agentmemory/tree/main/integrations/hermes).
```

## Test plan

- [x] `npm run build` passes
- [x] `npx vitest run test/cli-connect.test.ts` — 13/13 pass (dispatcher + claude-code adapter unchanged)
- [x] Drove `runOnboarding()` non-interactively with mocked `@clack/prompts` + `connect/index.js`: callout renders, wire prompt fires, per-agent step lines print, summary buckets wired vs manual correctly
- [ ] Manual smoke on a real first-run via `npx agentmemory@latest --reset` once published

## Diff stat

```
 src/cli/connect/index.ts |  2 +-
 src/cli/onboarding.ts    | 86 ++++++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 87 insertions(+), 1 deletion(-)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Agent wiring is now integrated into the onboarding process
- After selecting agents, users can wire them immediately or opt to run manual connection commands later
- Onboarding displays information about shared memory behavior when agents are selected
- Wiring summary shows successful connections, agents requiring manual setup, and any failures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/408)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->