### PR TITLE
feat: add Astraflow provider support (global + China endpoints)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,10 @@
 # OPENROUTER_API_KEY=sk-or-...
 # OPENROUTER_MODEL=anthropic/claude-sonnet-4-20250514
 
+# ASTRAFLOW_API_KEY=...                          # Astraflow by UCloud — OpenAI-compatible platform supporting 200+ models (global endpoint). Sign up: https://astraflow.ucloud-global.com
+# ASTRAFLOW_CN_API_KEY=...                       # Astraflow by UCloud — OpenAI-compatible platform supporting 200+ models (China endpoint). Sign up: https://astraflow.ucloud.cn
+# ASTRAFLOW_MODEL=gpt-4o-mini                    # Model to use with Astraflow (default: gpt-4o-mini)
+
 # MINIMAX_API_KEY=...
 # MINIMAX_MODEL=MiniMax-M2.7
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -50,6 +50,25 @@ function hasRealValue(v: string | undefined): v is string {
 function detectProvider(env: Record<string, string>): ProviderConfig {
   const maxTokens = parseInt(env["MAX_TOKENS"] || "4096", 10);
 
+  // Astraflow (UCloud) — OpenAI-compatible, 200+ models
+  // Global endpoint: ASTRAFLOW_API_KEY; China endpoint: ASTRAFLOW_CN_API_KEY
+  if (hasRealValue(env["ASTRAFLOW_API_KEY"])) {
+    return {
+      provider: "astraflow",
+      model: env["ASTRAFLOW_MODEL"] || "gpt-4o-mini",
+      maxTokens,
+      baseURL: "https://api-us-ca.umodelverse.ai/v1",
+    };
+  }
+  if (hasRealValue(env["ASTRAFLOW_CN_API_KEY"])) {
+    return {
+      provider: "astraflow-cn",
+      model: env["ASTRAFLOW_MODEL"] || "gpt-4o-mini",
+      maxTokens,
+      baseURL: "https://api.modelverse.cn/v1",
+    };
+  }
+
   // OpenAI-compatible: supports OpenAI, DeepSeek, SiliconFlow, Azure, vLLM, LM Studio
   if (hasRealValue(env["OPENAI_API_KEY"]) && env["OPENAI_API_KEY_FOR_LLM"] !== "false") {
     return {
@@ -166,6 +185,8 @@ export function detectLlmProviderKind(): "llm" | "noop" {
     hasRealValue(env["GEMINI_API_KEY"]) ||
     hasRealValue(env["GOOGLE_API_KEY"]) ||
     hasRealValue(env["OPENROUTER_API_KEY"]) ||
+    hasRealValue(env["ASTRAFLOW_API_KEY"]) ||
+    hasRealValue(env["ASTRAFLOW_CN_API_KEY"]) ||
     hasRealValue(env["MINIMAX_API_KEY"]) ||
     (hasRealValue(env["OPENAI_API_KEY"]) &&
       env["OPENAI_API_KEY_FOR_LLM"] !== "false")
@@ -305,6 +326,8 @@ const VALID_PROVIDERS = new Set([
   "agent-sdk",
   "minimax",
   "openai",
+  "astraflow",
+  "astraflow-cn",
 ]);
 
 export function loadFallbackConfig(): FallbackConfig {

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -109,6 +109,34 @@ function createBaseProvider(config: ProviderConfig): MemoryProvider {
         config.baseURL,
       );
     }
+    case "astraflow": {
+      const astraflowKey = getEnvVar("ASTRAFLOW_API_KEY");
+      if (!astraflowKey) {
+        throw new Error(
+          "ASTRAFLOW_API_KEY is required for the astraflow provider",
+        );
+      }
+      return new OpenAIProvider(
+        astraflowKey,
+        config.model,
+        config.maxTokens,
+        config.baseURL ?? "https://api-us-ca.umodelverse.ai",
+      );
+    }
+    case "astraflow-cn": {
+      const astraflowCnKey = getEnvVar("ASTRAFLOW_CN_API_KEY");
+      if (!astraflowCnKey) {
+        throw new Error(
+          "ASTRAFLOW_CN_API_KEY is required for the astraflow-cn provider",
+        );
+      }
+      return new OpenAIProvider(
+        astraflowCnKey,
+        config.model,
+        config.maxTokens,
+        config.baseURL ?? "https://api.modelverse.cn",
+      );
+    }
     case "noop":
       return new NoopProvider();
     case "agent-sdk":


### PR DESCRIPTION
## Summary

Adds [Astraflow](https://astraflow.ucloud-global.com) by UCloud as a supported LLM provider. Astraflow is an OpenAI-compatible AI model aggregation platform that supports 200+ models. Because it is fully OpenAI-compatible, the integration reuses the existing `OpenAIProvider` class — no new SDK or subpackage is needed.

## Changes

### `src/config.ts`
- Added `ASTRAFLOW_API_KEY` and `ASTRAFLOW_CN_API_KEY` detection in `detectProvider()`, inserted just before the existing `OPENAI_API_KEY` check (so users with a dedicated Astraflow key get the right base URL automatically).
- Added both keys to `detectLlmProviderKind()` so the `"llm"` kind is returned correctly.
- Added `"astraflow"` and `"astraflow-cn"` to `VALID_PROVIDERS` so they are accepted in the `FALLBACK_PROVIDERS` chain.

### `src/providers/index.ts`
- Added `"astraflow"` and `"astraflow-cn"` cases to `createBaseProvider()`, each constructing an `OpenAIProvider` with the appropriate base URL and API key env var.

### `.env.example`
- Documented `ASTRAFLOW_API_KEY`, `ASTRAFLOW_CN_API_KEY`, and `ASTRAFLOW_MODEL` alongside the existing provider entries.

## Endpoints

| Variant | Env var | Base URL |
|---|---|---|
| Global | `ASTRAFLOW_API_KEY` | `https://api-us-ca.umodelverse.ai/v1` |
| China  | `ASTRAFLOW_CN_API_KEY` | `https://api.modelverse.cn/v1` |

## Usage

```sh
# ~/.agentmemory/.env
ASTRAFLOW_API_KEY=your-key-here
# Optional: ASTRAFLOW_MODEL=gpt-4o-mini
```

The detection priority sits between `MINIMAX_API_KEY` and `OPENAI_API_KEY`, so existing users are unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Astraflow (UCloud) as an LLM provider
  * Supports both global and China endpoints with separate API key configuration options
  * Enables custom model name configuration for Astraflow deployments

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/485?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->