### PR TITLE
fix(mcp): memory_recall hits the right endpoint and forwards format/token_budget (#507)

### DIFF
--- a/src/mcp/standalone.ts
+++ b/src/mcp/standalone.ts
@@ -89,6 +89,8 @@ interface Validated {
   files?: string[];
   query?: string;
   limit?: number;
+  format?: string;
+  tokenBudget?: number;
   memoryIds?: string[];
   reason?: string;
 }
@@ -118,6 +120,17 @@ function validate(toolName: string, args: Record<string, unknown>): Validated {
       }
       v.query = query.trim();
       v.limit = parseLimit(args["limit"]);
+      const fmt = args["format"];
+      if (typeof fmt === "string" && fmt.trim()) {
+        v.format = fmt.trim().toLowerCase();
+      }
+      const budget = args["token_budget"];
+      if (typeof budget === "number" && Number.isFinite(budget) && budget > 0) {
+        v.tokenBudget = Math.floor(budget);
+      } else if (typeof budget === "string" && budget.trim()) {
+        const n = Number(budget);
+        if (Number.isFinite(n) && n > 0) v.tokenBudget = Math.floor(n);
+      }
       return v;
     }
     case "memory_sessions": {
@@ -159,11 +172,26 @@ async function handleProxy(
       });
       return textResponse(result);
     }
-    case "memory_recall":
+    case "memory_recall": {
+      const body: Record<string, unknown> = {
+        query: v.query,
+        limit: v.limit,
+        format: v.format ?? "full",
+      };
+      if (v.tokenBudget != null) body["token_budget"] = v.tokenBudget;
+      const result = await handle.call("/agentmemory/search", {
+        method: "POST",
+        body: JSON.stringify(body),
+      });
+      return textResponse(result, true);
+    }
     case "memory_smart_search": {
+      const body: Record<string, unknown> = { query: v.query, limit: v.limit };
+      if (v.format != null) body["format"] = v.format;
+      if (v.tokenBudget != null) body["token_budget"] = v.tokenBudget;
       const result = await handle.call("/agentmemory/smart-search", {
         method: "POST",
-        body: JSON.stringify({ query: v.query, limit: v.limit }),
+        body: JSON.stringify(body),
       });
       return textResponse(result, true);
     }

--- a/test/mcp-standalone-proxy.test.ts
+++ b/test/mcp-standalone-proxy.test.ts
@@ -75,6 +75,61 @@ describe("@agentmemory/mcp standalone — server proxy (issue #159)", () => {
     expect(body.results[0].id).toBe("m1");
   });
 
+  it("proxies memory_recall to POST /agentmemory/search and forwards format/token_budget (#507)", async () => {
+    const calls: Array<{ url: string; body?: unknown }> = [];
+    installFetch((url, init) => {
+      if (url.endsWith("/agentmemory/livez")) return new Response("ok", { status: 200 });
+      const body = init?.body ? JSON.parse(init.body as string) : undefined;
+      calls.push({ url, body });
+      if (url.endsWith("/agentmemory/search")) {
+        return new Response(
+          JSON.stringify({
+            mode: "full",
+            facts: [{ id: "m1" }],
+            narrative: "n",
+            concepts: ["c"],
+            files: ["f"],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    });
+    const res = await handleToolCall("memory_recall", {
+      query: "auth bug",
+      limit: 5,
+      format: "full",
+      token_budget: 800,
+    });
+    const body = JSON.parse(res.content[0].text);
+    expect(body.mode).toBe("full");
+    expect(body.facts[0].id).toBe("m1");
+    const searchCall = calls.find((c) => c.url.endsWith("/agentmemory/search"));
+    expect(searchCall).toBeDefined();
+    expect(searchCall?.body).toEqual({
+      query: "auth bug",
+      limit: 5,
+      format: "full",
+      token_budget: 800,
+    });
+    expect(calls.find((c) => c.url.endsWith("/agentmemory/smart-search"))).toBeUndefined();
+  });
+
+  it("memory_recall defaults format to 'full' when omitted (#507)", async () => {
+    let recallBody: Record<string, unknown> | undefined;
+    installFetch((url, init) => {
+      if (url.endsWith("/agentmemory/livez")) return new Response("ok", { status: 200 });
+      if (url.endsWith("/agentmemory/search")) {
+        recallBody = init?.body ? JSON.parse(init.body as string) : undefined;
+        return new Response(JSON.stringify({ mode: "full", facts: [] }), { status: 200 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+    await handleToolCall("memory_recall", { query: "x" });
+    expect(recallBody?.["format"]).toBe("full");
+    expect(recallBody).not.toHaveProperty("token_budget");
+  });
+
   it("proxies memory_governance_delete to the DELETE REST endpoint", async () => {
     const calls: Array<{ url: string; method: string; body?: unknown }> = [];
     installFetch((url, init) => {


### PR DESCRIPTION
## Problem

`memory_recall` in the standalone MCP shim always returns compact results, ignoring the `format` and `token_budget` parameters that the tool's input schema advertises (`src/mcp/tools-registry.ts`).

Two root causes in `src/mcp/standalone.ts`:

1. **Wrong endpoint.** `memory_recall` and `memory_smart_search` share a single `case` that routes both to `POST /agentmemory/smart-search`. That endpoint always returns compact mode and does not honor `format`. The endpoint that supports `format` (and exposes the full `facts` / `narrative` / `concepts` / `files` shape) is `POST /agentmemory/search`.
2. **Parameters dropped.** `validate()` never parses `format` or `token_budget`, and `handleProxy()` never includes them in the request body, so even after the endpoint is corrected the server has nothing to act on.

Fixes #507.

## Solution

- Parse `format` (string, lower-cased) and `token_budget` (positive integer, accepts string or number) in `validate()` for both `memory_recall` and `memory_smart_search`.
- Split the proxy case: `memory_recall` calls `POST /agentmemory/search` with `format` defaulted to `"full"` (matching the schema's documented default) and forwards `token_budget` when set. `memory_smart_search` keeps its existing `POST /agentmemory/smart-search` endpoint but now also forwards `format` and `token_budget` when the caller supplies them.
- Local `InMemoryKV` fallback behavior is unchanged.

## Testing

`npm test` — 1036 / 1036 passing locally.

Two new tests in `test/mcp-standalone-proxy.test.ts`:

- `proxies memory_recall to POST /agentmemory/search and forwards format/token_budget (#507)` — asserts the request URL, the body shape (`{query, limit, format, token_budget}`), and that `smart-search` is not called.
- `memory_recall defaults format to 'full' when omitted (#507)` — pins the default so the wire call matches the schema's documented default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Memory tools now accept `format` and `token_budget` optional parameters for customized query behavior
* Memory recall defaults to `"full"` format when format parameter is unspecified
* Token budget parameter validates and accepts both numeric values and numeric string inputs

## Tests
* Added test coverage for memory tool proxy request formatting and parameter handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/516?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->