### PR TITLE
fix(context): auto-inject lessons into mem::context payload (#457)

### DIFF
--- a/src/functions/context.ts
+++ b/src/functions/context.ts
@@ -6,6 +6,7 @@ import type {
   ContextBlock,
   ProjectProfile,
   MemorySlot,
+  Lesson,
 } from "../types.js";
 import { KV } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
@@ -39,13 +40,14 @@ export function registerContextFunction(
       const budget = data.budget || tokenBudget;
       const blocks: ContextBlock[] = [];
 
-      const [pinnedSlots, profile] = await Promise.all([
+      const [pinnedSlots, profile, lessons] = await Promise.all([
         isSlotsEnabled()
           ? listPinnedSlots(kv).catch(() => [] as MemorySlot[])
           : Promise.resolve([] as MemorySlot[]),
         kv
           .get<ProjectProfile>(KV.profiles, data.project)
           .catch(() => null),
+        kv.list<Lesson>(KV.lessons).catch(() => [] as Lesson[]),
       ]);
 
       const slotContent = renderPinnedContext(pinnedSlots);
@@ -92,6 +94,42 @@ export function registerContextFunction(
             recency: new Date(profile.updatedAt).getTime(),
           });
         }
+      }
+
+      // Lessons — closes the loop opened by mem::lesson-save / mem::reflect.
+      // Without this block, lessons sit in KV and only surface when the agent
+      // thinks to call memory_lesson_recall. Ranking puts project-scoped
+      // lessons ahead of global ones, then weights by confidence; we cap at
+      // 10 to keep the block bounded since the outer token-budget loop
+      // below will drop the whole block if it doesn't fit. #457.
+      const relevantLessons = lessons
+        .filter((l) => !l.deleted && (!l.project || l.project === data.project))
+        .sort((a, b) => {
+          const scoreA = (a.project === data.project ? 1.5 : 1) * a.confidence;
+          const scoreB = (b.project === data.project ? 1.5 : 1) * b.confidence;
+          return scoreB - scoreA;
+        })
+        .slice(0, 10);
+
+      if (relevantLessons.length > 0) {
+        const items = relevantLessons
+          .map(
+            (l) =>
+              `- (${l.confidence.toFixed(2)}) ${l.content}${l.context ? ` — ${l.context}` : ""}`,
+          )
+          .join("\n");
+        const lessonsContent = `## Lessons Learned\n${items}`;
+        const mostRecent = relevantLessons.reduce((acc, l) => {
+          const t = new Date(l.lastReinforcedAt || l.updatedAt).getTime();
+          return t > acc ? t : acc;
+        }, 0);
+        blocks.push({
+          type: "memory",
+          content: lessonsContent,
+          tokens: estimateTokens(lessonsContent),
+          recency: mostRecent,
+          sourceIds: relevantLessons.map((l) => l.id),
+        });
       }
 
       const allSessions = await kv.list<Session>(KV.sessions);

--- a/test/context-lessons.test.ts
+++ b/test/context-lessons.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { registerContextFunction } from "../src/functions/context.js";
+import { KV } from "../src/state/schema.js";
+import type { Lesson } from "../src/types.js";
+
+function mockKV() {
+  const store = new Map<string, Map<string, unknown>>();
+  return {
+    get: async <T>(scope: string, key: string): Promise<T | null> => {
+      return (store.get(scope)?.get(key) as T) ?? null;
+    },
+    set: async <T>(scope: string, key: string, data: T): Promise<T> => {
+      if (!store.has(scope)) store.set(scope, new Map());
+      store.get(scope)!.set(key, data);
+      return data;
+    },
+    delete: async (scope: string, key: string): Promise<void> => {
+      store.get(scope)?.delete(key);
+    },
+    list: async <T>(scope: string): Promise<T[]> => {
+      if (!store.has(scope)) return [];
+      return Array.from(store.get(scope)!.values()) as T[];
+    },
+  };
+}
+
+type ContextHandler = (data: {
+  sessionId: string;
+  project: string;
+  budget?: number;
+}) => Promise<{ context: string; blocks: number; tokens: number }>;
+
+function wireContext(kv: ReturnType<typeof mockKV>, budget = 4000) {
+  let handler: ContextHandler | undefined;
+  const sdk = {
+    registerFunction: vi.fn((id: string, cb: ContextHandler) => {
+      if (id === "mem::context") handler = cb;
+    }),
+  } as unknown as import("iii-sdk").ISdk;
+  registerContextFunction(sdk, kv as never, budget);
+  if (!handler) throw new Error("mem::context not registered");
+  return handler;
+}
+
+function makeLesson(over: Partial<Lesson> = {}): Lesson {
+  const now = new Date().toISOString();
+  return {
+    id: over.id ?? `lesson_${Math.random().toString(36).slice(2)}`,
+    content: over.content ?? "default lesson content",
+    context: over.context ?? "",
+    confidence: over.confidence ?? 0.7,
+    reinforcements: over.reinforcements ?? 1,
+    source: over.source ?? "manual",
+    sourceIds: over.sourceIds ?? [],
+    project: over.project,
+    tags: over.tags ?? [],
+    createdAt: over.createdAt ?? now,
+    updatedAt: over.updatedAt ?? now,
+    lastReinforcedAt: over.lastReinforcedAt,
+    lastDecayedAt: over.lastDecayedAt,
+    decayRate: over.decayRate ?? 0.05,
+    deleted: over.deleted,
+  };
+}
+
+async function seedLesson(
+  kv: ReturnType<typeof mockKV>,
+  partial: Partial<Lesson>,
+) {
+  const lesson = makeLesson(partial);
+  await kv.set(KV.lessons, lesson.id, lesson);
+  return lesson;
+}
+
+describe("mem::context — lessons auto-injection (#457)", () => {
+  let kv: ReturnType<typeof mockKV>;
+  let handler: ContextHandler;
+
+  beforeEach(() => {
+    kv = mockKV();
+    handler = wireContext(kv);
+  });
+
+  it("includes a 'Lessons Learned' block when KV has lessons for the project", async () => {
+    await seedLesson(kv, {
+      id: "lesson_a",
+      content: "always run npm test before commit",
+      project: "/tmp/proj",
+      confidence: 0.85,
+    });
+
+    const result = await handler({
+      sessionId: "ses_a",
+      project: "/tmp/proj",
+    });
+
+    expect(result.context).toContain("Lessons Learned");
+    expect(result.context).toContain("always run npm test before commit");
+    expect(result.blocks).toBeGreaterThan(0);
+  });
+
+  it("omits the lessons block entirely when KV has no lessons", async () => {
+    const result = await handler({
+      sessionId: "ses_empty",
+      project: "/tmp/proj",
+    });
+
+    expect(result.context).not.toContain("Lessons Learned");
+  });
+
+  it("ranks project-scoped lessons above global lessons", async () => {
+    await seedLesson(kv, {
+      id: "lesson_global",
+      content: "global-lesson-marker",
+      project: undefined,
+      confidence: 0.9,
+    });
+    await seedLesson(kv, {
+      id: "lesson_project",
+      content: "project-lesson-marker",
+      project: "/tmp/proj",
+      confidence: 0.7,
+    });
+
+    const result = await handler({
+      sessionId: "ses_rank",
+      project: "/tmp/proj",
+    });
+
+    const projectIdx = result.context.indexOf("project-lesson-marker");
+    const globalIdx = result.context.indexOf("global-lesson-marker");
+    expect(projectIdx).toBeGreaterThan(-1);
+    expect(globalIdx).toBeGreaterThan(-1);
+    expect(projectIdx).toBeLessThan(globalIdx);
+  });
+
+  it("excludes lessons scoped to a different project", async () => {
+    await seedLesson(kv, {
+      id: "lesson_other",
+      content: "other-project-lesson",
+      project: "/tmp/other-project",
+      confidence: 0.9,
+    });
+
+    const result = await handler({
+      sessionId: "ses_isolate",
+      project: "/tmp/proj",
+    });
+
+    expect(result.context).not.toContain("other-project-lesson");
+  });
+
+  it("excludes deleted lessons", async () => {
+    await seedLesson(kv, {
+      id: "lesson_deleted",
+      content: "tombstoned-lesson",
+      project: "/tmp/proj",
+      confidence: 0.9,
+      deleted: true,
+    });
+
+    const result = await handler({
+      sessionId: "ses_deleted",
+      project: "/tmp/proj",
+    });
+
+    expect(result.context).not.toContain("tombstoned-lesson");
+  });
+
+  it("caps at the top 10 lessons by confidence", async () => {
+    for (let i = 0; i < 15; i++) {
+      await seedLesson(kv, {
+        id: `lesson_${i}`,
+        content: `lesson-marker-${i}`,
+        project: "/tmp/proj",
+        confidence: i / 100,
+      });
+    }
+
+    const result = await handler({
+      sessionId: "ses_cap",
+      project: "/tmp/proj",
+    });
+
+    const matched = result.context.match(/lesson-marker-/g) ?? [];
+    expect(matched.length).toBe(10);
+    expect(result.context).toContain("lesson-marker-14");
+    expect(result.context).toContain("lesson-marker-5");
+    expect(result.context).not.toContain("lesson-marker-0");
+  });
+
+  it("shows lesson confidence in the rendered line", async () => {
+    await seedLesson(kv, {
+      id: "lesson_conf",
+      content: "test confidence rendering",
+      project: "/tmp/proj",
+      confidence: 0.83,
+    });
+
+    const result = await handler({
+      sessionId: "ses_conf",
+      project: "/tmp/proj",
+    });
+
+    expect(result.context).toContain("(0.83)");
+  });
+
+  it("appends optional context string when present", async () => {
+    await seedLesson(kv, {
+      id: "lesson_ctx",
+      content: "use TaskCreate for >5-file work",
+      context: "when working on multi-file refactors",
+      project: "/tmp/proj",
+      confidence: 0.8,
+    });
+
+    const result = await handler({
+      sessionId: "ses_ctx",
+      project: "/tmp/proj",
+    });
+
+    expect(result.context).toContain(
+      "use TaskCreate for >5-file work — when working on multi-file refactors",
+    );
+  });
+});


### PR DESCRIPTION
Closes #457. Surfaced in #381.

## Problem

Lessons were stored but never auto-injected. `mem::context` (the function the session-start hook calls when `AGENTMEMORY_INJECT_CONTEXT=true`) assembled blocks from pinned slots, project profile, session summaries, and top observations — **not** lessons. So lessons could only reach the agent through an explicit `memory_lesson_recall` MCP call, which agents rarely make unprompted.

@rockarxiv flagged this in #381:

> I'm trying to understand where the lessons are being injected/used by the agent. It doesn't seem like any of the hooks involve injecting them into the context.

He was right.

## Fix

`mem::context` now reads `KV.lessons` in parallel with slots + profile, ranks by `(project-relevance × confidence)`, caps at 10, and emits a `## Lessons Learned` block alongside the other context blocks. The outer token-budget loop owns drop-on-overflow, so lesson blocks compete fairly with summaries / observations.

### Ranking rule

```
score = (lesson.project === currentProject ? 1.5 : 1) × lesson.confidence
```

- Project-scoped lessons rank above global ones for the matching project.
- High-confidence lessons rank above low-confidence ones within the same scope.
- Cross-project lessons are filtered out entirely (not just down-ranked).
- Soft-deleted lessons (`deleted: true`) are filtered out.

### Block shape

```
## Lessons Learned
- (0.85) always run npm test before commit
- (0.80) use TaskCreate for >5-file work — when working on multi-file refactors
- (0.72) prefer Edit over Write for known files
...
```

`block.recency` is the most-recent `lastReinforcedAt || updatedAt` across the selected lessons, so the outer recency sort puts hot lessons above cold ones when budget gets tight.

## Tests

New `test/context-lessons.test.ts` — 8 cases:

1. Lessons block included when KV has lessons
2. Block omitted when KV empty
3. Project-scoped lessons rank above globals
4. Cross-project lessons excluded
5. Soft-deleted lessons skipped
6. Caps at top-10 by confidence
7. Confidence rendered as `(0.NN)` prefix
8. Optional `context` string appended with em-dash separator

**1007/1007 tests pass locally** (90 → 91 files, +8 new tests).

## Out of scope (separate followups)

- `memory_smart_search` integration — lessons aren't in the hybrid BM25+vector index yet.
- Pull-side `memory_lesson_recall` UX (substring match → embedding).
- Viewer surfaces for "recently injected" lessons.

## Verification

```bash
npm run build && npm test
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Context output now automatically includes a "Lessons Learned" section featuring up to 10 relevant lessons, with project-scoped lessons prioritized and deleted lessons filtered out.

* **Tests**
  * Added test suite verifying lesson injection, ranking, filtering, and formatting in context output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/458?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->