### PR TITLE
feat(cli): clarify MCP is opt-in — REST primary, MCP for MCP-only clients

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -133,7 +133,8 @@ Commands:
                      --force bypasses the Docker-heuristic guard and signals
                      whatever pidfile+lsof report on the REST port (use when
                      the engine was started natively but state file is missing).
-  mcp                Start standalone MCP server (no engine required)
+  mcp                Start standalone MCP shim — opt-in surface for MCP-only clients
+                     (Cursor, Gemini CLI, etc). REST always available at :3111.
   import-jsonl [p]   Import Claude Code JSONL transcripts (default: ~/.claude/projects)
                      --max-files <N> | --max-files=<N>: override scan cap (default 200, max 1000;
                      out-of-range is rejected; for trees >1000 files, batch by subdirectory)

--- a/src/cli/connect/claude-code.ts
+++ b/src/cli/connect/claude-code.ts
@@ -34,6 +34,8 @@ export const adapter: ConnectAdapter = {
   name: "claude-code",
   displayName: "Claude Code",
   docs: "https://github.com/rohitg00/agentmemory#claude-code-one-block-paste-it",
+  protocolNote:
+    "→ Using MCP. Hooks are also available — see docs/claude-code.md.",
 
   detect(): boolean {
     return existsSync(CLAUDE_DIR);

--- a/src/cli/connect/codex.ts
+++ b/src/cli/connect/codex.ts
@@ -56,6 +56,8 @@ export const adapter: ConnectAdapter = {
   name: "codex",
   displayName: "Codex CLI",
   docs: "https://github.com/rohitg00/agentmemory#codex-cli-codex-plugin-platform",
+  protocolNote:
+    "→ Using MCP. Hooks are also available — see docs/codex.md.",
 
   detect(): boolean {
     return existsSync(CODEX_DIR);

--- a/src/cli/connect/cursor.ts
+++ b/src/cli/connect/cursor.ts
@@ -8,4 +8,6 @@ export const adapter = createJsonMcpAdapter({
   detectDir: join(homedir(), ".cursor"),
   configPath: join(homedir(), ".cursor", "mcp.json"),
   docs: "https://github.com/rohitg00/agentmemory#other-agents",
+  protocolNote:
+    "→ Using MCP (the only protocol Cursor speaks). Memory bridge runs at :3111 underneath.",
 });

--- a/src/cli/connect/gemini-cli.ts
+++ b/src/cli/connect/gemini-cli.ts
@@ -8,4 +8,6 @@ export const adapter = createJsonMcpAdapter({
   detectDir: join(homedir(), ".gemini"),
   configPath: join(homedir(), ".gemini", "settings.json"),
   docs: "https://github.com/rohitg00/agentmemory#other-agents",
+  protocolNote:
+    "→ Using MCP (the only protocol Gemini CLI speaks). Memory bridge runs at :3111 underneath.",
 });

--- a/src/cli/connect/hermes.ts
+++ b/src/cli/connect/hermes.ts
@@ -12,6 +12,8 @@ export const adapter: ConnectAdapter = {
   name: "hermes",
   displayName: "Hermes Agent",
   docs: DOCS,
+  protocolNote:
+    "→ Using MCP. Hooks are also available — see docs/hermes.md.",
 
   detect(): boolean {
     return existsSync(HERMES_DIR);

--- a/src/cli/connect/index.ts
+++ b/src/cli/connect/index.ts
@@ -60,6 +60,9 @@ async function runAdapter(
     return { kind: "skipped", reason: "not-detected" };
   }
   p.log.step(`Wiring ${adapter.displayName}…`);
+  if (adapter.protocolNote) {
+    p.log.message(adapter.protocolNote);
+  }
   try {
     return await adapter.install(opts);
   } catch (err) {

--- a/src/cli/connect/json-mcp-adapter.ts
+++ b/src/cli/connect/json-mcp-adapter.ts
@@ -18,6 +18,7 @@ export type JsonMcpAdapterConfig = {
   detectDir: string;
   configPath: string;
   docs?: string;
+  protocolNote?: string;
 };
 
 type McpEntry = typeof AGENTMEMORY_MCP_BLOCK;
@@ -41,6 +42,9 @@ export function createJsonMcpAdapter(
     name: config.name,
     displayName: config.displayName,
     ...(config.docs !== undefined && { docs: config.docs }),
+    ...(config.protocolNote !== undefined && {
+      protocolNote: config.protocolNote,
+    }),
 
     detect(): boolean {
       return existsSync(config.detectDir);

--- a/src/cli/connect/openclaw.ts
+++ b/src/cli/connect/openclaw.ts
@@ -8,4 +8,6 @@ export const adapter = createJsonMcpAdapter({
   detectDir: join(homedir(), ".openclaw"),
   configPath: join(homedir(), ".openclaw", "openclaw.json"),
   docs: "https://github.com/rohitg00/agentmemory/tree/main/integrations/openclaw",
+  protocolNote:
+    "→ Using MCP. Hooks are also available — see docs/openclaw.md.",
 });

--- a/src/cli/connect/openhuman.ts
+++ b/src/cli/connect/openhuman.ts
@@ -11,6 +11,8 @@ export const adapter: ConnectAdapter = {
   name: "openhuman",
   displayName: "OpenHuman",
   docs: DOCS,
+  protocolNote:
+    "→ Using native hooks (REST API at :3111). MCP not required.",
 
   detect(): boolean {
     return existsSync(OPENHUMAN_DIR);

--- a/src/cli/connect/pi.ts
+++ b/src/cli/connect/pi.ts
@@ -12,6 +12,8 @@ export const adapter: ConnectAdapter = {
   name: "pi",
   displayName: "pi",
   docs: DOCS,
+  protocolNote:
+    "→ Using native hooks (REST API at :3111). MCP not required.",
 
   detect(): boolean {
     return existsSync(PI_DIR);

--- a/src/cli/connect/types.ts
+++ b/src/cli/connect/types.ts
@@ -7,6 +7,13 @@ export type ConnectAdapter = {
   name: string;
   displayName: string;
   docs?: string;
+  /**
+   * One-line explanation of which protocol this adapter wires (REST hooks vs
+   * MCP) and why. Printed above the install summary so users see — before
+   * any config mutation — that REST is the primary surface and MCP is the
+   * opt-in bridge for MCP-only clients.
+   */
+  protocolNote?: string;
   detect(): boolean;
   install(opts: ConnectOptions): Promise<ConnectResult>;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -461,7 +461,10 @@ async function main() {
     `Ready. ${embeddingProvider ? "Triple-stream (BM25+Vector+Graph)" : "BM25+Graph"} search active.`,
   );
   bootLog(
-    `Endpoints: 107 REST + ${getAllTools().length} MCP tools + 6 MCP resources + 3 MCP prompts`,
+    `REST API: 107 endpoints at http://localhost:${config.restPort}/agentmemory/*`,
+  );
+  bootLog(
+    `MCP surface (opt-in via \`npx @agentmemory/mcp\`): ${getAllTools().length} tools · 6 resources · 3 prompts`,
   );
 
   const viewerPort = config.restPort + 2;


### PR DESCRIPTION
## Summary

Today's boot output foregrounds MCP equally with REST, and the `connect` adapter logs say nothing about which protocol they're wiring. Users were reading this as MCP being required. It isn't — REST is the primary surface for hooks-supporting agents (Claude Code, Codex, OpenClaw, Hermes, pi, OpenHuman), and MCP is the bridge for MCP-only clients (Cursor, Gemini CLI, OpenCode, Cline, Goose, Kilo Code, Aider, Claude Desktop, Windsurf, Roo Code).

Three rewording passes, same numbers everywhere, no behavioral change.

### 1. Boot endpoints summary (`src/index.ts`)

Before:

\`\`\`
Endpoints: 107 REST + 51 MCP tools + 6 MCP resources + 3 MCP prompts
\`\`\`

After:

\`\`\`
REST API: 107 endpoints at http://localhost:3111/agentmemory/*
MCP surface (opt-in via \`npx @agentmemory/mcp\`): 51 tools · 6 resources · 3 prompts
\`\`\`

### 2. `connect` adapter pre-install lines

Added a `protocolNote: string` field on `ConnectAdapter`. `runAdapter` prints it once, right after the existing \`Wiring <agent>…\` step. Same field is plumbed through `createJsonMcpAdapter` so cursor/gemini-cli/openclaw set it too.

- claude-code, codex, openclaw, hermes (hooks-supporting agents wired via MCP):
  \`→ Using MCP. Hooks are also available — see docs/<agent>.md.\`
- pi, openhuman (hooks-supporting agents wired via REST/native extension):
  \`→ Using native hooks (REST API at :3111). MCP not required.\`
- cursor, gemini-cli (MCP-only clients):
  \`→ Using MCP (the only protocol <agent> speaks). Memory bridge runs at :3111 underneath.\`

### 3. `mcp` subcommand `--help` text (`src/cli.ts`)

Before: \`mcp  Start standalone MCP server (no engine required)\`

After: \`mcp  Start standalone MCP shim — opt-in surface for MCP-only clients (Cursor, Gemini CLI, etc). REST always available at :3111.\`

## Why

Rohit pushed back directly: today's CLI surface reads as MCP-required. This is a copy fix that puts REST in the primary slot everywhere a user first encounters the protocol choice — boot output, `connect`, `--help`.

## Test plan

- [x] `npm run build` passes
- [x] Full test suite: 954/954 pass (same as `origin/main` baseline)
- [x] Diff stat: 13 files, +36/-2
- [x] No README touch — that's a separate doc-only PR
- [x] No version bump, no CHANGELOG entry
- [x] No touching the CLI ready panel (sibling PR's surface area)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated help text to clarify MCP as a "standalone MCP shim" with opt-in surface while REST remains available.
  * Added protocol notes to all adapter configurations explaining whether they use MCP or native hooks.
  * Protocol notes now display during adapter connection setup.
  * Updated startup logging to separately display REST API and MCP endpoint information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/409)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->