### PR TITLE
fix(hermes): declare all plugin hooks

### DIFF
--- a/integrations/hermes/plugin.yaml
+++ b/integrations/hermes/plugin.yaml
@@ -4,6 +4,9 @@ description: "Persistent cross-session memory for Hermes Agent via agentmemory. 
 author: "Rohit Ghumare"
 homepage: "https://github.com/rohitg00/agentmemory"
 hooks:
+  - prefetch
+  - sync_turn
   - on_session_end
   - on_pre_compress
   - on_memory_write
+  - system_prompt_block

--- a/test/hermes-plugin.test.ts
+++ b/test/hermes-plugin.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+const expectedHermesHooks = [
+  "prefetch",
+  "sync_turn",
+  "on_session_end",
+  "on_pre_compress",
+  "on_memory_write",
+  "system_prompt_block",
+];
+
+function readHermesPluginHooks(): string[] {
+  const manifest = readFileSync("integrations/hermes/plugin.yaml", "utf8");
+  const hooks: string[] = [];
+  let inHooks = false;
+
+  for (const line of manifest.split(/\r?\n/)) {
+    if (line.trim() === "hooks:") {
+      inHooks = true;
+      continue;
+    }
+    if (!inHooks) continue;
+    if (line.trim() === "") continue;
+    if (!line.startsWith(" ")) break;
+
+    const match = line.match(/^\s*-\s*([A-Za-z_][A-Za-z0-9_]*)\s*$/);
+    if (match) hooks.push(match[1]);
+  }
+
+  return hooks;
+}
+
+function readAgentMemoryProviderHookMethods(): string[] {
+  const source = readFileSync("integrations/hermes/__init__.py", "utf8");
+  const methods: string[] = [];
+  const hookMethodPattern =
+    /^    def (prefetch|sync_turn|on_session_end|on_pre_compress|on_memory_write|system_prompt_block)\(/gm;
+
+  for (const match of source.matchAll(hookMethodPattern)) {
+    methods.push(match[1]);
+  }
+
+  return methods;
+}
+
+describe("Hermes plugin manifest", () => {
+  it("declares every implemented lifecycle hook", () => {
+    const implementedHooks = readAgentMemoryProviderHookMethods();
+
+    expect(implementedHooks).toEqual(expect.arrayContaining(expectedHermesHooks));
+    expect(readHermesPluginHooks()).toEqual(expectedHermesHooks);
+  });
+});

--- a/test/hermes-plugin.test.ts
+++ b/test/hermes-plugin.test.ts
@@ -31,14 +31,23 @@ function readHermesPluginHooks(): string[] {
   return hooks;
 }
 
+function isHermesLifecycleHook(methodName: string): boolean {
+  return (
+    methodName === "prefetch" ||
+    methodName === "sync_turn" ||
+    methodName === "system_prompt_block" ||
+    methodName.startsWith("on_")
+  );
+}
+
 function readAgentMemoryProviderHookMethods(): string[] {
   const source = readFileSync("integrations/hermes/__init__.py", "utf8");
   const methods: string[] = [];
-  const hookMethodPattern =
-    /^    def (prefetch|sync_turn|on_session_end|on_pre_compress|on_memory_write|system_prompt_block)\(/gm;
+  const providerMethodPattern = /^    def ([a-z_][a-z0-9_]*)\(/gm;
 
-  for (const match of source.matchAll(hookMethodPattern)) {
-    methods.push(match[1]);
+  for (const match of source.matchAll(providerMethodPattern)) {
+    const methodName = match[1];
+    if (isHermesLifecycleHook(methodName)) methods.push(methodName);
   }
 
   return methods;
@@ -46,9 +55,10 @@ function readAgentMemoryProviderHookMethods(): string[] {
 
 describe("Hermes plugin manifest", () => {
   it("declares every implemented lifecycle hook", () => {
+    const declaredHooks = readHermesPluginHooks();
     const implementedHooks = readAgentMemoryProviderHookMethods();
 
-    expect(implementedHooks).toEqual(expect.arrayContaining(expectedHermesHooks));
-    expect(readHermesPluginHooks()).toEqual(expectedHermesHooks);
+    expect([...declaredHooks].sort()).toEqual([...implementedHooks].sort());
+    expect(declaredHooks).toEqual(expectedHermesHooks);
   });
 });


### PR DESCRIPTION
## Summary
- Declare all Hermes lifecycle hooks implemented by `AgentMemoryProvider` in `integrations/hermes/plugin.yaml`.
- Add a manifest regression test so the Hermes hook list cannot silently drift from the provider implementation again.

## Why
`AgentMemoryProvider` already implements `prefetch`, `sync_turn`, and `system_prompt_block`, and the Hermes README documents them. The plugin manifest only declared `on_session_end`, `on_pre_compress`, and `on_memory_write`, so Hermes may never invoke the missing lifecycle hooks. That can silently disable context prefetching, turn capture, and system-prompt context injection for Hermes users.

Closes #478.

## Conflict / duplicate check
- Checked open PRs touching `integrations/hermes/plugin.yaml`, `integrations/hermes/__init__.py`, or `test/hermes-plugin.test.ts`: none found.
- This PR only changes the Hermes plugin manifest plus a focused drift test; it does not change AgentMemory server/runtime behavior.

## Test plan
- RED: `PATH=/opt/homebrew/bin:$PATH npm test -- test/hermes-plugin.test.ts --reporter=verbose`
  - failed on current main because the manifest only declared `on_session_end`, `on_pre_compress`, and `on_memory_write`.
- GREEN: `PATH=/opt/homebrew/bin:$PATH npm test -- test/hermes-plugin.test.ts --reporter=verbose`
  - `1 passed`
- Relevant guard: `PATH=/opt/homebrew/bin:$PATH npm test -- test/hermes-plugin.test.ts test/integration-plaintext-http.test.ts --reporter=verbose`
  - `14 passed`
- Full suite: `PATH=/opt/homebrew/bin:$PATH npm test -- --reporter=dot`
  - `92 passed`, `1008 passed`
- Build: `PATH=/opt/homebrew/bin:$PATH npm run build`
  - completed successfully
- `git diff --check`
  - clean

Note: local shell defaulted to Node 16, so I used Homebrew Node `v23.11.0` on PATH for the repo's Node >=20 toolchain.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended Hermes plugin integration with additional lifecycle hooks to enable more flexible plugin behavior and richer interactions during session and sync flows.

* **Tests**
  * Added a validation test suite to ensure the plugin manifest stays consistent with the implemented hooks and preserves expected hook ordering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/486?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->