### PR TITLE
fix(fs-watcher): redact PEM private-key blocks and standalone JWTs in previews (#448)

### DIFF
--- a/integrations/filesystem-watcher/watcher.mjs
+++ b/integrations/filesystem-watcher/watcher.mjs
@@ -29,6 +29,10 @@ const DEFAULT_IGNORE = [
 const MAX_PREVIEW_BYTES = 4096;
 const DEBOUNCE_MS = 500;
 const REDACTED = "[REDACTED]";
+const PEM_BEGIN_RE = /-----BEGIN [A-Z ]*PRIVATE KEY-----/;
+const PEM_END_RE = /-----END [A-Z ]*PRIVATE KEY-----/;
+const JWT_RE = /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g;
+const JWT_MIN_LEN = 100;
 
 function isDotEnvPath(path) {
   const name = basename(path).toLowerCase();
@@ -53,7 +57,14 @@ function isSensitiveKey(key) {
   ].some((needle) => normalized.includes(needle));
 }
 
+function redactJwtTokens(line) {
+  return line.replace(JWT_RE, (match) => (match.length >= JWT_MIN_LEN ? REDACTED : match));
+}
+
 function redactSensitiveLine(line) {
+  if (PEM_BEGIN_RE.test(line) || PEM_END_RE.test(line)) {
+    return line;
+  }
   const assignment = line.match(
     /^(\s*(?:export\s+)?["']?([A-Za-z_][A-Za-z0-9_.-]*)["']?\s*([=:])\s*)(.*)$/,
   );
@@ -61,11 +72,48 @@ function redactSensitiveLine(line) {
     const bearer = assignment[3] === ":" ? assignment[4].match(/^(Bearer\s+).+/i) : null;
     return `${assignment[1]}${bearer ? bearer[1] : ""}${REDACTED}`;
   }
-  return line.replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{8,}\b/gi, `$1${REDACTED}`);
+  const bearerRedacted = line.replace(
+    /\b(Bearer\s+)[A-Za-z0-9._~+/=-]{8,}\b/gi,
+    `$1${REDACTED}`,
+  );
+  return redactJwtTokens(bearerRedacted);
+}
+
+function redactPemBlocks(preview) {
+  const lines = preview.split("\n");
+  const out = [];
+  let inBlock = false;
+  for (const line of lines) {
+    if (!inBlock) {
+      const beginMatch = line.match(PEM_BEGIN_RE);
+      if (!beginMatch) {
+        out.push(line);
+        continue;
+      }
+      const beginIdx = beginMatch.index;
+      const endMatch = line.match(PEM_END_RE);
+      if (endMatch && endMatch.index > beginIdx) {
+        const before = line.slice(0, beginIdx);
+        const after = line.slice(endMatch.index + endMatch[0].length);
+        out.push(`${before}${beginMatch[0]}${REDACTED}${endMatch[0]}${after}`);
+      } else {
+        out.push(`${line.slice(0, beginIdx)}${beginMatch[0]}`);
+        out.push(REDACTED);
+        inBlock = true;
+      }
+    } else {
+      const endMatch = line.match(PEM_END_RE);
+      if (endMatch) {
+        out.push(`${endMatch[0]}${line.slice(endMatch.index + endMatch[0].length)}`);
+        inBlock = false;
+      }
+    }
+  }
+  return out.join("\n");
 }
 
 function redactSensitivePreview(preview) {
-  return preview.split("\n").map(redactSensitiveLine).join("\n");
+  return redactPemBlocks(preview).split("\n").map(redactSensitiveLine).join("\n");
 }
 
 export class FilesystemWatcher {

--- a/test/fs-watcher.test.ts
+++ b/test/fs-watcher.test.ts
@@ -212,6 +212,122 @@ describe("FilesystemWatcher", () => {
     expect(content).not.toContain("plaintext-token-value");
   });
 
+  it("collapses multi-line PEM private-key blocks while keeping BEGIN/END markers", async () => {
+    const dashes = "-".repeat(5);
+    const rsaBegin = `${dashes}BEGIN RSA PRIVATE KEY${dashes}`;
+    const rsaEnd = `${dashes}END RSA PRIVATE KEY${dashes}`;
+    const sshBegin = `${dashes}BEGIN OPENSSH PRIVATE KEY${dashes}`;
+    const sshEnd = `${dashes}END OPENSSH PRIVATE KEY${dashes}`;
+    writeFileSync(
+      join(root, "id_rsa.txt"),
+      [
+        rsaBegin,
+        "MIIEowIBAAKCAQEAuRFakeRsaBodyLine1ShouldNeverLeakToObservationPipeline",
+        "MoreFakeBase64BodyForRsaKeyMaterialThatMustStayRedacted",
+        "YetAnotherSecretLineOfBase64KeyContentNoOneShouldRead",
+        rsaEnd,
+        "",
+        sshBegin,
+        "b3BlbnNzaC1mYWtlLWtleS1ib2R5LWxpbmUtb25l",
+        "b3BlbnNzaC1mYWtlLWtleS1ib2R5LWxpbmUtdHdv",
+        sshEnd,
+        "",
+      ].join("\n"),
+    );
+    const w = new FilesystemWatcher({
+      roots: [root],
+      baseUrl: "http://localhost:3111",
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    await w.flush(root, "id_rsa.txt");
+
+    expect(captured).toHaveLength(1);
+    const content = (captured[0].body as { data: { content: string } }).data.content;
+    expect(content).toContain(rsaBegin);
+    expect(content).toContain(rsaEnd);
+    expect(content).toContain(sshBegin);
+    expect(content).toContain(sshEnd);
+    expect(content).toContain("[REDACTED]");
+    expect(content).not.toContain("MIIEowIBAAKCAQEAuRFakeRsaBodyLine1");
+    expect(content).not.toContain("MoreFakeBase64BodyForRsaKeyMaterial");
+    expect(content).not.toContain("YetAnotherSecretLineOfBase64KeyContent");
+    expect(content).not.toContain("b3BlbnNzaC1mYWtlLWtleS1ib2R5LWxpbmUtb25l");
+    expect(content).not.toContain("b3BlbnNzaC1mYWtlLWtleS1ib2R5LWxpbmUtdHdv");
+  });
+
+  it("redacts inline PEM blocks embedded in single-line JSON values", async () => {
+    const dashes = "-".repeat(5);
+    const pemBegin = `${dashes}BEGIN PRIVATE KEY${dashes}`;
+    const pemEnd = `${dashes}END PRIVATE KEY${dashes}`;
+    const inlinePem = `${pemBegin}\\nMIIEvgIBADANBgkqhkiG9w0FakeServiceAccountBody\\n${pemEnd}`;
+    writeFileSync(
+      join(root, "service-account.json"),
+      `{\n  "type": "service_account",\n  "private_key": "${inlinePem}",\n  "client_email": "demo@example.com"\n}\n`,
+    );
+    const w = new FilesystemWatcher({
+      roots: [root],
+      baseUrl: "http://localhost:3111",
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    await w.flush(root, "service-account.json");
+
+    expect(captured).toHaveLength(1);
+    const content = (captured[0].body as { data: { content: string } }).data.content;
+    expect(content).toContain(pemBegin);
+    expect(content).toContain(pemEnd);
+    expect(content).toContain("[REDACTED]");
+    expect(content).not.toContain("MIIEvgIBADANBgkqhkiG9w0FakeServiceAccountBody");
+    expect(content).toContain('"client_email": "demo@example.com"');
+  });
+
+  it("redacts standalone JWT-looking strings outside Bearer context", async () => {
+    const jwt =
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+    writeFileSync(
+      join(root, "notes.txt"),
+      ["session token below:", jwt, "end of token"].join("\n"),
+    );
+    const w = new FilesystemWatcher({
+      roots: [root],
+      baseUrl: "http://localhost:3111",
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    await w.flush(root, "notes.txt");
+
+    expect(captured).toHaveLength(1);
+    const content = (captured[0].body as { data: { content: string } }).data.content;
+    expect(content).toContain("[REDACTED]");
+    expect(content).not.toContain(jwt);
+    expect(content).toContain("end of token");
+  });
+
+  it("does not redact base64-looking words that are not three-segment JWTs of sufficient length", async () => {
+    const notJwt = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    const shortThreeSegment = "eyJabc.def.ghi";
+    expect(notJwt.length).toBe(62);
+    expect(shortThreeSegment.length).toBeLessThan(100);
+    writeFileSync(
+      join(root, "fixture.txt"),
+      ["random base64-ish word:", notJwt, "tiny segmented thing:", shortThreeSegment].join("\n"),
+    );
+    const w = new FilesystemWatcher({
+      roots: [root],
+      baseUrl: "http://localhost:3111",
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    await w.flush(root, "fixture.txt");
+
+    expect(captured).toHaveLength(1);
+    const content = (captured[0].body as { data: { content: string } }).data.content;
+    expect(content).toContain(notJwt);
+    expect(content).toContain(shortThreeSegment);
+    expect(content).not.toContain("[REDACTED]");
+  });
+
   it("debounces rapid writes to a single observation", async () => {
     const w = new FilesystemWatcher({
       roots: [root],


### PR DESCRIPTION
## Summary

PR #332 shipped the first preview-redaction pass for the filesystem watcher (assignment-style `KEY=value` and `Bearer <token>` shapes). Issue #448 calls out two remaining leak paths: multi-line PEM private-key blocks and standalone JWT-looking strings outside Bearer context.

This PR extends `redactSensitivePreview()` in `integrations/filesystem-watcher/watcher.mjs`:

- A PEM state machine runs first, collapsing every line between matching `-----BEGIN [A-Z ]*PRIVATE KEY-----` and `-----END [A-Z ]*PRIVATE KEY-----` into a single `[REDACTED]` line. BEGIN/END markers stay visible so the operator can tell what was redacted. The single regex covers `PRIVATE KEY`, `RSA PRIVATE KEY`, `EC PRIVATE KEY`, `DSA PRIVATE KEY`, `OPENSSH PRIVATE KEY`, and `ENCRYPTED PRIVATE KEY` in one shot.
- The same pass handles inline blocks (BEGIN and END on the same line, e.g. service-account JSON with escaped `\n` separators).
- Then the existing per-line redactor runs, now with an extra `redactJwtTokens()` step that replaces matches of `\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b` with `[REDACTED]` when the matched string is >= 100 chars. The three-segment pattern + length floor keep false positives off generic base64-looking tokens.
- `redactSensitiveLine` short-circuits on lines that carry PEM markers so the inline-JSON case keeps the marker visible instead of collapsing into a single `[REDACTED]` via the assignment redactor.

Order matters: PEM first (collapses huge multi-line blobs into a marker), assignment + Bearer + JWT pass second.

Diff stat: `2 files changed, 166 insertions(+), 2 deletions(-)`. Test count: 987 -> 991.

### Manual verify

Fixture `.env` written with a multi-line PEM block, an `OPENAI_API_KEY`, an `AUTHORIZATION=Bearer <jwt>` line, and a `session_cache=<jwt>` line. Captured payload's `data.content`:

```
.env (709 bytes)

# fixture env with multiple secret shapes
OPENAI_API_KEY=[REDACTED]
PUBLIC_FLAG=enabled
AUTHORIZATION=[REDACTED]

# inline PEM (a real ssh key in disguise)
-----BEGIN PRIVATE KEY-----
[REDACTED]
-----END PRIVATE KEY-----

# standalone JWT not in Bearer context
session_cache=[REDACTED]
```

PEM body, Bearer body, and bare JWT in `session_cache=` are all gone. BEGIN/END markers stay so an operator can tell what was redacted. `PUBLIC_FLAG=enabled` is left intact.

## Test plan

- [x] `npm test -- test/fs-watcher.test.ts` — 15 passed (11 existing + 4 new)
- [x] `npm test` — 991 passed (was 987 on `main`)
- [x] `npm run build` — clean
- [x] Manual verify shown above

Closes #448

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced sensitive data redaction in file previews, now covering cryptographic key blocks and JWT-like tokens with improved detection accuracy.

* **Tests**
  * Added comprehensive test coverage for redaction of private key blocks, embedded secrets, and authentication tokens.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/450?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->