### PR TITLE
Add sudo for global installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@
 ## Install
 
 ```bash
-sudo npm install -g @agentmemory/agentmemory     # once — bare `agentmemory` on PATH
+npm install -g `@agentmemory/agentmemory`          # once — bare `agentmemory` on PATH
+# If you hit EACCES on macOS/Linux system Node installs, retry with:
+# sudo npm install -g `@agentmemory/agentmemory`
 agentmemory                                      # start the memory server on :3111
 agentmemory demo                                 # seed sample sessions + prove recall
 agentmemory connect claude-code                  # wire your agent (also: codex, cursor, gemini-cli, ...)

--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@
 ## Install
 
 ```bash
-npm install -g `@agentmemory/agentmemory`          # once — bare `agentmemory` on PATH
+npm install -g @agentmemory/agentmemory          # once — bare `agentmemory` on PATH
 # If you hit EACCES on macOS/Linux system Node installs, retry with:
-# sudo npm install -g `@agentmemory/agentmemory`
+# sudo npm install -g @agentmemory/agentmemory
 agentmemory                                      # start the memory server on :3111
 agentmemory demo                                 # seed sample sessions + prove recall
 agentmemory connect claude-code                  # wire your agent (also: codex, cursor, gemini-cli, ...)
@@ -352,7 +352,7 @@ Open `http://localhost:3113` to watch the memory build live.
 ```bash
 npm install -g @agentmemory/agentmemory
 # If you hit EACCES on macOS/Linux system Node installs, retry with:
-# sudo npm install -g `@agentmemory/agentmemory`
+# sudo npm install -g @agentmemory/agentmemory
 agentmemory                    # start the server (same as the npx form)
 agentmemory stop               # tear it down
 agentmemory remove             # uninstall everything we created

--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@
 ## Install
 
 ```bash
-npm install -g @agentmemory/agentmemory     # once — bare `agentmemory` on PATH
-agentmemory                                  # start the memory server on :3111
-agentmemory demo                             # seed sample sessions + prove recall
-agentmemory connect claude-code              # wire your agent (also: codex, cursor, gemini-cli, ...)
+sudo npm install -g @agentmemory/agentmemory     # once — bare `agentmemory` on PATH
+agentmemory                                      # start the memory server on :3111
+agentmemory demo                                 # seed sample sessions + prove recall
+agentmemory connect claude-code                  # wire your agent (also: codex, cursor, gemini-cli, ...)
 ```
 
 Or via `npx` (no install):

--- a/README.md
+++ b/README.md
@@ -351,6 +351,8 @@ Open `http://localhost:3113` to watch the memory build live.
 
 ```bash
 npm install -g @agentmemory/agentmemory
+# If you hit EACCES on macOS/Linux system Node installs, retry with:
+# sudo npm install -g `@agentmemory/agentmemory`
 agentmemory                    # start the server (same as the npx form)
 agentmemory stop               # tear it down
 agentmemory remove             # uninstall everything we created


### PR DESCRIPTION
Hi,

I tried to install agentmemory globally, but the command threw a missing permissions error. Adding sudo fixes this.


Radek


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved README installation and Quick Start sections: reformatted global install command blocks for consistency and added a commented retry note suggesting elevated permissions on macOS/Linux to help users overcome permission errors during global installs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/454?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->