### PR TITLE
fix(viewer): soften graph layout velocity

### DIFF
--- a/src/viewer/index.html
+++ b/src/viewer/index.html
@@ -1546,7 +1546,7 @@
       }, 30000);
     }
 
-    var graphSim = { nodes: [], edges: [], running: false, canvas: null, ctx: null, raf: null, panX: 0, panY: 0, zoom: 1, dragNode: null, mouseX: 0, mouseY: 0 };
+    var graphSim = { nodes: [], edges: [], running: false, canvas: null, ctx: null, raf: null, panX: 0, panY: 0, zoom: 1, dragNode: null, mouseX: 0, mouseY: 0, tick: 0 };
 
     async function loadGraph() {
       var el = document.getElementById('view-graph');
@@ -1652,6 +1652,7 @@
       if (!canvas) return;
       graphSim.canvas = canvas;
       graphSim.ctx = canvas.getContext('2d');
+      graphSim.tick = 0;
 
       function resize() {
         var r = canvas.parentElement.getBoundingClientRect();
@@ -1693,6 +1694,13 @@
 
       setupGraphInteraction(canvas);
       runSimulation();
+    }
+
+    function getGraphVelocityCap(nodeCount, tick) {
+      var start = nodeCount > 100 ? 24 : nodeCount > 50 ? 20 : 16;
+      var floor = nodeCount > 100 ? 6 : 8;
+      var decay = nodeCount > 100 ? 0.996 : 0.997;
+      return Math.max(floor, start * Math.pow(decay, tick || 0));
     }
 
     function setupGraphInteraction(canvas) {
@@ -1870,6 +1878,7 @@
       var repulsion = nodeCount > 100 ? 2000 : nodeCount > 50 ? 1200 : 800;
       var attraction = nodeCount > 100 ? 0.002 : 0.005;
       var centerGravity = nodeCount > 100 ? 0.005 : 0.01;
+      var velocityCap = getGraphVelocityCap(nodeCount, graphSim.tick);
 
       var nodeMap = {};
       nodes.forEach(function(n) { nodeMap[n.id] = n; });
@@ -1891,6 +1900,12 @@
         fy -= n.y * centerGravity;
         n.vx = (n.vx + fx) * damping;
         n.vy = (n.vy + fy) * damping;
+        var speed = Math.sqrt(n.vx * n.vx + n.vy * n.vy) || 0;
+        if (speed > velocityCap) {
+          var scale = velocityCap / speed;
+          n.vx *= scale;
+          n.vy *= scale;
+        }
       }
 
       edges.forEach(function(e) {
@@ -1914,6 +1929,7 @@
       });
 
       renderGraph();
+      graphSim.tick += 1;
       graphSim.raf = requestAnimationFrame(runSimulation);
     }
 

--- a/src/viewer/index.html
+++ b/src/viewer/index.html
@@ -1900,12 +1900,6 @@
         fy -= n.y * centerGravity;
         n.vx = (n.vx + fx) * damping;
         n.vy = (n.vy + fy) * damping;
-        var speed = Math.sqrt(n.vx * n.vx + n.vy * n.vy) || 0;
-        if (speed > velocityCap) {
-          var scale = velocityCap / speed;
-          n.vx *= scale;
-          n.vy *= scale;
-        }
       }
 
       edges.forEach(function(e) {
@@ -1924,6 +1918,12 @@
 
       nodes.forEach(function(n) {
         if (graphSim.dragNode === n) return;
+        var speed = Math.sqrt(n.vx * n.vx + n.vy * n.vy);
+        if (speed > velocityCap && speed > 0) {
+          var scale = velocityCap / speed;
+          n.vx *= scale;
+          n.vy *= scale;
+        }
         n.x += n.vx;
         n.y += n.vy;
       });

--- a/test/viewer-session-id.test.ts
+++ b/test/viewer-session-id.test.ts
@@ -203,3 +203,17 @@ describe("viewer session rendering", () => {
     expect(tabButtons.some((button: any) => button.classList.contains("active"))).toBe(true);
   });
 });
+
+describe("viewer graph velocity cap", () => {
+  it("starts fast and gradually slows down over time", () => {
+    const { sandbox } = loadViewerSandbox();
+
+    const start = sandbox.getGraphVelocityCap(1500, 0);
+    const mid = sandbox.getGraphVelocityCap(1500, 200);
+    const late = sandbox.getGraphVelocityCap(1500, 800);
+
+    expect(start).toBeGreaterThan(mid);
+    expect(mid).toBeGreaterThan(late);
+    expect(late).toBeGreaterThanOrEqual(6);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a gradual velocity cap to the viewer graph simulation so large graphs start lively but slow down over time.
- Keep the original graph layout, node sizing, controls, rendering, and backend APIs unchanged.
- Add a viewer regression test for the decaying velocity cap.

## Verification
- `npx vitest run test/viewer-session-id.test.ts test/viewer-security.test.ts`
- `git diff --check upstream/main...HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * The Graph tab's force-directed simulation now applies a time-decaying velocity cap, improving animation stability, reducing acceleration spikes, and producing smoother node motion during interactive graph visualization.

* **Tests**
  * New tests validate that the velocity cap decreases over time and maintains a safe minimum to ensure stable long-term animation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/513?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->