### PR TITLE
fix(coolify): use environment map syntax for Coolify v4 parser

### DIFF
--- a/deploy/coolify/docker-compose.yml
+++ b/deploy/coolify/docker-compose.yml
@@ -9,7 +9,7 @@ services:
         III_SDK_VERSION: "0.11.2"
     restart: unless-stopped
     environment:
-      - SERVICE_FQDN_AGENTMEMORY_3111
+      SERVICE_FQDN_AGENTMEMORY_3111: ${SERVICE_FQDN_AGENTMEMORY_3111}
     expose:
       - "3111"
     volumes:


### PR DESCRIPTION
## Summary

Coolify v4's PHP-based docker-compose validator rejects the shorthand environment list syntax (`- VAR` without `=`) in `deploy/coolify/docker-compose.yml`, breaking the official one-click deploy flow.

The exact build error is:

```
Error: non-string key in services.agentmemory.environment: 0
exit status 1
```

This happens because Coolify's parser converts the YAML list into a PHP array with numeric indices (`0 => "SERVICE_FQDN_AGENTMEMORY_3111"`), then fails its "all environment keys must be strings" assertion.

## Fix

Switch to the equivalent map form with explicit `${VAR}` substitution:

```diff
     environment:
-      - SERVICE_FQDN_AGENTMEMORY_3111
+      SERVICE_FQDN_AGENTMEMORY_3111: ${SERVICE_FQDN_AGENTMEMORY_3111}
```

This preserves the original "inherit from build env" semantics — Coolify still resolves `SERVICE_FQDN_AGENTMEMORY_3111` through its magic-variable mechanism — while satisfying the stricter parser.

## Verification

Locally with Docker Compose v2:

```bash
SERVICE_FQDN_AGENTMEMORY_3111=https://example.com \
  docker compose -f deploy/coolify/docker-compose.yml \
                 --project-directory deploy/coolify config
```

Output shows `SERVICE_FQDN_AGENTMEMORY_3111: https://example.com` correctly substituted.

End-to-end test on a Coolify v4.0.0-beta.397 instance:
- Before this patch: deploy fails at compose validation step.
- After this patch: deploy succeeds, container reaches `running:healthy` on first try, `/agentmemory/livez` returns `{"service":"agentmemory","status":"ok"}` over HTTPS via Traefik.

## Notes

- No behaviour change on the runtime side — only a syntactic adjustment to be parser-friendly across Coolify versions.
- The shorthand list form remains valid in upstream Docker Compose, so this doesn't break any local-dev scenario.

## Test plan

- [ ] `docker compose -f deploy/coolify/docker-compose.yml --project-directory deploy/coolify config` resolves with `SERVICE_FQDN_AGENTMEMORY_3111` set
- [ ] Coolify v4 one-click deploy flow completes without "non-string key" error
- [ ] Container starts healthy on a fresh deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration for environment variable handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/424?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->