### PR TITLE
fix(mcp): inject livez probe to kill mcp-standalone test flake (#449)

### DIFF
--- a/src/mcp/rest-proxy.ts
+++ b/src/mcp/rest-proxy.ts
@@ -40,17 +40,48 @@ function authHeader(): Record<string, string> {
   return secret ? { authorization: `Bearer ${secret}` } : {};
 }
 
+/**
+ * Probes the agentmemory server's livez endpoint. Returns a Response-shaped
+ * object whose `ok` flag drives the proxy/local-fallback decision.
+ *
+ * Tests can swap this via {@link setLivezProbe} to avoid the real 2s
+ * AbortController race that destabilises mcp-standalone test runs (#449).
+ * Production callers should leave it on the default.
+ */
+export type LivezProbe = (
+  url: string,
+  timeoutMs: number,
+  headers: Record<string, string>,
+) => Promise<{ ok: boolean; status?: number; statusText?: string }>;
+
+const defaultLivezProbe: LivezProbe = async (url, timeoutMs, headers) => {
+  const res = await fetch(`${url}/agentmemory/livez`, {
+    method: "GET",
+    headers,
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  return { ok: res.ok, status: res.status, statusText: res.statusText };
+};
+
+let livezProbe: LivezProbe = defaultLivezProbe;
+
+/**
+ * Override the livez probe. Intended for tests — production code should rely
+ * on the default fetch-based probe. Calling without an argument restores the
+ * default. Pair with {@link resetHandleForTests} so the cached handle is
+ * dropped before the next call.
+ */
+export function setLivezProbe(fn?: LivezProbe): void {
+  livezProbe = fn ?? defaultLivezProbe;
+}
+
 async function probe(url: string): Promise<boolean> {
   const timeout = probeTimeoutMs();
   try {
-    const res = await fetch(`${url}/agentmemory/livez`, {
-      method: "GET",
-      headers: authHeader(),
-      signal: AbortSignal.timeout(timeout),
-    });
+    const res = await livezProbe(url, timeout, authHeader());
     if (!res.ok) {
       process.stderr.write(
-        `[@agentmemory/mcp] livez probe ${url}/agentmemory/livez -> ${res.status} ${res.statusText}; falling back to local InMemoryKV (set AGENTMEMORY_FORCE_PROXY=1 to skip the probe)\n`,
+        `[@agentmemory/mcp] livez probe ${url}/agentmemory/livez -> ${res.status ?? "?"} ${res.statusText ?? ""}; falling back to local InMemoryKV (set AGENTMEMORY_FORCE_PROXY=1 to skip the probe)\n`,
       );
     }
     return res.ok;
@@ -130,4 +161,5 @@ export function resetHandleForTests(): void {
   cached = null;
   cachedAt = 0;
   probeInFlight = null;
+  livezProbe = defaultLivezProbe;
 }

--- a/test/mcp-standalone.test.ts
+++ b/test/mcp-standalone.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
 vi.mock("../src/logger.js", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
@@ -26,7 +26,29 @@ import {
 } from "../src/mcp/tools-registry.js";
 import { InMemoryKV } from "../src/mcp/in-memory-kv.js";
 import { handleToolCall } from "../src/mcp/standalone.js";
+import {
+  resetHandleForTests,
+  setLivezProbe,
+} from "../src/mcp/rest-proxy.js";
 import { writeFileSync } from "node:fs";
+
+// Issue #449: hard-coded fetch() against :3111 in the livez probe was racing
+// with vitest's mock setup, making this file the "10-11 pre-existing failures"
+// referenced in the last 5 release notes. Stub the probe with an instant
+// ok:false response so the shim takes the deterministic InMemoryKV fallback
+// path on every test. Guard the real network with a fetch trap so any
+// regression that bypasses the DI seam fails loudly instead of timing out.
+const instantLocalFallbackProbe = vi.fn(async () => ({
+  ok: false,
+  status: 0,
+  statusText: "stubbed: forced local fallback",
+}));
+
+const fetchTrap = vi.fn(async (url: unknown) => {
+  throw new Error(
+    `unexpected real fetch() call in mcp-standalone.test.ts: ${String(url)} — the livez probe DI stub should have absorbed this`,
+  );
+});
 
 describe("Tools Registry", () => {
   it("getAllTools returns all tools with unique names", () => {
@@ -120,8 +142,31 @@ describe("InMemoryKV", () => {
 });
 
 describe("handleToolCall", () => {
+  const originalFetch = globalThis.fetch;
+
   beforeEach(() => {
     vi.mocked(writeFileSync).mockClear();
+    instantLocalFallbackProbe.mockClear();
+    fetchTrap.mockClear();
+    // Order matters: resetHandleForTests() restores the default probe and
+    // clears the cached handle. Install the stub AFTER the reset so the
+    // shim's next resolveHandle() call hits the stubbed instant-fail path
+    // instead of the real 2s AbortController fetch.
+    resetHandleForTests();
+    setLivezProbe(instantLocalFallbackProbe);
+    (globalThis as { fetch: typeof fetch }).fetch = fetchTrap as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    (globalThis as { fetch: typeof fetch }).fetch = originalFetch;
+    resetHandleForTests();
+  });
+
+  it("livez probe stub is invoked instead of the real fetch (issue #449)", async () => {
+    const kv = new InMemoryKV();
+    await handleToolCall("memory_save", { content: "regression guard" }, kv);
+    expect(instantLocalFallbackProbe).toHaveBeenCalledTimes(1);
+    expect(fetchTrap).not.toHaveBeenCalled();
   });
 
   it("memory_save persists to disk immediately after saving", async () => {


### PR DESCRIPTION
Closes #449.

## DI shape chosen: option A (module-level singleton with override)

Added `setLivezProbe(fn?: LivezProbe)` in `src/mcp/rest-proxy.ts`. Tests
swap in an instant-fail probe before each call; default stays the real
fetch-based probe so production wire behaviour is identical.

**Why option A over constructor DI (option B):** the `rest-proxy.ts` module
is already singleton-shaped — `resolveHandle()` reads a module-scoped cache,
`invalidateHandle()` and `resetHandleForTests()` mutate that cache. The probe
is the same shape of dependency. A constructor seam would have meant
refactoring every caller of `resolveHandle()` (and the `handleToolCall`
chain in `standalone.ts`) to thread the proxy instance through. That's
beyond "DI seam, don't touch the logic." Option A keeps the diff to two
files and 84 added lines.

Also wired the override into `resetHandleForTests()` so a stub from one test
file can't leak into another.

## 10-run flake-kill validation

```
=== run 1 ===
      Tests  25 passed (25)
   Duration  185ms (transform 68ms, setup 0ms, import 87ms, tests 17ms, environment 0ms)
=== run 2 ===
      Tests  25 passed (25)
   Duration  188ms (transform 67ms, setup 0ms, import 85ms, tests 18ms, environment 0ms)
=== run 3 ===
      Tests  25 passed (25)
   Duration  190ms (transform 67ms, setup 0ms, import 85ms, tests 20ms, environment 0ms)
=== run 4 ===
      Tests  25 passed (25)
   Duration  190ms (transform 68ms, setup 0ms, import 87ms, tests 17ms, environment 0ms)
=== run 5 ===
      Tests  25 passed (25)
   Duration  188ms (transform 67ms, setup 0ms, import 85ms, tests 17ms, environment 0ms)
=== run 6 ===
      Tests  25 passed (25)
   Duration  180ms (transform 65ms, setup 0ms, import 82ms, tests 17ms, environment 0ms)
=== run 7 ===
      Tests  25 passed (25)
   Duration  192ms (transform 69ms, setup 0ms, import 87ms, tests 18ms, environment 0ms)
=== run 8 ===
      Tests  25 passed (25)
   Duration  182ms (transform 64ms, setup 0ms, import 81ms, tests 18ms, environment 0ms)
=== run 9 ===
      Tests  25 passed (25)
   Duration  185ms (transform 64ms, setup 0ms, import 82ms, tests 18ms, environment 0ms)
=== run 10 ===
      Tests  25 passed (25)
   Duration  183ms (transform 65ms, setup 0ms, import 83ms, tests 18ms, environment 0ms)
```

25 tests = 24 original + 1 new regression-guard (`livez probe stub is
invoked instead of the real fetch (issue #449)`) that asserts the DI seam
is wired and the real network is never touched.

Pre-fix baseline was 2.2s per run with intermittent timeouts; post-fix is
~185ms with zero variance across 10 runs.

## Full-suite stability

```
=== full-suite run 1 ===
 Test Files  90 passed (90)
      Tests  988 passed (988)
=== full-suite run 2 ===
 Test Files  90 passed (90)
      Tests  988 passed (988)
=== full-suite run 3 ===
 Test Files  90 passed (90)
      Tests  988 passed (988)
```

988 = the 987 main has today + 1 new regression-guard test in this PR.

`mcp-standalone-proxy.test.ts` (the sibling file that intentionally exercises
the proxy path via `globalThis.fetch` stubbing) still passes 14/14
unchanged — `resetHandleForTests()` restores the default probe in its
`beforeEach`/`afterEach`, so it never sees the stub installed by the
standalone file.

`npm run build` clean.

## Diff stat

```
 src/mcp/rest-proxy.ts       | 44 ++++++++++++++++++++++++++++++++++++------
 test/mcp-standalone.test.ts | 47 ++++++++++++++++++++++++++++++++++++++++++++-
 2 files changed, 84 insertions(+), 7 deletions(-)
```

## Constraints honoured

- No version bump
- No CHANGELOG edit
- No `--no-verify`
- No shim logic rewrite — probe behaviour (probe ok → proxy; probe fail →
  local KV) is byte-identical in production
- Branch `fix/449-mcp-standalone-probe-di`, conventional commit, not merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure with deterministic mocking for the liveness probe mechanism, preventing test contamination and improving reliability of proxy/fallback decision testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/451?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->