### PR TITLE
fix(website): compare section polish

### DIFF
--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -142,6 +142,7 @@ button {
   letter-spacing: -0.01em;
   margin: 0 0 24px;
   text-transform: uppercase;
+  text-wrap: balance;
 }
 .section-lede {
   max-width: 680px;

--- a/website/components/Compare.module.css
+++ b/website/components/Compare.module.css
@@ -11,13 +11,14 @@
 }
 .row {
   display: grid;
-  grid-template-columns: 1.6fr 1fr 1fr 1fr 1fr;
+  grid-template-columns: 1.4fr 1.3fr 1fr 1fr 1fr;
   gap: 16px;
-  padding: 20px 0;
+  padding: 20px 24px;
   border-bottom: 1px solid var(--charcoal);
   align-items: center;
   font-size: 14px;
   letter-spacing: 0.12px;
+  word-break: break-word;
 }
 .row > span {
   color: var(--steel);

--- a/website/components/Compare.tsx
+++ b/website/components/Compare.tsx
@@ -6,7 +6,7 @@ const ROWS = [
   ["REST ENDPOINTS", "121", "—", "—", "—"],
   ["MCP TOOLS", "51", "12", "18", "9"],
   ["AUTO-HOOKS", "12", "0", "0", "0"],
-  ["NATIVE PLUGINS", "6 (Claude/Codex/OpenClaw/Hermes/pi/OpenHuman)", "—", "—", "—"],
+  ["NATIVE PLUGINS", "6", "—", "—", "—"],
   ["OPEN SOURCE", "YES (APACHE-2.0)", "YES", "YES", "YES"],
 ];
 
@@ -16,7 +16,7 @@ export function Compare() {
       <header className="section-head">
         <span className="section-eyebrow">VS.</span>
         <h2 id="cmp-title" className="section-title">
-          AGENTMEMORY VS. THE FIELD.
+          VS. THE FIELD.
         </h2>
         <p className="section-lede">
           NUMBERS STRAIGHT FROM THE LONGMEMEVAL-S BENCHMARK AND EACH PROJECT&apos;S

--- a/website/lib/generated-meta.json
+++ b/website/lib/generated-meta.json
@@ -3,6 +3,6 @@
   "mcpTools": 51,
   "hooks": 12,
   "restEndpoints": 121,
-  "testsPassing": 975,
-  "generatedAt": "2026-05-16T09:00:42.889Z"
+  "testsPassing": 977,
+  "generatedAt": "2026-05-16T09:33:03.891Z"
 }


### PR DESCRIPTION
## Summary

Compare section was looking cramped after the v0.9.16 changes landed:

1. `AGENTMEMORY VS. THE FIELD.` title was redundant (eyebrow already reads `VS.`) and wrapped ugly — FIELD. dangled on its own line at most desktop widths. Shortened to `VS. THE FIELD.` Plus added `text-wrap: balance` globally to `.section-title` so any wrapping title breaks at a balanced point.

2. `NATIVE PLUGINS` cell value was `6 (Claude/Codex/OpenClaw/Hermes/pi/OpenHuman)` — 49 chars stuffed into a ~180px grid column → forced multi-line wrap that looked cramped. The agent names are already visible in the Agents grid two sections above; cell now reads just `6`.

3. Row grid: agentmemory column bumped from 1fr → 1.3fr (label trimmed 1.6fr → 1.4fr) so cells like `YES (APACHE-2.0)` and `2 (Qdrant, Neo4j)` have breathing room. Added `word-break: break-word` as a safety net and 24px horizontal padding so cells don't kiss the section edge.

## Test plan

- [x] `npm run build` clean
- [ ] Vercel preview verify: 1920 / 1440 / 1280 — title single-line
- [ ] Mobile: title still readable at 375px


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved text wrapping behavior for section titles.
  * Optimized comparison table layout with refined column proportions and enhanced spacing.
  * Updated comparison table heading and native plugin feature descriptions.

* **Chores**
  * Updated test metrics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/427?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->