### PR TITLE
fix(mcp): preserve recall format option

### DIFF
--- a/src/mcp/standalone.ts
+++ b/src/mcp/standalone.ts
@@ -64,11 +64,19 @@ function normalizeList(value: unknown): string[] {
 
 const DEFAULT_LIMIT = 10;
 const MAX_LIMIT = 100;
+type SearchFormat = "compact" | "full";
+
 function parseLimit(raw: unknown, fallback = DEFAULT_LIMIT): number {
   if (typeof raw !== "number" && typeof raw !== "string") return fallback;
   const n = Number(raw);
   if (!Number.isFinite(n) || n <= 0) return fallback;
   return Math.min(Math.floor(n), MAX_LIMIT);
+}
+
+function parseSearchFormat(raw: unknown): SearchFormat | undefined {
+  if (typeof raw !== "string") return undefined;
+  const format = raw.trim().toLowerCase();
+  return format === "compact" || format === "full" ? format : undefined;
 }
 
 function textResponse(payload: unknown, pretty = false): {
@@ -89,6 +97,7 @@ interface Validated {
   files?: string[];
   query?: string;
   limit?: number;
+  format?: SearchFormat;
   memoryIds?: string[];
   reason?: string;
 }
@@ -118,6 +127,7 @@ function validate(toolName: string, args: Record<string, unknown>): Validated {
       }
       v.query = query.trim();
       v.limit = parseLimit(args["limit"]);
+      v.format = parseSearchFormat(args["format"]);
       return v;
     }
     case "memory_sessions": {
@@ -161,9 +171,14 @@ async function handleProxy(
     }
     case "memory_recall":
     case "memory_smart_search": {
+      const body: { query?: string; limit?: number; format?: SearchFormat } = {
+        query: v.query,
+        limit: v.limit,
+      };
+      if (v.format) body.format = v.format;
       const result = await handle.call("/agentmemory/smart-search", {
         method: "POST",
-        body: JSON.stringify({ query: v.query, limit: v.limit }),
+        body: JSON.stringify(body),
       });
       return textResponse(result, true);
     }
@@ -227,6 +242,7 @@ async function handleLocal(
     case "memory_smart_search": {
       const query = (v.query || "").toLowerCase();
       const limit = v.limit ?? DEFAULT_LIMIT;
+      const format = v.format ?? "compact";
       const all =
         await kvInstance.list<Record<string, unknown>>("mem:memories");
       const results = all
@@ -244,7 +260,7 @@ async function handleLocal(
           return query.split(/\s+/).every((word) => text.includes(word));
         })
         .slice(0, limit);
-      return textResponse({ mode: "compact", results }, true);
+      return textResponse({ mode: format, format, results }, true);
     }
 
     case "memory_sessions": {

--- a/test/mcp-standalone.test.ts
+++ b/test/mcp-standalone.test.ts
@@ -222,6 +222,52 @@ describe("handleToolCall", () => {
     expect(parsed.results[0].content).toBe("TypeScript is great");
   });
 
+  it("memory_recall preserves a safe format option in local fallback (#440)", async () => {
+    const kv = new InMemoryKV();
+    await handleToolCall("memory_save", { content: "TypeScript is great" }, kv);
+
+    const result = await handleToolCall(
+      "memory_recall",
+      { query: "typescript", format: "full" },
+      kv,
+    );
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.format).toBe("full");
+    expect(parsed.mode).toBe("full");
+    expect(parsed.results[0].content).toBe("TypeScript is great");
+  });
+
+  it("memory_recall and memory_smart_search forward safe format to smart-search proxy (#440)", async () => {
+    const proxyProbe = vi.fn(async () => ({ ok: true, status: 200 }));
+    setLivezProbe(proxyProbe);
+
+    const proxyFetch = vi.fn(async () =>
+      new Response(JSON.stringify({ results: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    (globalThis as { fetch: typeof fetch }).fetch = proxyFetch as unknown as typeof fetch;
+
+    for (const toolName of ["memory_recall", "memory_smart_search"]) {
+      resetHandleForTests();
+      setLivezProbe(proxyProbe);
+      await handleToolCall(
+        toolName,
+        { query: "typescript", limit: 3, format: "full" },
+        new InMemoryKV(),
+      );
+    }
+
+    expect(proxyFetch).toHaveBeenCalledTimes(2);
+    for (const [, init] of proxyFetch.mock.calls) {
+      expect((init as RequestInit).method).toBe("POST");
+      const body = JSON.parse((init as RequestInit).body as string);
+      expect(body).toEqual({ query: "typescript", limit: 3, format: "full" });
+    }
+  });
+
   it("memory_save accepts concepts/files as arrays (plugin skill format, #139)", async () => {
     const kv = new InMemoryKV();
     const result = await handleToolCall(


### PR DESCRIPTION
## Summary
- Preserve the optional `format` argument when the standalone MCP shim validates `memory_recall` / `memory_smart_search` calls.
- Forward the validated format through the proxy smart-search request and keep invalid values rejected at the boundary.

## Test Plan
- RED: `npm test -- test/mcp-standalone.test.ts` failed before the implementation when `format` was omitted from the proxied body.
- GREEN: `npm test` → 91 files / 1009 tests passed.
- GREEN: `git diff --check`

Closes #440


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added format customization to memory search operations, allowing users to choose between "compact" and "full" result formats for greater control over search output detail levels.
  * Format option defaults to "compact" when not specified.
  * Format preference is consistently applied across all search pathways.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/489?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->