### PR TITLE
fix: end Codex sessions on Stop hook

### DIFF
--- a/plugin/hooks/hooks.codex.json
+++ b/plugin/hooks/hooks.codex.json
@@ -59,6 +59,10 @@
           {
             "type": "command",
             "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/stop.mjs"
+          },
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/session-end.mjs"
           }
         ]
       }

--- a/test/codex-plugin.test.ts
+++ b/test/codex-plugin.test.ts
@@ -91,6 +91,19 @@ describe("Codex plugin manifest (developers.openai.com/codex/plugins)", () => {
       expect(existsSync(join(pluginRoot, rel)), `missing hook script: ${rel}`).toBe(true);
     }
   });
+
+  it("Stop hook summarizes and ends the session", () => {
+    type HookHandler = { type: string; command: string };
+    type HookEntry = { hooks: HookHandler[] };
+    const hooks = readJson<{ hooks: Record<string, HookEntry[]> }>(
+      join(pluginRoot, "hooks/hooks.codex.json"),
+    );
+    const stopCommands = hooks.hooks.Stop.flatMap((entry) =>
+      entry.hooks.map((handler) => handler.command),
+    );
+    expect(stopCommands).toContain("node ${CLAUDE_PLUGIN_ROOT}/scripts/stop.mjs");
+    expect(stopCommands).toContain("node ${CLAUDE_PLUGIN_ROOT}/scripts/session-end.mjs");
+  });
 });
 
 describe("Codex marketplace.json (.codex-plugin/marketplace.json at repo root)", () => {


### PR DESCRIPTION
## Summary

- Wire Codex `Stop` to run the existing `session-end.mjs` hook after `stop.mjs`.
- Preserve the current best-effort summarize behavior while closing the session lifecycle for Codex, which does not use a separate `SessionEnd` entry in `hooks.codex.json`.
- Add regression coverage that the Codex Stop hook includes both summarize and session-end commands.

Fixes #493.
Related: #308.

## Verification

- `npx tsdown` passed in isolated fork clone.
- `node -e "JSON.parse(require('fs').readFileSync('plugin/hooks/hooks.codex.json','utf8')); console.log('hooks.codex.json OK')"` passed.
- Tests not run locally per local environment constraint; full `npm test` intentionally skipped to avoid any accidental interaction with the live AgentMemory setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced session cleanup process configuration.

* **Tests**
  * Added verification tests for session cleanup functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/495?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->