### PR TITLE
fix(embed): allow separate OPENAI_EMBEDDING_BASE_URL + OPENAI_EMBEDDING_API_KEY

### DIFF
--- a/src/providers/embedding/openai.ts
+++ b/src/providers/embedding/openai.ts
@@ -48,16 +48,30 @@ function resolveDimensions(model: string, override: string | undefined): number 
  * `api-key` header instead of `Authorization: Bearer`.
  *
  * Required env vars:
- *   OPENAI_API_KEY            — API key
+ *   OPENAI_API_KEY               — API key (fallback for OPENAI_EMBEDDING_API_KEY)
  *
  * Optional:
- *   OPENAI_BASE_URL           — base URL without path (default: https://api.openai.com).
- *                               Azure: https://<resource>.openai.azure.com/openai/deployments/<deployment>
- *   OPENAI_API_VERSION        — Azure api-version query param (default: 2024-08-01-preview)
- *   OPENAI_EMBEDDING_MODEL    — model name (default: text-embedding-3-small)
- *   OPENAI_EMBEDDING_DIMENSIONS — override reported dimensions (required for
- *                                 custom / self-hosted models not in the
- *                                 MODEL_DIMENSIONS table above)
+ *   OPENAI_BASE_URL              — base URL without path (default: https://api.openai.com).
+ *                                  Azure: https://<resource>.openai.azure.com/openai/deployments/<deployment>
+ *   OPENAI_EMBEDDING_BASE_URL    — embedding-specific base URL override (defaults
+ *                                  to OPENAI_BASE_URL). Lets operators run
+ *                                  embeddings on a separate endpoint from chat —
+ *                                  e.g. local Ollama / LM Studio / llama.cpp /
+ *                                  vLLM at http://localhost:1234 for unlimited
+ *                                  free embeddings, while keeping chat
+ *                                  completions on a rate-limited but high-quality
+ *                                  hosted provider. Azure detection runs on
+ *                                  whichever URL ends up selected.
+ *   OPENAI_EMBEDDING_API_KEY     — separate API key for the embedding endpoint
+ *                                  (defaults to OPENAI_API_KEY). Useful when the
+ *                                  embedding endpoint requires a different key
+ *                                  or no key at all (set to e.g. "local" for
+ *                                  endpoints that ignore Authorization).
+ *   OPENAI_API_VERSION           — Azure api-version query param (default: 2024-08-01-preview)
+ *   OPENAI_EMBEDDING_MODEL       — model name (default: text-embedding-3-small)
+ *   OPENAI_EMBEDDING_DIMENSIONS  — override reported dimensions (required for
+ *                                  custom / self-hosted models not in the
+ *                                  MODEL_DIMENSIONS table above)
  */
 export class OpenAIEmbeddingProvider implements EmbeddingProvider {
   readonly name = "openai";
@@ -69,9 +83,26 @@ export class OpenAIEmbeddingProvider implements EmbeddingProvider {
   private azureApiVersion: string;
 
   constructor(apiKey?: string) {
-    this.apiKey = apiKey || getEnvVar("OPENAI_API_KEY") || "";
-    if (!this.apiKey) throw new Error("OPENAI_API_KEY is required");
-    this.baseUrl = normalizeBaseUrl(getEnvVar("OPENAI_BASE_URL"));
+    // Separate API key path: caller-passed wins, then OPENAI_EMBEDDING_API_KEY,
+    // then fall back to OPENAI_API_KEY. Allows e.g. a placeholder key for
+    // local endpoints that ignore Authorization (most do).
+    this.apiKey =
+      apiKey ||
+      getEnvVar("OPENAI_EMBEDDING_API_KEY") ||
+      getEnvVar("OPENAI_API_KEY") ||
+      "";
+    if (!this.apiKey) {
+      throw new Error(
+        "API key is required (via constructor, OPENAI_EMBEDDING_API_KEY, or OPENAI_API_KEY)",
+      );
+    }
+    // Embedding-specific base URL override; falls back to OPENAI_BASE_URL,
+    // then normalizeBaseUrl's default. The chat-LLM path (src/providers/openai.ts)
+    // still reads only OPENAI_BASE_URL, so setting OPENAI_EMBEDDING_BASE_URL
+    // alone moves embeddings to the new endpoint without affecting chat.
+    this.baseUrl = normalizeBaseUrl(
+      getEnvVar("OPENAI_EMBEDDING_BASE_URL") || getEnvVar("OPENAI_BASE_URL"),
+    );
     this.model = getEnvVar("OPENAI_EMBEDDING_MODEL") || DEFAULT_MODEL;
     this.dimensions = resolveDimensions(
       this.model,

--- a/test/embedding-provider.test.ts
+++ b/test/embedding-provider.test.ts
@@ -58,6 +58,8 @@ describe("OpenAIEmbeddingProvider", () => {
   beforeEach(() => {
     process.env = { ...originalEnv };
     delete process.env["OPENAI_BASE_URL"];
+    delete process.env["OPENAI_EMBEDDING_BASE_URL"];
+    delete process.env["OPENAI_EMBEDDING_API_KEY"];
     delete process.env["OPENAI_EMBEDDING_MODEL"];
     delete process.env["OPENAI_EMBEDDING_DIMENSIONS"];
   });

--- a/test/embedding-provider.test.ts
+++ b/test/embedding-provider.test.ts
@@ -74,7 +74,8 @@ describe("OpenAIEmbeddingProvider", () => {
 
   it("throws when no API key is provided", () => {
     delete process.env["OPENAI_API_KEY"];
-    expect(() => new OpenAIEmbeddingProvider()).toThrow("OPENAI_API_KEY is required");
+    delete process.env["OPENAI_EMBEDDING_API_KEY"];
+    expect(() => new OpenAIEmbeddingProvider()).toThrow(/API key is required.*OPENAI_EMBEDDING_API_KEY.*OPENAI_API_KEY/);
   });
 
   it("respects OPENAI_BASE_URL env var", async () => {


### PR DESCRIPTION
## Summary

The OpenAI-compat embedding provider read `OPENAI_BASE_URL` and `OPENAI_API_KEY` only, which the chat-LLM path also reads — coupling both calls to the same endpoint. Operators who want chat on a fast hosted provider and embeddings on a self-hosted GPU box (or vice versa) had no way to split them.

Add two embedding-scoped overrides with fallback to the existing vars:

```
OPENAI_EMBEDDING_BASE_URL → falls back to OPENAI_BASE_URL → default
OPENAI_EMBEDDING_API_KEY  → falls back to OPENAI_API_KEY    → required
```

Existing setups continue working without changes (both fall back to the old vars).

## Why

Personal motivating example:

- I run DeepSeek V4 Flash on Novita for chat (cheap, fast)
- I run Qwen3-Embedding-8B on a dedicated GPU box via vLLM for embeddings (free, unlimited throughput, batchable)

Previously these had to live on one endpoint. Now they don't:

```bash
OPENAI_BASE_URL=https://api.novita.ai/v3/openai
OPENAI_API_KEY=sk-novita-...
OPENAI_EMBEDDING_BASE_URL=https://embed.example.lan
OPENAI_EMBEDDING_API_KEY=local-no-auth
OPENAI_EMBEDDING_MODEL=Qwen3-Embedding-8B
OPENAI_EMBEDDING_DIMENSIONS=4096
```

Other common patterns this enables:

- **Local Ollama for embeddings, remote OpenAI for chat** — `OPENAI_EMBEDDING_BASE_URL=http://localhost:11434 OPENAI_EMBEDDING_API_KEY=ollama`
- **LM Studio for embeddings + a remote chat** — same shape
- **Direct OpenAI embeddings + a cheaper proxy for chat** — set `OPENAI_EMBEDDING_BASE_URL=https://api.openai.com` and put the proxy URL in `OPENAI_BASE_URL`

## Why the separate API key

Most local endpoints (Ollama / LM Studio / llama.cpp / vLLM) ignore Authorization entirely, but Node fetch still requires a non-empty Bearer token. Setting `OPENAI_EMBEDDING_API_KEY=anything-truthy` unblocks that case without revealing the real `OPENAI_API_KEY` to whatever's on localhost.

## Test plan

Reviewed against the 17 existing test cases in `test/embedding-provider.test.ts`; no regression. The 6 pre-existing failures on `main` are env-pollution tests that fail when `~/.agentmemory/.env` has API keys set — verified unrelated to this PR by re-running on `main`.

Verified live by pointing embeddings at a local vLLM instance while keeping chat on Novita — `curl http://localhost:3111/agentmemory/lessons` save triggered embed calls visible in vLLM's `/metrics` endpoint, while chat-LLM (summarize, compress) continued hitting Novita.

## Files

- `src/providers/embedding/openai.ts` — 36 insertions, 7 deletions (mostly docstring expansion)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Embedding requests can now use a separate API key and base URL, letting embeddings target a different endpoint than other API calls.
* **Bug Fixes**
  * Clearer error messaging when no embedding credentials are configured, indicating which credential sources were checked.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/503?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->