### PR TITLE
fix(codex): canonicalize project identity for git worktrees

### DIFF
--- a/src/functions/branch-aware.ts
+++ b/src/functions/branch-aware.ts
@@ -3,7 +3,7 @@ import type { StateKV } from "../state/kv.js";
 import { KV } from "../state/schema.js";
 import type { Session } from "../types.js";
 import { execFile } from "node:child_process";
-import { resolve } from "node:path";
+import { detectGitProject } from "./project-identity.js";
 
 function execAsync(
   cmd: string,
@@ -26,41 +26,22 @@ export function registerBranchAwareFunction(sdk: ISdk, kv: StateKV): void {
       }
 
       try {
-        const gitDir = await execAsync(
-          "git",
-          ["rev-parse", "--git-dir"],
-          data.cwd,
-        );
-        const commonDir = await execAsync(
-          "git",
-          ["rev-parse", "--git-common-dir"],
-          data.cwd,
-        );
-        const branch = await execAsync(
-          "git",
-          ["rev-parse", "--abbrev-ref", "HEAD"],
-          data.cwd,
-        ).catch(() => "detached");
-
-        const topLevel = await execAsync(
-          "git",
-          ["rev-parse", "--show-toplevel"],
-          data.cwd,
-        );
-
-        const isWorktree = resolve(data.cwd, gitDir) !== resolve(data.cwd, commonDir);
-        const mainRepoRoot = isWorktree
-          ? resolve(data.cwd, commonDir, "..")
-          : topLevel;
+        const git = await detectGitProject(data.cwd);
+        if (!git) {
+          return {
+            success: true,
+            isWorktree: false,
+            branch: null,
+            topLevel: data.cwd,
+            mainRepoRoot: data.cwd,
+            gitDir: null,
+            commonDir: null,
+          };
+        }
 
         return {
           success: true,
-          isWorktree,
-          branch,
-          topLevel,
-          mainRepoRoot,
-          gitDir: resolve(data.cwd, gitDir),
-          commonDir: resolve(data.cwd, commonDir),
+          ...git,
         };
       } catch {
         return {

--- a/src/functions/context.ts
+++ b/src/functions/context.ts
@@ -17,6 +17,11 @@ import {
   listPinnedSlots,
   renderPinnedContext,
 } from "./slots.js";
+import {
+  expandProjectAliases,
+  projectValueMatches,
+  sessionMatchesProjectAliases,
+} from "./project-identity.js";
 
 function estimateTokens(text: string): number {
   return Math.ceil(text.length / 3);
@@ -30,6 +35,22 @@ function escapeXmlAttr(s: string): string {
     .replace(/>/g, "&gt;");
 }
 
+async function loadProjectProfile(
+  kv: StateKV,
+  project: string,
+  projectAliases: ReadonlySet<string>,
+): Promise<ProjectProfile | null> {
+  const exact = await kv
+    .get<ProjectProfile>(KV.profiles, project)
+    .catch(() => null);
+  if (exact) return exact;
+
+  const profiles = await kv.list<ProjectProfile>(KV.profiles).catch(() => []);
+  return (
+    profiles.find((p) => projectValueMatches(p.project, projectAliases)) ?? null
+  );
+}
+
 export function registerContextFunction(
   sdk: ISdk,
   kv: StateKV,
@@ -39,14 +60,22 @@ export function registerContextFunction(
     async (data: { sessionId: string; project: string; budget?: number }) => {
       const budget = data.budget || tokenBudget;
       const blocks: ContextBlock[] = [];
+      const currentSession = await kv
+        .get<Session>(KV.sessions, data.sessionId)
+        .catch(() => null);
+      const projectAliases = new Set(
+        expandProjectAliases(
+          data.project,
+          currentSession?.project,
+          currentSession?.cwd,
+        ),
+      );
 
       const [pinnedSlots, profile, lessons] = await Promise.all([
         isSlotsEnabled()
           ? listPinnedSlots(kv).catch(() => [] as MemorySlot[])
           : Promise.resolve([] as MemorySlot[]),
-        kv
-          .get<ProjectProfile>(KV.profiles, data.project)
-          .catch(() => null),
+        loadProjectProfile(kv, data.project, projectAliases),
         kv.list<Lesson>(KV.lessons).catch(() => [] as Lesson[]),
       ]);
 
@@ -103,10 +132,18 @@ export function registerContextFunction(
       // 10 to keep the block bounded since the outer token-budget loop
       // below will drop the whole block if it doesn't fit. #457.
       const relevantLessons = lessons
-        .filter((l) => !l.deleted && (!l.project || l.project === data.project))
+        .filter(
+          (l) =>
+            !l.deleted &&
+            (!l.project || projectValueMatches(l.project, projectAliases)),
+        )
         .sort((a, b) => {
-          const scoreA = (a.project === data.project ? 1.5 : 1) * a.confidence;
-          const scoreB = (b.project === data.project ? 1.5 : 1) * b.confidence;
+          const scoreA =
+            (projectValueMatches(a.project, projectAliases) ? 1.5 : 1) *
+            a.confidence;
+          const scoreB =
+            (projectValueMatches(b.project, projectAliases) ? 1.5 : 1) *
+            b.confidence;
           return scoreB - scoreA;
         })
         .slice(0, 10);
@@ -134,7 +171,11 @@ export function registerContextFunction(
 
       const allSessions = await kv.list<Session>(KV.sessions);
       const sessions = allSessions
-        .filter((s) => s.project === data.project && s.id !== data.sessionId)
+        .filter(
+          (s) =>
+            s.id !== data.sessionId &&
+            sessionMatchesProjectAliases(s, projectAliases),
+        )
         .sort(
           (a, b) =>
             new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),

--- a/src/functions/project-identity.ts
+++ b/src/functions/project-identity.ts
@@ -1,0 +1,169 @@
+import { execFile } from "node:child_process";
+import { basename, resolve, sep } from "node:path";
+
+export interface GitProjectInfo {
+  isWorktree: boolean;
+  branch: string | null;
+  topLevel: string;
+  mainRepoRoot: string;
+  gitDir: string;
+  commonDir: string;
+}
+
+export interface ProjectIdentity {
+  project: string;
+  cwd: string;
+  aliases: string[];
+  git?: GitProjectInfo;
+}
+
+function execAsync(
+  cmd: string,
+  args: string[],
+  cwd: string,
+): Promise<string> {
+  return new Promise((resolveOutput, reject) => {
+    execFile(cmd, args, { cwd, timeout: 5000 }, (err, stdout) => {
+      if (err) reject(err);
+      else resolveOutput(stdout.trim());
+    });
+  });
+}
+
+function cleanValue(value: string | null | undefined): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function looksLikePath(value: string): boolean {
+  return (
+    value.startsWith(".") ||
+    value.startsWith("~") ||
+    value.includes("/") ||
+    value.includes("\\")
+  );
+}
+
+export function expandProjectAliases(
+  ...values: Array<string | null | undefined>
+): string[] {
+  const aliases: string[] = [];
+  const seen = new Set<string>();
+
+  const add = (value: string | null | undefined) => {
+    const cleaned = cleanValue(value);
+    if (!cleaned || seen.has(cleaned)) return;
+    seen.add(cleaned);
+    aliases.push(cleaned);
+
+    if (looksLikePath(cleaned)) {
+      const absolute = resolve(cleaned);
+      if (!seen.has(absolute)) {
+        seen.add(absolute);
+        aliases.push(absolute);
+      }
+    }
+
+    const base = basename(cleaned);
+    if (base && base !== cleaned && !seen.has(base)) {
+      seen.add(base);
+      aliases.push(base);
+    }
+  };
+
+  for (const value of values) add(value);
+  return aliases;
+}
+
+export function projectValueMatches(
+  value: string | null | undefined,
+  aliases: ReadonlySet<string>,
+): boolean {
+  const cleaned = cleanValue(value);
+  if (!cleaned) return false;
+  const expanded = expandProjectAliases(cleaned);
+  if (looksLikePath(cleaned)) {
+    return expanded.some((alias) => looksLikePath(alias) && aliases.has(alias));
+  }
+  return expanded.some((alias) => aliases.has(alias));
+}
+
+export function sessionMatchesProjectAliases(
+  session: { project: string; cwd: string },
+  aliases: ReadonlySet<string>,
+): boolean {
+  if (projectValueMatches(session.project, aliases)) return true;
+  if (projectValueMatches(session.cwd, aliases)) return true;
+
+  for (const alias of aliases) {
+    if (!looksLikePath(alias)) continue;
+    const prefix = alias.endsWith("/") || alias.endsWith("\\")
+      ? alias
+      : `${alias}${sep}`;
+    if (session.cwd.startsWith(prefix)) return true;
+  }
+
+  return false;
+}
+
+export async function detectGitProject(
+  cwd: string,
+): Promise<GitProjectInfo | null> {
+  try {
+    const gitDir = await execAsync("git", ["rev-parse", "--git-dir"], cwd);
+    const commonDir = await execAsync(
+      "git",
+      ["rev-parse", "--git-common-dir"],
+      cwd,
+    );
+    const branch = await execAsync(
+      "git",
+      ["rev-parse", "--abbrev-ref", "HEAD"],
+      cwd,
+    ).catch(() => "detached");
+    const topLevel = await execAsync(
+      "git",
+      ["rev-parse", "--show-toplevel"],
+      cwd,
+    );
+
+    const gitDirPath = resolve(cwd, gitDir);
+    const commonDirPath = resolve(cwd, commonDir);
+    const isWorktree = gitDirPath !== commonDirPath;
+    const mainRepoRoot = isWorktree ? resolve(commonDirPath, "..") : topLevel;
+
+    return {
+      isWorktree,
+      branch,
+      topLevel,
+      mainRepoRoot,
+      gitDir: gitDirPath,
+      commonDir: commonDirPath,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function resolveProjectIdentity(input: {
+  project?: string | null;
+  cwd?: string | null;
+}): Promise<ProjectIdentity> {
+  const cwd = cleanValue(input.cwd) ?? cleanValue(input.project) ?? process.cwd();
+  const requestedProject = cleanValue(input.project) ?? cwd;
+  const git = await detectGitProject(cwd);
+  const project = git?.mainRepoRoot ?? requestedProject;
+
+  return {
+    project,
+    cwd,
+    aliases: expandProjectAliases(
+      requestedProject,
+      cwd,
+      git?.topLevel,
+      git?.mainRepoRoot,
+    ),
+    ...(git ? { git } : {}),
+  };
+}

--- a/src/functions/project-identity.ts
+++ b/src/functions/project-identity.ts
@@ -1,7 +1,8 @@
 import { execFile } from "node:child_process";
 import { basename, resolve, sep } from "node:path";
 
-const GIT_IDENTITY_TIMEOUT_MS = 500;
+const DEFAULT_GIT_IDENTITY_TIMEOUT_MS = 500;
+const GIT_IDENTITY_TIMEOUT_ENV = "AGENTMEMORY_GIT_IDENTITY_TIMEOUT_MS";
 
 export interface GitProjectInfo {
   isWorktree: boolean;
@@ -19,12 +20,23 @@ export interface ProjectIdentity {
   git?: GitProjectInfo;
 }
 
+const gitProjectCache = new Map<string, GitProjectInfo>();
+
+function gitIdentityTimeoutMs(): number {
+  const raw = process.env[GIT_IDENTITY_TIMEOUT_ENV];
+  if (!raw) return DEFAULT_GIT_IDENTITY_TIMEOUT_MS;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_GIT_IDENTITY_TIMEOUT_MS;
+}
+
 function execAsync(cmd: string, args: string[], cwd: string): Promise<string> {
   return new Promise((resolveOutput, reject) => {
     execFile(
       cmd,
       args,
-      { cwd, timeout: GIT_IDENTITY_TIMEOUT_MS },
+      { cwd, timeout: gitIdentityTimeoutMs() },
       (err, stdout) => {
         if (err) reject(err);
         else resolveOutput(stdout.trim());
@@ -46,6 +58,40 @@ function looksLikePath(value: string): boolean {
     value.includes("/") ||
     value.includes("\\")
   );
+}
+
+function pathKey(value: string): string {
+  return resolve(value);
+}
+
+function rememberGitProject(cwd: string, git: GitProjectInfo): void {
+  for (const key of [
+    cwd,
+    git.topLevel,
+    git.mainRepoRoot,
+    git.gitDir,
+    git.commonDir,
+  ]) {
+    gitProjectCache.set(pathKey(key), git);
+  }
+}
+
+function cachedGitProject(cwd: string): GitProjectInfo | null {
+  const target = pathKey(cwd);
+  const exact = gitProjectCache.get(target);
+  if (exact) return exact;
+
+  let best: { key: string; git: GitProjectInfo } | null = null;
+  for (const [key, git] of gitProjectCache) {
+    const prefix = key.endsWith(sep) ? key : `${key}${sep}`;
+    if (!target.startsWith(prefix)) continue;
+    if (!best || key.length > best.key.length) best = { key, git };
+  }
+  return best?.git ?? null;
+}
+
+function normalizeBranch(branch: string | undefined): string | null {
+  return branch && branch !== "HEAD" ? branch : null;
 }
 
 export function expandProjectAliases(
@@ -134,16 +180,18 @@ export async function detectGitProject(
     const isWorktree = gitDirPath !== commonDirPath;
     const mainRepoRoot = isWorktree ? resolve(commonDirPath, "..") : topLevel;
 
-    return {
+    const git = {
       isWorktree,
-      branch: branch || null,
+      branch: normalizeBranch(branch),
       topLevel,
       mainRepoRoot,
       gitDir: gitDirPath,
       commonDir: commonDirPath,
     };
+    rememberGitProject(cwd, git);
+    return git;
   } catch {
-    return null;
+    return cachedGitProject(cwd);
   }
 }
 
@@ -154,7 +202,7 @@ export async function resolveProjectIdentity(input: {
   const cwd =
     cleanValue(input.cwd) ?? cleanValue(input.project) ?? process.cwd();
   const requestedProject = cleanValue(input.project) ?? cwd;
-  const git = await detectGitProject(cwd);
+  const git = (await detectGitProject(cwd)) ?? cachedGitProject(cwd);
   const project = git?.mainRepoRoot ?? requestedProject;
 
   return {

--- a/src/functions/project-identity.ts
+++ b/src/functions/project-identity.ts
@@ -1,6 +1,8 @@
 import { execFile } from "node:child_process";
 import { basename, resolve, sep } from "node:path";
 
+const GIT_IDENTITY_TIMEOUT_MS = 500;
+
 export interface GitProjectInfo {
   isWorktree: boolean;
   branch: string | null;
@@ -17,16 +19,17 @@ export interface ProjectIdentity {
   git?: GitProjectInfo;
 }
 
-function execAsync(
-  cmd: string,
-  args: string[],
-  cwd: string,
-): Promise<string> {
+function execAsync(cmd: string, args: string[], cwd: string): Promise<string> {
   return new Promise((resolveOutput, reject) => {
-    execFile(cmd, args, { cwd, timeout: 5000 }, (err, stdout) => {
-      if (err) reject(err);
-      else resolveOutput(stdout.trim());
-    });
+    execFile(
+      cmd,
+      args,
+      { cwd, timeout: GIT_IDENTITY_TIMEOUT_MS },
+      (err, stdout) => {
+        if (err) reject(err);
+        else resolveOutput(stdout.trim());
+      },
+    );
   });
 }
 
@@ -98,9 +101,8 @@ export function sessionMatchesProjectAliases(
 
   for (const alias of aliases) {
     if (!looksLikePath(alias)) continue;
-    const prefix = alias.endsWith("/") || alias.endsWith("\\")
-      ? alias
-      : `${alias}${sep}`;
+    const prefix =
+      alias.endsWith("/") || alias.endsWith("\\") ? alias : `${alias}${sep}`;
     if (session.cwd.startsWith(prefix)) return true;
   }
 
@@ -111,22 +113,21 @@ export async function detectGitProject(
   cwd: string,
 ): Promise<GitProjectInfo | null> {
   try {
-    const gitDir = await execAsync("git", ["rev-parse", "--git-dir"], cwd);
-    const commonDir = await execAsync(
-      "git",
-      ["rev-parse", "--git-common-dir"],
-      cwd,
-    );
-    const branch = await execAsync(
-      "git",
-      ["rev-parse", "--abbrev-ref", "HEAD"],
-      cwd,
-    ).catch(() => "detached");
-    const topLevel = await execAsync(
-      "git",
-      ["rev-parse", "--show-toplevel"],
-      cwd,
-    );
+    const [gitDir, commonDir, branch, topLevel] = (
+      await execAsync(
+        "git",
+        [
+          "rev-parse",
+          "--git-dir",
+          "--git-common-dir",
+          "--abbrev-ref",
+          "HEAD",
+          "--show-toplevel",
+        ],
+        cwd,
+      )
+    ).split(/\r?\n/);
+    if (!gitDir || !commonDir || !topLevel) return null;
 
     const gitDirPath = resolve(cwd, gitDir);
     const commonDirPath = resolve(cwd, commonDir);
@@ -135,7 +136,7 @@ export async function detectGitProject(
 
     return {
       isWorktree,
-      branch,
+      branch: branch || null,
       topLevel,
       mainRepoRoot,
       gitDir: gitDirPath,
@@ -150,7 +151,8 @@ export async function resolveProjectIdentity(input: {
   project?: string | null;
   cwd?: string | null;
 }): Promise<ProjectIdentity> {
-  const cwd = cleanValue(input.cwd) ?? cleanValue(input.project) ?? process.cwd();
+  const cwd =
+    cleanValue(input.cwd) ?? cleanValue(input.project) ?? process.cwd();
   const requestedProject = cleanValue(input.project) ?? cwd;
   const git = await detectGitProject(cwd);
   const project = git?.mainRepoRoot ?? requestedProject;

--- a/src/functions/project-identity.ts
+++ b/src/functions/project-identity.ts
@@ -3,6 +3,7 @@ import { basename, resolve, sep } from "node:path";
 
 const DEFAULT_GIT_IDENTITY_TIMEOUT_MS = 500;
 const GIT_IDENTITY_TIMEOUT_ENV = "AGENTMEMORY_GIT_IDENTITY_TIMEOUT_MS";
+const MAX_GIT_PROJECT_CACHE_KEYS = 512;
 
 export interface GitProjectInfo {
   isWorktree: boolean;
@@ -21,6 +22,20 @@ export interface ProjectIdentity {
 }
 
 const gitProjectCache = new Map<string, GitProjectInfo>();
+
+function touchGitProjectCache(
+  key: string,
+  git: GitProjectInfo,
+): GitProjectInfo {
+  gitProjectCache.delete(key);
+  gitProjectCache.set(key, git);
+  while (gitProjectCache.size > MAX_GIT_PROJECT_CACHE_KEYS) {
+    const oldestKey = gitProjectCache.keys().next().value;
+    if (!oldestKey) break;
+    gitProjectCache.delete(oldestKey);
+  }
+  return git;
+}
 
 function gitIdentityTimeoutMs(): number {
   const raw = process.env[GIT_IDENTITY_TIMEOUT_ENV];
@@ -72,14 +87,14 @@ function rememberGitProject(cwd: string, git: GitProjectInfo): void {
     git.gitDir,
     git.commonDir,
   ]) {
-    gitProjectCache.set(pathKey(key), git);
+    touchGitProjectCache(pathKey(key), git);
   }
 }
 
 function cachedGitProject(cwd: string): GitProjectInfo | null {
   const target = pathKey(cwd);
   const exact = gitProjectCache.get(target);
-  if (exact) return exact;
+  if (exact) return touchGitProjectCache(target, exact);
 
   let best: { key: string; git: GitProjectInfo } | null = null;
   for (const [key, git] of gitProjectCache) {
@@ -87,7 +102,7 @@ function cachedGitProject(cwd: string): GitProjectInfo | null {
     if (!target.startsWith(prefix)) continue;
     if (!best || key.length > best.key.length) best = { key, git };
   }
-  return best?.git ?? null;
+  return best ? touchGitProjectCache(best.key, best.git) : null;
 }
 
 function normalizeBranch(branch: string | undefined): string | null {

--- a/src/functions/search.ts
+++ b/src/functions/search.ts
@@ -8,6 +8,7 @@ import type { EmbeddingProvider } from '../types.js'
 import { memoryToObservation } from '../state/memory-utils.js'
 import { recordAccessBatch } from './access-tracker.js'
 import { logger } from "../logger.js";
+import { expandProjectAliases, sessionMatchesProjectAliases } from './project-identity.js'
 
 let index: SearchIndex | null = null
 let vectorIndex: VectorIndex | null = null
@@ -189,6 +190,9 @@ export function registerSearchFunction(sdk: ISdk, kv: StateKV): void {
       }
       const projectFilter = typeof data.project === 'string' && data.project.length > 0 ? data.project : undefined
       const cwdFilter = typeof data.cwd === 'string' && data.cwd.length > 0 ? data.cwd : undefined
+      const projectAliases = projectFilter
+        ? new Set(expandProjectAliases(projectFilter, cwdFilter))
+        : undefined
       const format = typeof data.format === 'string' ? data.format : 'full'
       if (!['full', 'compact', 'narrative'].includes(format)) {
         throw new Error("mem::search: format must be one of 'full', 'compact', or 'narrative'")
@@ -228,7 +232,9 @@ export function registerSearchFunction(sdk: ISdk, kv: StateKV): void {
         if (filtering) {
           const s = await loadSession(r.sessionId)
           if (!s) continue
-          if (projectFilter && s.project !== projectFilter) continue
+          if (projectAliases && !sessionMatchesProjectAliases(s, projectAliases)) {
+            continue
+          }
           if (cwdFilter && s.cwd !== cwdFilter) continue
         }
         candidates.push(r)

--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -18,6 +18,7 @@ import {
   detectEmbeddingProvider,
   detectLlmProviderKind,
 } from "../config.js";
+import { resolveProjectIdentity } from "../functions/project-identity.js";
 
 type Response = {
   status_code: number;
@@ -533,10 +534,11 @@ export function registerApiTriggers(
         };
       }
       const title = typeof body.title === "string" ? body.title.trim() : undefined;
+      const identity = await resolveProjectIdentity({ project, cwd });
       const session: Session = {
         id: sessionId,
-        project,
-        cwd,
+        project: identity.project,
+        cwd: identity.cwd,
         startedAt: new Date().toISOString(),
         status: "active",
         observationCount: 0,
@@ -547,7 +549,10 @@ export function registerApiTriggers(
       const contextResult = await sdk.trigger<
         { sessionId: string; project: string },
         { context: string }
-      >({ function_id: "mem::context", payload: { sessionId, project } });
+      >({
+        function_id: "mem::context",
+        payload: { sessionId, project: identity.project },
+      });
       return {
         status_code: 200,
         body: { session, context: contextResult.context },

--- a/src/triggers/events.ts
+++ b/src/triggers/events.ts
@@ -5,15 +5,20 @@ import { StateKV } from "../state/kv.js";
 import { isReflectEnabled } from "../functions/slots.js";
 import { isGraphExtractionEnabled } from "../config.js";
 import { logger } from "../logger.js";
+import { resolveProjectIdentity } from "../functions/project-identity.js";
 
 export function registerEventTriggers(sdk: ISdk, kv: StateKV): void {
   sdk.registerFunction(
     "event::session::started",
     async (data: { sessionId: string; project: string; cwd: string }) => {
-      const session: Session = {
-        id: data.sessionId,
+      const identity = await resolveProjectIdentity({
         project: data.project,
         cwd: data.cwd,
+      });
+      const session: Session = {
+        id: data.sessionId,
+        project: identity.project,
+        cwd: identity.cwd,
         startedAt: new Date().toISOString(),
         status: "active",
         observationCount: 0,
@@ -24,7 +29,7 @@ export function registerEventTriggers(sdk: ISdk, kv: StateKV): void {
         { context: string }
       >({
         function_id: "mem::context",
-        payload: { sessionId: data.sessionId, project: data.project },
+        payload: { sessionId: data.sessionId, project: identity.project },
       });
       return { session, context: contextResult.context };
     },

--- a/test/context-project-alias.test.ts
+++ b/test/context-project-alias.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerContextFunction } from "../src/functions/context.js";
+import type { StateKV } from "../src/state/kv.js";
+import { KV } from "../src/state/schema.js";
+import type { Lesson, Session, SessionSummary } from "../src/types.js";
+
+function mockKV() {
+  const store = new Map<string, Map<string, unknown>>();
+  return {
+    get: async <T>(scope: string, key: string): Promise<T | null> => {
+      return (store.get(scope)?.get(key) as T) ?? null;
+    },
+    set: async <T>(scope: string, key: string, data: T): Promise<T> => {
+      if (!store.has(scope)) store.set(scope, new Map());
+      store.get(scope)!.set(key, data);
+      return data;
+    },
+    list: async <T>(scope: string): Promise<T[]> => {
+      const entries = store.get(scope);
+      return entries ? (Array.from(entries.values()) as T[]) : [];
+    },
+  };
+}
+
+type ContextHandler = (data: {
+  sessionId: string;
+  project: string;
+  budget?: number;
+}) => Promise<{ context: string; blocks: number; tokens: number }>;
+
+function wireContext(kv: ReturnType<typeof mockKV>) {
+  let handler: ContextHandler | undefined;
+  const sdk = {
+    registerFunction: vi.fn((id: string, cb: ContextHandler) => {
+      if (id === "mem::context") handler = cb;
+    }),
+  } as unknown as import("iii-sdk").ISdk;
+  registerContextFunction(sdk, kv as unknown as StateKV, 4000);
+  if (!handler) throw new Error("mem::context not registered");
+  return handler;
+}
+
+function makeSession(overrides: Partial<Session>): Session {
+  return {
+    id: "ses",
+    project: "/tmp/repo",
+    cwd: "/tmp/repo",
+    startedAt: "2026-01-01T00:00:00Z",
+    status: "active",
+    observationCount: 0,
+    ...overrides,
+  };
+}
+
+function makeLesson(overrides: Partial<Lesson>): Lesson {
+  return {
+    id: "lesson_worktree",
+    content: "reuse the project memory when launched from a Codex worktree",
+    context: "",
+    confidence: 0.9,
+    reinforcements: 1,
+    source: "manual",
+    sourceIds: [],
+    tags: [],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    decayRate: 0.05,
+    ...overrides,
+  };
+}
+
+describe("mem::context project aliases", () => {
+  let kv: ReturnType<typeof mockKV>;
+  let handler: ContextHandler;
+
+  beforeEach(() => {
+    kv = mockKV();
+    handler = wireContext(kv);
+  });
+
+  it("loads lessons and summaries saved under the current worktree cwd", async () => {
+    const canonicalProject = "/tmp/repo";
+    const worktreeCwd = "/tmp/repo-worktrees/feature";
+
+    const current = makeSession({
+      id: "ses_current",
+      project: canonicalProject,
+      cwd: worktreeCwd,
+    });
+    const legacy = makeSession({
+      id: "ses_legacy",
+      project: worktreeCwd,
+      cwd: worktreeCwd,
+      startedAt: "2026-01-02T00:00:00Z",
+      status: "completed",
+    });
+    const summary: SessionSummary = {
+      sessionId: legacy.id,
+      title: "Worktree context carried over",
+      narrative: "Previous Codex worktree session found the API mismatch.",
+      keyDecisions: ["canonicalize project identity"],
+      filesModified: ["src/functions/project-identity.ts"],
+      createdAt: "2026-01-02T00:00:00Z",
+    };
+    const lesson = makeLesson({ project: worktreeCwd });
+
+    await kv.set(KV.sessions, current.id, current);
+    await kv.set(KV.sessions, legacy.id, legacy);
+    await kv.set(KV.summaries, legacy.id, summary);
+    await kv.set(KV.lessons, lesson.id, lesson);
+
+    const result = await handler({
+      sessionId: current.id,
+      project: canonicalProject,
+    });
+
+    expect(result.context).toContain("reuse the project memory");
+    expect(result.context).toContain("Worktree context carried over");
+    expect(result.context).toContain("canonicalize project identity");
+  });
+});

--- a/test/context-project-alias.test.ts
+++ b/test/context-project-alias.test.ts
@@ -37,14 +37,17 @@ type ContextHandler = (data: {
   budget?: number;
 }) => Promise<{ context: string; blocks: number; tokens: number }>;
 
+const registerFunction = vi.fn();
+const sdk = {
+  registerFunction,
+} as unknown as ISdk;
+
 function wireContext(kv: ReturnType<typeof mockKV>) {
   let handler: ContextHandler | undefined;
-  const registerFunction = vi.fn((id: string, cb: ContextHandler) => {
+  registerFunction.mockReset();
+  registerFunction.mockImplementation((id: string, cb: ContextHandler) => {
     if (id === "mem::context") handler = cb;
   });
-  const sdk = {
-    registerFunction,
-  } as unknown as ISdk;
   registerContextFunction(sdk, kv as unknown as StateKV, 4000);
   if (!handler) throw new Error("mem::context not registered");
   return handler;

--- a/test/context-project-alias.test.ts
+++ b/test/context-project-alias.test.ts
@@ -3,6 +3,15 @@ import { registerContextFunction } from "../src/functions/context.js";
 import type { StateKV } from "../src/state/kv.js";
 import { KV } from "../src/state/schema.js";
 import type { Lesson, Session, SessionSummary } from "../src/types.js";
+import type { ISdk } from "iii-sdk";
+
+vi.mock("iii-sdk", () => ({
+  TriggerAction: {
+    Enqueue: vi.fn(),
+    Void: vi.fn(),
+  },
+  registerWorker: vi.fn(),
+}));
 
 function mockKV() {
   const store = new Map<string, Map<string, unknown>>();
@@ -30,11 +39,12 @@ type ContextHandler = (data: {
 
 function wireContext(kv: ReturnType<typeof mockKV>) {
   let handler: ContextHandler | undefined;
+  const registerFunction = vi.fn((id: string, cb: ContextHandler) => {
+    if (id === "mem::context") handler = cb;
+  });
   const sdk = {
-    registerFunction: vi.fn((id: string, cb: ContextHandler) => {
-      if (id === "mem::context") handler = cb;
-    }),
-  } as unknown as import("iii-sdk").ISdk;
+    registerFunction,
+  } as unknown as ISdk;
   registerContextFunction(sdk, kv as unknown as StateKV, 4000);
   if (!handler) throw new Error("mem::context not registered");
   return handler;

--- a/test/project-identity.test.ts
+++ b/test/project-identity.test.ts
@@ -46,6 +46,53 @@ describe("project identity", () => {
     expect(identity.aliases).toContain("repo");
   });
 
+  it("reuses a cached git identity when a later lookup fails under the same repo path", async () => {
+    const root = mkdtempSync(join(tmpdir(), "agentmemory-project-cache-"));
+    const mainRepo = join(root, "repo");
+    const worktree = join(root, "repo-feature");
+
+    execFileSync("git", ["init", mainRepo], { stdio: "ignore" });
+    git(mainRepo, ["config", "user.name", "AgentMemory Test"]);
+    git(mainRepo, ["config", "user.email", "agentmemory@example.com"]);
+    writeFileSync(join(mainRepo, "README.md"), "# test\n");
+    git(mainRepo, ["add", "README.md"]);
+    git(mainRepo, ["commit", "-m", "init"]);
+    git(mainRepo, ["worktree", "add", "-b", "feature", worktree]);
+
+    const identity = await resolveProjectIdentity({
+      project: worktree,
+      cwd: worktree,
+    });
+    const fallback = await resolveProjectIdentity({
+      project: join(worktree, "missing-dir"),
+      cwd: join(worktree, "missing-dir"),
+    });
+
+    expect(fallback.project).toBe(identity.project);
+    expect(fallback.git?.mainRepoRoot).toBe(identity.git?.mainRepoRoot);
+  });
+
+  it("normalizes detached HEAD to a null branch name", async () => {
+    const root = mkdtempSync(join(tmpdir(), "agentmemory-project-detached-"));
+    const mainRepo = join(root, "repo");
+
+    execFileSync("git", ["init", mainRepo], { stdio: "ignore" });
+    git(mainRepo, ["config", "user.name", "AgentMemory Test"]);
+    git(mainRepo, ["config", "user.email", "agentmemory@example.com"]);
+    writeFileSync(join(mainRepo, "README.md"), "# test\n");
+    git(mainRepo, ["add", "README.md"]);
+    git(mainRepo, ["commit", "-m", "init"]);
+    const commit = git(mainRepo, ["rev-parse", "HEAD"]);
+    git(mainRepo, ["checkout", commit]);
+
+    const identity = await resolveProjectIdentity({
+      project: mainRepo,
+      cwd: mainRepo,
+    });
+
+    expect(identity.git?.branch).toBeNull();
+  });
+
   it("matches sessions saved under project aliases and nested cwd paths", () => {
     const aliases = new Set(
       expandProjectAliases("/tmp/repo", "/tmp/repo-worktrees/feature"),

--- a/test/project-identity.test.ts
+++ b/test/project-identity.test.ts
@@ -1,0 +1,89 @@
+import { mkdtempSync, realpathSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+import {
+  expandProjectAliases,
+  resolveProjectIdentity,
+  sessionMatchesProjectAliases,
+} from "../src/functions/project-identity.js";
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+describe("project identity", () => {
+  it("canonicalizes git worktree sessions to the main repository root", async () => {
+    const root = mkdtempSync(join(tmpdir(), "agentmemory-project-"));
+    const mainRepo = join(root, "repo");
+    const worktree = join(root, "repo-feature");
+
+    execFileSync("git", ["init", mainRepo], { stdio: "ignore" });
+    git(mainRepo, ["config", "user.name", "AgentMemory Test"]);
+    git(mainRepo, ["config", "user.email", "agentmemory@example.com"]);
+    writeFileSync(join(mainRepo, "README.md"), "# test\n");
+    git(mainRepo, ["add", "README.md"]);
+    git(mainRepo, ["commit", "-m", "init"]);
+    git(mainRepo, ["worktree", "add", "-b", "feature", worktree]);
+
+    const identity = await resolveProjectIdentity({
+      project: worktree,
+      cwd: worktree,
+    });
+
+    const realMainRepo = realpathSync(mainRepo);
+
+    expect(identity.project).toBe(realMainRepo);
+    expect(identity.cwd).toBe(worktree);
+    expect(identity.git?.isWorktree).toBe(true);
+    expect(identity.aliases).toContain(realMainRepo);
+    expect(identity.aliases).toContain(worktree);
+    expect(identity.aliases).toContain("repo");
+  });
+
+  it("matches sessions saved under project aliases and nested cwd paths", () => {
+    const aliases = new Set(
+      expandProjectAliases("/tmp/repo", "/tmp/repo-worktrees/feature"),
+    );
+
+    expect(
+      sessionMatchesProjectAliases(
+        {
+          project: "/tmp/repo-worktrees/feature",
+          cwd: "/tmp/repo-worktrees/feature/src",
+        },
+        aliases,
+      ),
+    ).toBe(true);
+
+    expect(
+      sessionMatchesProjectAliases(
+        { project: "other", cwd: "/tmp/other/src" },
+        aliases,
+      ),
+    ).toBe(false);
+  });
+
+  it("does not match unrelated path-like projects only by basename", () => {
+    const aliases = new Set(expandProjectAliases("/tmp/team-a/app"));
+
+    expect(
+      sessionMatchesProjectAliases(
+        { project: "/tmp/team-b/app", cwd: "/tmp/team-b/app" },
+        aliases,
+      ),
+    ).toBe(false);
+
+    expect(
+      sessionMatchesProjectAliases(
+        { project: "app", cwd: "/tmp/legacy/app" },
+        aliases,
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- canonicalize session project identity to the main git repo root on session start while preserving the actual cwd
- reuse the shared git worktree detector for branch-aware project metadata
- let context/search project matching include canonical project, cwd, worktree top-level, main repo root, and project-name aliases so existing worktree-scoped memory can still surface

Fixes #515

## Tests
- npm test -- test/project-identity.test.ts test/context-project-alias.test.ts
- npm test
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project identity is normalized and expanded into alias sets (including path-like aliases), improving session creation, search, and context selection.
  * Session creation and event handling now persist normalized project/cwd identity so memories saved in worktrees are recognized and reused across main-repo/worktree boundaries.
  * Search and context lookups now match sessions and lessons by expanded project aliases, producing more relevant results across related paths.

* **Tests**
  * Added tests validating project identity canonicalization, worktree handling, alias matching, and alias-aware context/search behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/530?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->