### PR TITLE
fix(api): add graph build endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,7 @@ Hook scripts in `src/hooks/` are standalone Node.js scripts (no iii-sdk import).
 ## Current Stats (v0.9.16)
 
 - 53 MCP tools (8 visible by default, `AGENTMEMORY_TOOLS=all` for all)
-- 124 REST endpoints
+- 125 REST endpoints
 - 6 MCP resources, 3 MCP prompts
 - 12 hooks, 4 skills
 - 50+ iii functions

--- a/README.md
+++ b/README.md
@@ -1173,7 +1173,7 @@ Create `~/.agentmemory/.env`:
 
 <h2 id="api"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/section-api.svg"><img src="assets/tags/section-api.svg" alt="API" height="32" /></picture></h2>
 
-124 endpoints on port `3111`. The REST API binds to `127.0.0.1` by default. Protected endpoints require `Authorization: Bearer <secret>` when `AGENTMEMORY_SECRET` is set, and mesh sync endpoints require `AGENTMEMORY_SECRET` on both peers.
+125 endpoints on port `3111`. The REST API binds to `127.0.0.1` by default. Protected endpoints require `Authorization: Bearer <secret>` when `AGENTMEMORY_SECRET` is set, and mesh sync endpoints require `AGENTMEMORY_SECRET` on both peers.
 
 <details>
 <summary>Key endpoints</summary>

--- a/src/index.ts
+++ b/src/index.ts
@@ -473,7 +473,7 @@ async function main() {
     `Ready. ${embeddingProvider ? "Triple-stream (BM25+Vector+Graph)" : "BM25+Graph"} search active.`,
   );
   bootLog(
-    `REST API: 124 endpoints at http://localhost:${config.restPort}/agentmemory/*`,
+    `REST API: 125 endpoints at http://localhost:${config.restPort}/agentmemory/*`,
   );
   bootLog(
     `MCP surface (opt-in via \`npx @agentmemory/mcp\`): ${getAllTools().length} tools · 6 resources · 3 prompts`,

--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -1,8 +1,15 @@
 import type { ISdk, ApiRequest } from "iii-sdk";
-import type { Session, CompressedObservation, HookPayload, CommitLink } from "../types.js";
+import type {
+  Session,
+  CompressedObservation,
+  HookPayload,
+  CommitLink,
+  Memory,
+} from "../types.js";
 import { withKeyedLock } from "../state/keyed-mutex.js";
 import { KV } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
+import { memoryToObservation } from "../state/memory-utils.js";
 import { getLatestHealth } from "../health/monitor.js";
 import type { MetricsStore } from "../eval/metrics-store.js";
 import type { ResilientProvider } from "../providers/resilient.js";
@@ -18,12 +25,17 @@ import {
   detectEmbeddingProvider,
   detectLlmProviderKind,
 } from "../config.js";
+import { logger } from "../logger.js";
 
 type Response = {
   status_code: number;
   headers?: Record<string, string>;
   body: unknown;
 };
+
+const GRAPH_BUILD_DEFAULT_LIMIT = 200;
+const GRAPH_BUILD_MAX_LIMIT = 500;
+const GRAPH_BUILD_BATCH_SIZE = 20;
 
 function parseOptionalInt(raw: unknown): number | undefined {
   if (raw === undefined || raw === null || raw === "") return undefined;
@@ -110,6 +122,80 @@ function parseOptionalPositiveInt(value: unknown): number | undefined | null {
   if (parsed === undefined || parsed === null) return parsed;
   if (!Number.isInteger(parsed) || parsed < 1) return null;
   return parsed;
+}
+
+function messageFromError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isMissingGraphExtractFunction(error: unknown): boolean {
+  const message = messageFromError(error).toLowerCase();
+  return (
+    message.includes("mem::graph-extract") &&
+    (message.includes("no function") ||
+      message.includes("not registered") ||
+      message.includes("not found") ||
+      message.includes("unknown function"))
+  );
+}
+
+async function collectGraphBuildObservations(
+  kv: StateKV,
+  limit: number,
+): Promise<{ observations: CompressedObservation[]; truncated: boolean }> {
+  const observations: CompressedObservation[] = [];
+  const seen = new Set<string>();
+
+  const list = async <T>(scope: string): Promise<T[]> => {
+    try {
+      return await kv.list<T>(scope);
+    } catch (error) {
+      logger.error("Graph build KV list failed", {
+        scope,
+        error: messageFromError(error),
+      });
+      throw error;
+    }
+  };
+
+  const pushObservation = (obs: CompressedObservation | null | undefined) => {
+    if (!obs?.id || seen.has(obs.id) || observations.length >= limit) return;
+    if (!obs.title || !obs.narrative) return;
+    seen.add(obs.id);
+    observations.push(obs);
+  };
+
+  const sessions = await list<Session>(KV.sessions);
+  for (let i = 0; i < sessions.length && observations.length < limit; i += 10) {
+    const chunk = sessions.slice(i, i + 10);
+    const perSession = await Promise.all(
+      chunk.map((session) =>
+        list<CompressedObservation>(KV.observations(session.id)),
+      ),
+    );
+    for (const sessionObservations of perSession) {
+      for (const obs of sessionObservations) {
+        pushObservation(obs);
+        if (observations.length >= limit) break;
+      }
+      if (observations.length >= limit) break;
+    }
+  }
+
+  const memories = await list<Memory>(KV.memories);
+  for (const memory of memories) {
+    if (observations.length >= limit) break;
+    if (memory.isLatest === false) continue;
+    pushObservation(memoryToObservation(memory));
+  }
+
+  const availableCount =
+    sessions.reduce((sum, session) => sum + (session.observationCount || 0), 0) +
+    memories.filter((memory) => memory.isLatest !== false).length;
+  return {
+    observations,
+    truncated: availableCount > observations.length,
+  };
 }
 
 export function registerApiTriggers(
@@ -1249,6 +1335,128 @@ export function registerApiTriggers(
     type: "http",
     function_id: "api::graph-extract",
     config: { api_path: "/agentmemory/graph/extract", http_method: "POST" },
+  });
+
+  sdk.registerFunction("api::graph-build",
+    async (
+      req: ApiRequest<{
+        limit?: number | string;
+      }>,
+    ): Promise<Response> => {
+      const authErr = checkAuth(req, secret);
+      if (authErr) return authErr;
+
+      const parsedLimit = parseOptionalPositiveInt(req.body?.limit);
+      if (parsedLimit === null) {
+        return {
+          status_code: 400,
+          body: { error: "limit must be a positive integer" },
+        };
+      }
+      const limit = Math.min(
+        parsedLimit ?? GRAPH_BUILD_DEFAULT_LIMIT,
+        GRAPH_BUILD_MAX_LIMIT,
+      );
+
+      let collected: {
+        observations: CompressedObservation[];
+        truncated: boolean;
+      };
+      try {
+        collected = await collectGraphBuildObservations(kv, limit);
+      } catch (error) {
+        return {
+          status_code: 500,
+          body: {
+            success: false,
+            observationsProcessed: 0,
+            nodesAdded: 0,
+            edgesAdded: 0,
+            truncated: false,
+            errors: [
+              `Failed to collect graph inputs: ${messageFromError(error)}`,
+            ],
+          },
+        };
+      }
+
+      if (collected.observations.length === 0) {
+        return {
+          status_code: 200,
+          body: {
+            success: false,
+            observationsProcessed: 0,
+            nodesAdded: 0,
+            edgesAdded: 0,
+            truncated: false,
+            error: "No observations or memories found to build the graph",
+          },
+        };
+      }
+
+      let nodesAdded = 0;
+      let edgesAdded = 0;
+      const errors: string[] = [];
+      for (
+        let i = 0;
+        i < collected.observations.length;
+        i += GRAPH_BUILD_BATCH_SIZE
+      ) {
+        const batch = collected.observations.slice(
+          i,
+          i + GRAPH_BUILD_BATCH_SIZE,
+        );
+        try {
+          const result = (await sdk.trigger({
+            function_id: "mem::graph-extract",
+            payload: { observations: batch },
+          })) as {
+            success?: boolean;
+            nodesAdded?: number;
+            edgesAdded?: number;
+            error?: string;
+          };
+          if (result.success === false) {
+            errors.push(
+              `Batch ${Math.floor(i / GRAPH_BUILD_BATCH_SIZE) + 1}: ${
+                result.error || "graph extraction failed"
+              }`,
+            );
+            continue;
+          }
+          nodesAdded += result.nodesAdded || 0;
+          edgesAdded += result.edgesAdded || 0;
+        } catch (error) {
+          if (isMissingGraphExtractFunction(error)) {
+            return graphDisabledResponse();
+          }
+          const batchNumber = Math.floor(i / GRAPH_BUILD_BATCH_SIZE) + 1;
+          errors.push(
+            `Batch ${batchNumber}: ${messageFromError(error)}`,
+          );
+        }
+      }
+
+      return {
+        status_code: 200,
+        body: {
+          success: errors.length === 0,
+          observationsProcessed: collected.observations.length,
+          batches: Math.ceil(
+            collected.observations.length / GRAPH_BUILD_BATCH_SIZE,
+          ),
+          nodesAdded,
+          edgesAdded,
+          truncated: collected.truncated,
+          ...(errors.length ? { errors } : {}),
+        },
+      };
+    },
+  );
+  sdk.registerTrigger({
+    type: "http",
+    function_id: "api::graph-build",
+    config: { api_path: "/agentmemory/graph/build", http_method: "POST" },
   });
 
   sdk.registerFunction("api::consolidate-pipeline", 

--- a/test/api-graph-build.test.ts
+++ b/test/api-graph-build.test.ts
@@ -4,54 +4,74 @@ vi.mock("../src/logger.js", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
+vi.mock("iii-sdk", () => ({
+  TriggerAction: {
+    Enqueue: vi.fn(),
+    Void: vi.fn(),
+  },
+  registerWorker: vi.fn(),
+}));
+
 import { registerGraphFunction } from "../src/functions/graph.js";
 import { registerApiTriggers } from "../src/triggers/api.js";
 import { KV } from "../src/state/schema.js";
 import type { CompressedObservation, Memory, Session } from "../src/types.js";
 
-function mockKV() {
+type RegisteredHandler = (payload: unknown) => unknown | Promise<unknown>;
+type RegisteredTrigger = {
+  function_id: string;
+  config?: { api_path?: string };
+};
+
+function createMockKV() {
   const store = new Map<string, Map<string, unknown>>();
   return {
-    get: async <T>(scope: string, key: string): Promise<T | null> => {
+    get: vi.fn(async <T>(scope: string, key: string): Promise<T | null> => {
       return (store.get(scope)?.get(key) as T) ?? null;
-    },
-    set: async <T>(scope: string, key: string, data: T): Promise<T> => {
+    }),
+    set: vi.fn(async <T>(scope: string, key: string, data: T): Promise<T> => {
       if (!store.has(scope)) store.set(scope, new Map());
       store.get(scope)!.set(key, data);
       return data;
-    },
-    delete: async (scope: string, key: string): Promise<void> => {
+    }),
+    delete: vi.fn(async (scope: string, key: string): Promise<void> => {
       store.get(scope)?.delete(key);
-    },
-    list: async <T>(scope: string): Promise<T[]> => {
+    }),
+    list: vi.fn(async <T>(scope: string): Promise<T[]> => {
       const entries = store.get(scope);
       return entries ? (Array.from(entries.values()) as T[]) : [];
-    },
+    }),
   };
 }
 
-function mockSdk() {
-  const functions = new Map<string, Function>();
-  const triggers: Array<{ function_id: string; config?: { api_path?: string } }> = [];
+function createMockSdk() {
+  const functions = new Map<string, RegisteredHandler>();
+  const triggers: RegisteredTrigger[] = [];
   return {
     triggers,
-    registerFunction: (idOrOpts: string | { id: string }, handler: Function) => {
-      const id = typeof idOrOpts === "string" ? idOrOpts : idOrOpts.id;
-      functions.set(id, handler);
-    },
-    registerTrigger: (trigger: { function_id: string; config?: { api_path?: string } }) => {
+    registerFunction: vi.fn(
+      (idOrOpts: string | { id: string }, handler: RegisteredHandler) => {
+        const id = typeof idOrOpts === "string" ? idOrOpts : idOrOpts.id;
+        functions.set(id, handler);
+      },
+    ),
+    registerTrigger: vi.fn((trigger: RegisteredTrigger) => {
       triggers.push(trigger);
-    },
-    trigger: async (
-      idOrInput: string | { function_id: string; payload: unknown },
-      data?: unknown,
-    ) => {
-      const id = typeof idOrInput === "string" ? idOrInput : idOrInput.function_id;
-      const payload = typeof idOrInput === "string" ? data : idOrInput.payload;
-      const fn = functions.get(id);
-      if (!fn) throw new Error(`No function: ${id}`);
-      return fn(payload);
-    },
+    }),
+    trigger: vi.fn(
+      async (
+        idOrInput: string | { function_id: string; payload: unknown },
+        data?: unknown,
+      ) => {
+        const id =
+          typeof idOrInput === "string" ? idOrInput : idOrInput.function_id;
+        const payload =
+          typeof idOrInput === "string" ? data : idOrInput.payload;
+        const fn = functions.get(id);
+        if (!fn) throw new Error(`No function: ${id}`);
+        return fn(payload);
+      },
+    ),
   };
 }
 
@@ -101,8 +121,8 @@ function makeMemory(id: string): Memory {
 
 describe("api::graph-build", () => {
   it("registers POST /agentmemory/graph/build and backfills graph data (#505)", async () => {
-    const sdk = mockSdk();
-    const kv = mockKV();
+    const sdk = createMockSdk();
+    const kv = createMockKV();
     registerGraphFunction(sdk as never, kv as never, mockProvider as never);
     registerApiTriggers(sdk as never, kv as never);
 
@@ -115,7 +135,11 @@ describe("api::graph-build", () => {
       observationCount: 1,
     };
     await kv.set(KV.sessions, session.id, session);
-    await kv.set(KV.observations(session.id), "obs_1", makeObservation("obs_1"));
+    await kv.set(
+      KV.observations(session.id),
+      "obs_1",
+      makeObservation("obs_1"),
+    );
     await kv.set(KV.memories, "mem_1", makeMemory("mem_1"));
 
     const trigger = sdk.triggers.find(
@@ -136,8 +160,8 @@ describe("api::graph-build", () => {
   });
 
   it("validates graph build limit", async () => {
-    const sdk = mockSdk();
-    const kv = mockKV();
+    const sdk = createMockSdk();
+    const kv = createMockKV();
     registerApiTriggers(sdk as never, kv as never);
 
     const response = (await sdk.trigger("api::graph-build", {
@@ -150,8 +174,8 @@ describe("api::graph-build", () => {
   });
 
   it("marks graph build results as truncated when limit cuts off inputs", async () => {
-    const sdk = mockSdk();
-    const kv = mockKV();
+    const sdk = createMockSdk();
+    const kv = createMockKV();
     registerGraphFunction(sdk as never, kv as never, mockProvider as never);
     registerApiTriggers(sdk as never, kv as never);
 
@@ -164,8 +188,16 @@ describe("api::graph-build", () => {
       observationCount: 2,
     };
     await kv.set(KV.sessions, session.id, session);
-    await kv.set(KV.observations(session.id), "obs_1", makeObservation("obs_1"));
-    await kv.set(KV.observations(session.id), "obs_2", makeObservation("obs_2"));
+    await kv.set(
+      KV.observations(session.id),
+      "obs_1",
+      makeObservation("obs_1"),
+    );
+    await kv.set(
+      KV.observations(session.id),
+      "obs_2",
+      makeObservation("obs_2"),
+    );
 
     const response = (await sdk.trigger("api::graph-build", {
       headers: {},
@@ -181,8 +213,8 @@ describe("api::graph-build", () => {
   });
 
   it("fails fast when graph build cannot read storage", async () => {
-    const sdk = mockSdk();
-    const kv = mockKV();
+    const sdk = createMockSdk();
+    const kv = createMockKV();
     const failingKv = {
       ...kv,
       list: vi.fn(async (scope: string): Promise<unknown[]> => {
@@ -206,8 +238,8 @@ describe("api::graph-build", () => {
   });
 
   it("reports extraction failures without hiding partial graph build results", async () => {
-    const sdk = mockSdk();
-    const kv = mockKV();
+    const sdk = createMockSdk();
+    const kv = createMockKV();
     registerApiTriggers(sdk as never, kv as never);
     sdk.registerFunction("mem::graph-extract", async () => {
       throw new Error("provider unavailable");
@@ -222,7 +254,11 @@ describe("api::graph-build", () => {
       observationCount: 1,
     };
     await kv.set(KV.sessions, session.id, session);
-    await kv.set(KV.observations(session.id), "obs_1", makeObservation("obs_1"));
+    await kv.set(
+      KV.observations(session.id),
+      "obs_1",
+      makeObservation("obs_1"),
+    );
 
     const response = (await sdk.trigger("api::graph-build", {
       headers: {},
@@ -247,8 +283,8 @@ describe("api::graph-build", () => {
   });
 
   it("returns the graph disabled response when extraction is not registered", async () => {
-    const sdk = mockSdk();
-    const kv = mockKV();
+    const sdk = createMockSdk();
+    const kv = createMockKV();
     registerApiTriggers(sdk as never, kv as never);
 
     const session: Session = {
@@ -260,7 +296,11 @@ describe("api::graph-build", () => {
       observationCount: 1,
     };
     await kv.set(KV.sessions, session.id, session);
-    await kv.set(KV.observations(session.id), "obs_1", makeObservation("obs_1"));
+    await kv.set(
+      KV.observations(session.id),
+      "obs_1",
+      makeObservation("obs_1"),
+    );
 
     const response = (await sdk.trigger("api::graph-build", {
       headers: {},

--- a/test/api-graph-build.test.ts
+++ b/test/api-graph-build.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { registerGraphFunction } from "../src/functions/graph.js";
+import { registerApiTriggers } from "../src/triggers/api.js";
+import { KV } from "../src/state/schema.js";
+import type { CompressedObservation, Memory, Session } from "../src/types.js";
+
+function mockKV() {
+  const store = new Map<string, Map<string, unknown>>();
+  return {
+    get: async <T>(scope: string, key: string): Promise<T | null> => {
+      return (store.get(scope)?.get(key) as T) ?? null;
+    },
+    set: async <T>(scope: string, key: string, data: T): Promise<T> => {
+      if (!store.has(scope)) store.set(scope, new Map());
+      store.get(scope)!.set(key, data);
+      return data;
+    },
+    delete: async (scope: string, key: string): Promise<void> => {
+      store.get(scope)?.delete(key);
+    },
+    list: async <T>(scope: string): Promise<T[]> => {
+      const entries = store.get(scope);
+      return entries ? (Array.from(entries.values()) as T[]) : [];
+    },
+  };
+}
+
+function mockSdk() {
+  const functions = new Map<string, Function>();
+  const triggers: Array<{ function_id: string; config?: { api_path?: string } }> = [];
+  return {
+    triggers,
+    registerFunction: (idOrOpts: string | { id: string }, handler: Function) => {
+      const id = typeof idOrOpts === "string" ? idOrOpts : idOrOpts.id;
+      functions.set(id, handler);
+    },
+    registerTrigger: (trigger: { function_id: string; config?: { api_path?: string } }) => {
+      triggers.push(trigger);
+    },
+    trigger: async (
+      idOrInput: string | { function_id: string; payload: unknown },
+      data?: unknown,
+    ) => {
+      const id = typeof idOrInput === "string" ? idOrInput : idOrInput.function_id;
+      const payload = typeof idOrInput === "string" ? data : idOrInput.payload;
+      const fn = functions.get(id);
+      if (!fn) throw new Error(`No function: ${id}`);
+      return fn(payload);
+    },
+  };
+}
+
+const mockProvider = {
+  name: "test",
+  compress: vi.fn().mockResolvedValue(`<entities>
+<entity type="concept" name="Agent Memory"><property key="kind">memory</property></entity>
+<entity type="file" name="src/memory.ts"><property key="path">src/memory.ts</property></entity>
+</entities>
+<relationships>
+<relationship type="touches" source="Agent Memory" target="src/memory.ts" weight="0.8"/>
+</relationships>`),
+  summarize: vi.fn(),
+};
+
+function makeObservation(id: string): CompressedObservation {
+  return {
+    id,
+    sessionId: "ses_1",
+    timestamp: "2026-05-19T08:00:00Z",
+    type: "decision",
+    title: "Agent memory graph backfill",
+    facts: ["Existing observations should populate the graph"],
+    narrative: "Build a knowledge graph from existing memory observations.",
+    concepts: ["agent-memory", "graph"],
+    files: ["src/memory.ts"],
+    importance: 8,
+  };
+}
+
+function makeMemory(id: string): Memory {
+  return {
+    id,
+    type: "fact",
+    title: "Saved memory graph fact",
+    content: "Explicit memories should also be available to graph build.",
+    concepts: ["agent-memory", "graph"],
+    files: ["src/memory.ts"],
+    sessionIds: [],
+    strength: 7,
+    version: 1,
+    isLatest: true,
+    createdAt: "2026-05-19T08:00:00Z",
+    updatedAt: "2026-05-19T08:00:00Z",
+  };
+}
+
+describe("api::graph-build", () => {
+  it("registers POST /agentmemory/graph/build and backfills graph data (#505)", async () => {
+    const sdk = mockSdk();
+    const kv = mockKV();
+    registerGraphFunction(sdk as never, kv as never, mockProvider as never);
+    registerApiTriggers(sdk as never, kv as never);
+
+    const session: Session = {
+      id: "ses_1",
+      project: "demo",
+      cwd: "/tmp/demo",
+      startedAt: "2026-05-19T08:00:00Z",
+      status: "completed",
+      observationCount: 1,
+    };
+    await kv.set(KV.sessions, session.id, session);
+    await kv.set(KV.observations(session.id), "obs_1", makeObservation("obs_1"));
+    await kv.set(KV.memories, "mem_1", makeMemory("mem_1"));
+
+    const trigger = sdk.triggers.find(
+      (entry) => entry.function_id === "api::graph-build",
+    );
+    expect(trigger?.config?.api_path).toBe("/agentmemory/graph/build");
+
+    const response = (await sdk.trigger("api::graph-build", {
+      headers: {},
+      body: {},
+    })) as { status_code: number; body: Record<string, unknown> };
+
+    expect(response.status_code).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.observationsProcessed).toBe(2);
+    expect(response.body.nodesAdded).toBeGreaterThan(0);
+    expect(response.body.edgesAdded).toBeGreaterThan(0);
+  });
+
+  it("validates graph build limit", async () => {
+    const sdk = mockSdk();
+    const kv = mockKV();
+    registerApiTriggers(sdk as never, kv as never);
+
+    const response = (await sdk.trigger("api::graph-build", {
+      headers: {},
+      body: { limit: 0 },
+    })) as { status_code: number; body: { error?: string } };
+
+    expect(response.status_code).toBe(400);
+    expect(response.body.error).toContain("limit");
+  });
+
+  it("marks graph build results as truncated when limit cuts off inputs", async () => {
+    const sdk = mockSdk();
+    const kv = mockKV();
+    registerGraphFunction(sdk as never, kv as never, mockProvider as never);
+    registerApiTriggers(sdk as never, kv as never);
+
+    const session: Session = {
+      id: "ses_1",
+      project: "demo",
+      cwd: "/tmp/demo",
+      startedAt: "2026-05-19T08:00:00Z",
+      status: "completed",
+      observationCount: 2,
+    };
+    await kv.set(KV.sessions, session.id, session);
+    await kv.set(KV.observations(session.id), "obs_1", makeObservation("obs_1"));
+    await kv.set(KV.observations(session.id), "obs_2", makeObservation("obs_2"));
+
+    const response = (await sdk.trigger("api::graph-build", {
+      headers: {},
+      body: { limit: 1 },
+    })) as {
+      status_code: number;
+      body: { observationsProcessed?: number; truncated?: boolean };
+    };
+
+    expect(response.status_code).toBe(200);
+    expect(response.body.observationsProcessed).toBe(1);
+    expect(response.body.truncated).toBe(true);
+  });
+
+  it("fails fast when graph build cannot read storage", async () => {
+    const sdk = mockSdk();
+    const kv = mockKV();
+    const failingKv = {
+      ...kv,
+      list: vi.fn(async (scope: string): Promise<unknown[]> => {
+        if (scope === KV.sessions) throw new Error("kv unavailable");
+        return kv.list(scope);
+      }),
+    };
+    registerApiTriggers(sdk as never, failingKv as never);
+
+    const response = (await sdk.trigger("api::graph-build", {
+      headers: {},
+      body: {},
+    })) as {
+      status_code: number;
+      body: { success?: boolean; errors?: string[] };
+    };
+
+    expect(response.status_code).toBe(500);
+    expect(response.body.success).toBe(false);
+    expect(response.body.errors?.[0]).toContain("kv unavailable");
+  });
+
+  it("reports extraction failures without hiding partial graph build results", async () => {
+    const sdk = mockSdk();
+    const kv = mockKV();
+    registerApiTriggers(sdk as never, kv as never);
+    sdk.registerFunction("mem::graph-extract", async () => {
+      throw new Error("provider unavailable");
+    });
+
+    const session: Session = {
+      id: "ses_1",
+      project: "demo",
+      cwd: "/tmp/demo",
+      startedAt: "2026-05-19T08:00:00Z",
+      status: "completed",
+      observationCount: 1,
+    };
+    await kv.set(KV.sessions, session.id, session);
+    await kv.set(KV.observations(session.id), "obs_1", makeObservation("obs_1"));
+
+    const response = (await sdk.trigger("api::graph-build", {
+      headers: {},
+      body: {},
+    })) as {
+      status_code: number;
+      body: {
+        success?: boolean;
+        observationsProcessed?: number;
+        nodesAdded?: number;
+        edgesAdded?: number;
+        errors?: string[];
+      };
+    };
+
+    expect(response.status_code).toBe(200);
+    expect(response.body.success).toBe(false);
+    expect(response.body.observationsProcessed).toBe(1);
+    expect(response.body.nodesAdded).toBe(0);
+    expect(response.body.edgesAdded).toBe(0);
+    expect(response.body.errors?.[0]).toContain("provider unavailable");
+  });
+
+  it("returns the graph disabled response when extraction is not registered", async () => {
+    const sdk = mockSdk();
+    const kv = mockKV();
+    registerApiTriggers(sdk as never, kv as never);
+
+    const session: Session = {
+      id: "ses_1",
+      project: "demo",
+      cwd: "/tmp/demo",
+      startedAt: "2026-05-19T08:00:00Z",
+      status: "completed",
+      observationCount: 1,
+    };
+    await kv.set(KV.sessions, session.id, session);
+    await kv.set(KV.observations(session.id), "obs_1", makeObservation("obs_1"));
+
+    const response = (await sdk.trigger("api::graph-build", {
+      headers: {},
+      body: {},
+    })) as { status_code: number; body: { flag?: string } };
+
+    expect(response.status_code).toBe(503);
+    expect(response.body.flag).toBe("GRAPH_EXTRACTION_ENABLED");
+  });
+});


### PR DESCRIPTION
## Summary

- add `POST /agentmemory/graph/build` for the viewer Rebuild Graph action
- backfill graph extraction from existing session observations and latest saved memories
- batch extraction through existing `mem::graph-extract` and return processed counts, truncation, and errors
- update documented REST endpoint counts

Fixes #505

## Tests

- `npm test -- test/api-graph-build.test.ts test/graph.test.ts`
- `npm test -- test/consistency.test.ts test/api-graph-build.test.ts test/graph.test.ts`
- `npm run build`
- `npm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added POST /agentmemory/graph/build to build knowledge graphs from agent memory with batching, configurable limits, truncation reporting, and per-request success/failure summaries.

* **Documentation**
  * Updated docs and startup logs to reflect the API now exposes 125 REST endpoints (was 124).

* **Tests**
  * Expanded test coverage for the graph-build endpoint covering validation, storage failures, extraction errors, truncation, and missing-extractor behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/533?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->