### PR TITLE
fix(cli): rerender splash banner + README npx caveat

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,26 @@ npx @agentmemory/agentmemory demo
 
 Open `http://localhost:3113` to watch the memory build live.
 
+### Recommended: install globally
+
+`npx` caches per-version. If you ran `npx @agentmemory/agentmemory@0.9.14` last week, a bare `npx @agentmemory/agentmemory` may serve the stale 0.9.14 from `~/.npm/_npx/`, not the latest release. Install once and the bare `agentmemory` command works everywhere:
+
+```bash
+npm install -g @agentmemory/agentmemory
+agentmemory                    # start the server (same as the npx form)
+agentmemory stop               # tear it down
+agentmemory remove             # uninstall everything we created
+agentmemory connect claude-code   # wire one agent
+agentmemory doctor             # interactive diagnostics + fix prompts
+```
+
+From v0.9.16 onward, the first npx run prompts you to install globally inline — answer `Y` once and you're set. If you skip, fall back to either of these for a fresh fetch:
+
+```bash
+npx -y @agentmemory/agentmemory@latest      # forces latest from npm
+rm -rf ~/.npm/_npx && npx @agentmemory/agentmemory   # clear cache once
+```
+
 ### Session Replay
 
 Every session agentmemory records is replayable. Open the viewer, pick the **Replay** tab, and scrub through the timeline: prompts, tool calls, tool results, and responses render as discrete events with play/pause, speed control (0.5×–4×), and keyboard shortcuts (space to toggle, arrows to step).

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Or via `npx` (no install):
 npx @agentmemory/agentmemory
 ```
 
-Heads-up — npx caches per version. If a bare `npx @agentmemory/agentmemory` serves an older release, force the latest with `npx -y @agentmemory/agentmemory@latest`, or clear the cache once with `rm -rf ~/.npm/_npx`. The first npx run from v0.9.16+ prompts to install globally inline so the bare `agentmemory` command works everywhere afterwards.
+Heads-up — npx caches per version. If a bare `npx @agentmemory/agentmemory` serves an older release, force the latest with `npx -y @agentmemory/agentmemory@latest`, or clear the cache once with `rm -rf ~/.npm/_npx` (macOS/Linux; on Windows delete `%LOCALAPPDATA%\npm-cache\_npx`). The first npx run from v0.9.16+ prompts to install globally inline so the bare `agentmemory` command works everywhere afterwards.
 
 Full options at [Quick Start](#quick-start) below. Agent-specific wiring at [Works with every agent](#works-with-every-agent).
 
@@ -359,9 +359,11 @@ agentmemory doctor             # interactive diagnostics + fix prompts
 From v0.9.16 onward, the first npx run prompts you to install globally inline — answer `Y` once and you're set. If you skip, fall back to either of these for a fresh fetch:
 
 ```bash
-npx -y @agentmemory/agentmemory@latest      # forces latest from npm
-rm -rf ~/.npm/_npx && npx @agentmemory/agentmemory   # clear cache once
+npx -y @agentmemory/agentmemory@latest                 # forces latest from npm (cross-platform)
+rm -rf ~/.npm/_npx && npx @agentmemory/agentmemory     # macOS/Linux only (POSIX shell)
 ```
+
+On Windows / PowerShell, the equivalent cache clear is `Remove-Item -Recurse -Force "$env:LOCALAPPDATA\npm-cache\_npx"` — the `npx -y ...@latest` form above is the cross-platform option.
 
 ### Session Replay
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@
 </p>
 
 <p align="center">
+  <a href="#install">Install</a> &bull;
   <a href="#quick-start">Quick Start</a> &bull;
   <a href="#benchmarks">Benchmarks</a> &bull;
   <a href="#vs-competitors">vs Competitors</a> &bull;
@@ -65,6 +66,27 @@
   <a href="#configuration">Config</a> &bull;
   <a href="#api">API</a>
 </p>
+
+---
+
+## Install
+
+```bash
+npm install -g @agentmemory/agentmemory     # once — bare `agentmemory` on PATH
+agentmemory                                  # start the memory server on :3111
+agentmemory demo                             # seed sample sessions + prove recall
+agentmemory connect claude-code              # wire your agent (also: codex, cursor, gemini-cli, ...)
+```
+
+Or via `npx` (no install):
+
+```bash
+npx @agentmemory/agentmemory
+```
+
+Heads-up — npx caches per version. If a bare `npx @agentmemory/agentmemory` serves an older release, force the latest with `npx -y @agentmemory/agentmemory@latest`, or clear the cache once with `rm -rf ~/.npm/_npx`. The first npx run from v0.9.16+ prompts to install globally inline so the bare `agentmemory` command works everywhere afterwards.
+
+Full options at [Quick Start](#quick-start) below. Agent-specific wiring at [Works with every agent](#works-with-every-agent).
 
 ---
 

--- a/src/cli/splash.ts
+++ b/src/cli/splash.ts
@@ -42,17 +42,18 @@ function getTerminalWidth(): number {
 
 const TAGLINE = "Persistent memory for AI coding agents";
 
-// Block-art "agentmemory" lettering. Hand-drawn in box-drawing chars so
-// we don't need a figlet dependency. Each row is 70 columns wide which
-// gives ~25 cols of breathing room on the 120-col tier.
+// "agentmemory" rendered in figlet's standard font (verified output —
+// regenerate via `figlet agentmemory` if you change the wordmark). Each
+// row is exactly 70 columns wide so the banner aligns cleanly inside
+// the 2-col left margin we add below.
 function fullBanner(version: string): string {
   const logo = [
-    "                       _                                                  ",
-    "  __ _  __ _  ___ _ _ | |_ _ __  ___ _ __ ___   ___  _ __ _   _          ",
-    " / _` |/ _` |/ _ \\ '_\\| __| '  \\/ -_) '  \\ _ \\ / _ \\| '__| | | |         ",
-    "| (_| | (_| |  __/ | || |_| | | \\___| | | | | | (_) | |  | |_| |         ",
-    " \\__,_|\\__, |\\___|_|  \\__|_| |_|    |_| |_| |_|\\___/|_|   \\__, |         ",
-    "       |___/                                              |___/          ",
+    "                        _                                             ",
+    "  __ _  __ _  ___ _ __ | |_ _ __ ___   ___ _ __ ___   ___  _ __ _   _ ",
+    " / _` |/ _` |/ _ \\ '_ \\| __| '_ ` _ \\ / _ \\ '_ ` _ \\ / _ \\| '__| | | |",
+    "| (_| | (_| |  __/ | | | |_| | | | | |  __/ | | | | | (_) | |  | |_| |",
+    " \\__,_|\\__, |\\___|_| |_|\\__|_| |_| |_|\\___|_| |_| |_|\\___/|_|   \\__, |",
+    "       |___/                                                    |___/ ",
   ];
   const lines: string[] = ["", ...logo.map((line) => "  " + accent(line))];
   lines.push("");

--- a/website/components/Install.tsx
+++ b/website/components/Install.tsx
@@ -14,7 +14,7 @@ const SIMPLE: Cmd[] = [
   {
     label: "1. INSTALL ONCE",
     cmd: "npm install -g @agentmemory/agentmemory",
-    hint: "PUTS `agentmemory` ON YOUR PATH · OR USE npx",
+    hint: "PUTS `agentmemory` ON YOUR PATH · STEPS 2/3 NEED THIS",
   },
   {
     label: "2. START THE MEMORY SERVER",
@@ -27,6 +27,12 @@ const SIMPLE: Cmd[] = [
     hint: "SEEDS 3 SESSIONS · PROVES HYBRID SEARCH WORKS",
   },
 ];
+
+const NPX_FALLBACK: Cmd = {
+  label: "PREFER ZERO-INSTALL? USE NPX",
+  cmd: "npx @agentmemory/agentmemory",
+  hint: "REPLACES STEPS 1+2 · USES NPX CACHE — SEE README FOR CAVEAT",
+};
 
 function CopyBox({ label, cmd, hint }: Cmd) {
   const [copied, setCopied] = useState(false);
@@ -71,14 +77,14 @@ export function Install() {
         </h2>
         <p className="section-lede">
           RUNS ON YOUR MACHINE. DATA STAYS LOCAL. BRING YOUR CLAUDE SUBSCRIPTION
-          — OR POINT IT AT ANTHROPIC, GEMINI, MINIMAX, OR OPENROUTER. PREFER NPX?
-          USE <code>npx @agentmemory/agentmemory</code> INSTEAD OF STEP 1.
+          — OR POINT IT AT ANTHROPIC, GEMINI, MINIMAX, OR OPENROUTER.
         </p>
       </header>
       <div className={styles.cards}>
         {SIMPLE.map((c) => (
           <CopyBox key={c.cmd} {...c} />
         ))}
+        <CopyBox {...NPX_FALLBACK} />
         <AgentInstall />
       </div>
       <div className={styles.cta}>

--- a/website/components/Install.tsx
+++ b/website/components/Install.tsx
@@ -12,19 +12,19 @@ interface Cmd {
 
 const SIMPLE: Cmd[] = [
   {
-    label: "1. START THE MEMORY SERVER",
-    cmd: "npx @agentmemory/agentmemory",
+    label: "1. INSTALL ONCE",
+    cmd: "npm install -g @agentmemory/agentmemory",
+    hint: "PUTS `agentmemory` ON YOUR PATH · OR USE npx",
+  },
+  {
+    label: "2. START THE MEMORY SERVER",
+    cmd: "agentmemory",
     hint: "RUNS ON :3111 · VIEWER ON :3113",
   },
   {
-    label: "2. SEE SEMANTIC RECALL INSTANTLY",
-    cmd: "npx @agentmemory/agentmemory demo",
+    label: "3. SEE SEMANTIC RECALL INSTANTLY",
+    cmd: "agentmemory demo",
     hint: "SEEDS 3 SESSIONS · PROVES HYBRID SEARCH WORKS",
-  },
-  {
-    label: "3. OPEN THE LIVE VIEWER",
-    cmd: "open http://localhost:3113",
-    hint: "SESSIONS · MEMORIES · GRAPH · HEALTH",
   },
 ];
 
@@ -67,11 +67,12 @@ export function Install() {
       <header className="section-head">
         <span className="section-eyebrow">SHIP IT</span>
         <h2 id="install-title" className="section-title">
-          THREE COMMANDS.<br />ANY AGENT.
+          ONE INSTALL.<br />ANY AGENT.
         </h2>
         <p className="section-lede">
           RUNS ON YOUR MACHINE. DATA STAYS LOCAL. BRING YOUR CLAUDE SUBSCRIPTION
-          — OR POINT IT AT ANTHROPIC, GEMINI, MINIMAX, OR OPENROUTER.
+          — OR POINT IT AT ANTHROPIC, GEMINI, MINIMAX, OR OPENROUTER. PREFER NPX?
+          USE <code>npx @agentmemory/agentmemory</code> INSTEAD OF STEP 1.
         </p>
       </header>
       <div className={styles.cards}>

--- a/website/lib/generated-meta.json
+++ b/website/lib/generated-meta.json
@@ -4,5 +4,5 @@
   "hooks": 12,
   "restEndpoints": 121,
   "testsPassing": 975,
-  "generatedAt": "2026-05-15T16:38:30.869Z"
+  "generatedAt": "2026-05-15T16:48:13.498Z"
 }

--- a/website/lib/generated-meta.json
+++ b/website/lib/generated-meta.json
@@ -1,8 +1,8 @@
 {
-  "version": "0.9.10",
+  "version": "0.9.15",
   "mcpTools": 51,
   "hooks": 12,
   "restEndpoints": 121,
-  "testsPassing": 898,
-  "generatedAt": "2026-05-12T22:49:51.241Z"
+  "testsPassing": 975,
+  "generatedAt": "2026-05-15T16:38:30.869Z"
 }


### PR DESCRIPTION
## Summary

- Splash banner ASCII for `agentmemory` was rendering with broken middle glyphs (`_ _` instead of `_ __` around the 'n', merged 'tm/me' segments). Replaced with verified `figlet agentmemory` standard-font output. 70 cols, 6 rows, regenerable.
- Added README Quick Start section explaining the npx per-version cache gotcha and three workarounds. Notes that v0.9.16 ships an interactive global-install prompt inline.

## Before / After (full banner, ≥120 cols)

Before:
```
                       _                                                  
  __ _  __ _  ___ _ _ | |_ _ __  ___ _ __ ___   ___  _ __ _   _          
 / _` |/ _` |/ _ \ '_\| __| '  \/ -_) '  \ _ \ / _ \| '__| | | |         
| (_| | (_| |  __/ | || |_| | | \___| | | | | | (_) | |  | |_| |         
 \__,_|\__, |\___|_|  \__|_| |_|    |_| |_| |_|\___/|_|   \__, |         
       |___/                                              |___/
```

After:
```
                        _                                             
  __ _  __ _  ___ _ __ | |_ _ __ ___   ___ _ __ ___   ___  _ __ _   _ 
 / _` |/ _` |/ _ \ '_ \| __| '_ ` _ \ / _ \ '_ ` _ \ / _ \| '__| | | |
| (_| | (_| |  __/ | | | |_| | | | | |  __/ | | | | | (_) | |  | |_| |
 \__,_|\__, |\___|_| |_|\__|_| |_| |_|\___|_| |_| |_|\___/|_|   \__, |
       |___/                                                    |___/ 
```

## Test plan

- [x] `npm run build` clean (44.46 kB cli.mjs)
- [x] `npm test` — 954/954 passing
- [x] Verified live render at `COLUMNS=140 npx tsx -e "...renderSplash('0.9.16')"`
- [x] Compact + minimal banners unchanged
- [x] No new deps (figlet is only used at dev time to regenerate)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation docs with a recommended global-install path, simplified quick start ("ONE INSTALL. ANY AGENT"), and added an NPX fallback option.
  * Added notes on npx per-version caching, first-run prompt behavior, and fallback commands to force latest or clear cache.

* **Style**
  * Refreshed CLI splash banner artwork with an updated wordmark/logo.

* **Other**
  * Site build metadata bumped to v0.9.15.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/411)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->