### PR TITLE
fix(embeddings): allow custom OpenAI embedding path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,7 @@
 # COHERE_API_KEY=...                             # General-purpose embeddings
 
 # Reuses OPENAI_API_KEY / OPENAI_BASE_URL above when EMBEDDING_PROVIDER=openai.
+# OPENAI_EMBEDDING_PATH=/v1/embeddings          # Override when a proxy expects a different embeddings route
 # OPENAI_EMBEDDING_MODEL=text-embedding-3-small  # Embedding model when EMBEDDING_PROVIDER=openai
 # OPENAI_EMBEDDING_DIMENSIONS=1536               # Required when the model is not in the known-models table
 

--- a/README.md
+++ b/README.md
@@ -1090,6 +1090,7 @@ Create `~/.agentmemory/.env`:
 # VOYAGE_API_KEY=...
 # OPENAI_API_KEY=sk-...
 # OPENAI_BASE_URL=https://api.openai.com   # Override for Azure / vLLM / LM Studio / proxies
+# OPENAI_EMBEDDING_PATH=/v1/embeddings     # Override when a proxy expects a different embeddings route
 # OPENAI_EMBEDDING_MODEL=text-embedding-3-small
 # OPENAI_EMBEDDING_DIMENSIONS=1536        # Required when the model is not in the known-models table
 

--- a/src/providers/_openai-shared.ts
+++ b/src/providers/_openai-shared.ts
@@ -104,13 +104,15 @@ export function buildEmbeddingUrl(
   baseUrl: string,
   isAzure: boolean,
   azureApiVersion: string,
+  embeddingPath?: string,
 ): string {
+  const route = embeddingPath ?? "/embeddings";
   if (isAzure) {
     return azureStyleOf(baseUrl) === "legacy"
-      ? legacyAzureUrl(baseUrl, "/embeddings", azureApiVersion)
-      : v1AzureUrl(baseUrl, "/embeddings");
+      ? legacyAzureUrl(baseUrl, route, azureApiVersion)
+      : v1AzureUrl(baseUrl, route);
   }
-  return `${baseUrl}/v1/embeddings`;
+  return embeddingPath ? `${baseUrl}${route}` : `${baseUrl}/v1/embeddings`;
 }
 
 // Azure key-auth uses `api-key: <KEY>`; standard OpenAI-compatible

--- a/src/providers/embedding/openai.ts
+++ b/src/providers/embedding/openai.ts
@@ -37,6 +37,12 @@ function resolveDimensions(model: string, override: string | undefined): number 
   return MODEL_DIMENSIONS[model] ?? DEFAULT_DIMENSIONS;
 }
 
+function normalizeEmbeddingPath(path: string | null | undefined): string | undefined {
+  const trimmed = path?.trim();
+  if (!trimmed) return undefined;
+  return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+}
+
 /**
  * OpenAI-compatible embedding provider.
  *
@@ -54,6 +60,7 @@ function resolveDimensions(model: string, override: string | undefined): number 
  *   OPENAI_BASE_URL           — base URL without path (default: https://api.openai.com).
  *                               Azure: https://<resource>.openai.azure.com/openai/deployments/<deployment>
  *   OPENAI_API_VERSION        — Azure api-version query param (default: 2024-08-01-preview)
+ *   OPENAI_EMBEDDING_PATH     — embedding endpoint path override for OpenAI-compatible servers
  *   OPENAI_EMBEDDING_MODEL    — model name (default: text-embedding-3-small)
  *   OPENAI_EMBEDDING_DIMENSIONS — override reported dimensions (required for
  *                                 custom / self-hosted models not in the
@@ -64,6 +71,7 @@ export class OpenAIEmbeddingProvider implements EmbeddingProvider {
   readonly dimensions: number;
   private apiKey: string;
   private baseUrl: string;
+  private embeddingPath: string | undefined;
   private model: string;
   private isAzure: boolean;
   private azureApiVersion: string;
@@ -72,6 +80,7 @@ export class OpenAIEmbeddingProvider implements EmbeddingProvider {
     this.apiKey = apiKey || getEnvVar("OPENAI_API_KEY") || "";
     if (!this.apiKey) throw new Error("OPENAI_API_KEY is required");
     this.baseUrl = normalizeBaseUrl(getEnvVar("OPENAI_BASE_URL"));
+    this.embeddingPath = normalizeEmbeddingPath(getEnvVar("OPENAI_EMBEDDING_PATH"));
     this.model = getEnvVar("OPENAI_EMBEDDING_MODEL") || DEFAULT_MODEL;
     this.dimensions = resolveDimensions(
       this.model,
@@ -92,6 +101,7 @@ export class OpenAIEmbeddingProvider implements EmbeddingProvider {
       this.baseUrl,
       this.isAzure,
       this.azureApiVersion,
+      this.embeddingPath,
     );
     const response = await fetchWithTimeout(url, {
       method: "POST",

--- a/test/embedding-provider.test.ts
+++ b/test/embedding-provider.test.ts
@@ -58,6 +58,7 @@ describe("OpenAIEmbeddingProvider", () => {
   beforeEach(() => {
     process.env = { ...originalEnv };
     delete process.env["OPENAI_BASE_URL"];
+    delete process.env["OPENAI_EMBEDDING_PATH"];
     delete process.env["OPENAI_EMBEDDING_MODEL"];
     delete process.env["OPENAI_EMBEDDING_DIMENSIONS"];
   });
@@ -88,6 +89,42 @@ describe("OpenAIEmbeddingProvider", () => {
     await provider.embed("hello");
     expect(fetchSpy).toHaveBeenCalledWith(
       "https://my-proxy.example.com/v1/embeddings",
+      expect.any(Object),
+    );
+
+    fetchSpy.mockRestore();
+  });
+
+  it("respects OPENAI_EMBEDDING_PATH for OpenAI-compatible servers with custom routes", async () => {
+    process.env["OPENAI_BASE_URL"] = "http://localhost:11434/v1/";
+    process.env["OPENAI_EMBEDDING_PATH"] = "/embeddings";
+    const provider = new OpenAIEmbeddingProvider("test-key");
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ data: [{ embedding: [0.1, 0.2, 0.3] }] }), { status: 200 }),
+    );
+
+    await provider.embed("hello");
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "http://localhost:11434/v1/embeddings",
+      expect.any(Object),
+    );
+
+    fetchSpy.mockRestore();
+  });
+
+  it("normalizes OPENAI_EMBEDDING_PATH without a leading slash", async () => {
+    process.env["OPENAI_BASE_URL"] = "http://localhost:11434/v1/";
+    process.env["OPENAI_EMBEDDING_PATH"] = "embeddings";
+    const provider = new OpenAIEmbeddingProvider("test-key");
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ data: [{ embedding: [0.1, 0.2, 0.3] }] }), { status: 200 }),
+    );
+
+    await provider.embed("hello");
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "http://localhost:11434/v1/embeddings",
       expect.any(Object),
     );
 


### PR DESCRIPTION
## Summary
- Adds `OPENAI_EMBEDDING_PATH` so OpenAI-compatible embedding providers can use custom embedding routes without duplicating `/v1`.
- Trims trailing slashes from `OPENAI_BASE_URL` before appending the embedding path.
- Documents the new setting in `.env.example` and README.

## Notes
- Related to the OpenAI-compatible provider work in #462, but this is a separate small slice: configurable embedding route path only.
- Default behavior remains `https://api.openai.com/v1/embeddings`.

## Test Plan
- [x] RED: `npm test -- --run test/embedding-provider.test.ts` failed because `OPENAI_BASE_URL=http://localhost:11434/v1/` still produced `/v1//v1/embeddings`
- [x] GREEN: `npm test -- --run test/embedding-provider.test.ts` → 18 passed
- [x] `npm run build`
- [x] `npm test` → 91 files passed, 1008 tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for customizing the OpenAI embeddings endpoint path via a new OPENAI_EMBEDDING_PATH environment variable, improving compatibility with proxies or alternate routing.

* **Documentation**
  * README and example configuration updated to document OPENAI_EMBEDDING_PATH, including normalization guidance (leading slash) and usage examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/467?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->