### PR TITLE
fix(viewer): self-host SVG favicon + restore tight img-src CSP (#447)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "agentmemory": "dist/cli.mjs"
   },
   "scripts": {
-    "build": "tsdown && (cp iii-config.yaml dist/ 2>/dev/null || true) && (cp iii-config.docker.yaml dist/ 2>/dev/null || true) && (cp docker-compose.yml dist/ 2>/dev/null || true) && (cp .env.example dist/ 2>/dev/null || true) && mkdir -p dist/viewer && cp src/viewer/index.html dist/viewer/",
+    "build": "tsdown && (cp iii-config.yaml dist/ 2>/dev/null || true) && (cp iii-config.docker.yaml dist/ 2>/dev/null || true) && (cp docker-compose.yml dist/ 2>/dev/null || true) && (cp .env.example dist/ 2>/dev/null || true) && mkdir -p dist/viewer && cp src/viewer/index.html dist/viewer/ && cp src/viewer/favicon.svg dist/viewer/",
     "dev": "tsx src/index.ts",
     "start": "node dist/cli.mjs",
     "migrate": "node dist/functions/migrate.js",

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -24,7 +24,7 @@ export function buildViewerCsp(nonce: string): string {
     "script-src-attr 'none'",
     "style-src 'unsafe-inline'",
     "connect-src 'self' http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:* wss://localhost:* wss://127.0.0.1:*",
-    "img-src 'self' data:",
+    "img-src 'self'",
     "font-src 'self'",
   ].join("; ");
 }

--- a/src/viewer/favicon.svg
+++ b/src/viewer/favicon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><rect width="64" height="64" rx="10" fill="#111111"/><text x="32" y="41" text-anchor="middle" font-family="Arial,sans-serif" font-size="24" font-weight="700" fill="#2D6A4F">AM</text></svg>

--- a/src/viewer/index.html
+++ b/src/viewer/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>agentmemory viewer</title>
-  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='10' fill='%23111111'/%3E%3Ctext x='32' y='41' text-anchor='middle' font-family='Arial,sans-serif' font-size='24' font-weight='700' fill='%232D6A4F'%3EAM%3C/text%3E%3C/svg%3E">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <!-- Removed Google Fonts <link> in #323: the viewer CSP is strict
        (default-src 'none', style-src 'unsafe-inline', font-src 'self')
        and external stylesheets from fonts.googleapis.com were blocked,

--- a/src/viewer/server.ts
+++ b/src/viewer/server.ts
@@ -4,7 +4,29 @@ import {
   type IncomingMessage,
   type ServerResponse,
 } from "node:http";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import { renderViewerDocument } from "./document.js";
+
+// Self-host the viewer favicon at /favicon.svg instead of an inline
+// data: URI so the viewer CSP can stay tight at `img-src 'self'`.
+// Mirrors loadViewerTemplate() in document.ts — same candidate paths so
+// it resolves both from source (vitest) and from dist/ (npm run start).
+function loadViewerFavicon(): Buffer | null {
+  const base = dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    join(base, "..", "src", "viewer", "favicon.svg"),
+    join(base, "..", "viewer", "favicon.svg"),
+    join(base, "viewer", "favicon.svg"),
+  ];
+  for (const path of candidates) {
+    try {
+      return readFileSync(path);
+    } catch {}
+  }
+  return null;
+}
 
 const ALLOWED_ORIGINS = (
   process.env.VIEWER_ALLOWED_ORIGINS ||
@@ -171,6 +193,21 @@ export function startViewerServer(
       }
       res.writeHead(404, { "Content-Type": "text/plain" });
       res.end("viewer not found");
+      return;
+    }
+
+    if (method === "GET" && pathname === "/favicon.svg") {
+      const favicon = loadViewerFavicon();
+      if (favicon) {
+        res.writeHead(200, {
+          "Content-Type": "image/svg+xml",
+          "Cache-Control": "public, max-age=3600",
+        });
+        res.end(favicon);
+        return;
+      }
+      res.writeHead(404, { "Content-Type": "text/plain" });
+      res.end("favicon not found");
       return;
     }
 

--- a/test/viewer-security.test.ts
+++ b/test/viewer-security.test.ts
@@ -16,10 +16,31 @@ describe("viewer document security", () => {
 
     expect(rendered.csp).toContain("script-src 'nonce-");
     expect(rendered.csp).toContain("script-src-attr 'none'");
-    expect(rendered.csp).toContain("img-src 'self' data:");
+    expect(rendered.csp).toContain("img-src 'self'");
     expect(rendered.csp).not.toContain("script-src 'unsafe-inline'");
     expect(rendered.html).toContain("<script nonce=\"");
     expect(rendered.html).not.toContain("__AGENTMEMORY_VIEWER_NONCE__");
+  });
+
+  it("does not loosen img-src with bare data: URI allowance (#447)", () => {
+    // #313 added `data:` so an inline-SVG favicon could load. #447 reverts
+    // that by self-hosting the favicon at /favicon.svg — `data:` would
+    // also allow any data:image/png;base64,... and (in some browsers)
+    // data:text/html;base64,..., which the viewer never needs.
+    const rendered = renderViewerDocument();
+    expect(rendered.found).toBe(true);
+    if (!rendered.found) return;
+
+    const directives = rendered.csp.split(";").map((d) => d.trim());
+    const imgSrc = directives.find((d) => d.startsWith("img-src"));
+    expect(imgSrc).toBeDefined();
+    expect(imgSrc).toBe("img-src 'self'");
+    expect(imgSrc).not.toContain("data:");
+
+    // Favicon link in the HTML must reference the self-hosted file, not
+    // an inline data: URI — that's what lets the CSP stay tight.
+    expect(rendered.html).toContain('href="/favicon.svg"');
+    expect(rendered.html).not.toContain("data:image/svg+xml");
   });
 
   it("does not contain inline DOM event handlers", () => {
@@ -133,7 +154,7 @@ describe("viewer request handler DNS rebinding defence (e2e)", () => {
     port: number,
     hostHeader: string,
     pathname = "/agentmemory/livez",
-  ): Promise<{ status: number; body: string }> {
+  ): Promise<{ status: number; body: string; headers: Record<string, string | string[] | undefined> }> {
     return new Promise((resolve, reject) => {
       const req = httpRequest(
         {
@@ -149,7 +170,11 @@ describe("viewer request handler DNS rebinding defence (e2e)", () => {
             body += chunk.toString();
           });
           res.on("end", () => {
-            resolve({ status: res.statusCode ?? 0, body });
+            resolve({
+              status: res.statusCode ?? 0,
+              body,
+              headers: res.headers,
+            });
           });
         },
       );
@@ -183,5 +208,19 @@ describe("viewer request handler DNS rebinding defence (e2e)", () => {
     if (res.status === 200) {
       expect(res.body).toContain("agentmemory viewer");
     }
+  });
+
+  it("serves /favicon.svg with image/svg+xml so the tight CSP can drop data: (#447)", async () => {
+    const { port } = await spinUpViewer();
+    const res = await request(port, `localhost:${port}`, "/favicon.svg");
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toBe("image/svg+xml");
+    expect(res.headers["cache-control"]).toBe("public, max-age=3600");
+    // SVG payload must actually be SVG, not the proxied REST error body.
+    expect(res.body).toMatch(/^<svg\b/);
+    expect(res.body).toContain("</svg>");
+    // Sanity-check the artwork: rounded dark tile + green "AM" lettering.
+    expect(res.body).toContain('fill="#111111"');
+    expect(res.body).toContain(">AM<");
   });
 });


### PR DESCRIPTION
## Summary

Closes #447.

#313 loosened the viewer's CSP from `img-src 'self'` to `img-src 'self' data:` so an inline-SVG favicon encoded as `data:image/svg+xml,...` could load. Bare `data:` in `img-src` is broader than the viewer needs — it also allows `data:image/png;base64,<anything>` (and in some browsers, even `data:text/html;base64,<anything>`).

This PR self-hosts the favicon at `/favicon.svg` and reverts the CSP to `img-src 'self'`. Same artwork (dark rounded tile + green "AM" lettering), now served from a real URL.

## Changes

- **new file** `src/viewer/favicon.svg` — extracted from the URL-decoded inline blob in `index.html`
- `src/auth.ts:buildViewerCsp()` — `img-src 'self' data:` reverted to `img-src 'self'`
- `src/viewer/index.html` — favicon `<link>` switched from `href="data:image/svg+xml,..."` to `href="/favicon.svg"`
- `src/viewer/server.ts` — new `GET /favicon.svg` route returning `Content-Type: image/svg+xml` + `Cache-Control: public, max-age=3600`. Loader mirrors `loadViewerTemplate()` so it resolves both from source (vitest) and from `dist/` (`npm run start`)
- `package.json` — build script copies `favicon.svg` into `dist/viewer/` alongside `index.html`
- `test/viewer-security.test.ts` — CSP assertion now requires bare `img-src 'self'` and rejects any `data:` allowance; new e2e test hits `/favicon.svg` and verifies SVG payload + headers

## CSP before / after

Before (#313):
```
img-src 'self' data:
```

After (this PR):
```
img-src 'self'
```

## Manual verification

```
$ curl -i http://localhost:3113/ | grep -i content-security
Content-Security-Policy: ... img-src 'self'; font-src 'self'

$ curl -i http://localhost:3113/favicon.svg
HTTP/1.1 200 OK
Content-Type: image/svg+xml
Cache-Control: public, max-age=3600
...
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">...AM</text></svg>
```

## Test plan

- [x] `npm test` — 989 passed (15 viewer-security tests, including 2 new ones)
- [x] `npm run build` — clean
- [x] curl `/` — `Content-Security-Policy` header no longer contains `data:` for `img-src`
- [x] curl `/favicon.svg` — 200 + `Content-Type: image/svg+xml` + valid SVG bytes
- [ ] Browser tab favicon still renders (visual)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security**
  * Strengthened Content Security Policy for image loading to allow self-hosted sources only, removing support for embedded data URIs.

* **Infrastructure**
  * Favicon now served as an external asset through a dedicated HTTP endpoint with appropriate caching headers.

* **Tests**
  * Enhanced security test coverage to verify stricter CSP enforcement and favicon serving behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/452?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->