### PR TITLE
fix(plugin): inherit AGENTMEMORY_URL/SECRET via env passthrough (#375)

### DIFF
--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -2,7 +2,11 @@
   "mcpServers": {
     "agentmemory": {
       "command": "npx",
-      "args": ["-y", "@agentmemory/mcp"]
+      "args": ["-y", "@agentmemory/mcp"],
+      "env": {
+        "AGENTMEMORY_URL": "${AGENTMEMORY_URL}",
+        "AGENTMEMORY_SECRET": "${AGENTMEMORY_SECRET}"
+      }
     }
   }
 }

--- a/src/cli/connect/util.ts
+++ b/src/cli/connect/util.ts
@@ -10,11 +10,19 @@ import { dirname, join } from "node:path";
 import { homedir } from "node:os";
 import * as p from "@clack/prompts";
 
+// Env values use ${VAR} expansion so the wired MCP entry inherits
+// AGENTMEMORY_URL / AGENTMEMORY_SECRET from the user's shell. When the
+// vars are unset, the host (Claude Code, Cursor, etc.) substitutes an
+// empty string; the standalone shim treats empty as missing and falls
+// back to http://localhost:3111. This lets a single wired entry serve
+// both local and remote (Kubernetes / reverse-proxied) deployments
+// without doctor-warning duplicates (#375).
 export const AGENTMEMORY_MCP_BLOCK = {
   command: "npx",
   args: ["-y", "@agentmemory/mcp"],
   env: {
-    AGENTMEMORY_URL: "http://localhost:3111",
+    AGENTMEMORY_URL: "${AGENTMEMORY_URL}",
+    AGENTMEMORY_SECRET: "${AGENTMEMORY_SECRET}",
   },
 };
 

--- a/test/cli-connect.test.ts
+++ b/test/cli-connect.test.ts
@@ -112,6 +112,27 @@ describe("agentmemory connect — claude-code adapter (mock filesystem)", () => 
     expect(second.kind).toBe("already-wired");
   });
 
+  it("install() writes env passthrough block for AGENTMEMORY_URL + AGENTMEMORY_SECRET (#375)", async () => {
+    // Remote deployments (k8s, reverse proxy) set AGENTMEMORY_URL +
+    // AGENTMEMORY_SECRET in the shell. The wired MCP entry must honour
+    // those via ${VAR} expansion so a single entry covers both local
+    // and remote without the user needing to add a duplicate config
+    // that triggers a /doctor duplicate-server warning.
+    const claudeDir = join(tmpHome, ".claude");
+    require("node:fs").mkdirSync(claudeDir, { recursive: true });
+    writeFileSync(join(tmpHome, ".claude.json"), JSON.stringify({}));
+
+    const a = await loadAdapter();
+    const result = await a.install({ dryRun: false, force: false });
+    expect(result.kind).toBe("installed");
+
+    const config = JSON.parse(readFileSync(join(tmpHome, ".claude.json"), "utf-8"));
+    const entry = config.mcpServers.agentmemory;
+    expect(entry.env).toBeDefined();
+    expect(entry.env.AGENTMEMORY_URL).toBe("${AGENTMEMORY_URL}");
+    expect(entry.env.AGENTMEMORY_SECRET).toBe("${AGENTMEMORY_SECRET}");
+  });
+
   it("install() with --force re-writes even when already wired", async () => {
     require("node:fs").mkdirSync(join(tmpHome, ".claude"), { recursive: true });
     writeFileSync(


### PR DESCRIPTION
Closes #375.

## Problem

`plugin/.mcp.json` (the bundled plugin manifest) and `AGENTMEMORY_MCP_BLOCK` in `src/cli/connect/util.ts` (the template `agentmemory connect <agent>` writes into `~/.claude.json`, `~/.cursor/mcp.json`, etc.) both **hardcoded the MCP server to `localhost:3111` with no env-var seam**. Users running agentmemory remotely (k8s cluster-internal DNS, reverse proxy with API key auth) hit a permanent `/doctor` warning:

> MCP server "agentmemory" skipped — same command/URL as already-configured "agentmemory"

…because they had to add a second `.mcp.json` entry pointing at the real `AGENTMEMORY_URL` + `AGENTMEMORY_SECRET`, and both entries fought for the `agentmemory` name.

## Fix

Both files now use `${AGENTMEMORY_URL}` / `${AGENTMEMORY_SECRET}` shell-style expansion. The MCP host (Claude Code, Cursor, etc.) substitutes the user's shell value at MCP-server launch.

When the vars are unset, the host passes an empty string. The standalone shim already handles this:

```ts
// src/mcp/standalone.ts + src/mcp/rest-proxy.ts
return (process.env["AGENTMEMORY_URL"] || DEFAULT_URL).replace(/\/+$/, "");
```

Empty string is falsy in JS → falls back to `http://localhost:3111`. **One wired entry now covers both local and remote without duplicates.**

## Files

- `plugin/.mcp.json` — `env` block added with `${VAR}` expansion
- `src/cli/connect/util.ts` — `AGENTMEMORY_MCP_BLOCK.env` updated; comment documents the empty-string-fallback contract so a future contributor doesn't "fix" it by re-hardcoding
- `test/cli-connect.test.ts` — regression test asserts the env block shape after `install()`, so a future regression where the literal localhost URL leaks back in gets caught at PR time

## Use cases unblocked

- Kubernetes deployment with cluster-internal DNS (`http://agentmemory.agentmemory.svc.cluster.local:3111`)
- Remote server behind reverse proxy with API key auth
- Any non-localhost deployment where hooks are still needed

## Verification

```bash
npm run build && npm test
# 91 files, 1008 tests pass (added 1 regression for this fix)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP agent memory configuration now supports environment variable expansion for URL and secret credentials, enabling flexible deployment configurations across local, Kubernetes, and reverse-proxy environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/460?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->