### PR TITLE
Security: Bearer token sent over plaintext HTTP

### DIFF
--- a/src/hooks/stop.ts
+++ b/src/hooks/stop.ts
@@ -12,6 +12,23 @@ function isSdkChildContext(payload: unknown): boolean {
 const REST_URL = process.env["AGENTMEMORY_URL"] || "http://localhost:3111";
 const SECRET = process.env["AGENTMEMORY_SECRET"] || "";
 
+function isSecureUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol === "https:") return true;
+    const hostname = parsed.hostname.toLowerCase();
+    if (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1") return true;
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+if (SECRET && !isSecureUrl(REST_URL)) {
+  console.error("Error: AGENTMEMORY_SECRET is set but AGENTMEMORY_URL uses insecure http:// protocol. Use https:// or a loopback address.");
+  process.exit(1);
+}
+
 function authHeaders(): Record<string, string> {
   const h: Record<string, string> = { "Content-Type": "application/json" };
   if (SECRET) h["Authorization"] = `Bearer ${SECRET}`;


### PR DESCRIPTION
## Problem

The hook scripts (stop.ts, post-tool-use.ts, etc.) send Bearer tokens in Authorization headers to REST_URL. When AGENTMEMORY_URL defaults to 'http://localhost:3111', tokens are transmitted over plaintext HTTP. While localhost traffic typically doesn't leave the machine, this could be intercepted by local malware or other processes on multi-tenant systems.

**Severity**: `high`
**File**: `src/hooks/stop.ts`

## Solution

Enforce HTTPS or validate that the URL uses https:// protocol. Consider adding a configuration check that errors if AGENTMEMORY_SECRET is set but AGENTMEMORY_URL uses http:// (non-loopback). The integrations/pi/security.ts already has a guard for this pattern - consider centralizing this logic.

## Changes

- `src/hooks/stop.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security validation to prevent sensitive authentication credentials from being transmitted over unsecured network connections. When an authorization secret is configured, the application now enforces HTTPS encryption for all remote connections or restricts to local loopback addresses only, ensuring bearer tokens are never accidentally exposed via unencrypted HTTP.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/418?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->