### PR TITLE
fix(cli): skip onboarding prompts without a tty

### DIFF
--- a/src/cli/onboarding.ts
+++ b/src/cli/onboarding.ts
@@ -137,7 +137,31 @@ export interface OnboardingResult {
   provider: string | null;
 }
 
+function shouldSkipInteractiveOnboarding(): boolean {
+  const ci = process.env["CI"];
+  return (
+    process.stdin.isTTY !== true ||
+    process.stdout.isTTY !== true ||
+    (ci !== undefined && ci !== "" && ci !== "0" && ci.toLowerCase() !== "false")
+  );
+}
+
+function writeDefaultOnboardingPrefs(): OnboardingResult {
+  writePrefs({
+    lastAgent: null,
+    lastAgents: [],
+    lastProvider: null,
+    skipSplash: true,
+    firstRunAt: new Date().toISOString(),
+  });
+  return { agents: [], provider: null };
+}
+
 export async function runOnboarding(): Promise<OnboardingResult> {
+  if (shouldSkipInteractiveOnboarding()) {
+    return writeDefaultOnboardingPrefs();
+  }
+
   p.note(
     [
       "Welcome to agentmemory.",

--- a/test/cli-onboarding.test.ts
+++ b/test/cli-onboarding.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const prompts = vi.hoisted(() => ({
+  note: vi.fn(),
+  multiselect: vi.fn(async () => {
+    throw new Error("interactive multiselect should not run in non-TTY onboarding");
+  }),
+  select: vi.fn(async () => {
+    throw new Error("interactive select should not run in non-TTY onboarding");
+  }),
+  confirm: vi.fn(async () => true),
+  isCancel: vi.fn(() => false),
+  cancel: vi.fn(),
+  log: {
+    warn: vi.fn(),
+    step: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@clack/prompts", () => prompts);
+vi.mock("../src/cli/connect/index.js", () => ({
+  resolveAdapter: vi.fn(),
+  runAdapter: vi.fn(),
+}));
+
+const ORIGINAL_HOME = process.env["HOME"];
+const ORIGINAL_USERPROFILE = process.env["USERPROFILE"];
+const stdinTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+const stdoutTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+
+let sandboxHome: string;
+
+function setTTY(value: boolean): void {
+  Object.defineProperty(process.stdin, "isTTY", { value, configurable: true });
+  Object.defineProperty(process.stdout, "isTTY", { value, configurable: true });
+}
+
+function restoreTTY(): void {
+  if (stdinTtyDescriptor) Object.defineProperty(process.stdin, "isTTY", stdinTtyDescriptor);
+  else delete (process.stdin as NodeJS.ReadStream & { isTTY?: boolean }).isTTY;
+  if (stdoutTtyDescriptor) Object.defineProperty(process.stdout, "isTTY", stdoutTtyDescriptor);
+  else delete (process.stdout as NodeJS.WriteStream & { isTTY?: boolean }).isTTY;
+}
+
+async function freshOnboarding() {
+  vi.resetModules();
+  return await import("../src/cli/onboarding.js");
+}
+
+describe("cli onboarding", () => {
+  beforeEach(() => {
+    sandboxHome = mkdtempSync(join(tmpdir(), "agentmemory-onboarding-"));
+    process.env["HOME"] = sandboxHome;
+    process.env["USERPROFILE"] = sandboxHome;
+    setTTY(false);
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    restoreTTY();
+    if (ORIGINAL_HOME === undefined) delete process.env["HOME"];
+    else process.env["HOME"] = ORIGINAL_HOME;
+    if (ORIGINAL_USERPROFILE === undefined) delete process.env["USERPROFILE"];
+    else process.env["USERPROFILE"] = ORIGINAL_USERPROFILE;
+    rmSync(sandboxHome, { recursive: true, force: true });
+  });
+
+  it("does not prompt and records default preferences when onboarding runs without a TTY", async () => {
+    const { runOnboarding } = await freshOnboarding();
+
+    const result = await runOnboarding();
+
+    expect(result).toEqual({ agents: [], provider: null });
+    expect(prompts.multiselect).not.toHaveBeenCalled();
+    expect(prompts.select).not.toHaveBeenCalled();
+    expect(prompts.confirm).not.toHaveBeenCalled();
+
+    const preferencesPath = join(sandboxHome, ".agentmemory", "preferences.json");
+    expect(existsSync(preferencesPath)).toBe(true);
+    const preferences = JSON.parse(readFileSync(preferencesPath, "utf-8"));
+    expect(preferences).toMatchObject({
+      schemaVersion: 1,
+      lastAgent: null,
+      lastAgents: [],
+      lastProvider: null,
+      skipSplash: true,
+    });
+    expect(typeof preferences.firstRunAt).toBe("string");
+  });
+});


### PR DESCRIPTION
## Summary
- Detect non-interactive/CI environments before starting first-run onboarding prompts.
- Seed default preferences in non-TTY runs so deployments can continue without hanging on interactive setup.
- Add regression coverage that non-TTY onboarding does not call prompt APIs.

## Test Plan
- RED: `npm test -- test/cli-onboarding.test.ts` failed before the non-TTY guard because interactive prompt APIs were invoked.
- GREEN: `npm test -- test/cli-onboarding.test.ts test/preferences.test.ts` → 8 tests passed.
- GREEN: `npm test` → 92 files / 1008 tests passed.
- GREEN: `npm run build`
- GREEN: `git diff --check`

Closes #484


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Onboarding now automatically detects non-interactive environments (CI systems or shells without TTY support) and bypasses interactive prompts, applying default settings instead. Default behavior includes disabling the splash screen and recording the initial onboarding timestamp.

* **Tests**
  * Added test coverage for non-interactive onboarding scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/491?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->