### PR TITLE
fix(test): stub history + removeAttribute after #313 + #366 collision

### DIFF
--- a/test/viewer-session-id.test.ts
+++ b/test/viewer-session-id.test.ts
@@ -53,6 +53,12 @@ function loadViewerSandbox() {
       setAttribute: (name: string, value: unknown) => {
         attributes.set(name, String(value));
       },
+      // Added in #313 — switchTab toggles aria-selected via removeAttribute
+      // on the non-active tab buttons. The mock previously only had
+      // get/setAttribute, so the new hash-routing path threw TypeError.
+      removeAttribute: (name: string) => {
+        attributes.delete(name);
+      },
       querySelectorAll: () => [],
     };
   };
@@ -117,6 +123,16 @@ function loadViewerSandbox() {
       },
       matchMedia: () => ({ matches: false }),
       addEventListener: () => {},
+    },
+    // Stubbed in #313 — the viewer now calls history.replaceState
+    // inside updateTabRoute → switchTab to drive the hash-route surface.
+    // The vm sandbox is otherwise zero-globals so the call would
+    // throw ReferenceError. No-op is fine for the rendering tests.
+    history: { replaceState: () => {}, pushState: () => {} },
+    location: {
+      hash: "",
+      pathname: "/",
+      search: "",
     },
     localStorage: { getItem: () => null, setItem: () => {} },
     fetch: async () => ({ ok: true, json: async () => ({}) }),


### PR DESCRIPTION
Cross-PR regression caught while re-reviewing merged work. #366's viewer sandbox passed on its own. #313's hash-routing added `history.replaceState` + `removeAttribute` calls in `switchTab`. Combined main fails:

```
TypeError: b.removeAttribute is not a function
ReferenceError: history is not defined
```

Two-line stub fix to the sandbox.

## Test plan
- [x] `npm test` — 987/987 passing on this branch
- [x] reproduced the failure on plain main before the fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated viewer session test harness to support new routing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/445?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->