### PR TITLE
fix: parse self-closing graph entities

### DIFF
--- a/src/functions/graph.ts
+++ b/src/functions/graph.ts
@@ -27,12 +27,12 @@ function parseGraphXml(
   const now = new Date().toISOString();
 
   const entityRegex =
-    /<entity\s+type="([^"]+)"\s+name="([^"]+)"[^>]*>([\s\S]*?)<\/entity>/g;
+    /<entity\s+type="([^"]+)"\s+name="([^"]+)"[^>]*(?:\/>|>([\s\S]*?)<\/entity>)/g;
   let match;
   while ((match = entityRegex.exec(xml)) !== null) {
     const type = match[1] as GraphNode["type"];
     const name = match[2];
-    const propsBlock = match[3];
+    const propsBlock = match[3] ?? "";
     const properties: Record<string, string> = {};
 
     const propRegex = /<property\s+key="([^"]+)">([^<]*)<\/property>/g;

--- a/test/graph.test.ts
+++ b/test/graph.test.ts
@@ -106,6 +106,32 @@ describe("Graph Functions", () => {
     expect(edges[0].type).toBe("uses");
   });
 
+  it("graph-extract accepts self-closing entity tags", async () => {
+    mockProvider.compress.mockResolvedValueOnce(`<entities>
+<entity type="file" name="src/index.ts"/>
+<entity type="function" name="main"><property key="lang">typescript</property></entity>
+</entities>
+<relationships>
+<relationship type="uses" source="src/index.ts" target="main" weight="0.9"/>
+</relationships>`);
+
+    const result = (await sdk.trigger("mem::graph-extract", {
+      observations: [testObs],
+    })) as { success: boolean; nodesAdded: number; edgesAdded: number };
+
+    expect(result.success).toBe(true);
+    expect(result.nodesAdded).toBe(2);
+    expect(result.edgesAdded).toBe(1);
+
+    const nodes = await kv.list<GraphNode>("mem:graph:nodes");
+    expect(nodes.some((n) => n.name === "src/index.ts")).toBe(true);
+    expect(nodes.some((n) => n.name === "main")).toBe(true);
+
+    const edges = await kv.list<GraphEdge>("mem:graph:edges");
+    expect(edges).toHaveLength(1);
+    expect(edges[0].type).toBe("uses");
+  });
+
   it("graph-query with search returns matching nodes", async () => {
     await sdk.trigger("mem::graph-extract", { observations: [testObs] });
 


### PR DESCRIPTION
## Summary

- Accept self-closing graph `<entity .../>` tags in `parseGraphXml`.
- Keep existing explicit closing-tag entity parsing and property parsing behavior.
- Add regression coverage for a self-closing entity that participates in a relationship.

Fixes #492.
Related to #559: fixes one parser-loss path where real provider output with self-closing `<entity .../>` tags can parse as `0 nodes / 0 edges`.

## Verification

- `npx tsdown` passed in isolated fork clone.
- `npm run build` reached tsdown build completion but failed afterward on Windows shell-only copy fallback (`true` is not recognized / shell syntax). No live AgentMemory service was started.
- Tests not run locally per local environment constraint; full `npm test` intentionally skipped to avoid any accidental interaction with the live AgentMemory setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved XML entity parsing to support both self-closing and standard tag formats.

* **Tests**
  * Added test case for entity parsing with self-closing XML tags to ensure robust format handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/494?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
