### PR TITLE
fix(boot): make rebuildIndex non-blocking so viewer + later boot steps run

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -412,16 +412,24 @@ async function main() {
   const needsRebuild = bm25Index.size === 0;
 
   if (needsRebuild) {
-    const indexCount = await rebuildIndex(kv).catch((err) => {
-      console.warn(`[agentmemory] Failed to rebuild search index:`, err);
-      return 0;
-    });
-    if (indexCount > 0) {
-      bootLog(
-        `Search index rebuilt: ${indexCount} entries`,
-      );
-      indexPersistence.scheduleSave();
-    }
+    // Fire-and-forget. rebuildIndex iterates every observation across
+    // every session and AWAITS an embedding-provider call per record.
+    // On a large corpus + rate-limited embedding endpoint that can
+    // take HOURS; awaiting it here blocks every subsequent boot step
+    // (including startViewerServer below, leaving the viewer port
+    // unbound for the duration). The index lazily fills in over time
+    // and search degrades gracefully — partial coverage > no viewer
+    // for hours. Errors still surface via the inner .catch.
+    void rebuildIndex(kv)
+      .then((indexCount) => {
+        if (indexCount > 0) {
+          bootLog(`Search index rebuilt: ${indexCount} entries`);
+          indexPersistence.scheduleSave();
+        }
+      })
+      .catch((err) => {
+        console.warn(`[agentmemory] Failed to rebuild search index:`, err);
+      });
   } else {
     // Backfill memories into BM25 for users upgrading from <0.9.5: prior
     // versions of mem::remember never indexed memories, so the persisted


### PR DESCRIPTION
## Summary

The worker boot flow in `src/index.ts` awaits `rebuildIndex(kv)` before reaching `startViewerServer` (and several other boot steps). `rebuildIndex` iterates every observation across every session and AWAITS an embedding-provider call per record. On a real corpus + a rate-limited embedding endpoint that takes **hours to days**, and everything that runs after it is silently delayed for the same duration.

## Symptom in the wild

Operator imports a sizable jsonl corpus (in our case 320 sessions / ~500k observations), restarts agentmemory with `EMBEDDING_PROVIDER` pointed at any rate-limited OpenAI-compat endpoint (Novita / DeepInfra / etc., typically 100 RPM on the cheap plans), and:

- ✅ REST API on `:3111` responds normally
- ❌ Viewer on `:3113` is never reachable (no listening socket)
- ❌ `agentmemory doctor` reports `viewer-unreachable`
- 🌊 Log floods with `vector-index add: embed failed — skipping {429: ...}` from the still-running rebuild burning the embedding rate limit
- No error message — the worker stays alive serving HTTP because `sdk.registerFunction` calls had already completed synchronously before the rebuild hung

The "obvious" workaround of `agentmemory stop && agentmemory` just re-enters the same hang.

## Root cause

```ts
// src/index.ts
const needsRebuild = bm25Index.size === 0;

if (needsRebuild) {
  const indexCount = await rebuildIndex(kv).catch(...);   // ← hours-to-days
  ...
}

// ...
const viewerServer = startViewerServer(viewerPort, ...);  // ← never reached
```

`rebuildIndex(kv)` (in `src/functions/search.ts`) per-record awaits `vectorIndexAddGuarded(...)` which calls the embedding provider. For a ~500k-observation corpus at 100 RPM = 5,000 minutes = **3.5 days**. The viewer / auto-forget / lesson-decay / consolidation timers all sit behind it.

## Fix

Detach with `void` + `.then/.catch`. The index lazily fills in over hours; search degrades gracefully (BM25 keeps working immediately, vector results fill in as the embed queue drains); the viewer + everything else in main() come up in seconds.

```ts
void rebuildIndex(kv)
  .then((indexCount) => {
    if (indexCount > 0) {
      bootLog(`Search index rebuilt: ${indexCount} entries`);
      indexPersistence.scheduleSave();
    }
  })
  .catch((err) => {
    console.warn(`[agentmemory] Failed to rebuild search index:`, err);
  });
```

## Verification

Tested live on the affected corpus before and after:

**Before:** every restart left `lsof -ti :3113` empty, doctor reported `viewer-unreachable`, log showed 429s pile up indefinitely.

**After:** viewer binds within ~5 seconds of starting, returns the full 188 KB HTML payload on `GET /`. Rebuild continues in the background; vector search results improve over the following minutes.

## Test plan

No unit tests added. `main()` isn't unit-tested today and wiring up a fake slow `rebuildIndex` + asserting the post-rebuild boot lines run early would need the full worker mock harness — disproportionate to a one-line behavior change. The failure mode is dramatic enough that visual review + integration smoke covers regression risk.

## Files

- `src/index.ts` — 18 insertions, 10 deletions (mostly the comment explaining the rationale)

## Related

Surfaced while operating an agentmemory install against a 320-session bulk-imported corpus. The 429 floods that finally pointed at this had me chasing port-conflict / stale-process explanations first (see #474). The real cause is here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved application boot performance by optimizing search-index initialization to run in the background without blocking startup steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/500?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->