### PR TITLE
fix(mcp): use DELETE for governance memory deletion proxy

### DIFF
--- a/src/mcp/standalone.ts
+++ b/src/mcp/standalone.ts
@@ -176,7 +176,7 @@ async function handleProxy(
     }
     case "memory_governance_delete": {
       const result = await handle.call("/agentmemory/governance/memories", {
-        method: "POST",
+        method: "DELETE",
         body: JSON.stringify({ memoryIds: v.memoryIds, reason: v.reason }),
       });
       return textResponse(result);

--- a/test/mcp-standalone-proxy.test.ts
+++ b/test/mcp-standalone-proxy.test.ts
@@ -75,6 +75,43 @@ describe("@agentmemory/mcp standalone — server proxy (issue #159)", () => {
     expect(body.results[0].id).toBe("m1");
   });
 
+  it("proxies memory_governance_delete to the DELETE REST endpoint", async () => {
+    const calls: Array<{ url: string; method: string; body?: unknown }> = [];
+    installFetch((url, init) => {
+      const method = init?.method || "GET";
+      if (url.endsWith("/agentmemory/livez")) return new Response("ok", { status: 200 });
+      calls.push({
+        url,
+        method,
+        body: init?.body ? JSON.parse(init.body as string) : undefined,
+      });
+      if (url.endsWith("/agentmemory/governance/memories") && method === "DELETE") {
+        return new Response(JSON.stringify({ success: true, deleted: 2 }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("method not allowed", { status: 405, statusText: "Method Not Allowed" });
+    });
+
+    const res = await handleToolCall("memory_governance_delete", {
+      memoryIds: "mem_1, mem_2",
+      reason: "cleanup stale test data",
+    });
+
+    expect(JSON.parse(res.content[0].text)).toEqual({ success: true, deleted: 2 });
+    expect(calls).toEqual([
+      {
+        url: `${BASE}/agentmemory/governance/memories`,
+        method: "DELETE",
+        body: {
+          memoryIds: ["mem_1", "mem_2"],
+          reason: "cleanup stale test data",
+        },
+      },
+    ]);
+  });
+
   it("local fallback returns the same shape as proxy for memory_smart_search", async () => {
     installFetch(() => {
       throw new Error("ECONNREFUSED");


### PR DESCRIPTION
## Summary
- Fix standalone MCP proxy for `memory_governance_delete` to call the REST governance endpoint with `DELETE` instead of `POST`
- Add a regression test that verifies method, endpoint, and payload forwarding

## Why
`src/triggers/api.ts` registers `/agentmemory/governance/memories` as a `DELETE` endpoint. The standalone MCP proxy was using `POST`, which returns `405 Method Not Allowed` against the live server and then falls back to local KV instead of deleting server memories.

## Test Plan
- RED: `AGENTMEMORY_URL=http://127.0.0.1:9 AGENTMEMORY_PROBE_TIMEOUT_MS=50 npx vitest run test/mcp-standalone-proxy.test.ts -t "proxies memory_governance_delete"` failed before the implementation with `POST /agentmemory/governance/memories -> 405 Method Not Allowed`
- GREEN: `AGENTMEMORY_URL=http://127.0.0.1:9 AGENTMEMORY_PROBE_TIMEOUT_MS=50 npx vitest run test/mcp-standalone-proxy.test.ts -t "proxies memory_governance_delete"`
- `npm run build`
- `AGENTMEMORY_URL=http://127.0.0.1:9 AGENTMEMORY_PROBE_TIMEOUT_MS=50 npx vitest run test/mcp-standalone-proxy.test.ts`
- Broader suite note: `AGENTMEMORY_URL=http://127.0.0.1:9 AGENTMEMORY_PROBE_TIMEOUT_MS=50 npm test` reached 953/955 or 954/955 passing in repeated runs; the remaining failures were existing timing/flaky tests in `test/context-injection.test.ts` and `test/fs-watcher.test.ts`, outside this PR's diff. Rerunning the targeted failing tests individually passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected HTTP method used for memory deletion operations to comply with REST standards.

* **Tests**
  * Added test coverage for memory deletion endpoint functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/423?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->