### PR TITLE
fix(providers/openai): send explicit stream:false in chat completion body

### DIFF
--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -80,6 +80,13 @@ export class OpenAIProvider implements MemoryProvider {
     const body: Record<string, unknown> = {
       model: this.model,
       max_tokens: this.maxTokens,
+      // OpenAI API spec defines `stream` as defaulting to false, so omitting
+      // it should yield a JSON response. Some OpenAI-compatible proxies
+      // (notably 9Router < 0.4.56 — see decolua/9router#1260) default to
+      // text/event-stream when `stream` is absent, which crashes the
+      // `response.json()` call below with `Unexpected token 'd', "data: {"id"...`.
+      // Send it explicitly so non-spec endpoints route to non-streaming too.
+      stream: false,
       messages: [
         { role: "system", content: systemPrompt },
         { role: "user", content: userPrompt },


### PR DESCRIPTION
## Summary

`OpenAIProvider.call` omits the `stream` field, relying on the OpenAI spec default of `false`. Some OpenAI-compatible proxies disagree and return `text/event-stream` instead of JSON, which crashes `response.json()` with:

```
Unexpected token 'd', "data: {"id"... is not valid JSON
```

After a few of these in a row, `ResilientProvider`'s circuit breaker trips and every subsequent compression / summarisation / reflection fails with `circuit_breaker_open` — silently disabling all LLM-backed memory enrichment.

This PR sends `stream: false` explicitly in the request body.

## Why this is upstream-worthy even with a proxy-side fix

Reproduced concretely with [9Router](https://github.com/decolua/9router), an OpenAI-compatible proxy that ships with default `stream` resolved as `body.stream !== false` (i.e. `undefined !== false` → `true`). I opened https://github.com/decolua/9router/pull/1272 against that, but defensive `stream: false` here protects against:

- Other OpenAI-compatible endpoints with the same spec gap (older self-hosted proxies, vLLM compat shims, custom routers)
- 9Router users on versions < 0.4.56 (the fix has not shipped yet)
- Future regressions in any proxy that re-introduces the bug

For spec-compliant endpoints (openai.com, Azure OpenAI, well-behaved proxies): no behavior change — they already default to non-streaming when `stream` is absent, so setting it is a no-op.

## Repro

```bash
EMBEDDING_PROVIDER=openrouter
OPENAI_API_KEY=...
OPENAI_BASE_URL=http://localhost:20128/v1   # any proxy that streams by default
OPENAI_MODEL=haiku                          # any model that proxy understands
```

Then:

```bash
curl -X POST http://localhost:3111/agentmemory/remember \
  -H 'content-type: application/json' \
  -d '{"content":"test","type":"fact","concepts":["test"]}'
```

Wrapper log without this PR:
```
[agentmemory] error Compression failed
  {"obsId":"...","error":"Unexpected token 'd', \"data: {\"id\"... is not valid JSON"}
[agentmemory] error Compression failed
  {"obsId":"...","error":"circuit_breaker_open"}  # ← all subsequent calls
```

With this PR: response is JSON, `data.choices[0].message.content` extracted, compress succeeds.

## Test plan

- [ ] Existing tests pass
- [ ] Manual: against a known-good endpoint (openai.com, Azure) — request body now contains `"stream":false`, response shape unchanged
- [ ] Manual: against an SSE-default proxy (9Router) — request now resolves correctly instead of SSE-crashing the JSON parser

## Related

- `decolua/9router#1260` — upstream proxy bug
- `decolua/9router#1272` — proxy-side fix PR (defensive, this PR is the agentmemory-side defense in depth)
- `#149` / `#181` — earlier circuit-breaker / Stop-hook recursion fixes; this is the same `ResilientProvider` path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed compatibility issues with OpenAI-compatible proxy services that were causing API request failures. This ensures that chat completion requests work reliably whether you're using official OpenAI services or compatible alternative providers. Users will no longer experience unexpected response format errors during API operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/526?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->