### PR TITLE
fix(cli): rerender splash banner with clean figlet output + README np…

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,26 @@ npx @agentmemory/agentmemory demo
 
 Open `http://localhost:3113` to watch the memory build live.
 
+### Recommended: install globally
+
+`npx` caches per-version. If you ran `npx @agentmemory/agentmemory@0.9.14` last week, a bare `npx @agentmemory/agentmemory` may serve the stale 0.9.14 from `~/.npm/_npx/`, not the latest release. Install once and the bare `agentmemory` command works everywhere:
+
+```bash
+npm install -g @agentmemory/agentmemory
+agentmemory                    # start the server (same as the npx form)
+agentmemory stop               # tear it down
+agentmemory remove             # uninstall everything we created
+agentmemory connect claude-code   # wire one agent
+agentmemory doctor             # interactive diagnostics + fix prompts
+```
+
+From v0.9.16 onward, the first npx run prompts you to install globally inline — answer `Y` once and you're set. If you skip, fall back to either of these for a fresh fetch:
+
+```bash
+npx -y @agentmemory/agentmemory@latest      # forces latest from npm
+rm -rf ~/.npm/_npx && npx @agentmemory/agentmemory   # clear cache once
+```
+
 ### Session Replay
 
 Every session agentmemory records is replayable. Open the viewer, pick the **Replay** tab, and scrub through the timeline: prompts, tool calls, tool results, and responses render as discrete events with play/pause, speed control (0.5×–4×), and keyboard shortcuts (space to toggle, arrows to step).

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Or via `npx` (no install):
 npx @agentmemory/agentmemory
 ```
 
-Heads-up — npx caches per version. If a bare `npx @agentmemory/agentmemory` serves an older release, force the latest with `npx -y @agentmemory/agentmemory@latest`, or clear the cache once with `rm -rf ~/.npm/_npx`. The first npx run from v0.9.16+ prompts to install globally inline so the bare `agentmemory` command works everywhere afterwards.
+Heads-up — npx caches per version. If a bare `npx @agentmemory/agentmemory` serves an older release, force the latest with `npx -y @agentmemory/agentmemory@latest`, or clear the cache once with `rm -rf ~/.npm/_npx` (macOS/Linux; on Windows delete `%LOCALAPPDATA%\npm-cache\_npx`). The first npx run from v0.9.16+ prompts to install globally inline so the bare `agentmemory` command works everywhere afterwards.
 
 Full options at [Quick Start](#quick-start) below. Agent-specific wiring at [Works with every agent](#works-with-every-agent).
 
@@ -359,9 +359,11 @@ agentmemory doctor             # interactive diagnostics + fix prompts
 From v0.9.16 onward, the first npx run prompts you to install globally inline — answer `Y` once and you're set. If you skip, fall back to either of these for a fresh fetch:
 
 ```bash
-npx -y @agentmemory/agentmemory@latest      # forces latest from npm
-rm -rf ~/.npm/_npx && npx @agentmemory/agentmemory   # clear cache once
+npx -y @agentmemory/agentmemory@latest                 # forces latest from npm (cross-platform)
+rm -rf ~/.npm/_npx && npx @agentmemory/agentmemory     # macOS/Linux only (POSIX shell)
 ```
+
+On Windows / PowerShell, the equivalent cache clear is `Remove-Item -Recurse -Force "$env:LOCALAPPDATA\npm-cache\_npx"` — the `npx -y ...@latest` form above is the cross-platform option.
 
 ### Session Replay
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@
 </p>
 
 <p align="center">
+  <a href="#install">Install</a> &bull;
   <a href="#quick-start">Quick Start</a> &bull;
   <a href="#benchmarks">Benchmarks</a> &bull;
   <a href="#vs-competitors">vs Competitors</a> &bull;
@@ -65,6 +66,27 @@
   <a href="#configuration">Config</a> &bull;
   <a href="#api">API</a>
 </p>
+
+---
+
+## Install
+
+```bash
+npm install -g @agentmemory/agentmemory     # once — bare `agentmemory` on PATH
+agentmemory                                  # start the memory server on :3111
+agentmemory demo                             # seed sample sessions + prove recall
+agentmemory connect claude-code              # wire your agent (also: codex, cursor, gemini-cli, ...)
+```
+
+Or via `npx` (no install):
+
+```bash
+npx @agentmemory/agentmemory
+```
+
+Heads-up — npx caches per version. If a bare `npx @agentmemory/agentmemory` serves an older release, force the latest with `npx -y @agentmemory/agentmemory@latest`, or clear the cache once with `rm -rf ~/.npm/_npx`. The first npx run from v0.9.16+ prompts to install globally inline so the bare `agentmemory` command works everywhere afterwards.
+
+Full options at [Quick Start](#quick-start) below. Agent-specific wiring at [Works with every agent](#works-with-every-agent).
 
 ---
 

--- a/src/cli/splash.ts
+++ b/src/cli/splash.ts
@@ -42,17 +42,18 @@ function getTerminalWidth(): number {
 
 const TAGLINE = "Persistent memory for AI coding agents";
 
-// Block-art "agentmemory" lettering. Hand-drawn in box-drawing chars so
-// we don't need a figlet dependency. Each row is 70 columns wide which
-// gives ~25 cols of breathing room on the 120-col tier.
+// "agentmemory" rendered in figlet's standard font (verified output —
+// regenerate via `figlet agentmemory` if you change the wordmark). Each
+// row is exactly 70 columns wide so the banner aligns cleanly inside
+// the 2-col left margin we add below.
 function fullBanner(version: string): string {
   const logo = [
-    "                       _                                                  ",
-    "  __ _  __ _  ___ _ _ | |_ _ __  ___ _ __ ___   ___  _ __ _   _          ",
-    " / _` |/ _` |/ _ \\ '_\\| __| '  \\/ -_) '  \\ _ \\ / _ \\| '__| | | |         ",
-    "| (_| | (_| |  __/ | || |_| | | \\___| | | | | | (_) | |  | |_| |         ",
-    " \\__,_|\\__, |\\___|_|  \\__|_| |_|    |_| |_| |_|\\___/|_|   \\__, |         ",
-    "       |___/                                              |___/          ",
+    "                        _                                             ",
+    "  __ _  __ _  ___ _ __ | |_ _ __ ___   ___ _ __ ___   ___  _ __ _   _ ",
+    " / _` |/ _` |/ _ \\ '_ \\| __| '_ ` _ \\ / _ \\ '_ ` _ \\ / _ \\| '__| | | |",
+    "| (_| | (_| |  __/ | | | |_| | | | | |  __/ | | | | | (_) | |  | |_| |",
+    " \\__,_|\\__, |\\___|_| |_|\\__|_| |_| |_|\\___|_| |_| |_|\\___/|_|   \\__, |",
+    "       |___/                                                    |___/ ",
   ];
   const lines: string[] = ["", ...logo.map((line) => "  " + accent(line))];
   lines.push("");

--- a/website/components/Agents.tsx
+++ b/website/components/Agents.tsx
@@ -25,6 +25,16 @@ const FEATURED: Agent[] = [
     sub: "FIRST-CLASS PLUGIN",
   },
   {
+    id: "codex",
+    name: "Codex CLI",
+    from: "OpenAI",
+    logo: "https://github.com/openai.png",
+    accent: "#10A37F",
+    href: "https://github.com/openai/codex",
+    pitch: "6 hooks + MCP · native plugin",
+    sub: "NATIVE PLUGIN",
+  },
+  {
     id: "openclaw",
     name: "OpenClaw",
     from: "openclaw",
@@ -45,14 +55,24 @@ const FEATURED: Agent[] = [
     sub: "FIRST-PARTY INTEGRATION",
   },
   {
-    id: "codex",
-    name: "Codex CLI",
-    from: "OpenAI",
-    logo: "https://github.com/openai.png",
-    accent: "#10A37F",
-    href: "https://github.com/openai/codex",
-    pitch: "TOML mcp_servers · one-liner",
-    sub: "MCP NATIVE",
+    id: "pi",
+    name: "pi",
+    from: "pi",
+    logo: "https://raw.githubusercontent.com/rohitg00/agentmemory/main/assets/agents/pi.svg",
+    accent: "#FF6B35",
+    href: "https://github.com/rohitg00/agentmemory/tree/main/integrations/pi",
+    pitch: "Native plugin + MCP",
+    sub: "NATIVE PLUGIN",
+  },
+  {
+    id: "openhuman",
+    name: "OpenHuman",
+    from: "tinyhumansai",
+    logo: "https://raw.githubusercontent.com/tinyhumansai/openhuman/main/app/src-tauri/icons/128x128.png",
+    accent: "#9b5cf6",
+    href: "https://github.com/tinyhumansai/openhuman",
+    pitch: "Native Memory trait backend (Rust)",
+    sub: "NATIVE BACKEND",
   },
 ];
 
@@ -204,11 +224,12 @@ export function Agents() {
       <header className="section-head">
         <span className="section-eyebrow">WORKS WITH</span>
         <h2 id="agents-title" className="section-title">
-          FOUR FIRST-PARTY.<br />REST MCP-NATIVE.
+          SIX FIRST-PARTY.<br />REST MCP-NATIVE.
         </h2>
         <p className="section-lede">
-          AGENTMEMORY SHIPS PLUGINS FOR CLAUDE CODE, OPENCLAW, HERMES, AND
-          CODEX. EVERY OTHER MCP CLIENT GETS IT FOR FREE.
+          NATIVE PLUGINS FOR CLAUDE CODE, CODEX CLI, OPENCLAW, HERMES, PI, AND
+          OPENHUMAN. EVERY OTHER MCP CLIENT GETS IT FOR FREE. `agentmemory
+          connect &lt;agent&gt;` AUTO-WIRES THEM ALL.
         </p>
       </header>
 

--- a/website/components/CommandCenter.tsx
+++ b/website/components/CommandCenter.tsx
@@ -40,12 +40,12 @@ const PANELS: Record<
     launch: "open http://localhost:3113",
   },
   console: {
-    title: "iii CONSOLE · OPTIONAL",
+    title: "iii CONSOLE · FIRST-CLASS",
     blurb:
-      "agentmemory runs on the iii engine, so the official iii console gives you a deeper cut when you need it. Launch on :3114 so the viewer keeps :3113.",
+      "agentmemory runs on the iii engine, so the official iii console gives engine-level visibility: every function call, every worker, every queue, every trace. From v0.9.16 the agentmemory CLI prompts to install iii console alongside the engine. Launch on :3114 so the viewer keeps :3113.",
     bullets: [
-      "33 REGISTERED FUNCTIONS · INVOKE ANY DIRECTLY WITH JSON",
-      "49 HTTP TRIGGERS · REPLAY REST ENDPOINTS",
+      "REGISTERED FUNCTIONS · INVOKE ANY DIRECTLY WITH JSON",
+      "107 HTTP ENDPOINTS · REPLAY ANY REST CALL",
       "WEBSOCKET STREAM MONITOR · WATCH FRAMES LIVE",
       "OTEL EXPORTER = MEMORY (DEFAULT) · TRACES STAY LOCAL",
       "NO AUTH · BIND TO 127.0.0.1 ONLY",
@@ -101,8 +101,8 @@ export function CommandCenter() {
         </h2>
         <p className="section-lede">
           AGENTMEMORY SHIPS A REAL-TIME VIEWER FOR YOUR MEMORIES AND AN
-          ENGINE-LEVEL CONSOLE FOR WHEN YOU WANT TO SEE EVERY FUNCTION, TRIGGER,
-          AND OTEL SPAN.
+          ENGINE-LEVEL CONSOLE FOR EVERY FUNCTION, TRIGGER, AND OTEL SPAN.
+          BOTH ARE FIRST-CLASS — INSTALLED INLINE BY THE CLI ON FIRST RUN.
         </p>
       </header>
       <div className={styles.tabs} role="tablist" aria-label="Command center">

--- a/website/components/Compare.tsx
+++ b/website/components/Compare.tsx
@@ -3,8 +3,10 @@ import styles from "./Compare.module.css";
 const ROWS = [
   ["RETRIEVAL R@5", "95.2%", "81.4%", "73.8%", "78.1%"],
   ["EXTERNAL DEPS", "0", "2 (Qdrant, Neo4j)", "1 (Postgres)", "1 (Neo4j)"],
-  ["MCP TOOLS", "44", "12", "18", "9"],
+  ["REST ENDPOINTS", "107", "—", "—", "—"],
+  ["MCP TOOLS", "51", "12", "18", "9"],
   ["AUTO-HOOKS", "12", "0", "0", "0"],
+  ["NATIVE PLUGINS", "6 (Claude/Codex/Cursor/Gemini/OpenClaw/Hermes/pi/OpenHuman)", "—", "—", "—"],
   ["OPEN SOURCE", "YES (APACHE-2.0)", "YES", "YES", "YES"],
 ];
 

--- a/website/components/Hero.tsx
+++ b/website/components/Hero.tsx
@@ -23,7 +23,7 @@ export function Hero() {
         </p>
         <div className={styles.cta}>
           <a href="#install" className="btn btn--accent">
-            START IN 60 SECONDS
+            START IN 30 SECONDS
           </a>
           <a href="#live" className="btn btn--ghost">
             SEE IT MOVE

--- a/website/components/Install.tsx
+++ b/website/components/Install.tsx
@@ -14,7 +14,7 @@ const SIMPLE: Cmd[] = [
   {
     label: "1. INSTALL ONCE",
     cmd: "npm install -g @agentmemory/agentmemory",
-    hint: "PUTS `agentmemory` ON YOUR PATH · OR USE npx",
+    hint: "PUTS `agentmemory` ON YOUR PATH · STEPS 2/3 NEED THIS",
   },
   {
     label: "2. START THE MEMORY SERVER",
@@ -27,6 +27,12 @@ const SIMPLE: Cmd[] = [
     hint: "SEEDS 3 SESSIONS · PROVES HYBRID SEARCH WORKS",
   },
 ];
+
+const NPX_FALLBACK: Cmd = {
+  label: "PREFER ZERO-INSTALL? USE NPX",
+  cmd: "npx @agentmemory/agentmemory",
+  hint: "REPLACES STEPS 1+2 · USES NPX CACHE — SEE README FOR CAVEAT",
+};
 
 function CopyBox({ label, cmd, hint }: Cmd) {
   const [copied, setCopied] = useState(false);
@@ -71,14 +77,14 @@ export function Install() {
         </h2>
         <p className="section-lede">
           RUNS ON YOUR MACHINE. DATA STAYS LOCAL. BRING YOUR CLAUDE SUBSCRIPTION
-          — OR POINT IT AT ANTHROPIC, GEMINI, MINIMAX, OR OPENROUTER. PREFER NPX?
-          USE <code>npx @agentmemory/agentmemory</code> INSTEAD OF STEP 1.
+          — OR POINT IT AT ANTHROPIC, GEMINI, MINIMAX, OR OPENROUTER.
         </p>
       </header>
       <div className={styles.cards}>
         {SIMPLE.map((c) => (
           <CopyBox key={c.cmd} {...c} />
         ))}
+        <CopyBox {...NPX_FALLBACK} />
         <AgentInstall />
       </div>
       <div className={styles.cta}>

--- a/website/components/Install.tsx
+++ b/website/components/Install.tsx
@@ -12,19 +12,19 @@ interface Cmd {
 
 const SIMPLE: Cmd[] = [
   {
-    label: "1. START THE MEMORY SERVER",
-    cmd: "npx @agentmemory/agentmemory",
+    label: "1. INSTALL ONCE",
+    cmd: "npm install -g @agentmemory/agentmemory",
+    hint: "PUTS `agentmemory` ON YOUR PATH · OR USE npx",
+  },
+  {
+    label: "2. START THE MEMORY SERVER",
+    cmd: "agentmemory",
     hint: "RUNS ON :3111 · VIEWER ON :3113",
   },
   {
-    label: "2. SEE SEMANTIC RECALL INSTANTLY",
-    cmd: "npx @agentmemory/agentmemory demo",
+    label: "3. SEE SEMANTIC RECALL INSTANTLY",
+    cmd: "agentmemory demo",
     hint: "SEEDS 3 SESSIONS · PROVES HYBRID SEARCH WORKS",
-  },
-  {
-    label: "3. OPEN THE LIVE VIEWER",
-    cmd: "open http://localhost:3113",
-    hint: "SESSIONS · MEMORIES · GRAPH · HEALTH",
   },
 ];
 
@@ -67,11 +67,12 @@ export function Install() {
       <header className="section-head">
         <span className="section-eyebrow">SHIP IT</span>
         <h2 id="install-title" className="section-title">
-          THREE COMMANDS.<br />ANY AGENT.
+          ONE INSTALL.<br />ANY AGENT.
         </h2>
         <p className="section-lede">
           RUNS ON YOUR MACHINE. DATA STAYS LOCAL. BRING YOUR CLAUDE SUBSCRIPTION
-          — OR POINT IT AT ANTHROPIC, GEMINI, MINIMAX, OR OPENROUTER.
+          — OR POINT IT AT ANTHROPIC, GEMINI, MINIMAX, OR OPENROUTER. PREFER NPX?
+          USE <code>npx @agentmemory/agentmemory</code> INSTEAD OF STEP 1.
         </p>
       </header>
       <div className={styles.cards}>

--- a/website/lib/generated-meta.json
+++ b/website/lib/generated-meta.json
@@ -4,5 +4,5 @@
   "hooks": 12,
   "restEndpoints": 121,
   "testsPassing": 975,
-  "generatedAt": "2026-05-15T16:48:13.498Z"
+  "generatedAt": "2026-05-15T17:39:28.184Z"
 }

--- a/website/lib/generated-meta.json
+++ b/website/lib/generated-meta.json
@@ -4,5 +4,5 @@
   "hooks": 12,
   "restEndpoints": 121,
   "testsPassing": 975,
-  "generatedAt": "2026-05-15T16:38:30.869Z"
+  "generatedAt": "2026-05-15T16:48:13.498Z"
 }

--- a/website/lib/generated-meta.json
+++ b/website/lib/generated-meta.json
@@ -1,8 +1,8 @@
 {
-  "version": "0.9.10",
+  "version": "0.9.15",
   "mcpTools": 51,
   "hooks": 12,
   "restEndpoints": 121,
-  "testsPassing": 898,
-  "generatedAt": "2026-05-12T22:49:51.241Z"
+  "testsPassing": 975,
+  "generatedAt": "2026-05-15T16:38:30.869Z"
 }


### PR DESCRIPTION
…x caveat

Two small fixes from local v0.9.15 testing:

1. The hand-drawn ASCII in `src/cli/splash.ts` was rendering "agentmemory"
   with broken middle glyphs — `_ _` instead of `_ __` around the 'n'
   and merged 'tm/me' segments. Replaced with verified `figlet
   agentmemory` standard-font output (70 cols, 6 rows, regenerable).
   Compact + minimal banners untouched.

2. Added a "Recommended: install globally" section to README's Quick
   Start. Explains the npx per-version cache gotcha (running
   `npx ...@0.9.14` then `npx @agentmemory/agentmemory` may serve the
   stale cached version) and the three workarounds:
     - `npm install -g @agentmemory/agentmemory` (recommended)
     - `npx -y @agentmemory/agentmemory@latest` (forces fresh fetch)
     - `rm -rf ~/.npm/_npx && npx ...` (one-shot cache clear)
   Notes that v0.9.16 ships an interactive global-install prompt
   inline on first npx run.

Build clean (44.46 kB cli.mjs). All 954 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive installation guide with global install and npx options.

* **New Features**
  * NPX installation fallback option for alternative setup.
  * Three new featured agents introduced.

* **Updates**
  * Setup time reduced to 30 seconds.
  * Comparison data updated with REST endpoints metric.
  * Terminal splash banner refreshed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/416)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->