### PR TITLE
fix(hermes): keep plugin hook manifest in sync

### DIFF
--- a/integrations/hermes/plugin.yaml
+++ b/integrations/hermes/plugin.yaml
@@ -4,6 +4,9 @@ description: "Persistent cross-session memory for Hermes Agent via agentmemory. 
 author: "Rohit Ghumare"
 homepage: "https://github.com/rohitg00/agentmemory"
 hooks:
+  - system_prompt_block
+  - prefetch
+  - sync_turn
   - on_session_end
   - on_pre_compress
   - on_memory_write

--- a/test/consistency.test.ts
+++ b/test/consistency.test.ts
@@ -20,6 +20,41 @@ function countRestApiEndpoints(): number {
   return Array.from(src.matchAll(/api_path:\s*["`]/g)).length;
 }
 
+function readYamlStringList(relativePath: string, key: string): string[] {
+  const lines = readText(relativePath).split(/\r?\n/);
+  const values: string[] = [];
+  let inList = false;
+
+  for (const line of lines) {
+    if (line.trim() === `${key}:`) {
+      inList = true;
+      continue;
+    }
+    if (!inList) continue;
+    if (line.trim() && !line.startsWith(" ")) break;
+    const match = line.match(/^\s*-\s+([A-Za-z_][\w]*)\s*$/);
+    if (match) values.push(match[1]!);
+  }
+
+  return values;
+}
+
+function readHermesReadmeHookNames(): string[] {
+  return Array.from(
+    readText("integrations/hermes/README.md").matchAll(/^- `([a-z_][\w]*)\(\)` /gm),
+    (match) => match[1]!,
+  );
+}
+
+function readAgentMemoryProviderMethodNames(): Set<string> {
+  return new Set(
+    Array.from(
+      readText("integrations/hermes/__init__.py").matchAll(/^    def ([a-z_][\w]*)\(/gm),
+      (match) => match[1]!,
+    ),
+  );
+}
+
 describe("Consistency checks", () => {
   const toolCount = getAllTools().length;
   const restEndpointCount = countRestApiEndpoints();
@@ -72,6 +107,25 @@ describe("Consistency checks", () => {
       expect(tool.inputSchema).toBeDefined();
       expect(tool.inputSchema.type).toBe("object");
     }
+  });
+
+  it("Hermes plugin manifest lists all advertised implemented memory hooks (#478)", () => {
+    const manifestHooks = readYamlStringList("integrations/hermes/plugin.yaml", "hooks");
+    const readmeHooks = readHermesReadmeHookNames();
+    const implementedMethods = readAgentMemoryProviderMethodNames();
+
+    expect(readmeHooks).toEqual([
+      "prefetch",
+      "sync_turn",
+      "on_session_end",
+      "on_pre_compress",
+      "on_memory_write",
+      "system_prompt_block",
+    ]);
+    for (const hook of readmeHooks) {
+      expect(implementedMethods.has(hook), `${hook} is advertised but not implemented`).toBe(true);
+    }
+    expect([...manifestHooks].sort()).toEqual([...readmeHooks].sort());
   });
 
   it("every host-path bind mount in docker-compose.yml is in the published files list (#136)", () => {


### PR DESCRIPTION
## Summary
- Add the missing Hermes integration hook names to `integrations/hermes/plugin.yaml`.
- Add a consistency guard that compares the manifest hook list with the exported Hermes provider lifecycle methods.

## Test Plan
- RED: `npm test -- test/consistency.test.ts` failed with the new manifest/provider parity test before updating `plugin.yaml`.
- GREEN: `npm test` → 91 files / 1008 tests passed.
- GREEN: `npm run build`
- GREEN: `git diff --check`

Closes #478


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded Hermes integration plugin capabilities with three new hook handlers enabling system prompt blocking, request data prefetching, and conversation turn synchronization features that are now available to users.

* **Tests**
  * Added comprehensive consistency tests ensuring the plugin configuration accurately reflects all advertised Hermes plugin hooks and maintains proper alignment with implementation details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/488?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->