### PR TITLE
feat(embedding/openrouter): env-aware dimensions + known-model table

### DIFF
--- a/src/providers/embedding/openrouter.ts
+++ b/src/providers/embedding/openrouter.ts
@@ -4,9 +4,39 @@ import { fetchWithTimeout } from "../_fetch.js";
 
 const API_URL = "https://openrouter.ai/api/v1/embeddings";
 
+// Default fallback when no env override + unknown model.
+// Matches `openai/text-embedding-3-small`, the prior hardcoded value.
+const DEFAULT_DIMENSIONS = 1536;
+
+/**
+ * Known dimensions for popular OpenRouter-hosted embedding models.
+ * Extend as new models ship. Override via OPENROUTER_EMBEDDING_DIMENSIONS
+ * (or OPENAI_EMBEDDING_DIMENSIONS for parity with the OpenAI provider).
+ */
+const MODEL_DIMENSIONS: Record<string, number> = {
+  "openai/text-embedding-3-small": 1536,
+  "openai/text-embedding-3-large": 3072,
+  "openai/text-embedding-ada-002": 1536,
+  "qwen/qwen3-embedding-8b": 4096,
+  "openrouter/qwen/qwen3-embedding-8b": 4096,
+};
+
+function resolveDimensions(model: string, override?: string | null): number {
+  if (override !== undefined && override !== null && override.trim().length > 0) {
+    const parsed = parseInt(override, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      throw new Error(
+        `OPENROUTER_EMBEDDING_DIMENSIONS must be a positive integer, got: ${override}`,
+      );
+    }
+    return parsed;
+  }
+  return MODEL_DIMENSIONS[model] ?? DEFAULT_DIMENSIONS;
+}
+
 export class OpenRouterEmbeddingProvider implements EmbeddingProvider {
   readonly name = "openrouter";
-  readonly dimensions = 1536;
+  readonly dimensions: number;
   private apiKey: string;
   private model: string;
 
@@ -16,6 +46,15 @@ export class OpenRouterEmbeddingProvider implements EmbeddingProvider {
     this.model =
       getEnvVar("OPENROUTER_EMBEDDING_MODEL") ||
       "openai/text-embedding-3-small";
+    // Precedence: OPENROUTER_EMBEDDING_DIMENSIONS (provider-specific)
+    //          → OPENAI_EMBEDDING_DIMENSIONS (parity alias with the OpenAI provider)
+    //          → MODEL_DIMENSIONS table lookup
+    //          → DEFAULT_DIMENSIONS (1536, prior hardcoded value)
+    this.dimensions = resolveDimensions(
+      this.model,
+      getEnvVar("OPENROUTER_EMBEDDING_DIMENSIONS") ||
+        getEnvVar("OPENAI_EMBEDDING_DIMENSIONS"),
+    );
   }
 
   async embed(text: string): Promise<Float32Array> {


### PR DESCRIPTION
## Summary

`OpenRouterEmbeddingProvider` hardcodes `dimensions = 1536`, which only matches `openai/text-embedding-3-small`. Any other OpenRouter-hosted embedding model trips `withDimensionGuard` and silently drops every observation/memory from the vector index.

This PR adopts the same env-aware design already shipped in `OpenAIEmbeddingProvider` (see #371 / `_openai-shared`):

1. `MODEL_DIMENSIONS` table for common OpenRouter-hosted models
2. `OPENROUTER_EMBEDDING_DIMENSIONS` env override (provider-specific)
3. `OPENAI_EMBEDDING_DIMENSIONS` alias for parity with the OpenAI provider — many users already have this set and expect it to apply to the chosen embedding backend
4. `DEFAULT_DIMENSIONS = 1536` preserved as the no-override no-table fallback (no behavior change for existing users)

## Real-world break

Tested with `OPENROUTER_EMBEDDING_MODEL=openrouter/qwen/qwen3-embedding-8b` (4096-dim). Every save and observation log:

```
[agentmemory] warn vector-index add: embed failed — skipping
  {"kind":"memory","id":"mem_...","provider":"openrouter",
   "error":"Embedding dimension mismatch in openrouter.embed: expected 1536, got 4096"}
```

BM25 search still works, but vector search returns nothing because nothing was ever indexed. The mismatch is silent unless the user reads the wrapper log.

With this patch + `OPENAI_EMBEDDING_DIMENSIONS=4096` (already set in `.env.example` for the OpenAI embedding provider), the same model works end-to-end:

```
[agentmemory] info Observation captured ...
[agentmemory] info Observation compressed ... qualityScore:100
[agentmemory] info Memory saved ...
```

— no `embed failed` warnings.

## Why both env names

`.env.example` documents `OPENAI_EMBEDDING_DIMENSIONS` as 'required when the model is not in the known-models table' for the OpenAI provider. Users following that hint and then switching `EMBEDDING_PROVIDER=openrouter` reasonably expect their dimension override to keep working. The new `OPENROUTER_EMBEDDING_DIMENSIONS` is the explicit one; the OpenAI alias avoids forcing users to duplicate the same value.

Precedence is provider-specific first, alias second, table third, default last.

## Related

- `#371` — Consolidate OpenAI LLM + embedding providers into one class (precedent for env-aware dimensions)
- `#469` — Vector Index Dimension Mismatch Crashes Server on Startup (related symptom)
- `#455` — Worker refuses to start after embedding provider change (related symptom)
- `#247` — Embedding providers silently corrupt the vector index when an API returns wrong-dimension vectors (this PR is the cooperative half: provider declares correct dimensions up front)

## Test plan

- [ ] Existing tests pass (no changes to `embed`/`embedBatch` shape)
- [ ] Manual: `EMBEDDING_PROVIDER=openrouter`, `OPENROUTER_EMBEDDING_MODEL=qwen/qwen3-embedding-8b`, `OPENROUTER_EMBEDDING_DIMENSIONS=4096` → memory save + smart-search succeed without dim-mismatch warnings
- [ ] Manual: default (no env, no model override) → unchanged behaviour, `dimensions === 1536`
- [ ] Manual: invalid override (`OPENROUTER_EMBEDDING_DIMENSIONS=abc`) → constructor throws actionable error
- [ ] Manual: `OPENROUTER_EMBEDDING_MODEL=openai/text-embedding-3-large` (no env override) → `dimensions === 3072` via MODEL_DIMENSIONS table

## Out of scope

- Persisted index migration: still requires the existing `AGENTMEMORY_DROP_STALE_INDEX` path (or the planned fix from #456/#469) when an existing index was written at a different dimension.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Embedding dimensions are now dynamically determined based on the selected model rather than using a fixed value.
  * Support for model-specific embedding configurations via environment variable overrides, with intelligent fallback to model defaults.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/525?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->