### PR TITLE
fix(memory): audit remember attribution

### DIFF
--- a/src/functions/remember.ts
+++ b/src/functions/remember.ts
@@ -9,6 +9,18 @@ import { recordAudit } from "./audit.js";
 import { getSearchIndex, vectorIndexAddGuarded } from "./search.js";
 import { logger } from "../logger.js";
 
+function normalizeStringList(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => (typeof item === "string" ? item.trim() : ""))
+      .filter(Boolean);
+  }
+  if (typeof value === "string") {
+    return value.split(",").map((item) => item.trim()).filter(Boolean);
+  }
+  return [];
+}
+
 export function registerRememberFunction(sdk: ISdk, kv: StateKV): void {
   sdk.registerFunction("mem::remember", 
     async (data: {
@@ -16,6 +28,9 @@ export function registerRememberFunction(sdk: ISdk, kv: StateKV): void {
       type?: string;
       concepts?: string[];
       files?: string[];
+      sessionId?: string;
+      sessionIds?: string[];
+      tags?: string[];
       ttlDays?: number;
       sourceObservationIds?: string[];
     }) => {
@@ -35,6 +50,12 @@ export function registerRememberFunction(sdk: ISdk, kv: StateKV): void {
       if (data.sourceObservationIds && !Array.isArray(data.sourceObservationIds)) {
         return { success: false, error: "sourceObservationIds must be an array" };
       }
+      if (data.sessionIds && !Array.isArray(data.sessionIds)) {
+        return { success: false, error: "sessionIds must be an array" };
+      }
+      if (data.tags && !Array.isArray(data.tags)) {
+        return { success: false, error: "tags must be an array" };
+      }
       const validTypes = new Set([
         "pattern",
         "preference",
@@ -48,6 +69,13 @@ export function registerRememberFunction(sdk: ISdk, kv: StateKV): void {
         : "fact";
 
       const now = new Date().toISOString();
+      const sessionIds = [
+        ...(typeof data.sessionId === "string" && data.sessionId.trim()
+          ? [data.sessionId.trim()]
+          : []),
+        ...normalizeStringList(data.sessionIds),
+      ].filter((id, index, all) => all.indexOf(id) === index);
+      const tags = normalizeStringList(data.tags);
 
       return withKeyedLock("mem:remember", async () => {
         const existingMemories = await kv.list<Memory>(KV.memories);
@@ -78,7 +106,8 @@ export function registerRememberFunction(sdk: ISdk, kv: StateKV): void {
           content: data.content,
           concepts: data.concepts || [],
           files: data.files || [],
-          sessionIds: [],
+          tags,
+          sessionIds,
           strength: 7,
           version: supersededId ? supersededVersion + 1 : 1,
           parentId: supersededId,
@@ -98,6 +127,19 @@ export function registerRememberFunction(sdk: ISdk, kv: StateKV): void {
           await kv.set(KV.memories, supersededMemory.id, supersededMemory);
         }
         await kv.set(KV.memories, memory.id, memory);
+
+        await recordAudit(kv, "remember", "mem::remember", [memory.id], {
+          type: memory.type,
+          sessionIds: memory.sessionIds,
+          tags,
+          concepts: memory.concepts,
+          files: memory.files,
+          sourceObservationIds: memory.sourceObservationIds || [],
+          supersededMemoryId: supersededId,
+          version: memory.version,
+          ttlDays: data.ttlDays,
+          forgetAfter: memory.forgetAfter,
+        });
 
         // Without this, mem::remember persists the row but the BM25
         // index never sees it, so memory_smart_search and memory_recall

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -164,20 +164,20 @@ export function registerMcpEndpoints(
             }
             const type = (args.type as string) || "fact";
             const concepts =
-              typeof args.concepts === "string"
-                ? args.concepts.split(",").map((c: string) => c.trim()).filter(Boolean)
-                : [];
-            const files =
-              typeof args.files === "string"
-                ? args.files.split(",").map((f: string) => f.trim()).filter(Boolean)
-                : [];
+              parseCsvList(args.concepts);
+            const files = parseCsvList(args.files);
+            const tags = parseCsvList(args.tags);
+            const sessionId = asNonEmptyString(args.sessionId);
 
-            const result = await sdk.trigger({ function_id: "mem::remember", payload: {
+            const payload: Record<string, unknown> = {
               content: args.content,
               type,
               concepts,
               files,
-            } });
+            };
+            if (sessionId) payload.sessionId = sessionId;
+            if (tags.length > 0) payload.tags = tags;
+            const result = await sdk.trigger({ function_id: "mem::remember", payload });
             return {
               status_code: 200,
               body: {

--- a/src/mcp/standalone.ts
+++ b/src/mcp/standalone.ts
@@ -87,6 +87,8 @@ interface Validated {
   type?: string;
   concepts?: string[];
   files?: string[];
+  sessionId?: string;
+  tags?: string[];
   query?: string;
   limit?: number;
   memoryIds?: string[];
@@ -108,6 +110,10 @@ function validate(toolName: string, args: Record<string, unknown>): Validated {
       v.type = (args["type"] as string) || "fact";
       v.concepts = normalizeList(args["concepts"]);
       v.files = normalizeList(args["files"]);
+      v.sessionId = typeof args["sessionId"] === "string" && args["sessionId"].trim()
+        ? args["sessionId"].trim()
+        : undefined;
+      v.tags = normalizeList(args["tags"]);
       return v;
     }
     case "memory_recall":
@@ -155,6 +161,8 @@ async function handleProxy(
           type: v.type,
           concepts: v.concepts,
           files: v.files,
+          sessionId: v.sessionId,
+          tags: v.tags,
         }),
       });
       return textResponse(result);
@@ -212,12 +220,13 @@ async function handleLocal(
         content: v.content,
         concepts: v.concepts,
         files: v.files,
+        tags: v.tags,
         createdAt: isoNow,
         updatedAt: isoNow,
         strength: 7,
         version: 1,
         isLatest: true,
-        sessionIds: [],
+        sessionIds: v.sessionId ? [v.sessionId] : [],
       });
       kvInstance.persist();
       return textResponse({ saved: id });

--- a/src/mcp/tools-registry.ts
+++ b/src/mcp/tools-registry.ts
@@ -75,6 +75,14 @@ export const CORE_TOOLS: McpToolDef[] = [
           type: "string",
           description: "Comma-separated relevant file paths",
         },
+        sessionId: {
+          type: "string",
+          description: "Session ID to attribute this saved memory to",
+        },
+        tags: {
+          type: "string",
+          description: "Comma-separated tags for audit and filtering context",
+        },
       },
       required: ["content"],
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,7 @@ export interface Memory {
   content: string;
   concepts: string[];
   files: string[];
+  tags?: string[];
   sessionIds: string[];
   strength: number;
   version: number;

--- a/test/mcp-standalone-proxy.test.ts
+++ b/test/mcp-standalone-proxy.test.ts
@@ -112,6 +112,39 @@ describe("@agentmemory/mcp standalone — server proxy (issue #159)", () => {
     ]);
   });
 
+  it("standalone proxy preserves memory_save sessionId and tags in the REST body", async () => {
+    let rememberBody: unknown;
+    installFetch((url, init) => {
+      if (url.endsWith("/agentmemory/livez")) return new Response("ok", { status: 200 });
+      if (url.endsWith("/agentmemory/remember")) {
+        rememberBody = JSON.parse((init?.body as string) || "{}");
+        return new Response(JSON.stringify({ success: true, memory: { id: "mem_1" } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    await handleToolCall("memory_save", {
+      content: "Remember release procedure",
+      type: "workflow",
+      concepts: "release, deploy",
+      files: ["docs/release.md"],
+      sessionId: "ses_proxy",
+      tags: "ops, prod",
+    });
+
+    expect(rememberBody).toEqual({
+      content: "Remember release procedure",
+      type: "workflow",
+      concepts: ["release", "deploy"],
+      files: ["docs/release.md"],
+      sessionId: "ses_proxy",
+      tags: ["ops", "prod"],
+    });
+  });
+
   it("local fallback returns the same shape as proxy for memory_smart_search", async () => {
     installFetch(() => {
       throw new Error("ECONNREFUSED");

--- a/test/mcp-standalone.test.ts
+++ b/test/mcp-standalone.test.ts
@@ -222,6 +222,26 @@ describe("handleToolCall", () => {
     expect(parsed.results[0].content).toBe("TypeScript is great");
   });
 
+  it("memory_save stores sessionId and tags in local fallback memories", async () => {
+    const kv = new InMemoryKV();
+    const result = await handleToolCall(
+      "memory_save",
+      {
+        content: "Session-tagged standalone memory",
+        sessionId: "ses_local",
+        tags: "ops, local",
+      },
+      kv,
+    );
+    const saved = JSON.parse(result.content[0].text);
+    const mem = await kv.get<{ sessionIds: string[]; tags: string[] }>(
+      "mem:memories",
+      saved.saved,
+    );
+    expect(mem?.sessionIds).toEqual(["ses_local"]);
+    expect(mem?.tags).toEqual(["ops", "local"]);
+  });
+
   it("memory_save accepts concepts/files as arrays (plugin skill format, #139)", async () => {
     const kv = new InMemoryKV();
     const result = await handleToolCall(

--- a/test/mcp-tools-call.test.ts
+++ b/test/mcp-tools-call.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../src/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { registerMcpEndpoints } from "../src/mcp/server.js";
+
+function mockKV() {
+  const store = new Map<string, Map<string, unknown>>();
+  return {
+    get: async <T>(scope: string, key: string): Promise<T | null> =>
+      (store.get(scope)?.get(key) as T) ?? null,
+    set: async <T>(scope: string, key: string, data: T): Promise<T> => {
+      if (!store.has(scope)) store.set(scope, new Map());
+      store.get(scope)!.set(key, data);
+      return data;
+    },
+    delete: async (scope: string, key: string): Promise<void> => {
+      store.get(scope)?.delete(key);
+    },
+    list: async <T>(scope: string): Promise<T[]> => {
+      const entries = store.get(scope);
+      return entries ? (Array.from(entries.values()) as T[]) : [];
+    },
+  };
+}
+
+function mockSdk() {
+  const functions = new Map<string, Function>();
+  const triggerOverrides = new Map<string, Function>();
+  return {
+    registerFunction: (idOrOpts: string | { id: string }, handler: Function) => {
+      const id = typeof idOrOpts === "string" ? idOrOpts : idOrOpts.id;
+      functions.set(id, handler);
+    },
+    registerTrigger: () => {},
+    trigger: async (
+      idOrInput: string | { function_id: string; payload: unknown },
+      data?: unknown,
+    ) => {
+      const id = typeof idOrInput === "string" ? idOrInput : idOrInput.function_id;
+      const payload = typeof idOrInput === "string" ? data : idOrInput.payload;
+      if (triggerOverrides.has(id)) return triggerOverrides.get(id)!(payload);
+      const fn = functions.get(id);
+      if (!fn) throw new Error(`No function: ${id}`);
+      return fn(payload);
+    },
+    overrideTrigger: (id: string, handler: Function) => {
+      triggerOverrides.set(id, handler);
+    },
+    getFunction: (id: string) => functions.get(id),
+  };
+}
+
+function makeReq(body?: unknown, headers?: Record<string, string>) {
+  return {
+    body,
+    headers: headers || {},
+    query_params: {},
+  };
+}
+
+describe("MCP tools call", () => {
+  it("passes memory_save sessionId and tags through to mem::remember", async () => {
+    const sdk = mockSdk();
+    const kv = mockKV();
+    let capturedPayload: unknown;
+    sdk.overrideTrigger("mem::remember", async (payload: unknown) => {
+      capturedPayload = payload;
+      return { success: true, memory: { id: "mem_1" } };
+    });
+    registerMcpEndpoints(sdk as never, kv as never);
+
+    const fn = sdk.getFunction("mcp::tools::call")!;
+    const result = (await fn(
+      makeReq({
+        name: "memory_save",
+        arguments: {
+          content: "Remember session-scoped deployment note",
+          type: "workflow",
+          concepts: "deploy, runbook",
+          files: "docs/deploy.md",
+          sessionId: "ses_abc",
+          tags: "ops, prod",
+        },
+      }),
+    )) as { status_code: number };
+
+    expect(result.status_code).toBe(200);
+    expect(capturedPayload).toEqual({
+      content: "Remember session-scoped deployment note",
+      type: "workflow",
+      concepts: ["deploy", "runbook"],
+      files: ["docs/deploy.md"],
+      sessionId: "ses_abc",
+      tags: ["ops", "prod"],
+    });
+  });
+});

--- a/test/remember-forget-audit.test.ts
+++ b/test/remember-forget-audit.test.ts
@@ -45,6 +45,50 @@ function mockSdk() {
   };
 }
 
+describe("mem::remember audit attribution", () => {
+  it("emits an audit row with session and tag attribution when a memory is saved", async () => {
+    const sdk = mockSdk();
+    const kv = mockKV();
+    registerRememberFunction(sdk as never, kv as never);
+
+    const result = await sdk.trigger({
+      function_id: "mem::remember",
+      payload: {
+        content: "Persist the deployment runbook",
+        type: "workflow",
+        concepts: ["deploy", "runbook"],
+        files: ["docs/deploy.md"],
+        sessionId: "ses_123",
+        tags: ["ops", "prod"],
+        sourceObservationIds: ["obs_1"],
+      },
+    });
+    const memory = (result as { memory: { id: string; sessionIds: string[] } }).memory;
+    expect(memory.sessionIds).toEqual(["ses_123"]);
+
+    const auditRows = await kv.list<{
+      operation: string;
+      functionId: string;
+      targetIds: string[];
+      details: Record<string, unknown>;
+    }>("mem:audit");
+    expect(auditRows).toHaveLength(1);
+    const [row] = auditRows;
+    expect(row.operation).toBe("remember");
+    expect(row.functionId).toBe("mem::remember");
+    expect(row.targetIds).toEqual([memory.id]);
+    expect(row.details).toMatchObject({
+      type: "workflow",
+      sessionIds: ["ses_123"],
+      tags: ["ops", "prod"],
+      concepts: ["deploy", "runbook"],
+      files: ["docs/deploy.md"],
+      sourceObservationIds: ["obs_1"],
+      version: 1,
+    });
+  });
+});
+
 describe("mem::forget audit coverage (issue #125)", () => {
   it("emits a single audit row when a memory is forgotten", async () => {
     const sdk = mockSdk();


### PR DESCRIPTION
## Summary
- records a `remember` audit row whenever `mem::remember` saves a memory
- carries `sessionId`/`sessionIds` and `tags` into saved memory attribution and audit details
- passes `sessionId` and comma-separated `tags` through `memory_save` from MCP server and standalone proxy/local fallback

## Test plan
- `npm test -- --run test/remember-forget-audit.test.ts test/mcp-tools-call.test.ts test/mcp-standalone-proxy.test.ts test/mcp-standalone.test.ts`
- `npm run build`
- `npm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Memory operations now support session IDs for organizing memories by session.
  * Tags functionality added to categorize and label saved memories.
  * Audit trail records memory operations with comprehensive metadata for tracking and accountability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/468?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->