### PR TITLE
revert: remove Codex Stop hook session-end

### DIFF
--- a/plugin/hooks/hooks.codex.json
+++ b/plugin/hooks/hooks.codex.json
@@ -59,10 +59,6 @@
           {
             "type": "command",
             "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/stop.mjs"
-          },
-          {
-            "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/session-end.mjs"
           }
         ]
       }

--- a/test/codex-plugin.test.ts
+++ b/test/codex-plugin.test.ts
@@ -91,19 +91,6 @@ describe("Codex plugin manifest (developers.openai.com/codex/plugins)", () => {
       expect(existsSync(join(pluginRoot, rel)), `missing hook script: ${rel}`).toBe(true);
     }
   });
-
-  it("Stop hook summarizes and ends the session", () => {
-    type HookHandler = { type: string; command: string };
-    type HookEntry = { hooks: HookHandler[] };
-    const hooks = readJson<{ hooks: Record<string, HookEntry[]> }>(
-      join(pluginRoot, "hooks/hooks.codex.json"),
-    );
-    const stopCommands = hooks.hooks.Stop.flatMap((entry) =>
-      entry.hooks.map((handler) => handler.command),
-    );
-    expect(stopCommands).toContain("node ${CLAUDE_PLUGIN_ROOT}/scripts/stop.mjs");
-    expect(stopCommands).toContain("node ${CLAUDE_PLUGIN_ROOT}/scripts/session-end.mjs");
-  });
 });
 
 describe("Codex marketplace.json (.codex-plugin/marketplace.json at repo root)", () => {


### PR DESCRIPTION
## Summary
- Reverts #495 because Codex Stop can fire before the overall conversation is truly finished.
- Restores the Codex Stop hook to summarize-only behavior.
- Removes the test that required session-end.mjs to run from Stop.

## Why
After testing in Codex, adding session-end.mjs to Stop marks sessions completed too early while later observations can still arrive. A separate SessionEnd hook is not surfaced by Codex /hooks for this plugin, so the safe behavior is to avoid ending sessions from Stop.

## Verification
- npx vitest run test/codex-plugin.test.ts

Refs #493

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified Stop hook by removing session-end command execution

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/501?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->