### PR TITLE
chore(telemetry): pin worker project_name in registerWorker options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -170,6 +170,18 @@ async function main() {
       serviceVersion: OTEL_CONFIG.serviceVersion,
       metricsExportIntervalMs: OTEL_CONFIG.metricsExportIntervalMs,
     },
+    // Explicit worker telemetry metadata. iii-sdk falls back to
+    // auto-detection (cwd / package.json name / hostname) when this
+    // is omitted, which produces inconsistent values per host —
+    // `agentmemory`, `node`, `npm`, occasionally the user's home
+    // directory basename. Pinning the value here gives every install
+    // the same stable project identifier for downstream attribution
+    // and grouping in the engine's metrics + traces output.
+    telemetry: {
+      project_name: "agentmemory",
+      language: "node",
+      framework: "iii-sdk",
+    },
   });
 
   const kv = new StateKV(sdk);


### PR DESCRIPTION
## Summary

`iii-sdk`'s `InitOptions.telemetry.project_name` auto-detects when omitted — falls through cwd → package.json basename → hostname. That produces inconsistent identifiers per host (`agentmemory`, `node`, `npm`, occasionally the user's home dir basename when launched via npx).

Pinning the value gives every install the same stable identifier in the engine's metrics + traces output, so grouping reads cleanly downstream.

Also pins `language: "node"` and `framework: "iii-sdk"` for the same reason.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 956/956 passing
- [x] iii-sdk field surface verified at `node_modules/iii-sdk/dist/index.d.mts:32-37` (`TelemetryOptions`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced telemetry tracking metadata in worker registration for improved analytics and monitoring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/426?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->