### PR TITLE
feat(retention): schedule evict sweeps

### DIFF
--- a/src/functions/evict-scheduler.ts
+++ b/src/functions/evict-scheduler.ts
@@ -1,0 +1,44 @@
+import type { ISdk } from "iii-sdk";
+
+const DEFAULT_EVICTION_INTERVAL_MS = 86_400_000;
+
+type TimerHandle = ReturnType<typeof setInterval>;
+type SetIntervalFn = (
+  callback: () => Promise<void>,
+  intervalMs: number,
+) => TimerHandle;
+
+function parseIntervalMs(value: string | undefined): number {
+  if (!value) return DEFAULT_EVICTION_INTERVAL_MS;
+  const parsed = parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_EVICTION_INTERVAL_MS;
+}
+
+export function getEvictSweepIntervalMs(
+  env: Record<string, string | undefined> = process.env,
+): number {
+  return parseIntervalMs(env["EVICTION_INTERVAL_MS"]);
+}
+
+export function startEvictSweep(
+  sdk: Pick<ISdk, "trigger">,
+  env: Record<string, string | undefined> = process.env,
+  setIntervalFn: SetIntervalFn = setInterval,
+): TimerHandle | null {
+  if (env["EVICTION_ENABLED"] === "false") return null;
+
+  const intervalMs = getEvictSweepIntervalMs(env);
+  const timer = setIntervalFn(async () => {
+    try {
+      await sdk.trigger({
+        function_id: "mem::evict",
+        payload: {},
+      });
+    } catch {}
+  }, intervalMs);
+
+  timer.unref?.();
+  return timer;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,10 @@ import { registerConsolidateFunction } from "./functions/consolidate.js";
 import { registerPatternsFunction } from "./functions/patterns.js";
 import { registerRememberFunction } from "./functions/remember.js";
 import { registerEvictFunction } from "./functions/evict.js";
+import {
+  startEvictSweep,
+  getEvictSweepIntervalMs,
+} from "./functions/evict-scheduler.js";
 import { registerRelationsFunction } from "./functions/relations.js";
 import { registerTimelineFunction } from "./functions/timeline.js";
 import { registerSmartSearchFunction } from "./functions/smart-search.js";
@@ -499,6 +503,13 @@ async function main() {
     }, autoForgetIntervalMs);
     autoForgetTimer.unref();
     bootLog(`Auto-forget: enabled (every ${autoForgetIntervalMs / 60000}m)`);
+  }
+
+  const evictSweepTimer = startEvictSweep(sdk);
+  if (evictSweepTimer) {
+    bootLog(
+      `Evict sweep: enabled (every ${getEvictSweepIntervalMs() / 60000}m)`,
+    );
   }
 
   if (process.env.LESSON_DECAY_ENABLED !== "false") {

--- a/test/evict-scheduler.test.ts
+++ b/test/evict-scheduler.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+import { startEvictSweep } from "../src/functions/evict-scheduler.js";
+
+describe("scheduled mem::evict sweep", () => {
+  it("schedules mem::evict by default every 24 hours", async () => {
+    const trigger = vi.fn().mockResolvedValue({ success: true });
+    const unref = vi.fn();
+    let callback: (() => Promise<void>) | undefined;
+    const setIntervalFn = vi.fn((cb: () => Promise<void>, intervalMs: number) => {
+      callback = cb;
+      expect(intervalMs).toBe(86_400_000);
+      return { unref };
+    });
+
+    const timer = startEvictSweep(
+      { trigger } as never,
+      {},
+      setIntervalFn as never,
+    );
+
+    expect(timer).toEqual({ unref });
+    expect(setIntervalFn).toHaveBeenCalledTimes(1);
+    expect(unref).toHaveBeenCalledTimes(1);
+
+    await callback?.();
+
+    expect(trigger).toHaveBeenCalledWith({
+      function_id: "mem::evict",
+      payload: {},
+    });
+  });
+
+  it("can be disabled explicitly", () => {
+    const trigger = vi.fn();
+    const setIntervalFn = vi.fn();
+
+    const timer = startEvictSweep(
+      { trigger } as never,
+      { EVICTION_ENABLED: "false" },
+      setIntervalFn as never,
+    );
+
+    expect(timer).toBeNull();
+    expect(setIntervalFn).not.toHaveBeenCalled();
+    expect(trigger).not.toHaveBeenCalled();
+  });
+
+  it("honors EVICTION_INTERVAL_MS", () => {
+    const trigger = vi.fn();
+    const setIntervalFn = vi.fn(() => ({ unref: vi.fn() }));
+
+    startEvictSweep(
+      { trigger } as never,
+      { EVICTION_INTERVAL_MS: "1234" },
+      setIntervalFn as never,
+    );
+
+    expect(setIntervalFn).toHaveBeenCalledWith(expect.any(Function), 1234);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a scheduled eviction sweep that triggers `mem::evict` on an interval.
- Match the requested environment contract: enabled by default unless `EVICTION_ENABLED=false`, with `EVICTION_INTERVAL_MS` overriding the 24h default.
- Keep the scheduler isolated and covered with unit tests.

## Test Plan
- RED: `npm test -- test/evict-scheduler.test.ts` failed before adding the scheduler implementation.
- GREEN: `npm test -- test/evict.test.ts test/evict-scheduler.test.ts` → 7 tests passed.
- GREEN: `npm test` → 92 files / 1010 tests passed.
- GREEN: `npm run build`
- GREEN: `git diff --check`

Closes #480


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic eviction scheduler now runs every 24 hours by default to manage system resources
  * Eviction interval is fully configurable through environment variables
  * Eviction can be disabled via environment settings
  * Comprehensive test coverage added for scheduler functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/490?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->