### PR TITLE
fix(cli): include auth on demo REST calls

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,6 +43,10 @@ import { isFirstRun, readPrefs, resetPrefs, writePrefs } from "./cli/preferences
 import { runOnboarding } from "./cli/onboarding.js";
 import { setBootVerbose } from "./logger.js";
 import { VERSION } from "./version.js";
+import {
+  agentmemoryAuthHeaders,
+  agentmemoryJsonHeaders,
+} from "./cli/http-auth.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const args = process.argv.slice(2);
@@ -1067,12 +1071,9 @@ async function main() {
 
 async function apiFetch<T = unknown>(base: string, path: string, timeoutMs = 5000): Promise<T | null> {
   try {
-    const headers: Record<string, string> = {};
-    const secret = process.env["AGENTMEMORY_SECRET"];
-    if (secret) headers["Authorization"] = `Bearer ${secret}`;
     const res = await fetch(`${base}/agentmemory/${path}`, {
       signal: AbortSignal.timeout(timeoutMs),
-      headers,
+      headers: agentmemoryAuthHeaders(),
     });
     return (await res.json()) as T;
   } catch {
@@ -1691,7 +1692,7 @@ async function postJson<T = unknown>(
   try {
     const res = await fetch(url, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: agentmemoryJsonHeaders(),
       body: JSON.stringify(body),
       signal: AbortSignal.timeout(timeoutMs),
     });
@@ -1709,7 +1710,7 @@ async function postJsonStrict<T = unknown>(
 ): Promise<T | null> {
   const res = await fetch(url, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: agentmemoryJsonHeaders(),
     body: JSON.stringify(body),
     signal: AbortSignal.timeout(timeoutMs),
   });
@@ -1751,7 +1752,7 @@ async function seedDemoSession(
     try {
       const res = await fetch(url, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: agentmemoryJsonHeaders(),
         body: JSON.stringify(payload),
         signal: AbortSignal.timeout(5000),
       });

--- a/src/cli/http-auth.ts
+++ b/src/cli/http-auth.ts
@@ -1,0 +1,15 @@
+export function agentmemoryAuthHeaders(
+  env: NodeJS.ProcessEnv = process.env,
+): Record<string, string> {
+  const secret = env["AGENTMEMORY_SECRET"]?.trim();
+  return secret ? { Authorization: `Bearer ${secret}` } : {};
+}
+
+export function agentmemoryJsonHeaders(
+  env: NodeJS.ProcessEnv = process.env,
+): Record<string, string> {
+  return {
+    "Content-Type": "application/json",
+    ...agentmemoryAuthHeaders(env),
+  };
+}

--- a/test/cli-http-auth.test.ts
+++ b/test/cli-http-auth.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import {
+  agentmemoryAuthHeaders,
+  agentmemoryJsonHeaders,
+} from "../src/cli/http-auth.js";
+
+describe("CLI HTTP auth headers", () => {
+  it("omits Authorization when AGENTMEMORY_SECRET is unset", () => {
+    expect(agentmemoryAuthHeaders({})).toEqual({});
+    expect(agentmemoryJsonHeaders({})).toEqual({
+      "Content-Type": "application/json",
+    });
+  });
+
+  it("adds Bearer auth when AGENTMEMORY_SECRET is configured", () => {
+    const env = { AGENTMEMORY_SECRET: "secret-token" };
+
+    expect(agentmemoryAuthHeaders(env)).toEqual({
+      Authorization: "Bearer secret-token",
+    });
+    expect(agentmemoryJsonHeaders(env)).toEqual({
+      "Content-Type": "application/json",
+      Authorization: "Bearer secret-token",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add shared CLI helpers for AGENTMEMORY_SECRET Bearer headers
- use those helpers for demo/session/observe/smart-search REST calls so `agentmemory demo` works against auth-protected servers
- keep existing unauthenticated behavior unchanged when AGENTMEMORY_SECRET is unset

Addresses the CLI demo/auth reproduction path in #518.

## Tests
- npm test -- test/cli-http-auth.test.ts
- npm test
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized HTTP header construction to centralize authentication and JSON content-type header handling in the CLI.

* **Tests**
  * Added test coverage for HTTP header utilities to verify proper header generation with and without authentication credentials.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/531?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->