### PR TITLE
fix(config): honor env file drop-stale-index flag

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -159,6 +159,10 @@ export function getEnvVar(key: string): string | undefined {
   return getMergedEnv()[key];
 }
 
+export function isDropStaleIndexEnabled(): boolean {
+  return getMergedEnv()["AGENTMEMORY_DROP_STALE_INDEX"] === "true";
+}
+
 export function detectLlmProviderKind(): "llm" | "noop" {
   const env = getMergedEnv();
   if (

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import {
   isAutoCompressEnabled,
   isConsolidationEnabled,
   isContextInjectionEnabled,
+  isDropStaleIndexEnabled,
 } from "./config.js";
 import {
   createProvider,
@@ -376,8 +377,7 @@ async function main() {
         .map((m) => `${m.obsId} (dim=${m.dim})`)
         .join(", ");
       const distinct = Array.from(seenDimensions).sort((a, b) => a - b).join(", ");
-      const dropStale =
-        process.env["AGENTMEMORY_DROP_STALE_INDEX"] === "true";
+      const dropStale = isDropStaleIndexEnabled();
       if (dropStale) {
         console.warn(
           `[agentmemory] Persisted vector index has ${mismatches.length} of ` +

--- a/test/env-loader.test.ts
+++ b/test/env-loader.test.ts
@@ -25,6 +25,7 @@ describe("loadEnvFile", () => {
     process.env["HOME"] = sandboxHome;
     process.env["USERPROFILE"] = sandboxHome;
     delete process.env["AGENTMEMORY_AUTO_COMPRESS"];
+    delete process.env["AGENTMEMORY_DROP_STALE_INDEX"];
     delete process.env["CONSOLIDATION_ENABLED"];
     delete process.env["GRAPH_EXTRACTION_ENABLED"];
     delete process.env["TOKEN"];
@@ -81,5 +82,11 @@ describe("loadEnvFile", () => {
     writeEnv("TOKEN='abc' # trailing comment");
     const cfg = await freshConfig();
     expect(cfg.getEnvVar("TOKEN")).toBe("abc");
+  });
+
+  it("reads AGENTMEMORY_DROP_STALE_INDEX from the env file", async () => {
+    writeEnv("AGENTMEMORY_DROP_STALE_INDEX=true");
+    const cfg = await freshConfig();
+    expect(cfg.isDropStaleIndexEnabled()).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Adds a config helper for `AGENTMEMORY_DROP_STALE_INDEX` so it uses the same merged env source as the rest of AgentMemory config
- Updates the persisted vector dimension guard to honor the flag from `~/.agentmemory/.env`, not only shell `process.env`
- Adds a regression test covering the `.env` path

Refs #456

## Test Plan
- RED: `npm test -- --run test/env-loader.test.ts` failed with `TypeError: cfg.isDropStaleIndexEnabled is not a function`
- GREEN: `npm test -- --run test/env-loader.test.ts test/vector-index-dimensions.test.ts` → 14 passed
- `npm run build`
- `npm test` → 91 files passed, 1008 tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced configuration handling for vector index management, improving reliability of environment-based settings during startup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/461?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->