### PR TITLE
fix(rebuild): batch embed calls in rebuildIndex (25h → 3h on large corpora)

### DIFF
--- a/src/functions/search.ts
+++ b/src/functions/search.ts
@@ -86,6 +86,90 @@ export async function vectorIndexAddGuarded(
   }
 }
 
+// Batched variant: calls EmbeddingProvider.embedBatch ONCE for the whole
+// batch, then writes each resulting vector. Use this for bulk paths
+// (rebuildIndex, future bulk-add APIs) where per-item serial awaits
+// dominate wallclock. A batch of N has roughly the latency of a single
+// embed (network + GPU setup amortized), so backfilling a 500k-obs
+// corpus drops from days to hours on a per-batch endpoint like vLLM.
+//
+// Per-item failure shape:
+//   - whole-batch network/provider error → all skipped, single warn line
+//   - per-item dimension mismatch → that item skipped, others continue
+export async function vectorIndexAddBatchGuarded(
+  items: Array<{
+    id: string
+    sessionId: string
+    text: string
+    context: { kind: "memory" | "observation" | "synthetic"; logId: string }
+  }>,
+): Promise<{ ok: number; fail: number }> {
+  const vi = vectorIndex
+  const ep = currentEmbeddingProvider
+  if (!vi || !ep || items.length === 0) return { ok: 0, fail: 0 }
+
+  let embeddings: Float32Array[]
+  try {
+    embeddings = await ep.embedBatch(items.map((i) => clipEmbedInput(i.text)))
+  } catch (err) {
+    logger.warn("vector-index add batch: embed failed — skipping batch", {
+      batchSize: items.length,
+      provider: ep.name,
+      error: err instanceof Error ? err.message : String(err),
+    })
+    return { ok: 0, fail: items.length }
+  }
+
+  if (embeddings.length !== items.length) {
+    logger.warn(
+      "vector-index add batch: provider returned wrong length — skipping batch",
+      {
+        batchSize: items.length,
+        returned: embeddings.length,
+        provider: ep.name,
+      },
+    )
+    return { ok: 0, fail: items.length }
+  }
+
+  let ok = 0
+  let fail = 0
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i]
+    const embedding = embeddings[i]
+    if (embedding.length !== ep.dimensions) {
+      logger.warn("vector-index add batch: dimension mismatch — skipping item", {
+        kind: item.context.kind,
+        id: item.context.logId,
+        provider: ep.name,
+        expected: ep.dimensions,
+        received: embedding.length,
+      })
+      fail++
+      continue
+    }
+    vi.add(item.id, item.sessionId, embedding)
+    ok++
+  }
+  return { ok, fail }
+}
+
+// Embed-batch size for rebuild. Each item is one /v1/embeddings call's
+// `input` array element; the provider sees the whole batch as one HTTP
+// round-trip. 32 fits comfortably under typical per-request token budgets
+// (32 × ~110 tok/item ≈ 3.5k tokens) and gets close to per-call
+// throughput for GPU-backed endpoints (vLLM, Triton, etc.). Override via
+// REBUILD_EMBED_BATCH_SIZE for endpoints that prefer smaller/larger
+// batches. Set to 1 to fall back to the legacy per-item path.
+const DEFAULT_REBUILD_EMBED_BATCH = 32
+
+function getRebuildEmbedBatchSize(): number {
+  const raw = process.env.REBUILD_EMBED_BATCH_SIZE
+  if (!raw) return DEFAULT_REBUILD_EMBED_BATCH
+  const n = parseInt(raw, 10)
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_REBUILD_EMBED_BATCH
+}
+
 export async function rebuildIndex(kv: StateKV): Promise<number> {
   const idx = getSearchIndex()
   idx.clear()
@@ -96,7 +180,27 @@ export async function rebuildIndex(kv: StateKV): Promise<number> {
   // repopulation loops run, so BM25 and vector stay in sync.
   vectorIndex?.clear()
 
+  const batchSize = getRebuildEmbedBatchSize()
+  // Accumulator for the batched embed flush. BM25 add is synchronous and
+  // doesn't need batching — only the vector path benefits.
+  type EmbedJob = {
+    id: string
+    sessionId: string
+    text: string
+    context: { kind: "memory" | "observation" | "synthetic"; logId: string }
+  }
+  const pending: EmbedJob[] = []
   let count = 0
+
+  const flush = async (): Promise<void> => {
+    if (pending.length === 0) return
+    await vectorIndexAddBatchGuarded(pending)
+    pending.length = 0
+  }
+  const enqueue = async (job: EmbedJob): Promise<void> => {
+    pending.push(job)
+    if (pending.length >= batchSize) await flush()
+  }
 
   // Memories live in their own KV scope outside per-session observation
   // scopes, so they need a separate walk. Without this, mem::remember
@@ -108,12 +212,12 @@ export async function rebuildIndex(kv: StateKV): Promise<number> {
       if (memory.isLatest === false) continue
       if (!memory.title || !memory.content) continue
       idx.add(memoryToObservation(memory))
-      await vectorIndexAddGuarded(
-        memory.id,
-        memory.sessionIds[0] ?? 'memory',
-        memory.title + ' ' + memory.content,
-        { kind: "memory", logId: memory.id },
-      )
+      await enqueue({
+        id: memory.id,
+        sessionId: memory.sessionIds[0] ?? 'memory',
+        text: memory.title + ' ' + memory.content,
+        context: { kind: "memory", logId: memory.id },
+      })
       count++
     }
   } catch (err) {
@@ -123,7 +227,10 @@ export async function rebuildIndex(kv: StateKV): Promise<number> {
   }
 
   const sessions = await kv.list<Session>(KV.sessions)
-  if (!sessions.length) return count
+  if (!sessions.length) {
+    await flush()
+    return count
+  }
 
   const obsPerSession: CompressedObservation[][] = []
   const failedSessions: string[] = []
@@ -148,16 +255,19 @@ export async function rebuildIndex(kv: StateKV): Promise<number> {
     for (const obs of observations) {
       if (obs.title && obs.narrative) {
         idx.add(obs)
-        await vectorIndexAddGuarded(
-          obs.id,
-          obs.sessionId,
-          obs.title + ' ' + obs.narrative,
-          { kind: "observation", logId: obs.id },
-        )
+        await enqueue({
+          id: obs.id,
+          sessionId: obs.sessionId,
+          text: obs.title + ' ' + obs.narrative,
+          context: { kind: "observation", logId: obs.id },
+        })
         count++
       }
     }
   }
+
+  // Drain the last partial batch.
+  await flush()
   return count
 }
 

--- a/src/functions/search.ts
+++ b/src/functions/search.ts
@@ -148,8 +148,17 @@ export async function vectorIndexAddBatchGuarded(
       fail++
       continue
     }
-    vi.add(item.id, item.sessionId, embedding)
-    ok++
+    try {
+      vi.add(item.id, item.sessionId, embedding)
+      ok++
+    } catch (err) {
+      logger.warn("vector-index add batch: index write failed — skipping item", {
+        kind: item.context.kind,
+        id: item.context.logId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+      fail++
+    }
   }
   return { ok, fail }
 }


### PR DESCRIPTION
## Summary

`rebuildIndex` called `await vectorIndexAddGuarded(...)` per memory and per observation — each is one HTTP round-trip embedding a single input. On a real bulk-imported corpus + any non-zero network latency, the per-item serialization dominates wallclock.

Add a batched helper `vectorIndexAddBatchGuarded()` that calls `provider.embedBatch()` once for a buffered group of items, and refactor `rebuildIndex` to accumulate + flush in batches of `REBUILD_EMBED_BATCH_SIZE` (default 32).

## The numbers

Measured against a self-hosted vLLM (Qwen3-Embedding-8B) endpoint:

| call shape | latency | per-item |
|---|---|---|
| single embed | 175 ms | 175 ms |
| batch of 32 | 737 ms | **23 ms** |

That's **~7.6× speedup** per item. For a 500k-observation corpus, projected rebuild time drops from **~25 hours** to **~3 hours**.

The same benefit applies to any batchable OpenAI-compat endpoint — vLLM, Triton, OpenAI's own `/v1/embeddings`, LM Studio, llama.cpp server, etc. All accept an `input` array; their providers already amortize network + GPU setup across the batch.

## Companion to #500

#500 made `rebuildIndex` non-blocking so the viewer + later boot steps run immediately. But the rebuild itself still took the same wallclock. This PR cuts the rebuild itself. After both, boot is fast AND the index hot-loads in a small multiple of the time it takes the provider to physically embed the corpus.

## Failure semantics

| failure | before | after |
|---|---|---|
| network/provider error on the call | per-item warn × N | single warn for the batch, N items marked failed |
| dimension mismatch on one record | per-item warn | per-item warn (item skipped, others in batch continue) |
| `rebuildIndex` return value | count of attempted items | unchanged |

The soft-fail surface (call always returns, embed errors don't abort the rebuild) is preserved item-for-item.

## Configuration

```
# default
REBUILD_EMBED_BATCH_SIZE=32

# small endpoints that prefer fewer items per call
REBUILD_EMBED_BATCH_SIZE=8

# fall back to per-item path (effectively pre-PR behavior)
REBUILD_EMBED_BATCH_SIZE=1
```

## Test plan

`npx vitest run test/search-index.test.ts test/vector-index*.test.ts test/remember-bm25-index.test.ts` — 39/39 pass unchanged.

No new test added for the batching path itself (would need mocking the provider's `embedBatch` and asserting buffered flush at boundaries — possible but not done in this PR; the existing tests cover that `rebuildIndex` produces the same final index, and the batched helper is a transparent optimization). Happy to add if reviewer prefers.

Verified live against a real corpus + vLLM endpoint by counting vLLM's `vllm:request_success_total` before/after a rebuild — request count drops by a factor of ~32 as expected.

## Files

- `src/functions/search.ts` — new `vectorIndexAddBatchGuarded`, refactor `rebuildIndex` to use it; +112 lines, -9 lines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batched embedding processing to speed up index rebuilds.

* **Improvements**
  * Granular success/failure tracking that skips problematic items without failing entire batches.
  * Configurable rebuild batch size (default 32) for optimized memory/observation indexing.
  * Faster handling when no sessions/data to process, avoiding unnecessary work.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/504?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->