### PR TITLE
Add consistency guards for MCP tools and REST endpoint drift

### DIFF
--- a/test/consistency.test.ts
+++ b/test/consistency.test.ts
@@ -74,6 +74,26 @@ describe("Consistency checks", () => {
     }
   });
 
+  it("tools-registry export list stays in sync with MCP handler switch cases", () => {
+    const tools = getAllTools();
+    const server = readText("src/mcp/server.ts");
+
+    const missing = tools
+      .map((t) => t.name)
+      .filter((toolName) => !server.includes(`case \"${toolName}\"`));
+
+    expect(
+      missing,
+      `Missing MCP handler switch cases for tools: ${missing.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  it("REST API path count in index.ts boot log remains accurate", () => {
+    const index = readText("src/index.ts");
+    const expected = `REST API: ${restEndpointCount} endpoints`;
+    expect(index).toContain(expected);
+  });
+
   it("every host-path bind mount in docker-compose.yml is in the published files list (#136)", () => {
     // Regression guard for #136: docker-compose.yml references
     // ./iii-config.docker.yaml as a read-only bind mount, but the file


### PR DESCRIPTION
## Summary
Adds two regression guards to prevent tool/endpoint count drift between code and documentation.

## Changes
- **New test**: Verify all tools in `getAllTools()` have corresponding switch cases in `src/mcp/server.ts`
- **New test**: Verify REST endpoint count in boot log matches actual registered paths

## Why
Per `AGENTS.md` consistency rules, tool/endpoint additions require updates across 7+ files. These guards catch drift at test time instead of runtime.

## Testing
`npx vitest run test/consistency.test.ts` — 10 tests pass (2 new)

Follows existing pattern in `test/consistency.test.ts` (README/version guards).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added consistency regression checks to validate system integrity and detect potential inconsistencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/470?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->