### PR TITLE
docs: refresh integration capability counts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -117,7 +117,7 @@
 # 6. CLI / runtime knobs
 # -----------------------------------------------------------------------------
 
-# AGENTMEMORY_TOOLS=all                          # core (7 tools, default) | all (51 tools) — surface exposed to MCP clients
+# AGENTMEMORY_TOOLS=all                          # core (8 tools, default) | all (51 tools) — surface exposed to MCP clients
 # AGENTMEMORY_SLOTS=memory                       # Comma-separated plugin slot names the CLI should claim
 # AGENTMEMORY_DEBUG=1                            # Trace MCP shim probe + standalone fallback decisions to stderr
 # AGENTMEMORY_FORCE_PROXY=1                      # Skip the MCP shim livez probe and trust AGENTMEMORY_URL (for sandboxed MCP clients that can't reach localhost)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,16 +104,16 @@ Hook scripts in `src/hooks/` are standalone Node.js scripts (no iii-sdk import).
 
 ## Testing
 
-- All tests must pass before PR: `npm test` (950+ tests)
+- All tests must pass before PR: `npm test` (1000+ tests)
 - Mock pattern: `vi.mock("iii-sdk")` with mock `sdk.trigger`, `kv.get/set/list`
 - Test files go in `test/` with `.test.ts` extension
 - Follow existing patterns in `test/crystallize.test.ts` for function tests
 
-## Current Stats (v0.9.16)
+## Current Stats (v0.9.18)
 
 - 51 MCP tools (8 visible by default, `AGENTMEMORY_TOOLS=all` for all)
 - 121 REST endpoints
 - 6 MCP resources, 3 MCP prompts
 - 12 hooks, 4 skills
 - 50+ iii functions
-- 950+ tests
+- 1000+ tests

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
   <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-tools.svg"><img src="assets/tags/stat-tools.svg" alt="51 MCP tools" height="38" /></picture>
   <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-hooks.svg"><img src="assets/tags/stat-hooks.svg" alt="12 auto hooks" height="38" /></picture>
   <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-deps.svg"><img src="assets/tags/stat-deps.svg" alt="0 external DBs" height="38" /></picture>
-  <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-tests.svg"><img src="assets/tags/stat-tests.svg" alt="950+ tests passing" height="38" /></picture>
+  <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-tests.svg"><img src="assets/tags/stat-tests.svg" alt="1000+ tests passing" height="38" /></picture>
 </p>
 
 <p align="center">
@@ -1017,7 +1017,7 @@ Full registry: [workers.iii.dev](https://workers.iii.dev). Every worker there co
 | Prometheus / Grafana | iii OTEL + health monitor |
 | Custom plugin systems | `iii worker add <name>` |
 
-**118 source files · ~21,800 LOC · 950+ tests · 123 functions · 34 KV scopes** — all on three primitives. No `agentmemory plugin install`. The plugin system is iii itself.
+**118 source files · ~21,800 LOC · 1000+ tests · 123 functions · 34 KV scopes** — all on three primitives. No `agentmemory plugin install`. The plugin system is iii itself.
 
 ---
 
@@ -1197,7 +1197,7 @@ Full endpoint list: [`src/triggers/api.ts`](src/triggers/api.ts)
 ```bash
 npm run dev               # Hot reload
 npm run build             # Production build
-npm test                  # 950+ tests
+npm test                  # 1000+ tests
 npm run test:integration  # API tests (requires running services)
 ```
 

--- a/assets/tags/light/stat-tests.svg
+++ b/assets/tags/light/stat-tests.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 48" fill="none" role="img" aria-label="TESTS PASSING: 950+">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 48" fill="none" role="img" aria-label="TESTS PASSING: 1000+">
   <rect x="0" y="0" width="140" height="48" rx="10" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1"/>
-  <text x="70" y="24" fill="#16A34A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="18" font-weight="900" text-anchor="middle" letter-spacing="-0.3">950+</text>
+  <text x="70" y="24" fill="#16A34A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="18" font-weight="900" text-anchor="middle" letter-spacing="-0.3">1000+</text>
   <text x="70" y="38" fill="#64748B" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="9" font-weight="600" text-anchor="middle" letter-spacing="1.5">TESTS PASSING</text>
 </svg>

--- a/assets/tags/stat-tests.svg
+++ b/assets/tags/stat-tests.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 48" fill="none" role="img" aria-label="TESTS PASSING: 950+">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 48" fill="none" role="img" aria-label="TESTS PASSING: 1000+">
   <rect x="0" y="0" width="140" height="48" rx="10" fill="#1A1A1A" stroke="#2A2A2A" stroke-width="1"/>
-  <text x="70" y="24" fill="#00D26A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="18" font-weight="900" text-anchor="middle" letter-spacing="-0.3">950+</text>
+  <text x="70" y="24" fill="#00D26A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="18" font-weight="900" text-anchor="middle" letter-spacing="-0.3">1000+</text>
   <text x="70" y="38" fill="#9CA3AF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="9" font-weight="600" text-anchor="middle" letter-spacing="1.5">TESTS PASSING</text>
 </svg>

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -13,7 +13,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/MCP-43_tools-1f6feb?style=flat-square" alt="43 MCP tools" />
+  <img src="https://img.shields.io/badge/MCP-51_tools-1f6feb?style=flat-square" alt="51 MCP tools" />
   <img src="https://img.shields.io/badge/Hooks-6_lifecycle-1f6feb?style=flat-square" alt="6 lifecycle hooks" />
   <img src="https://img.shields.io/badge/R@5-95.2%25-00875f?style=flat-square" alt="95.2% R@5" />
   <img src="https://img.shields.io/badge/Self--hosted-yes-00875f?style=flat-square" alt="Self-hosted" />
@@ -70,7 +70,7 @@ memory:
   provider: agentmemory
 ```
 
-This gives Hermes access to all 43 MCP tools and enables the agentmemory memory provider. Start the server separately:
+This gives Hermes access to all 51 MCP tools and enables the agentmemory memory provider. Start the server separately:
 
 ```bash
 npx @agentmemory/agentmemory

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -13,7 +13,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/MCP-43_tools-1f6feb?style=flat-square" alt="43 MCP tools" />
+  <img src="https://img.shields.io/badge/MCP-51_tools-1f6feb?style=flat-square" alt="51 MCP tools" />
   <img src="https://img.shields.io/badge/Plugin-memory_slot-1f6feb?style=flat-square" alt="OpenClaw memory plugin" />
   <img src="https://img.shields.io/badge/R@5-95.2%25-00875f?style=flat-square" alt="95.2% R@5" />
   <img src="https://img.shields.io/badge/Self--hosted-yes-00875f?style=flat-square" alt="Self-hosted" />
@@ -88,7 +88,7 @@ Then add to your OpenClaw MCP config:
 }
 ```
 
-OpenClaw now has access to all 43 MCP tools including `memory_recall`, `memory_save`, `memory_smart_search`, `memory_timeline`, `memory_profile`, and more.
+OpenClaw now has access to all 51 MCP tools including `memory_recall`, `memory_save`, `memory_smart_search`, `memory_timeline`, `memory_profile`, and more.
 
 ## Option 2: OpenClaw memory plugin (deeper integration)
 

--- a/test/consistency.test.ts
+++ b/test/consistency.test.ts
@@ -6,7 +6,7 @@ vi.mock("../src/logger.js", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
-import { getAllTools } from "../src/mcp/tools-registry.js";
+import { getAllTools, getVisibleTools } from "../src/mcp/tools-registry.js";
 import { VERSION } from "../src/version.js";
 
 const ROOT = join(import.meta.dirname, "..");
@@ -21,7 +21,12 @@ function countRestApiEndpoints(): number {
 }
 
 describe("Consistency checks", () => {
+  const originalToolMode = process.env["AGENTMEMORY_TOOLS"];
+  delete process.env["AGENTMEMORY_TOOLS"];
   const toolCount = getAllTools().length;
+  const defaultToolCount = getVisibleTools().length;
+  if (originalToolMode === undefined) delete process.env["AGENTMEMORY_TOOLS"];
+  else process.env["AGENTMEMORY_TOOLS"] = originalToolMode;
   const restEndpointCount = countRestApiEndpoints();
 
   it("version.ts matches package.json", () => {
@@ -46,6 +51,31 @@ describe("Consistency checks", () => {
     expect(readme).toMatch(toolCountPattern);
     const toolResourcePattern = new RegExp(`${toolCount}\\s+tools,\\s+6\\s+resources`);
     expect(readme).toMatch(toolResourcePattern);
+  });
+
+  it("integration READMEs mention the current MCP tool count", () => {
+    for (const path of ["integrations/hermes/README.md", "integrations/openclaw/README.md"]) {
+      const text = readText(path);
+      expect(text).toContain(`${toolCount} MCP tools`);
+      expect(text).not.toMatch(/43 MCP tools|43_tools/);
+    }
+  });
+
+  it("env example documents the current default and full MCP tool counts", () => {
+    const envExample = readText(".env.example");
+    expect(envExample).toContain(`core (${defaultToolCount} tools, default) | all (${toolCount} tools)`);
+  });
+
+  it("agent instructions current stats match package version and test scale", () => {
+    const agents = readText("AGENTS.md");
+    expect(agents).toContain(`## Current Stats (v${VERSION})`);
+    expect(agents).toContain("1000+ tests");
+  });
+
+  it("README test-count docs reflect the current test scale", () => {
+    const readme = readText("README.md");
+    expect(readme).toContain("1000+ tests");
+    expect(readme).not.toContain("950+ tests");
   });
 
   it("documented REST endpoint counts match registered API paths", () => {


### PR DESCRIPTION
## Summary
- Refresh Hermes and OpenClaw integration docs from the stale 43-tool badge/text to the current 51-tool MCP surface.
- Refresh test-count docs/badges from 950+ to 1000+ and update AGENTS.md current stats to v0.9.18.
- Extend consistency checks so integration README counts, `.env.example` tool visibility counts, and README/AGENTS test-count docs stay in sync.

## Test Plan
- [x] `npm test -- --run test/consistency.test.ts` → 12 passed
- [x] `npm run build`
- [x] `npm test` → 91 files passed, 1011 tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded MCP tools from 43 to 51, with default tools increased from 7 to 8.

* **Documentation**
  * Updated all integration documentation to reflect new tool counts and expanded test suite (1000+ tests).
  * Version and stats updated across project documentation.

* **Tests**
  * Enhanced consistency checks for MCP tool counts and documentation validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/464?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->