### PR TITLE
fix(hooks): resolve project name to repo basename, not raw cwd

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -125,6 +125,7 @@
 # AGENTMEMORY_FORCE_PROXY=1                      # Skip the MCP shim livez probe and trust AGENTMEMORY_URL (for sandboxed MCP clients that can't reach localhost)
 # AGENTMEMORY_PROBE_TIMEOUT_MS=2000              # MCP shim livez probe timeout
 # AGENTMEMORY_URL=http://localhost:3111          # REST base URL — honored by status, doctor, MCP shim
+# AGENTMEMORY_PROJECT_NAME=                      # Per-repo override for the project tag the hooks send. Default: basename of `git rev-parse --show-toplevel` (or basename of cwd if not in a git repo). Set this only when you have two repos that share a basename and need disambiguation, or to alias a project to a stable name independent of its filesystem location. For Claude Code, the easiest place to set per-repo is the `env` block in <repo>/.claude/settings.json.
 # AGENTMEMORY_VIEWER_URL=http://localhost:3113   # Override the viewer URL printed by `agentmemory status`
 # AGENTMEMORY_EXPORT_ROOT=~/agentmemory-backup   # Default destination for `agentmemory export`
 

--- a/plugin/scripts/_project--Krf34Q5.mjs
+++ b/plugin/scripts/_project--Krf34Q5.mjs
@@ -1,0 +1,26 @@
+import { execSync } from "node:child_process";
+import { basename } from "node:path";
+
+//#region src/hooks/_project.ts
+function resolveProject(cwd) {
+	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
+	if (explicit && explicit.trim()) return explicit.trim();
+	const dir = (typeof cwd === "string" ? cwd.trim() : "") || process.cwd();
+	try {
+		const top = execSync("git rev-parse --show-toplevel", {
+			cwd: dir,
+			stdio: [
+				"ignore",
+				"pipe",
+				"ignore"
+			],
+			timeout: 500
+		}).toString().trim();
+		if (top) return basename(top);
+	} catch {}
+	return basename(dir);
+}
+
+//#endregion
+export { resolveProject as t };
+//# sourceMappingURL=_project--Krf34Q5.mjs.map

--- a/plugin/scripts/notification.mjs
+++ b/plugin/scripts/notification.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { t as resolveProject } from "./_project--Krf34Q5.mjs";
+
 //#region src/hooks/notification.ts
 function isSdkChildContext(payload) {
 	if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -24,6 +26,8 @@ async function main() {
 	if (isSdkChildContext(data)) return;
 	if (data.notification_type !== "permission_prompt") return;
 	const sessionId = data.session_id || "unknown";
+	const cwd = typeof data.cwd === "string" && data.cwd.length > 0 ? data.cwd : process.cwd();
+	const project = resolveProject(cwd);
 	try {
 		await fetch(`${REST_URL}/agentmemory/observe`, {
 			method: "POST",
@@ -31,8 +35,8 @@ async function main() {
 			body: JSON.stringify({
 				hookType: "notification",
 				sessionId,
-				project: data.cwd || process.cwd(),
-				cwd: data.cwd || process.cwd(),
+				project,
+				cwd,
 				timestamp: (/* @__PURE__ */ new Date()).toISOString(),
 				data: {
 					notification_type: data.notification_type,

--- a/plugin/scripts/notification.mjs
+++ b/plugin/scripts/notification.mjs
@@ -26,7 +26,7 @@ async function main() {
 	if (isSdkChildContext(data)) return;
 	if (data.notification_type !== "permission_prompt") return;
 	const sessionId = data.session_id || "unknown";
-	const cwd = typeof data.cwd === "string" && data.cwd.length > 0 ? data.cwd : process.cwd();
+	const cwd = (typeof data.cwd === "string" ? data.cwd.trim() : "") || process.cwd();
 	const project = resolveProject(cwd);
 	try {
 		await fetch(`${REST_URL}/agentmemory/observe`, {

--- a/plugin/scripts/post-tool-failure.mjs
+++ b/plugin/scripts/post-tool-failure.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { t as resolveProject } from "./_project--Krf34Q5.mjs";
+
 //#region src/hooks/post-tool-failure.ts
 function isSdkChildContext(payload) {
 	if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -24,6 +26,8 @@ async function main() {
 	if (isSdkChildContext(data)) return;
 	if (data.is_interrupt) return;
 	const sessionId = data.session_id || "unknown";
+	const cwd = typeof data.cwd === "string" && data.cwd.length > 0 ? data.cwd : process.cwd();
+	const project = resolveProject(cwd);
 	try {
 		await fetch(`${REST_URL}/agentmemory/observe`, {
 			method: "POST",
@@ -31,8 +35,8 @@ async function main() {
 			body: JSON.stringify({
 				hookType: "post_tool_failure",
 				sessionId,
-				project: data.cwd || process.cwd(),
-				cwd: data.cwd || process.cwd(),
+				project,
+				cwd,
 				timestamp: (/* @__PURE__ */ new Date()).toISOString(),
 				data: {
 					tool_name: data.tool_name,

--- a/plugin/scripts/post-tool-failure.mjs
+++ b/plugin/scripts/post-tool-failure.mjs
@@ -26,7 +26,7 @@ async function main() {
 	if (isSdkChildContext(data)) return;
 	if (data.is_interrupt) return;
 	const sessionId = data.session_id || "unknown";
-	const cwd = typeof data.cwd === "string" && data.cwd.length > 0 ? data.cwd : process.cwd();
+	const cwd = (typeof data.cwd === "string" ? data.cwd.trim() : "") || process.cwd();
 	const project = resolveProject(cwd);
 	try {
 		await fetch(`${REST_URL}/agentmemory/observe`, {

--- a/plugin/scripts/post-tool-use.mjs
+++ b/plugin/scripts/post-tool-use.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { t as resolveProject } from "./_project--Krf34Q5.mjs";
+
 //#region src/hooks/post-tool-use.ts
 function isSdkChildContext(payload) {
 	if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -23,6 +25,8 @@ async function main() {
 	}
 	if (isSdkChildContext(data)) return;
 	const sessionId = data.session_id || "unknown";
+	const cwd = typeof data.cwd === "string" && data.cwd.length > 0 ? data.cwd : process.cwd();
+	const project = resolveProject(cwd);
 	const { imageData, cleanOutput } = extractImageData(data.tool_output);
 	try {
 		await fetch(`${REST_URL}/agentmemory/observe`, {
@@ -31,8 +35,8 @@ async function main() {
 			body: JSON.stringify({
 				hookType: "post_tool_use",
 				sessionId,
-				project: data.cwd || process.cwd(),
-				cwd: data.cwd || process.cwd(),
+				project,
+				cwd,
 				timestamp: (/* @__PURE__ */ new Date()).toISOString(),
 				data: {
 					tool_name: data.tool_name,

--- a/plugin/scripts/post-tool-use.mjs
+++ b/plugin/scripts/post-tool-use.mjs
@@ -25,7 +25,7 @@ async function main() {
 	}
 	if (isSdkChildContext(data)) return;
 	const sessionId = data.session_id || "unknown";
-	const cwd = typeof data.cwd === "string" && data.cwd.length > 0 ? data.cwd : process.cwd();
+	const cwd = (typeof data.cwd === "string" ? data.cwd.trim() : "") || process.cwd();
 	const project = resolveProject(cwd);
 	const { imageData, cleanOutput } = extractImageData(data.tool_output);
 	try {

--- a/plugin/scripts/prompt-submit.mjs
+++ b/plugin/scripts/prompt-submit.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { t as resolveProject } from "./_project--Krf34Q5.mjs";
+
 //#region src/hooks/prompt-submit.ts
 function isSdkChildContext(payload) {
 	if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -23,6 +25,8 @@ async function main() {
 	}
 	if (isSdkChildContext(data)) return;
 	const sessionId = data.session_id || "unknown";
+	const cwd = typeof data.cwd === "string" && data.cwd.length > 0 ? data.cwd : process.cwd();
+	const project = resolveProject(cwd);
 	try {
 		await fetch(`${REST_URL}/agentmemory/observe`, {
 			method: "POST",
@@ -30,8 +34,8 @@ async function main() {
 			body: JSON.stringify({
 				hookType: "prompt_submit",
 				sessionId,
-				project: data.cwd || process.cwd(),
-				cwd: data.cwd || process.cwd(),
+				project,
+				cwd,
 				timestamp: (/* @__PURE__ */ new Date()).toISOString(),
 				data: { prompt: data.prompt }
 			}),

--- a/plugin/scripts/prompt-submit.mjs
+++ b/plugin/scripts/prompt-submit.mjs
@@ -25,7 +25,7 @@ async function main() {
 	}
 	if (isSdkChildContext(data)) return;
 	const sessionId = data.session_id || "unknown";
-	const cwd = typeof data.cwd === "string" && data.cwd.length > 0 ? data.cwd : process.cwd();
+	const cwd = (typeof data.cwd === "string" ? data.cwd.trim() : "") || process.cwd();
 	const project = resolveProject(cwd);
 	try {
 		await fetch(`${REST_URL}/agentmemory/observe`, {

--- a/plugin/scripts/session-start.mjs
+++ b/plugin/scripts/session-start.mjs
@@ -28,7 +28,7 @@ async function main() {
 	}
 	if (isSdkChildContext(data)) return;
 	const sessionId = data.session_id || `ses_${Date.now().toString(36)}`;
-	const cwd = typeof data.cwd === "string" && data.cwd.length > 0 ? data.cwd : process.cwd();
+	const cwd = (typeof data.cwd === "string" ? data.cwd.trim() : "") || process.cwd();
 	const project = resolveProject(cwd);
 	const url = `${REST_URL}/agentmemory/session/start`;
 	const init = {

--- a/plugin/scripts/session-start.mjs
+++ b/plugin/scripts/session-start.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { t as resolveProject } from "./_project--Krf34Q5.mjs";
+
 //#region src/hooks/session-start.ts
 function isSdkChildContext(payload) {
 	if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -26,7 +28,8 @@ async function main() {
 	}
 	if (isSdkChildContext(data)) return;
 	const sessionId = data.session_id || `ses_${Date.now().toString(36)}`;
-	const project = data.cwd || process.cwd();
+	const cwd = typeof data.cwd === "string" && data.cwd.length > 0 ? data.cwd : process.cwd();
+	const project = resolveProject(cwd);
 	const url = `${REST_URL}/agentmemory/session/start`;
 	const init = {
 		method: "POST",
@@ -34,7 +37,7 @@ async function main() {
 		body: JSON.stringify({
 			sessionId,
 			project,
-			cwd: project
+			cwd
 		})
 	};
 	if (!INJECT_CONTEXT) {

--- a/plugin/scripts/subagent-start.mjs
+++ b/plugin/scripts/subagent-start.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { t as resolveProject } from "./_project--Krf34Q5.mjs";
+
 //#region src/hooks/subagent-start.ts
 function isSdkChildContext(payload) {
 	if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -24,14 +26,16 @@ async function main() {
 	}
 	if (isSdkChildContext(data)) return;
 	const sessionId = data.session_id || "unknown";
+	const cwd = typeof data.cwd === "string" && data.cwd.length > 0 ? data.cwd : process.cwd();
+	const project = resolveProject(cwd);
 	fetch(`${REST_URL}/agentmemory/observe`, {
 		method: "POST",
 		headers: authHeaders(),
 		body: JSON.stringify({
 			hookType: "subagent_start",
 			sessionId,
-			project: data.cwd || process.cwd(),
-			cwd: data.cwd || process.cwd(),
+			project,
+			cwd,
 			timestamp: (/* @__PURE__ */ new Date()).toISOString(),
 			data: {
 				agent_id: data.agent_id,

--- a/plugin/scripts/subagent-start.mjs
+++ b/plugin/scripts/subagent-start.mjs
@@ -26,7 +26,7 @@ async function main() {
 	}
 	if (isSdkChildContext(data)) return;
 	const sessionId = data.session_id || "unknown";
-	const cwd = typeof data.cwd === "string" && data.cwd.length > 0 ? data.cwd : process.cwd();
+	const cwd = (typeof data.cwd === "string" ? data.cwd.trim() : "") || process.cwd();
 	const project = resolveProject(cwd);
 	fetch(`${REST_URL}/agentmemory/observe`, {
 		method: "POST",

--- a/plugin/scripts/subagent-stop.mjs
+++ b/plugin/scripts/subagent-stop.mjs
@@ -25,7 +25,7 @@ async function main() {
 	}
 	if (isSdkChildContext(data)) return;
 	const sessionId = data.session_id || "unknown";
-	const cwd = typeof data.cwd === "string" && data.cwd.length > 0 ? data.cwd : process.cwd();
+	const cwd = (typeof data.cwd === "string" ? data.cwd.trim() : "") || process.cwd();
 	const project = resolveProject(cwd);
 	const lastMsg = typeof data.last_assistant_message === "string" ? data.last_assistant_message.slice(0, 4e3) : "";
 	try {

--- a/plugin/scripts/subagent-stop.mjs
+++ b/plugin/scripts/subagent-stop.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { t as resolveProject } from "./_project--Krf34Q5.mjs";
+
 //#region src/hooks/subagent-stop.ts
 function isSdkChildContext(payload) {
 	if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -23,6 +25,8 @@ async function main() {
 	}
 	if (isSdkChildContext(data)) return;
 	const sessionId = data.session_id || "unknown";
+	const cwd = typeof data.cwd === "string" && data.cwd.length > 0 ? data.cwd : process.cwd();
+	const project = resolveProject(cwd);
 	const lastMsg = typeof data.last_assistant_message === "string" ? data.last_assistant_message.slice(0, 4e3) : "";
 	try {
 		await fetch(`${REST_URL}/agentmemory/observe`, {
@@ -31,8 +35,8 @@ async function main() {
 			body: JSON.stringify({
 				hookType: "subagent_stop",
 				sessionId,
-				project: data.cwd || process.cwd(),
-				cwd: data.cwd || process.cwd(),
+				project,
+				cwd,
 				timestamp: (/* @__PURE__ */ new Date()).toISOString(),
 				data: {
 					agent_id: data.agent_id,

--- a/plugin/scripts/task-completed.mjs
+++ b/plugin/scripts/task-completed.mjs
@@ -25,7 +25,7 @@ async function main() {
 	}
 	if (isSdkChildContext(data)) return;
 	const sessionId = data.session_id || "unknown";
-	const cwd = typeof data.cwd === "string" && data.cwd.length > 0 ? data.cwd : process.cwd();
+	const cwd = (typeof data.cwd === "string" ? data.cwd.trim() : "") || process.cwd();
 	const project = resolveProject(cwd);
 	try {
 		await fetch(`${REST_URL}/agentmemory/observe`, {

--- a/plugin/scripts/task-completed.mjs
+++ b/plugin/scripts/task-completed.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { t as resolveProject } from "./_project--Krf34Q5.mjs";
+
 //#region src/hooks/task-completed.ts
 function isSdkChildContext(payload) {
 	if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -23,6 +25,8 @@ async function main() {
 	}
 	if (isSdkChildContext(data)) return;
 	const sessionId = data.session_id || "unknown";
+	const cwd = typeof data.cwd === "string" && data.cwd.length > 0 ? data.cwd : process.cwd();
+	const project = resolveProject(cwd);
 	try {
 		await fetch(`${REST_URL}/agentmemory/observe`, {
 			method: "POST",
@@ -30,8 +34,8 @@ async function main() {
 			body: JSON.stringify({
 				hookType: "task_completed",
 				sessionId,
-				project: data.cwd || process.cwd(),
-				cwd: data.cwd || process.cwd(),
+				project,
+				cwd,
 				timestamp: (/* @__PURE__ */ new Date()).toISOString(),
 				data: {
 					task_id: data.task_id,

--- a/src/functions/context.ts
+++ b/src/functions/context.ts
@@ -8,6 +8,7 @@ import type {
   MemorySlot,
   Lesson,
 } from "../types.js";
+import { basename } from "node:path";
 import { KV } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
 import { recordAccessBatch } from "./access-tracker.js";
@@ -20,6 +21,18 @@ import {
 
 function estimateTokens(text: string): number {
   return Math.ceil(text.length / 3);
+}
+
+// Hooks fixed in #lesson-visibility-pt2 now send `project` as a basename
+// (matching how mem::replay::import-jsonl and humans calling
+// memory_lesson_save tag their records). Older sessions registered via
+// previous hook versions still have the full cwd stored as `project`,
+// and existing lesson records may use either form. Match on both so the
+// context block isn't silently empty for mixed-vintage stores.
+function projectMatches(project: string | undefined, requested: string): boolean {
+  if (!project) return false;
+  if (project === requested) return true;
+  return basename(project) === basename(requested);
 }
 
 function escapeXmlAttr(s: string): string {
@@ -103,10 +116,15 @@ export function registerContextFunction(
       // 10 to keep the block bounded since the outer token-budget loop
       // below will drop the whole block if it doesn't fit. #457.
       const relevantLessons = lessons
-        .filter((l) => !l.deleted && (!l.project || l.project === data.project))
+        .filter(
+          (l) =>
+            !l.deleted && (!l.project || projectMatches(l.project, data.project)),
+        )
         .sort((a, b) => {
-          const scoreA = (a.project === data.project ? 1.5 : 1) * a.confidence;
-          const scoreB = (b.project === data.project ? 1.5 : 1) * b.confidence;
+          const scoreA =
+            (projectMatches(a.project, data.project) ? 1.5 : 1) * a.confidence;
+          const scoreB =
+            (projectMatches(b.project, data.project) ? 1.5 : 1) * b.confidence;
           return scoreB - scoreA;
         })
         .slice(0, 10);
@@ -134,7 +152,10 @@ export function registerContextFunction(
 
       const allSessions = await kv.list<Session>(KV.sessions);
       const sessions = allSessions
-        .filter((s) => s.project === data.project && s.id !== data.sessionId)
+        .filter(
+          (s) =>
+            projectMatches(s.project, data.project) && s.id !== data.sessionId,
+        )
         .sort(
           (a, b) =>
             new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),

--- a/src/hooks/_project.ts
+++ b/src/hooks/_project.ts
@@ -20,11 +20,15 @@
 import { execSync } from "node:child_process";
 import { basename } from "node:path";
 
-export function resolveProject(cwd?: string): string {
+export function resolveProject(cwd?: unknown): string {
   const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
   if (explicit && explicit.trim()) return explicit.trim();
 
-  const dir = cwd?.trim() || process.cwd();
+  // Defensive: hook stdin is untyped JSON, so `data.cwd` may arrive as
+  // a non-string (object/number/null) — guard before calling `.trim()`.
+  // Whitespace-only strings also fall through to `process.cwd()`.
+  const trimmed = typeof cwd === "string" ? cwd.trim() : "";
+  const dir = trimmed || process.cwd();
 
   try {
     const top = execSync("git rev-parse --show-toplevel", {

--- a/src/hooks/_project.ts
+++ b/src/hooks/_project.ts
@@ -1,0 +1,43 @@
+// Shared project-name resolution for hook scripts.
+//
+// Background: a Claude Code session started in /Users/me/work/foo previously
+// got `project = "/Users/me/work/foo"` (the full cwd). But native sessions,
+// mem::replay::import-jsonl, and most manual memory_lesson_save calls use
+// the basename ("foo"). The mismatch meant the auto-inject context block at
+// session start filtered out the bulk of relevant lessons. See #474 for the
+// full diagnosis.
+//
+// Resolution order (first non-empty wins):
+//   1. AGENTMEMORY_PROJECT_NAME env var (operator escape hatch — set per-repo
+//      via Claude Code's .claude/settings.json `env` block, direnv, or
+//      shell rc for cross-tool consistency)
+//   2. basename of `git rev-parse --show-toplevel` from cwd (handles sessions
+//      started in a subdirectory of the repo; survives moving the repo)
+//   3. basename of cwd (final fallback when not in a git repo)
+//
+// tsdown inlines this module into every hook bundle, so each hook ships
+// self-contained.
+import { execSync } from "node:child_process";
+import { basename } from "node:path";
+
+export function resolveProject(cwd?: string): string {
+  const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
+  if (explicit && explicit.trim()) return explicit.trim();
+
+  const dir = cwd && cwd.trim() ? cwd : process.cwd();
+
+  try {
+    const top = execSync("git rev-parse --show-toplevel", {
+      cwd: dir,
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 500,
+    })
+      .toString()
+      .trim();
+    if (top) return basename(top);
+  } catch {
+    // Not a git repo, git missing, or timeout — fall through.
+  }
+
+  return basename(dir);
+}

--- a/src/hooks/_project.ts
+++ b/src/hooks/_project.ts
@@ -24,7 +24,7 @@ export function resolveProject(cwd?: string): string {
   const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
   if (explicit && explicit.trim()) return explicit.trim();
 
-  const dir = cwd && cwd.trim() ? cwd : process.cwd();
+  const dir = cwd?.trim() || process.cwd();
 
   try {
     const top = execSync("git rev-parse --show-toplevel", {

--- a/src/hooks/notification.ts
+++ b/src/hooks/notification.ts
@@ -34,10 +34,13 @@ async function main() {
   if (data.notification_type !== "permission_prompt") return;
 
   const sessionId = (data.session_id as string) || "unknown";
-  const cwd =
-    typeof data.cwd === "string" && data.cwd.length > 0
-      ? data.cwd
-      : process.cwd();
+  // Trim before the length check so a whitespace-only `data.cwd`
+  // (e.g. `"   "` from a misformed JSON payload) falls back to
+  // process.cwd() instead of being forwarded as-is. CodeRabbit caught
+  // this in the #475 re-review on session-start.ts:58 and
+  // post-tool-failure.ts:40.
+  const trimmedCwd = typeof data.cwd === "string" ? data.cwd.trim() : "";
+  const cwd = trimmedCwd || process.cwd();
   const project = resolveProject(cwd);
 
   try {

--- a/src/hooks/notification.ts
+++ b/src/hooks/notification.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+import { resolveProject } from "./_project.js";
+
 function isSdkChildContext(payload: unknown): boolean {
   if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
   if (!payload || typeof payload !== "object") return false;
@@ -32,6 +34,8 @@ async function main() {
   if (data.notification_type !== "permission_prompt") return;
 
   const sessionId = (data.session_id as string) || "unknown";
+  const cwd = (data.cwd as string) || process.cwd();
+  const project = resolveProject(cwd);
 
   try {
     await fetch(`${REST_URL}/agentmemory/observe`, {
@@ -40,8 +44,8 @@ async function main() {
       body: JSON.stringify({
         hookType: "notification",
         sessionId,
-        project: data.cwd || process.cwd(),
-        cwd: data.cwd || process.cwd(),
+        project,
+        cwd,
         timestamp: new Date().toISOString(),
         data: {
           notification_type: data.notification_type,

--- a/src/hooks/notification.ts
+++ b/src/hooks/notification.ts
@@ -34,7 +34,10 @@ async function main() {
   if (data.notification_type !== "permission_prompt") return;
 
   const sessionId = (data.session_id as string) || "unknown";
-  const cwd = (data.cwd as string) || process.cwd();
+  const cwd =
+    typeof data.cwd === "string" && data.cwd.length > 0
+      ? data.cwd
+      : process.cwd();
   const project = resolveProject(cwd);
 
   try {

--- a/src/hooks/post-tool-failure.ts
+++ b/src/hooks/post-tool-failure.ts
@@ -34,10 +34,13 @@ async function main() {
   if (data.is_interrupt) return;
 
   const sessionId = (data.session_id as string) || "unknown";
-  const cwd =
-    typeof data.cwd === "string" && data.cwd.length > 0
-      ? data.cwd
-      : process.cwd();
+  // Trim before the length check so a whitespace-only `data.cwd`
+  // (e.g. `"   "` from a misformed JSON payload) falls back to
+  // process.cwd() instead of being forwarded as-is. CodeRabbit caught
+  // this in the #475 re-review on session-start.ts:58 and
+  // post-tool-failure.ts:40.
+  const trimmedCwd = typeof data.cwd === "string" ? data.cwd.trim() : "";
+  const cwd = trimmedCwd || process.cwd();
   const project = resolveProject(cwd);
 
   try {

--- a/src/hooks/post-tool-failure.ts
+++ b/src/hooks/post-tool-failure.ts
@@ -34,7 +34,10 @@ async function main() {
   if (data.is_interrupt) return;
 
   const sessionId = (data.session_id as string) || "unknown";
-  const cwd = (data.cwd as string) || process.cwd();
+  const cwd =
+    typeof data.cwd === "string" && data.cwd.length > 0
+      ? data.cwd
+      : process.cwd();
   const project = resolveProject(cwd);
 
   try {

--- a/src/hooks/post-tool-failure.ts
+++ b/src/hooks/post-tool-failure.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+import { resolveProject } from "./_project.js";
+
 function isSdkChildContext(payload: unknown): boolean {
   if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
   if (!payload || typeof payload !== "object") return false;
@@ -32,6 +34,8 @@ async function main() {
   if (data.is_interrupt) return;
 
   const sessionId = (data.session_id as string) || "unknown";
+  const cwd = (data.cwd as string) || process.cwd();
+  const project = resolveProject(cwd);
 
   try {
     await fetch(`${REST_URL}/agentmemory/observe`, {
@@ -40,8 +44,8 @@ async function main() {
       body: JSON.stringify({
         hookType: "post_tool_failure",
         sessionId,
-        project: data.cwd || process.cwd(),
-        cwd: data.cwd || process.cwd(),
+        project,
+        cwd,
         timestamp: new Date().toISOString(),
         data: {
           tool_name: data.tool_name,

--- a/src/hooks/post-tool-use.ts
+++ b/src/hooks/post-tool-use.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+import { resolveProject } from "./_project.js";
+
 function isSdkChildContext(payload: unknown): boolean {
   if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
   if (!payload || typeof payload !== "object") return false;
@@ -31,6 +33,8 @@ async function main() {
   if (isSdkChildContext(data)) return;
 
   const sessionId = (data.session_id as string) || "unknown";
+  const cwd = (data.cwd as string) || process.cwd();
+  const project = resolveProject(cwd);
 
   const { imageData, cleanOutput } = extractImageData(data.tool_output);
 
@@ -41,8 +45,8 @@ async function main() {
       body: JSON.stringify({
         hookType: "post_tool_use",
         sessionId,
-        project: data.cwd || process.cwd(),
-        cwd: data.cwd || process.cwd(),
+        project,
+        cwd,
         timestamp: new Date().toISOString(),
         data: {
           tool_name: data.tool_name,

--- a/src/hooks/post-tool-use.ts
+++ b/src/hooks/post-tool-use.ts
@@ -33,10 +33,13 @@ async function main() {
   if (isSdkChildContext(data)) return;
 
   const sessionId = (data.session_id as string) || "unknown";
-  const cwd =
-    typeof data.cwd === "string" && data.cwd.length > 0
-      ? data.cwd
-      : process.cwd();
+  // Trim before the length check so a whitespace-only `data.cwd`
+  // (e.g. `"   "` from a misformed JSON payload) falls back to
+  // process.cwd() instead of being forwarded as-is. CodeRabbit caught
+  // this in the #475 re-review on session-start.ts:58 and
+  // post-tool-failure.ts:40.
+  const trimmedCwd = typeof data.cwd === "string" ? data.cwd.trim() : "";
+  const cwd = trimmedCwd || process.cwd();
   const project = resolveProject(cwd);
 
   const { imageData, cleanOutput } = extractImageData(data.tool_output);

--- a/src/hooks/post-tool-use.ts
+++ b/src/hooks/post-tool-use.ts
@@ -33,7 +33,10 @@ async function main() {
   if (isSdkChildContext(data)) return;
 
   const sessionId = (data.session_id as string) || "unknown";
-  const cwd = (data.cwd as string) || process.cwd();
+  const cwd =
+    typeof data.cwd === "string" && data.cwd.length > 0
+      ? data.cwd
+      : process.cwd();
   const project = resolveProject(cwd);
 
   const { imageData, cleanOutput } = extractImageData(data.tool_output);

--- a/src/hooks/prompt-submit.ts
+++ b/src/hooks/prompt-submit.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+import { resolveProject } from "./_project.js";
+
 function isSdkChildContext(payload: unknown): boolean {
   if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
   if (!payload || typeof payload !== "object") return false;
@@ -31,6 +33,8 @@ async function main() {
   if (isSdkChildContext(data)) return;
 
   const sessionId = (data.session_id as string) || "unknown";
+  const cwd = (data.cwd as string) || process.cwd();
+  const project = resolveProject(cwd);
 
   try {
     await fetch(`${REST_URL}/agentmemory/observe`, {
@@ -39,8 +43,8 @@ async function main() {
       body: JSON.stringify({
         hookType: "prompt_submit",
         sessionId,
-        project: data.cwd || process.cwd(),
-        cwd: data.cwd || process.cwd(),
+        project,
+        cwd,
         timestamp: new Date().toISOString(),
         data: { prompt: data.prompt },
       }),

--- a/src/hooks/prompt-submit.ts
+++ b/src/hooks/prompt-submit.ts
@@ -33,10 +33,13 @@ async function main() {
   if (isSdkChildContext(data)) return;
 
   const sessionId = (data.session_id as string) || "unknown";
-  const cwd =
-    typeof data.cwd === "string" && data.cwd.length > 0
-      ? data.cwd
-      : process.cwd();
+  // Trim before the length check so a whitespace-only `data.cwd`
+  // (e.g. `"   "` from a misformed JSON payload) falls back to
+  // process.cwd() instead of being forwarded as-is. CodeRabbit caught
+  // this in the #475 re-review on session-start.ts:58 and
+  // post-tool-failure.ts:40.
+  const trimmedCwd = typeof data.cwd === "string" ? data.cwd.trim() : "";
+  const cwd = trimmedCwd || process.cwd();
   const project = resolveProject(cwd);
 
   try {

--- a/src/hooks/prompt-submit.ts
+++ b/src/hooks/prompt-submit.ts
@@ -33,7 +33,10 @@ async function main() {
   if (isSdkChildContext(data)) return;
 
   const sessionId = (data.session_id as string) || "unknown";
-  const cwd = (data.cwd as string) || process.cwd();
+  const cwd =
+    typeof data.cwd === "string" && data.cwd.length > 0
+      ? data.cwd
+      : process.cwd();
   const project = resolveProject(cwd);
 
   try {

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+import { resolveProject } from "./_project.js";
+
 // Inlined from ./sdk-guard so each hook bundles to a single self-contained
 // .mjs (matches the pattern used by every other hook entry in tsdown.config).
 function isSdkChildContext(payload: unknown): boolean {
@@ -50,13 +52,17 @@ async function main() {
 
   const sessionId =
     (data.session_id as string) || `ses_${Date.now().toString(36)}`;
-  const project = (data.cwd as string) || process.cwd();
+  const cwd = (data.cwd as string) || process.cwd();
+  // Project name is the short identifier the rest of the system keys off
+  // (imported sessions, memory_lesson_save, memory_lesson_recall all use
+  // basenames). See ./_project.ts for the resolution order.
+  const project = resolveProject(cwd);
 
   const url = `${REST_URL}/agentmemory/session/start`;
   const init: RequestInit = {
     method: "POST",
     headers: authHeaders(),
-    body: JSON.stringify({ sessionId, project, cwd: project }),
+    body: JSON.stringify({ sessionId, project, cwd }),
   };
 
   if (!INJECT_CONTEXT) {

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -52,10 +52,13 @@ async function main() {
 
   const sessionId =
     (data.session_id as string) || `ses_${Date.now().toString(36)}`;
-  const cwd =
-    typeof data.cwd === "string" && data.cwd.length > 0
-      ? data.cwd
-      : process.cwd();
+  // Trim before the length check so a whitespace-only `data.cwd`
+  // (e.g. `"   "` from a misformed JSON payload) falls back to
+  // process.cwd() instead of being forwarded as-is. CodeRabbit caught
+  // this in the #475 re-review on session-start.ts:58 and
+  // post-tool-failure.ts:40.
+  const trimmedCwd = typeof data.cwd === "string" ? data.cwd.trim() : "";
+  const cwd = trimmedCwd || process.cwd();
   // Project name is the short identifier the rest of the system keys off
   // (imported sessions, memory_lesson_save, memory_lesson_recall all use
   // basenames). See ./_project.ts for the resolution order.

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -52,7 +52,10 @@ async function main() {
 
   const sessionId =
     (data.session_id as string) || `ses_${Date.now().toString(36)}`;
-  const cwd = (data.cwd as string) || process.cwd();
+  const cwd =
+    typeof data.cwd === "string" && data.cwd.length > 0
+      ? data.cwd
+      : process.cwd();
   // Project name is the short identifier the rest of the system keys off
   // (imported sessions, memory_lesson_save, memory_lesson_recall all use
   // basenames). See ./_project.ts for the resolution order.

--- a/src/hooks/subagent-start.ts
+++ b/src/hooks/subagent-start.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+import { resolveProject } from "./_project.js";
+
 // Inlined from ./sdk-guard so each hook bundles to a single self-contained
 // .mjs (matches the pattern used by every other hook entry in tsdown.config).
 function isSdkChildContext(payload: unknown): boolean {
@@ -39,6 +41,8 @@ async function main() {
   if (isSdkChildContext(data)) return;
 
   const sessionId = (data.session_id as string) || "unknown";
+  const cwd = (data.cwd as string) || process.cwd();
+  const project = resolveProject(cwd);
 
   fetch(`${REST_URL}/agentmemory/observe`, {
     method: "POST",
@@ -46,8 +50,8 @@ async function main() {
     body: JSON.stringify({
       hookType: "subagent_start",
       sessionId,
-      project: data.cwd || process.cwd(),
-      cwd: data.cwd || process.cwd(),
+      project,
+      cwd,
       timestamp: new Date().toISOString(),
       data: {
         agent_id: data.agent_id,

--- a/src/hooks/subagent-start.ts
+++ b/src/hooks/subagent-start.ts
@@ -41,7 +41,10 @@ async function main() {
   if (isSdkChildContext(data)) return;
 
   const sessionId = (data.session_id as string) || "unknown";
-  const cwd = (data.cwd as string) || process.cwd();
+  const cwd =
+    typeof data.cwd === "string" && data.cwd.length > 0
+      ? data.cwd
+      : process.cwd();
   const project = resolveProject(cwd);
 
   fetch(`${REST_URL}/agentmemory/observe`, {

--- a/src/hooks/subagent-start.ts
+++ b/src/hooks/subagent-start.ts
@@ -41,10 +41,13 @@ async function main() {
   if (isSdkChildContext(data)) return;
 
   const sessionId = (data.session_id as string) || "unknown";
-  const cwd =
-    typeof data.cwd === "string" && data.cwd.length > 0
-      ? data.cwd
-      : process.cwd();
+  // Trim before the length check so a whitespace-only `data.cwd`
+  // (e.g. `"   "` from a misformed JSON payload) falls back to
+  // process.cwd() instead of being forwarded as-is. CodeRabbit caught
+  // this in the #475 re-review on session-start.ts:58 and
+  // post-tool-failure.ts:40.
+  const trimmedCwd = typeof data.cwd === "string" ? data.cwd.trim() : "";
+  const cwd = trimmedCwd || process.cwd();
   const project = resolveProject(cwd);
 
   fetch(`${REST_URL}/agentmemory/observe`, {

--- a/src/hooks/subagent-stop.ts
+++ b/src/hooks/subagent-stop.ts
@@ -33,10 +33,13 @@ async function main() {
   if (isSdkChildContext(data)) return;
 
   const sessionId = (data.session_id as string) || "unknown";
-  const cwd =
-    typeof data.cwd === "string" && data.cwd.length > 0
-      ? data.cwd
-      : process.cwd();
+  // Trim before the length check so a whitespace-only `data.cwd`
+  // (e.g. `"   "` from a misformed JSON payload) falls back to
+  // process.cwd() instead of being forwarded as-is. CodeRabbit caught
+  // this in the #475 re-review on session-start.ts:58 and
+  // post-tool-failure.ts:40.
+  const trimmedCwd = typeof data.cwd === "string" ? data.cwd.trim() : "";
+  const cwd = trimmedCwd || process.cwd();
   const project = resolveProject(cwd);
   const lastMsg =
     typeof data.last_assistant_message === "string"

--- a/src/hooks/subagent-stop.ts
+++ b/src/hooks/subagent-stop.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+import { resolveProject } from "./_project.js";
+
 function isSdkChildContext(payload: unknown): boolean {
   if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
   if (!payload || typeof payload !== "object") return false;
@@ -31,6 +33,8 @@ async function main() {
   if (isSdkChildContext(data)) return;
 
   const sessionId = (data.session_id as string) || "unknown";
+  const cwd = (data.cwd as string) || process.cwd();
+  const project = resolveProject(cwd);
   const lastMsg =
     typeof data.last_assistant_message === "string"
       ? data.last_assistant_message.slice(0, 4000)
@@ -43,8 +47,8 @@ async function main() {
       body: JSON.stringify({
         hookType: "subagent_stop",
         sessionId,
-        project: data.cwd || process.cwd(),
-        cwd: data.cwd || process.cwd(),
+        project,
+        cwd,
         timestamp: new Date().toISOString(),
         data: {
           agent_id: data.agent_id,

--- a/src/hooks/subagent-stop.ts
+++ b/src/hooks/subagent-stop.ts
@@ -33,7 +33,10 @@ async function main() {
   if (isSdkChildContext(data)) return;
 
   const sessionId = (data.session_id as string) || "unknown";
-  const cwd = (data.cwd as string) || process.cwd();
+  const cwd =
+    typeof data.cwd === "string" && data.cwd.length > 0
+      ? data.cwd
+      : process.cwd();
   const project = resolveProject(cwd);
   const lastMsg =
     typeof data.last_assistant_message === "string"

--- a/src/hooks/task-completed.ts
+++ b/src/hooks/task-completed.ts
@@ -33,10 +33,13 @@ async function main() {
   if (isSdkChildContext(data)) return;
 
   const sessionId = (data.session_id as string) || "unknown";
-  const cwd =
-    typeof data.cwd === "string" && data.cwd.length > 0
-      ? data.cwd
-      : process.cwd();
+  // Trim before the length check so a whitespace-only `data.cwd`
+  // (e.g. `"   "` from a misformed JSON payload) falls back to
+  // process.cwd() instead of being forwarded as-is. CodeRabbit caught
+  // this in the #475 re-review on session-start.ts:58 and
+  // post-tool-failure.ts:40.
+  const trimmedCwd = typeof data.cwd === "string" ? data.cwd.trim() : "";
+  const cwd = trimmedCwd || process.cwd();
   const project = resolveProject(cwd);
 
   try {

--- a/src/hooks/task-completed.ts
+++ b/src/hooks/task-completed.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+import { resolveProject } from "./_project.js";
+
 function isSdkChildContext(payload: unknown): boolean {
   if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
   if (!payload || typeof payload !== "object") return false;
@@ -31,6 +33,8 @@ async function main() {
   if (isSdkChildContext(data)) return;
 
   const sessionId = (data.session_id as string) || "unknown";
+  const cwd = (data.cwd as string) || process.cwd();
+  const project = resolveProject(cwd);
 
   try {
     await fetch(`${REST_URL}/agentmemory/observe`, {
@@ -39,8 +43,8 @@ async function main() {
       body: JSON.stringify({
         hookType: "task_completed",
         sessionId,
-        project: data.cwd || process.cwd(),
-        cwd: data.cwd || process.cwd(),
+        project,
+        cwd,
         timestamp: new Date().toISOString(),
         data: {
           task_id: data.task_id,

--- a/src/hooks/task-completed.ts
+++ b/src/hooks/task-completed.ts
@@ -33,7 +33,10 @@ async function main() {
   if (isSdkChildContext(data)) return;
 
   const sessionId = (data.session_id as string) || "unknown";
-  const cwd = (data.cwd as string) || process.cwd();
+  const cwd =
+    typeof data.cwd === "string" && data.cwd.length > 0
+      ? data.cwd
+      : process.cwd();
   const project = resolveProject(cwd);
 
   try {

--- a/test/context-lessons.test.ts
+++ b/test/context-lessons.test.ts
@@ -223,4 +223,61 @@ describe("mem::context — lessons auto-injection (#457)", () => {
       "use TaskCreate for >5-file work — when working on multi-file refactors",
     );
   });
+
+  describe("project basename fallback (#lesson-visibility-pt2)", () => {
+    it("matches lessons tagged with basename when caller passes the full path", async () => {
+      // Existing data shape: import-jsonl + manual lesson saves use the
+      // basename, while the old session-start hook sent the full cwd path.
+      // Verify mem::context surfaces lessons across both vintages.
+      await seedLesson(kv, {
+        id: "lesson_basename",
+        content: "lesson tagged with basename only",
+        project: "gitops-assistant",
+        confidence: 0.9,
+      });
+
+      const result = await handler({
+        sessionId: "ses_x",
+        project: "/Users/me/work/rootlease/gitops-assistant",
+      });
+
+      expect(result.context).toContain("lesson tagged with basename only");
+    });
+
+    it("matches lessons tagged with full path when caller passes the basename", async () => {
+      await seedLesson(kv, {
+        id: "lesson_fullpath",
+        content: "lesson tagged with full path",
+        project: "/Users/me/work/rootlease/gitops-assistant",
+        confidence: 0.9,
+      });
+
+      const result = await handler({
+        sessionId: "ses_x",
+        project: "gitops-assistant",
+      });
+
+      expect(result.context).toContain("lesson tagged with full path");
+    });
+
+    it("DOES match same-basename projects across different paths (documented behaviour)", async () => {
+      // Cross-store collision intended: /work/foo and /personal/foo share
+      // a basename and the resolver treats them as the same project. This
+      // test documents that behavior so a future tightening (e.g. exact
+      // path required when both forms exist) is a known break.
+      await seedLesson(kv, {
+        id: "lesson_a",
+        content: "lesson for project foo",
+        project: "foo",
+        confidence: 0.9,
+      });
+
+      const result = await handler({
+        sessionId: "ses_x",
+        project: "/wherever/foo",
+      });
+
+      expect(result.context).toContain("lesson for project foo");
+    });
+  });
 });

--- a/test/hook-project.test.ts
+++ b/test/hook-project.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, basename } from "node:path";
+import { execSync } from "node:child_process";
+
+import { resolveProject } from "../src/hooks/_project.js";
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  delete process.env.AGENTMEMORY_PROJECT_NAME;
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe("resolveProject (#lesson-visibility-pt2)", () => {
+  it("returns AGENTMEMORY_PROJECT_NAME verbatim when set", () => {
+    process.env.AGENTMEMORY_PROJECT_NAME = "explicit-name";
+    expect(resolveProject("/wherever/this/is")).toBe("explicit-name");
+  });
+
+  it("trims AGENTMEMORY_PROJECT_NAME whitespace", () => {
+    process.env.AGENTMEMORY_PROJECT_NAME = "  padded  ";
+    expect(resolveProject()).toBe("padded");
+  });
+
+  it("treats empty AGENTMEMORY_PROJECT_NAME as unset (falls through)", () => {
+    process.env.AGENTMEMORY_PROJECT_NAME = "   ";
+    const tmp = mkdtempSync(join(tmpdir(), "am-proj-"));
+    try {
+      expect(resolveProject(tmp)).toBe(basename(tmp));
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("returns basename of git toplevel when inside a git repo", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "am-proj-"));
+    try {
+      execSync("git init --quiet", { cwd: tmp });
+      const sub = join(tmp, "src", "deep");
+      execSync(`mkdir -p ${sub}`);
+      // When called from a subdirectory of the repo, project is still the
+      // repo basename, not the subdirectory basename. This handles sessions
+      // started inside subtrees (e.g. /repo/src/foo).
+      expect(resolveProject(sub)).toBe(basename(tmp));
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to basename(cwd) when not in a git repo", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "am-proj-not-git-"));
+    try {
+      // No git init. Should not throw; should return basename of the dir.
+      expect(resolveProject(tmp)).toBe(basename(tmp));
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("uses process.cwd() when no cwd argument is given", () => {
+    // Smoke-only: just ensure it returns a non-empty string.
+    const v = resolveProject();
+    expect(typeof v).toBe("string");
+    expect(v.length).toBeGreaterThan(0);
+  });
+});

--- a/test/hook-project.test.ts
+++ b/test/hook-project.test.ts
@@ -68,4 +68,37 @@ describe("resolveProject (#lesson-visibility-pt2)", () => {
     expect(typeof v).toBe("string");
     expect(v.length).toBeGreaterThan(0);
   });
+
+  // Maintainer asked for stricter assertion on the same-basename
+  // collision case: two distinct ancestor paths with the same leaf
+  // directory name MUST both resolve to that shared basename — not
+  // just to equal-but-arbitrary strings. This is the property that
+  // makes lessons + sessions cross-reference correctly when a user
+  // has e.g. ~/work/foo and ~/scratch/foo open in different Codex
+  // worktrees.
+  it("same-basename collision: distinct paths resolve to the shared basename", () => {
+    const root1 = mkdtempSync(join(tmpdir(), "am-proj-collision-a-"));
+    const root2 = mkdtempSync(join(tmpdir(), "am-proj-collision-b-"));
+    try {
+      const sharedName = "shared-leaf-name-9c2f";
+      const path1 = join(root1, sharedName);
+      const path2 = join(root2, sharedName);
+      mkdirSync(path1);
+      mkdirSync(path2);
+      expect(resolveProject(path1)).toBe(sharedName);
+      expect(resolveProject(path2)).toBe(sharedName);
+    } finally {
+      rmSync(root1, { recursive: true, force: true });
+      rmSync(root2, { recursive: true, force: true });
+    }
+  });
+
+  it("non-string cwd (object, number, null) falls back to process.cwd()", () => {
+    const baseline = resolveProject(process.cwd());
+    // The resolver typing widened to `unknown` so a runtime guard
+    // protects against malformed JSON (data.cwd as {} / 42 / null).
+    expect(resolveProject({} as unknown)).toBe(baseline);
+    expect(resolveProject(42 as unknown)).toBe(baseline);
+    expect(resolveProject(null as unknown)).toBe(baseline);
+  });
 });

--- a/test/hook-project.test.ts
+++ b/test/hook-project.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, basename } from "node:path";
 import { execSync } from "node:child_process";
@@ -42,7 +42,7 @@ describe("resolveProject (#lesson-visibility-pt2)", () => {
     try {
       execSync("git init --quiet", { cwd: tmp });
       const sub = join(tmp, "src", "deep");
-      execSync(`mkdir -p ${sub}`);
+      mkdirSync(sub, { recursive: true });
       // When called from a subdirectory of the repo, project is still the
       // repo basename, not the subdirectory basename. This handles sessions
       // started inside subtrees (e.g. /repo/src/foo).


### PR DESCRIPTION
## Summary

Follow-up to #473. The Claude Code SessionStart hook (and seven other hooks that POST observations) computed `project = data.cwd || process.cwd()` — i.e. the absolute path of the working directory. But every other code path that tags records with a project uses the **basename**:

- `mem::replay::import-jsonl` preserves whatever the JSONL file contains, which is the basename Claude Code itself stores in transcripts
- humans calling `memory_lesson_save` naturally pass the short name (`"gitops-assistant"`, not `"/Users/me/work/foo/gitops-assistant"`)

Result: the auto-inject context block at session start ran a project-equality filter that matched zero of the bulk of the operator's data. In my repro on a real corpus, a **4,351-lesson / 52-summary store rendered as a 3-block context payload with no Lessons Learned section at all** — only session summaries from the rare records tagged with the full cwd (which happen to be the ones the broken hook itself created in earlier sessions).

Filed against #474.

## Two-sided fix

### A) Hook side — resolve project to basename

Hooks now resolve project via a shared `src/hooks/_project.ts` helper. Resolution order:

1. `AGENTMEMORY_PROJECT_NAME` env var — operator escape hatch, settable per-repo via Claude Code's `.claude/settings.json` `env` block (which Claude Code inherits into hook subprocesses)
2. `basename(git rev-parse --show-toplevel)` — handles sessions started in a subdirectory of the repo, survives moving the repo
3. `basename(cwd)` — final fallback for non-git directories

All eight hooks that POST a project field were updated: `session-start`, `prompt-submit`, `post-tool-use`, `post-tool-failure`, `notification`, `subagent-start`, `subagent-stop`, `task-completed`.

### B) Server side — `mem::context` basename fallback

Tolerates the mixed-vintage corpus this regression has already produced. Project-match for both lessons and sessions now uses a basename-equality fallback: **exact match wins, then `basename(stored) === basename(requested)`**. Means existing records tagged with the full cwd continue to surface for callers passing the basename, and vice versa, without requiring re-import.

## Documented trade-off

Same-named repos in different paths now collapse to one logical project at retrieval time (e.g. `/work/foo` and `/personal/foo`). Operators who need to keep them separate set `AGENTMEMORY_PROJECT_NAME` explicitly per repo. Behavior is asserted in `test/context-lessons.test.ts` as a passing test, so any future tightening is a known break, not an accidental one.

## Tests

17/17 in the directly impacted files. Layout:

| file | added |
|---|---|
| `test/hook-project.test.ts` (new) | `AGENTMEMORY_PROJECT_NAME` precedence, whitespace handling, git-toplevel basename, cwd fallback when not in a repo, subdir-of-repo handling |
| `test/context-lessons.test.ts` | full-path-caller matches basename-tagged lesson, basename-caller matches full-path-tagged lesson, same-basename-different-path collapse (documented behavior) |

> **Note on full-suite output:** the 10 failures in `test/embedding-provider.test.ts` / `test/auto-compress.test.ts` / `test/fetch-timeout.test.ts` are pre-existing on `main` (env-pollution tests that fail when `~/.agentmemory/.env` has API keys set) — verified by checking out `main` and re-running. Unrelated to this PR.

## Files

- `src/hooks/_project.ts` (new) — shared `resolveProject()` helper
- `src/hooks/{session-start,prompt-submit,post-tool-use,post-tool-failure,notification,subagent-start,subagent-stop,task-completed}.ts` — use `resolveProject()`
- `src/functions/context.ts` — `projectMatches()` helper, applied to both the lessons filter and the sessions filter
- `test/hook-project.test.ts` (new) — 6 cases
- `test/context-lessons.test.ts` — 3 added cases
- `.env.example` — document `AGENTMEMORY_PROJECT_NAME`

## Why this matters

This is the difference between agentmemory's auto-inject doing something useful for a Claude Code session and silently doing nothing. In my repro the operator had 1,405 lessons in their `gitops-assistant` corpus and the SessionStart hook was filtering all of them out. After this fix, the same store renders a 4,539-token context block with the full Lessons Learned section.

Reproduces with: import any JSONL into agentmemory (`mem::replay::import-jsonl`), start a new Claude Code session in that project, observe that no `## Lessons Learned` block lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a commented env var to override the project identifier (AGENTMEMORY_PROJECT_NAME).
  * Unified project resolution so hooks and session/notification events send a consistent project and working-directory identifier.
  * Improved lesson/context matching so lessons persistently match across basename vs full-path repository formats.

* **Tests**
  * Added tests verifying project resolution behavior and lesson/context matching across basename/full-path scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/475?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->