### PR TITLE
feat(connect): automate Hermes config merge

### DIFF
--- a/src/cli/connect/hermes.ts
+++ b/src/cli/connect/hermes.ts
@@ -1,12 +1,105 @@
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import * as p from "@clack/prompts";
 import type { ConnectAdapter, ConnectOptions, ConnectResult } from "./types.js";
+import {
+  backupFile,
+  logAlreadyWired,
+  logBackup,
+  logInstalled,
+  writeTextAtomic,
+} from "./util.js";
 
 const HERMES_DIR = join(homedir(), ".hermes");
 const HERMES_CONFIG = join(HERMES_DIR, "config.yaml");
 const DOCS = "https://github.com/rohitg00/agentmemory/tree/main/integrations/hermes";
+const AGENTMEMORY_MCP_YAML = [
+  "  agentmemory:",
+  "    command: npx",
+  '    args: ["-y", "@agentmemory/mcp"]',
+];
+const MEMORY_PROVIDER_YAML = "  provider: agentmemory";
+
+function normalizeYaml(text: string): string {
+  if (text.length === 0) return "";
+  return text.endsWith("\n") ? text : `${text}\n`;
+}
+
+function nextTopLevelIndex(lines: string[], start: number): number {
+  for (let i = start + 1; i < lines.length; i++) {
+    if (/^[A-Za-z0-9_-]+:\s*(?:#.*)?$/.test(lines[i] ?? "")) return i;
+  }
+  return lines.length;
+}
+
+function findTopLevelSection(lines: string[], name: string): [number, number] | null {
+  const start = lines.findIndex((line) => line === `${name}:`);
+  if (start === -1) return null;
+  return [start, nextTopLevelIndex(lines, start)];
+}
+
+function removeChildBlock(lines: string[], start: number, end: number, child: string): void {
+  const childStart = lines.findIndex(
+    (line, index) => index > start && index < end && line === `  ${child}:`,
+  );
+  if (childStart === -1) return;
+  let childEnd = end;
+  for (let i = childStart + 1; i < end; i++) {
+    if (/^  [A-Za-z0-9_-]+:\s*(?:#.*)?$/.test(lines[i] ?? "")) {
+      childEnd = i;
+      break;
+    }
+  }
+  lines.splice(childStart, childEnd - childStart);
+}
+
+function upsertMcpServers(text: string): string {
+  const lines = normalizeYaml(text).split("\n");
+  if (lines.at(-1) === "") lines.pop();
+  const section = findTopLevelSection(lines, "mcp_servers");
+  if (!section) {
+    if (lines.length > 0) lines.push("");
+    lines.push("mcp_servers:", ...AGENTMEMORY_MCP_YAML);
+    return `${lines.join("\n")}\n`;
+  }
+
+  const [start, end] = section;
+  removeChildBlock(lines, start, end, "agentmemory");
+  lines.splice(start + 1, 0, ...AGENTMEMORY_MCP_YAML);
+  return `${lines.join("\n")}\n`;
+}
+
+function upsertMemoryProvider(text: string): string {
+  const lines = normalizeYaml(text).split("\n");
+  if (lines.at(-1) === "") lines.pop();
+  const section = findTopLevelSection(lines, "memory");
+  if (!section) {
+    if (lines.length > 0) lines.push("");
+    lines.push("memory:", MEMORY_PROVIDER_YAML);
+    return `${lines.join("\n")}\n`;
+  }
+
+  const [start, end] = section;
+  const providerIndex = lines.findIndex(
+    (line, index) => index > start && index < end && /^  provider:\s*/.test(line),
+  );
+  if (providerIndex === -1) lines.splice(start + 1, 0, MEMORY_PROVIDER_YAML);
+  else lines[providerIndex] = MEMORY_PROVIDER_YAML;
+  return `${lines.join("\n")}\n`;
+}
+
+function renderHermesConfig(existing: string): string {
+  return upsertMemoryProvider(upsertMcpServers(existing));
+}
+
+function isHermesWired(text: string): boolean {
+  return (
+    /^mcp_servers:\n(?:[\s\S]*?\n)?  agentmemory:\n(?:[\s\S]*?\n)?    command: npx\n(?:[\s\S]*?\n)?    args: \["-y", "@agentmemory\/mcp"\]/m.test(
+      text,
+    ) && /^memory:\n(?:[\s\S]*?\n)?  provider: agentmemory/m.test(text)
+  );
+}
 
 export const adapter: ConnectAdapter = {
   name: "hermes",
@@ -19,29 +112,29 @@ export const adapter: ConnectAdapter = {
     return existsSync(HERMES_DIR);
   },
 
-  async install(_opts: ConnectOptions): Promise<ConnectResult> {
-    p.log.warn(
-      "Hermes uses YAML config. Automated merge isn't implemented yet — manual install required.",
-    );
-    p.note(
-      [
-        `Add to ${HERMES_CONFIG}:`,
-        "",
-        "  mcp_servers:",
-        "    agentmemory:",
-        "      command: npx",
-        '      args: ["-y", "@agentmemory/mcp"]',
-        "",
-        "  memory:",
-        "    provider: agentmemory",
-        "",
-        `Full guide: ${DOCS}`,
-      ].join("\n"),
-      "Hermes manual install",
-    );
-    return {
-      kind: "stub",
-      reason: "yaml-merge-not-implemented",
-    };
+  async install(opts: ConnectOptions): Promise<ConnectResult> {
+    const before = existsSync(HERMES_CONFIG)
+      ? readFileSync(HERMES_CONFIG, "utf-8")
+      : "";
+
+    if (!opts.force && before && isHermesWired(before)) {
+      logAlreadyWired("Hermes", HERMES_CONFIG);
+      return { kind: "already-wired", mutatedPath: HERMES_CONFIG };
+    }
+
+    const next = renderHermesConfig(before);
+    if (opts.dryRun) {
+      p.log.info(`[dry-run] Would merge agentmemory MCP + memory provider into ${HERMES_CONFIG}`);
+      return { kind: "installed", mutatedPath: HERMES_CONFIG };
+    }
+
+    const backupPath = existsSync(HERMES_CONFIG)
+      ? backupFile(HERMES_CONFIG, "hermes", "yaml")
+      : undefined;
+    if (backupPath) logBackup(backupPath);
+    writeTextAtomic(HERMES_CONFIG, next);
+    logInstalled("Hermes", HERMES_CONFIG);
+    p.log.info("Restart Hermes to pick up the new MCP server and memory provider.");
+    return { kind: "installed", mutatedPath: HERMES_CONFIG, backupPath };
   },
 };

--- a/src/cli/connect/util.ts
+++ b/src/cli/connect/util.ts
@@ -60,6 +60,13 @@ export function writeJsonAtomic(path: string, value: unknown): void {
   renameSync(tmp, path);
 }
 
+export function writeTextAtomic(path: string, value: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tmp, value, "utf-8");
+  renameSync(tmp, path);
+}
+
 export function logInstalled(label: string, target: string): void {
   p.log.success(`${label} → wired into ${target}`);
 }

--- a/test/cli-connect.test.ts
+++ b/test/cli-connect.test.ts
@@ -159,13 +159,152 @@ describe("agentmemory connect — claude-code adapter (mock filesystem)", () => 
   });
 });
 
-describe("agentmemory connect — stub adapters log + return stub", () => {
-  it("hermes adapter returns stub regardless of detect", async () => {
-    const { adapter } = await import("../src/cli/connect/hermes.js");
-    const result = await adapter.install({ dryRun: false, force: false });
-    expect(result.kind).toBe("stub");
+describe("agentmemory connect — hermes adapter (mock filesystem)", () => {
+  let tmpHome: string;
+  let originalHome: string | undefined;
+  let originalUserprofile: string | undefined;
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), "am-connect-"));
+    originalHome = process.env["HOME"];
+    originalUserprofile = process.env["USERPROFILE"];
+    process.env["HOME"] = tmpHome;
+    process.env["USERPROFILE"] = tmpHome;
+    vi.resetModules();
   });
 
+  afterEach(() => {
+    if (originalHome !== undefined) process.env["HOME"] = originalHome;
+    else delete process.env["HOME"];
+    if (originalUserprofile !== undefined)
+      process.env["USERPROFILE"] = originalUserprofile;
+    else delete process.env["USERPROFILE"];
+    rmSync(tmpHome, { recursive: true, force: true });
+    vi.resetModules();
+  });
+
+  async function loadAdapter(): Promise<ConnectAdapter> {
+    const mod = await import("../src/cli/connect/hermes.js?t=" + Date.now());
+    return (mod as { adapter: ConnectAdapter }).adapter;
+  }
+
+  function mkdirHermes(): string {
+    const hermesDir = join(tmpHome, ".hermes");
+    require("node:fs").mkdirSync(hermesDir, { recursive: true });
+    return hermesDir;
+  }
+
+  it("detect() returns false when ~/.hermes doesn't exist", async () => {
+    const a = await loadAdapter();
+    expect(a.detect()).toBe(false);
+  });
+
+  it("install() creates config.yaml with MCP server and memory provider", async () => {
+    const hermesDir = mkdirHermes();
+    const a = await loadAdapter();
+    expect(a.detect()).toBe(true);
+
+    const result = await a.install({ dryRun: false, force: false });
+    expect(result.kind).toBe("installed");
+
+    const config = readFileSync(join(hermesDir, "config.yaml"), "utf-8");
+    expect(config).toContain("mcp_servers:");
+    expect(config).toContain("  agentmemory:");
+    expect(config).toContain("    command: npx");
+    expect(config).toContain('    args: ["-y", "@agentmemory/mcp"]');
+    expect(config).toContain("memory:");
+    expect(config).toContain("  provider: agentmemory");
+  });
+
+  it("install() preserves existing mcp_servers entries and memory keys", async () => {
+    const hermesDir = mkdirHermes();
+    writeFileSync(
+      join(hermesDir, "config.yaml"),
+      [
+        "mcp_servers:",
+        "  other:",
+        "    command: other-cmd",
+        "",
+        "memory:",
+        "  provider: builtin",
+        "  retain_days: 30",
+        "",
+      ].join("\n"),
+    );
+
+    const a = await loadAdapter();
+    const result = await a.install({ dryRun: false, force: false });
+    expect(result.kind).toBe("installed");
+
+    const config = readFileSync(join(hermesDir, "config.yaml"), "utf-8");
+    expect(config).toContain("  other:\n    command: other-cmd");
+    expect(config).toContain("  agentmemory:\n    command: npx");
+    expect(config).toContain("  provider: agentmemory");
+    expect(config).toContain("  retain_days: 30");
+  });
+
+  it("install() is idempotent when Hermes is already wired", async () => {
+    const hermesDir = mkdirHermes();
+    const wired = [
+      "mcp_servers:",
+      "  agentmemory:",
+      "    command: npx",
+      '    args: ["-y", "@agentmemory/mcp"]',
+      "",
+      "memory:",
+      "  provider: agentmemory",
+      "",
+    ].join("\n");
+    writeFileSync(join(hermesDir, "config.yaml"), wired);
+
+    const a = await loadAdapter();
+    const result = await a.install({ dryRun: false, force: false });
+    expect(result.kind).toBe("already-wired");
+    expect(readFileSync(join(hermesDir, "config.yaml"), "utf-8")).toBe(wired);
+  });
+
+  it("install() with --dry-run does not mutate config.yaml", async () => {
+    const hermesDir = mkdirHermes();
+    const before = "memory:\n  provider: builtin\n";
+    writeFileSync(join(hermesDir, "config.yaml"), before);
+
+    const a = await loadAdapter();
+    const result = await a.install({ dryRun: true, force: false });
+    expect(result.kind).toBe("installed");
+    expect(readFileSync(join(hermesDir, "config.yaml"), "utf-8")).toBe(before);
+  });
+
+  it("install() creates a backup file for existing config.yaml", async () => {
+    const hermesDir = mkdirHermes();
+    writeFileSync(join(hermesDir, "config.yaml"), "memory:\n  provider: builtin\n");
+
+    const a = await loadAdapter();
+    const result = await a.install({ dryRun: false, force: false });
+    expect(result.kind).toBe("installed");
+    if (result.kind === "installed") {
+      expect(result.backupPath).toBeDefined();
+      expect(existsSync(result.backupPath!)).toBe(true);
+      expect(result.backupPath!).toContain(".agentmemory/backups");
+    }
+  });
+
+  it("install() with --force re-writes even when already wired", async () => {
+    const hermesDir = mkdirHermes();
+    writeFileSync(
+      join(hermesDir, "config.yaml"),
+      "mcp_servers:\n  agentmemory:\n    command: old\n\nmemory:\n  provider: agentmemory\n",
+    );
+
+    const a = await loadAdapter();
+    const result = await a.install({ dryRun: false, force: true });
+    expect(result.kind).toBe("installed");
+    const config = readFileSync(join(hermesDir, "config.yaml"), "utf-8");
+    expect(config).toContain("    command: npx");
+    expect(config).toContain('    args: ["-y", "@agentmemory/mcp"]');
+  });
+});
+
+describe("agentmemory connect — stub adapters log + return stub", () => {
   it("openhuman adapter returns stub", async () => {
     const { adapter } = await import("../src/cli/connect/openhuman.js");
     const result = await adapter.install({ dryRun: false, force: false });


### PR DESCRIPTION
## Summary
- Replaces the Hermes connect stub with an automatic `~/.hermes/config.yaml` merge.
- Adds `mcp_servers.agentmemory` and sets `memory.provider: agentmemory` while preserving existing Hermes config keys.
- Adds atomic text writes, backup handling for existing YAML, idempotency, `--dry-run`, and `--force` coverage.

## Test Plan
- [x] RED: `npm test -- --run test/cli-connect.test.ts` failed with Hermes install still returning `stub`
- [x] GREEN: `npm test -- --run test/cli-connect.test.ts` → 19 passed
- [x] `npm run build`
- [x] `npm test` → 91 files passed, 1013 tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hermes configuration now automatically merges and installs MCP server settings and memory provider configuration.
  * Backup file automatically created when updating existing configurations.
  * Dry-run mode available to preview changes without applying them.
  * Force option to override existing Hermes configurations.
  * Automatic detection of whether Hermes is already properly configured.

* **Tests**
  * Added comprehensive test suite for Hermes integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/465?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->