### PR TITLE
fix(codex): install config-layer hook fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,9 @@ npx @agentmemory/agentmemory
 # 2. register the agentmemory marketplace and install the plugin
 codex plugin marketplace add rohitg00/agentmemory
 codex plugin install agentmemory
+
+# 3. activate config-layer hooks for automatic capture
+agentmemory connect codex
 ```
 
 The Codex plugin ships from the same `plugin/` directory as the Claude Code plugin. It registers:
@@ -416,7 +419,7 @@ The Codex plugin ships from the same `plugin/` directory as the Claude Code plug
 - 6 lifecycle hooks: `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `PreCompact`, `Stop`
 - 4 skills: `/recall`, `/remember`, `/session-history`, `/forget`
 
-Codex's hook engine injects `CLAUDE_PLUGIN_ROOT` into hook subprocesses (per [`codex-rs/hooks/src/engine/discovery.rs`](https://github.com/openai/codex/blob/main/codex-rs/hooks/src/engine/discovery.rs)), so the same hook scripts work across both hosts without duplication. Subagent / SessionEnd / Notification / TaskCompleted / PostToolUseFailure events are Claude-Code-only and are not registered for Codex.
+Current Codex builds discover hooks from config-layer files such as `~/.codex/hooks.json`; plugin-local hooks may install successfully without being dispatched. `agentmemory connect codex` writes both the MCP entry and an absolute-path hook fallback into `~/.codex/hooks.json` (including on Windows), so real Codex sessions create observations even while plugin-local hook discovery is still settling upstream. Subagent / SessionEnd / Notification / TaskCompleted / PostToolUseFailure events are Claude-Code-only and are not registered for Codex.
 
 <details>
 <summary><b>OpenClaw (paste this prompt)</b></summary>
@@ -492,7 +495,7 @@ The agentmemory entry is the **same MCP server block** across every host that us
 | **Gemini CLI** | `~/.gemini/settings.json` | `gemini mcp add agentmemory npx -y @agentmemory/mcp --scope user` (auto-merges). |
 | **OpenClaw** | OpenClaw MCP config | Same `mcpServers` block, or use the deeper [memory plugin](integrations/openclaw/). |
 | **Codex CLI (MCP only)** | `.codex/config.toml` | TOML shape: `codex mcp add agentmemory -- npx -y @agentmemory/mcp`, or add `[mcp_servers.agentmemory]` manually. |
-| **Codex CLI (full plugin)** | Codex plugin marketplace | `codex plugin marketplace add rohitg00/agentmemory` then `codex plugin install agentmemory`. Registers MCP + 6 lifecycle hooks (SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, PreCompact, Stop) + 4 skills. |
+| **Codex CLI (full plugin)** | Codex plugin marketplace + `~/.codex/hooks.json` | `codex plugin marketplace add rohitg00/agentmemory`, `codex plugin install agentmemory`, then `agentmemory connect codex`. The connect step adds config-layer hooks for automatic capture on Codex versions that do not dispatch plugin-local hooks yet. |
 | **OpenCode (MCP only)** | `opencode.json` | Different shape — top-level `mcp` key, command as array: `{"mcp": {"agentmemory": {"type": "local", "command": ["npx", "-y", "@agentmemory/mcp"], "enabled": true}}}`. |
 | **OpenCode (full plugin)** | `plugin/opencode/` | 22 auto-capture hooks covering session lifecycle, messages, tools, errors. Two slash commands (`/recall`, `/remember`). Copy `plugin/opencode/` into your OpenCode workspace and add the plugin entry to `opencode.json`. See [`plugin/opencode/README.md`](plugin/opencode/README.md) for the full hook table + gap analysis. |
 | **pi** | `~/.pi/agent/extensions/agentmemory` | Copy [`integrations/pi`](integrations/pi/) and restart pi. |

--- a/src/cli/connect/codex.ts
+++ b/src/cli/connect/codex.ts
@@ -1,6 +1,13 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir, platform } from "node:os";
 import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import * as p from "@clack/prompts";
 import type { ConnectAdapter, ConnectOptions, ConnectResult } from "./types.js";
 import {
@@ -12,6 +19,24 @@ import {
 
 const CODEX_DIR = join(homedir(), ".codex");
 const CODEX_TOML = join(CODEX_DIR, "config.toml");
+const CODEX_HOOKS_JSON = join(CODEX_DIR, "hooks.json");
+const MODULE_DIR = dirname(fileURLToPath(import.meta.url));
+const CODEX_HOOK_EVENTS = [
+  "SessionStart",
+  "UserPromptSubmit",
+  "PreToolUse",
+  "PostToolUse",
+  "PreCompact",
+  "Stop",
+] as const;
+const AGENTMEMORY_HOOK_SCRIPTS = [
+  "session-start.mjs",
+  "prompt-submit.mjs",
+  "pre-tool-use.mjs",
+  "post-tool-use.mjs",
+  "pre-compact.mjs",
+  "stop.mjs",
+] as const;
 
 const TOML_BLOCK = `[mcp_servers.agentmemory]
 command = "npx"
@@ -52,12 +77,219 @@ function stripExistingBlock(toml: string): string {
   return out.join("\n").replace(/\n{3,}$/, "\n\n").trimEnd() + "\n";
 }
 
+type HookHandler = {
+  type: string;
+  command: string;
+  statusMessage?: string;
+};
+type HookEntry = {
+  matcher?: string;
+  hooks: HookHandler[];
+};
+type HooksJson = {
+  hooks?: Record<string, HookEntry[]>;
+  [key: string]: unknown;
+};
+
+function shellQuote(value: string): string {
+  if (platform() === "win32") {
+    return `"${value.replace(/"/g, '\\"')}"`;
+  }
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function isCodexAgentmemoryPluginRoot(dir: string): boolean {
+  if (
+    !existsSync(join(dir, ".codex-plugin", "plugin.json")) ||
+    !existsSync(join(dir, "hooks", "hooks.codex.json")) ||
+    !existsSync(join(dir, "scripts", "post-tool-use.mjs"))
+  ) {
+    return false;
+  }
+  try {
+    const manifest = JSON.parse(
+      readFileSync(join(dir, ".codex-plugin", "plugin.json"), "utf-8"),
+    ) as { name?: string };
+    return manifest.name === "agentmemory";
+  } catch {
+    return false;
+  }
+}
+
+function findInstalledCodexPluginRoots(): string[] {
+  const cacheRoot = join(CODEX_DIR, "plugins", "cache");
+  if (!existsSync(cacheRoot)) return [];
+
+  const found: string[] = [];
+  const walk = (dir: string, depth: number): void => {
+    if (depth > 6) return;
+    if (isCodexAgentmemoryPluginRoot(dir)) {
+      found.push(dir);
+      return;
+    }
+
+    let entries: Array<{ isDirectory(): boolean; name: string }>;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (entry.isDirectory()) walk(join(dir, entry.name), depth + 1);
+    }
+  };
+
+  walk(cacheRoot, 0);
+  return found;
+}
+
+function pluginRootCandidates(): string[] {
+  return [
+    ...findInstalledCodexPluginRoots(),
+    join(MODULE_DIR, "..", "plugin"),
+    join(MODULE_DIR, "..", "..", "..", "plugin"),
+    join(process.cwd(), "plugin"),
+  ];
+}
+
+function resolvePluginRoot(): string {
+  for (const candidate of pluginRootCandidates()) {
+    if (
+      existsSync(join(candidate, "hooks", "hooks.codex.json")) &&
+      existsSync(join(candidate, "scripts", "post-tool-use.mjs"))
+    ) {
+      return candidate;
+    }
+  }
+  throw new Error(
+    "Could not locate bundled Codex hook scripts. Re-run from the published @agentmemory/agentmemory package.",
+  );
+}
+
+function buildConfigLayerHooks(pluginRoot: string): Record<string, HookEntry[]> {
+  return {
+    SessionStart: [
+      {
+        hooks: [
+          {
+            type: "command",
+            command: `node ${shellQuote(join(pluginRoot, "scripts", "session-start.mjs"))}`,
+            statusMessage: "agentmemory: loading session context",
+          },
+        ],
+      },
+    ],
+    UserPromptSubmit: [
+      {
+        hooks: [
+          {
+            type: "command",
+            command: `node ${shellQuote(join(pluginRoot, "scripts", "prompt-submit.mjs"))}`,
+            statusMessage: "agentmemory: recalling relevant memories",
+          },
+        ],
+      },
+    ],
+    PreToolUse: [
+      {
+        matcher: "Edit|Write|Read|Glob|Grep",
+        hooks: [
+          {
+            type: "command",
+            command: `node ${shellQuote(join(pluginRoot, "scripts", "pre-tool-use.mjs"))}`,
+          },
+        ],
+      },
+    ],
+    PostToolUse: [
+      {
+        hooks: [
+          {
+            type: "command",
+            command: `node ${shellQuote(join(pluginRoot, "scripts", "post-tool-use.mjs"))}`,
+          },
+        ],
+      },
+    ],
+    PreCompact: [
+      {
+        hooks: [
+          {
+            type: "command",
+            command: `node ${shellQuote(join(pluginRoot, "scripts", "pre-compact.mjs"))}`,
+          },
+        ],
+      },
+    ],
+    Stop: [
+      {
+        hooks: [
+          {
+            type: "command",
+            command: `node ${shellQuote(join(pluginRoot, "scripts", "stop.mjs"))}`,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function parseHooksJson(text: string, path: string): HooksJson {
+  try {
+    const parsed = JSON.parse(text) as HooksJson;
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch (err) {
+    throw new Error(
+      `${path} is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+function isAgentmemoryHookEntry(entry: HookEntry): boolean {
+  return (entry.hooks ?? []).some((handler) => {
+    const command = handler.command ?? "";
+    return (
+      command.toLowerCase().includes("agentmemory") &&
+      AGENTMEMORY_HOOK_SCRIPTS.some((script) => command.includes(script))
+    );
+  });
+}
+
+function mergeHooksJson(existing: HooksJson, pluginRoot: string): HooksJson {
+  const nextHooks: Record<string, HookEntry[]> = {};
+  const existingHooks =
+    existing.hooks && typeof existing.hooks === "object" ? existing.hooks : {};
+  for (const [event, entries] of Object.entries(existingHooks)) {
+    nextHooks[event] = Array.isArray(entries)
+      ? entries.filter((entry) => !isAgentmemoryHookEntry(entry))
+      : [];
+  }
+
+  const agentmemoryHooks = buildConfigLayerHooks(pluginRoot);
+  for (const event of CODEX_HOOK_EVENTS) {
+    nextHooks[event] = [
+      ...(nextHooks[event] ?? []),
+      ...(agentmemoryHooks[event] ?? []),
+    ];
+  }
+
+  return { ...existing, hooks: nextHooks };
+}
+
+function hooksJsonIsWired(text: string): boolean {
+  const hooksJson = parseHooksJson(text, CODEX_HOOKS_JSON);
+  const hooks = hooksJson.hooks ?? {};
+  return CODEX_HOOK_EVENTS.every((event) =>
+    (hooks[event] ?? []).some(isAgentmemoryHookEntry),
+  );
+}
+
 export const adapter: ConnectAdapter = {
   name: "codex",
   displayName: "Codex CLI",
   docs: "https://github.com/rohitg00/agentmemory#codex-cli-codex-plugin-platform",
   protocolNote:
-    "→ Using MCP. Hooks are also available — see docs/codex.md.",
+    "→ Using MCP plus config-layer Codex hooks for automatic capture.",
 
   detect(): boolean {
     return existsSync(CODEX_DIR);
@@ -67,31 +299,62 @@ export const adapter: ConnectAdapter = {
     const exists = existsSync(CODEX_TOML);
     const current = exists ? readFileSync(CODEX_TOML, "utf-8") : "";
     const wired = isWiredText(current);
+    const pluginRoot = resolvePluginRoot();
+    const hooksExists = existsSync(CODEX_HOOKS_JSON);
+    const currentHooks = hooksExists ? readFileSync(CODEX_HOOKS_JSON, "utf-8") : "";
+    const hooksWired = hooksExists ? hooksJsonIsWired(currentHooks) : false;
 
-    if (wired && !opts.force) {
-      logAlreadyWired("Codex CLI", CODEX_TOML);
-      return { kind: "already-wired", mutatedPath: CODEX_TOML };
+    if (wired && hooksWired && !opts.force) {
+      logAlreadyWired("Codex CLI", `${CODEX_TOML} + ${CODEX_HOOKS_JSON}`);
+      return {
+        kind: "already-wired",
+        mutatedPath: `${CODEX_TOML}, ${CODEX_HOOKS_JSON}`,
+      };
     }
 
     if (opts.dryRun) {
-      p.log.info(
-        `[dry-run] Would ${wired ? "rewrite" : "append"} [mcp_servers.agentmemory] in ${CODEX_TOML}`,
-      );
-      return { kind: "installed", mutatedPath: CODEX_TOML };
+      if (!wired || opts.force) {
+        p.log.info(
+          `[dry-run] Would ${wired ? "rewrite" : "append"} [mcp_servers.agentmemory] in ${CODEX_TOML}`,
+        );
+      }
+      if (!hooksWired || opts.force) {
+        p.log.info(
+          `[dry-run] Would ${hooksWired ? "rewrite" : "append"} agentmemory lifecycle hooks in ${CODEX_HOOKS_JSON}`,
+        );
+      }
+      return {
+        kind: "installed",
+        mutatedPath: `${CODEX_TOML}, ${CODEX_HOOKS_JSON}`,
+      };
     }
 
     let backupPath: string | undefined;
-    if (exists) {
+    if (exists && (!wired || opts.force)) {
       backupPath = backupFile(CODEX_TOML, "codex", "toml");
       logBackup(backupPath);
-    } else {
+    }
+    if (hooksExists && (!hooksWired || opts.force)) {
+      const hooksBackup = backupFile(CODEX_HOOKS_JSON, "codex-hooks", "json");
+      logBackup(hooksBackup);
+      backupPath ??= hooksBackup;
+    }
+    if (!exists || !hooksExists) {
       mkdirSync(dirname(CODEX_TOML), { recursive: true });
     }
 
-    const cleaned = wired ? stripExistingBlock(current) : current;
-    const joiner = cleaned.length === 0 || cleaned.endsWith("\n") ? "" : "\n";
-    const next = `${cleaned}${joiner}${cleaned.length > 0 ? "\n" : ""}${TOML_BLOCK}`;
-    writeFileSync(CODEX_TOML, next, "utf-8");
+    if (!wired || opts.force) {
+      const cleaned = wired ? stripExistingBlock(current) : current;
+      const joiner = cleaned.length === 0 || cleaned.endsWith("\n") ? "" : "\n";
+      const next = `${cleaned}${joiner}${cleaned.length > 0 ? "\n" : ""}${TOML_BLOCK}`;
+      writeFileSync(CODEX_TOML, next, "utf-8");
+    }
+
+    if (!hooksWired || opts.force) {
+      const existingHooks = hooksExists ? parseHooksJson(currentHooks, CODEX_HOOKS_JSON) : {};
+      const nextHooks = mergeHooksJson(existingHooks, pluginRoot);
+      writeFileSync(CODEX_HOOKS_JSON, `${JSON.stringify(nextHooks, null, 2)}\n`, "utf-8");
+    }
 
     const verify = readFileSync(CODEX_TOML, "utf-8");
     if (!isWiredText(verify)) {
@@ -100,14 +363,22 @@ export const adapter: ConnectAdapter = {
       );
       return { kind: "skipped", reason: "verification-failed" };
     }
+    const verifyHooks = readFileSync(CODEX_HOOKS_JSON, "utf-8");
+    if (!hooksJsonIsWired(verifyHooks)) {
+      p.log.error(
+        `Verification failed: ${CODEX_HOOKS_JSON} did not contain agentmemory Codex hooks after write.`,
+      );
+      return { kind: "skipped", reason: "verification-failed" };
+    }
 
     logInstalled("Codex CLI", CODEX_TOML);
+    logInstalled("Codex hooks", CODEX_HOOKS_JSON);
     p.log.info(
-      "Codex picks up MCP servers on next launch. For the deeper plugin install, run: codex plugin marketplace add rohitg00/agentmemory && codex plugin install agentmemory",
+      "Codex picks up MCP servers and config-layer hooks on next launch. Plugin-packaged hooks are still shipped, but current Codex builds may not dispatch them; this fallback keeps automatic capture working.",
     );
     return {
       kind: "installed",
-      mutatedPath: CODEX_TOML,
+      mutatedPath: `${CODEX_TOML}, ${CODEX_HOOKS_JSON}`,
       ...(backupPath !== undefined && { backupPath }),
     };
   },

--- a/src/cli/connect/codex.ts
+++ b/src/cli/connect/codex.ts
@@ -93,7 +93,11 @@ type HooksJson = {
 
 function shellQuote(value: string): string {
   if (platform() === "win32") {
-    return `"${value.replace(/"/g, '\\"')}"`;
+    const escaped = value
+      .replace(/"/g, '\\"')
+      .replace(/%/g, "%%")
+      .replace(/[\^&<>|!]/g, "^$&");
+    return `"${escaped}"`;
   }
   return `'${value.replace(/'/g, "'\\''")}'`;
 }
@@ -245,14 +249,16 @@ function parseHooksJson(text: string, path: string): HooksJson {
   }
 }
 
+function isAgentmemoryHookHandler(handler: HookHandler): boolean {
+  const command = handler.command ?? "";
+  return (
+    command.toLowerCase().includes("agentmemory") &&
+    AGENTMEMORY_HOOK_SCRIPTS.some((script) => command.includes(script))
+  );
+}
+
 function isAgentmemoryHookEntry(entry: HookEntry): boolean {
-  return (entry.hooks ?? []).some((handler) => {
-    const command = handler.command ?? "";
-    return (
-      command.toLowerCase().includes("agentmemory") &&
-      AGENTMEMORY_HOOK_SCRIPTS.some((script) => command.includes(script))
-    );
-  });
+  return (entry.hooks ?? []).some(isAgentmemoryHookHandler);
 }
 
 function mergeHooksJson(existing: HooksJson, pluginRoot: string): HooksJson {
@@ -261,7 +267,12 @@ function mergeHooksJson(existing: HooksJson, pluginRoot: string): HooksJson {
     existing.hooks && typeof existing.hooks === "object" ? existing.hooks : {};
   for (const [event, entries] of Object.entries(existingHooks)) {
     nextHooks[event] = Array.isArray(entries)
-      ? entries.filter((entry) => !isAgentmemoryHookEntry(entry))
+      ? entries
+          .map((entry) => ({
+            ...entry,
+            hooks: entry.hooks.filter((hook) => !isAgentmemoryHookHandler(hook)),
+          }))
+          .filter((entry) => entry.hooks.length > 0)
       : [];
   }
 

--- a/src/cli/connect/index.ts
+++ b/src/cli/connect/index.ts
@@ -74,17 +74,20 @@ export async function runAdapter(
 }
 
 export async function runConnect(args: string[]): Promise<void> {
-  if (platform() === "win32") {
-    p.intro("agentmemory connect");
-    p.log.warn(
-      "Windows: automated `connect` is not supported yet. See https://github.com/rohitg00/agentmemory#other-agents for manual install steps.",
-    );
-    p.outro("Windows: manual install required — see docs");
-    return;
-  }
-
   const { dryRun, force, all, positional } = parseFlags(args);
   const opts: ConnectOptions = { dryRun, force };
+
+  if (
+    platform() === "win32" &&
+    (all || positional.length === 0 || positional[0]?.toLowerCase() !== "codex")
+  ) {
+    p.intro("agentmemory connect");
+    p.log.warn(
+      "Windows: automated `connect` is currently supported for `agentmemory connect codex` only. See https://github.com/rohitg00/agentmemory#other-agents for manual install steps.",
+    );
+    p.outro("Windows: run `agentmemory connect codex` or use manual install steps.");
+    return;
+  }
 
   p.intro("agentmemory connect");
 

--- a/test/cli-connect.test.ts
+++ b/test/cli-connect.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -91,7 +98,7 @@ describe("agentmemory connect — claude-code adapter (mock filesystem)", () => 
 
   it("install() writes mcpServers.agentmemory into ~/.claude.json and is idempotent", async () => {
     const claudeDir = join(tmpHome, ".claude");
-    require("node:fs").mkdirSync(claudeDir, { recursive: true });
+    mkdirSync(claudeDir, { recursive: true });
     writeFileSync(
       join(tmpHome, ".claude.json"),
       JSON.stringify({ mcpServers: { other: { command: "x" } } }),
@@ -119,7 +126,7 @@ describe("agentmemory connect — claude-code adapter (mock filesystem)", () => 
     // and remote without the user needing to add a duplicate config
     // that triggers a /doctor duplicate-server warning.
     const claudeDir = join(tmpHome, ".claude");
-    require("node:fs").mkdirSync(claudeDir, { recursive: true });
+    mkdirSync(claudeDir, { recursive: true });
     writeFileSync(join(tmpHome, ".claude.json"), JSON.stringify({}));
 
     const a = await loadAdapter();
@@ -134,7 +141,7 @@ describe("agentmemory connect — claude-code adapter (mock filesystem)", () => 
   });
 
   it("install() with --force re-writes even when already wired", async () => {
-    require("node:fs").mkdirSync(join(tmpHome, ".claude"), { recursive: true });
+    mkdirSync(join(tmpHome, ".claude"), { recursive: true });
     writeFileSync(
       join(tmpHome, ".claude.json"),
       JSON.stringify({
@@ -150,7 +157,7 @@ describe("agentmemory connect — claude-code adapter (mock filesystem)", () => 
   });
 
   it("install() with --dry-run does not mutate the file", async () => {
-    require("node:fs").mkdirSync(join(tmpHome, ".claude"), { recursive: true });
+    mkdirSync(join(tmpHome, ".claude"), { recursive: true });
     const before = JSON.stringify({ mcpServers: {} });
     writeFileSync(join(tmpHome, ".claude.json"), before);
 
@@ -163,7 +170,7 @@ describe("agentmemory connect — claude-code adapter (mock filesystem)", () => 
   });
 
   it("install() creates a backup file under ~/.agentmemory/backups/", async () => {
-    require("node:fs").mkdirSync(join(tmpHome, ".claude"), { recursive: true });
+    mkdirSync(join(tmpHome, ".claude"), { recursive: true });
     writeFileSync(
       join(tmpHome, ".claude.json"),
       JSON.stringify({ mcpServers: {} }),
@@ -210,7 +217,7 @@ describe("agentmemory connect — codex adapter (mock filesystem)", () => {
   }
 
   function mkdirCodex(): void {
-    require("node:fs").mkdirSync(join(tmpHome, ".codex"), { recursive: true });
+    mkdirSync(join(tmpHome, ".codex"), { recursive: true });
   }
 
   function writeInstalledCodexPlugin(): string {
@@ -218,9 +225,9 @@ describe("agentmemory connect — codex adapter (mock filesystem)", () => {
       tmpHome,
       ".codex/plugins/cache/agentmemory/agentmemory/0.9.20",
     );
-    require("node:fs").mkdirSync(join(root, ".codex-plugin"), { recursive: true });
-    require("node:fs").mkdirSync(join(root, "hooks"), { recursive: true });
-    require("node:fs").mkdirSync(join(root, "scripts"), { recursive: true });
+    mkdirSync(join(root, ".codex-plugin"), { recursive: true });
+    mkdirSync(join(root, "hooks"), { recursive: true });
+    mkdirSync(join(root, "scripts"), { recursive: true });
     writeFileSync(
       join(root, ".codex-plugin/plugin.json"),
       JSON.stringify({ name: "agentmemory" }),
@@ -329,6 +336,39 @@ describe("agentmemory connect — codex adapter (mock filesystem)", () => {
     );
     expect(commands).toContain("echo keep-me");
     expect(commands.some((command) => command.includes("prompt-submit.mjs"))).toBe(true);
+  });
+
+  it("install() deduplicates stale agentmemory hook entries while preserving unrelated hooks", async () => {
+    mkdirCodex();
+    writeFileSync(
+      join(tmpHome, ".codex/hooks.json"),
+      JSON.stringify({
+        hooks: {
+          UserPromptSubmit: [
+            {
+              hooks: [
+                { type: "command", command: "echo keep-me" },
+                { type: "command", command: "node /old/agentmemory/path/prompt-submit.mjs" },
+                { type: "command", command: "node /old/agentmemory/path/prompt-submit.mjs" },
+              ],
+            },
+          ],
+        },
+      }),
+    );
+
+    const a = await loadAdapter();
+    const result = await a.install({ dryRun: false, force: false });
+    expect(result.kind).toBe("installed");
+
+    const hooks = JSON.parse(
+      readFileSync(join(tmpHome, ".codex/hooks.json"), "utf-8"),
+    ) as { hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>> };
+    const commands = hooks.hooks.UserPromptSubmit.flatMap((entry) =>
+      entry.hooks.map((hook) => hook.command),
+    );
+    expect(commands).toContain("echo keep-me");
+    expect(commands.filter((command) => command.includes("prompt-submit.mjs"))).toHaveLength(1);
   });
 
   it("install() is idempotent once MCP and hooks are both wired", async () => {

--- a/test/cli-connect.test.ts
+++ b/test/cli-connect.test.ts
@@ -180,6 +180,169 @@ describe("agentmemory connect — claude-code adapter (mock filesystem)", () => 
   });
 });
 
+describe("agentmemory connect — codex adapter (mock filesystem)", () => {
+  let tmpHome: string;
+  let originalHome: string | undefined;
+  let originalUserprofile: string | undefined;
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), "am-connect-codex-"));
+    originalHome = process.env["HOME"];
+    originalUserprofile = process.env["USERPROFILE"];
+    process.env["HOME"] = tmpHome;
+    process.env["USERPROFILE"] = tmpHome;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (originalHome !== undefined) process.env["HOME"] = originalHome;
+    else delete process.env["HOME"];
+    if (originalUserprofile !== undefined)
+      process.env["USERPROFILE"] = originalUserprofile;
+    else delete process.env["USERPROFILE"];
+    rmSync(tmpHome, { recursive: true, force: true });
+    vi.resetModules();
+  });
+
+  async function loadAdapter(): Promise<ConnectAdapter> {
+    const mod = await import("../src/cli/connect/codex.js?t=" + Date.now());
+    return (mod as { adapter: ConnectAdapter }).adapter;
+  }
+
+  function mkdirCodex(): void {
+    require("node:fs").mkdirSync(join(tmpHome, ".codex"), { recursive: true });
+  }
+
+  function writeInstalledCodexPlugin(): string {
+    const root = join(
+      tmpHome,
+      ".codex/plugins/cache/agentmemory/agentmemory/0.9.20",
+    );
+    require("node:fs").mkdirSync(join(root, ".codex-plugin"), { recursive: true });
+    require("node:fs").mkdirSync(join(root, "hooks"), { recursive: true });
+    require("node:fs").mkdirSync(join(root, "scripts"), { recursive: true });
+    writeFileSync(
+      join(root, ".codex-plugin/plugin.json"),
+      JSON.stringify({ name: "agentmemory" }),
+    );
+    writeFileSync(join(root, "hooks/hooks.codex.json"), JSON.stringify({ hooks: {} }));
+    for (const script of [
+      "session-start.mjs",
+      "prompt-submit.mjs",
+      "pre-tool-use.mjs",
+      "post-tool-use.mjs",
+      "pre-compact.mjs",
+      "stop.mjs",
+    ]) {
+      writeFileSync(join(root, "scripts", script), "");
+    }
+    return root;
+  }
+
+  it("detect() returns false when ~/.codex doesn't exist", async () => {
+    const a = await loadAdapter();
+    expect(a.detect()).toBe(false);
+  });
+
+  it("install() writes MCP config plus config-layer lifecycle hooks", async () => {
+    mkdirCodex();
+
+    const a = await loadAdapter();
+    const result = await a.install({ dryRun: false, force: false });
+    expect(result.kind).toBe("installed");
+
+    const toml = readFileSync(join(tmpHome, ".codex/config.toml"), "utf-8");
+    expect(toml).toContain("[mcp_servers.agentmemory]");
+    expect(toml).toContain('@agentmemory/mcp');
+
+    const hooks = JSON.parse(
+      readFileSync(join(tmpHome, ".codex/hooks.json"), "utf-8"),
+    ) as { hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>> };
+    expect(Object.keys(hooks.hooks)).toEqual(
+      expect.arrayContaining([
+        "SessionStart",
+        "UserPromptSubmit",
+        "PreToolUse",
+        "PostToolUse",
+        "PreCompact",
+        "Stop",
+      ]),
+    );
+    const postToolUse = hooks.hooks.PostToolUse[0].hooks[0].command;
+    expect(postToolUse).toContain("plugin/scripts/post-tool-use.mjs");
+    expect(postToolUse).not.toContain("CLAUDE_PLUGIN_ROOT");
+  });
+
+  it("install() backfills hooks when MCP config is already wired", async () => {
+    mkdirCodex();
+    writeFileSync(
+      join(tmpHome, ".codex/config.toml"),
+      '[mcp_servers.agentmemory]\ncommand = "npx"\n',
+    );
+
+    const a = await loadAdapter();
+    const result = await a.install({ dryRun: false, force: false });
+    expect(result.kind).toBe("installed");
+
+    const hooks = readFileSync(join(tmpHome, ".codex/hooks.json"), "utf-8");
+    expect(hooks).toContain("post-tool-use.mjs");
+  });
+
+  it("install() prefers the installed Codex plugin cache over the current package path", async () => {
+    mkdirCodex();
+    const installedRoot = writeInstalledCodexPlugin();
+
+    const a = await loadAdapter();
+    const result = await a.install({ dryRun: false, force: false });
+    expect(result.kind).toBe("installed");
+
+    const hooks = JSON.parse(
+      readFileSync(join(tmpHome, ".codex/hooks.json"), "utf-8"),
+    ) as { hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>> };
+    const postToolUse = hooks.hooks.PostToolUse[0].hooks[0].command;
+    expect(postToolUse).toContain(installedRoot);
+    expect(postToolUse).not.toContain("src/cli/connect");
+  });
+
+  it("install() preserves unrelated user hooks", async () => {
+    mkdirCodex();
+    writeFileSync(
+      join(tmpHome, ".codex/hooks.json"),
+      JSON.stringify({
+        hooks: {
+          UserPromptSubmit: [
+            { hooks: [{ type: "command", command: "echo keep-me" }] },
+          ],
+        },
+      }),
+    );
+
+    const a = await loadAdapter();
+    const result = await a.install({ dryRun: false, force: false });
+    expect(result.kind).toBe("installed");
+
+    const hooks = JSON.parse(
+      readFileSync(join(tmpHome, ".codex/hooks.json"), "utf-8"),
+    ) as { hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>> };
+    const commands = hooks.hooks.UserPromptSubmit.flatMap((entry) =>
+      entry.hooks.map((hook) => hook.command),
+    );
+    expect(commands).toContain("echo keep-me");
+    expect(commands.some((command) => command.includes("prompt-submit.mjs"))).toBe(true);
+  });
+
+  it("install() is idempotent once MCP and hooks are both wired", async () => {
+    mkdirCodex();
+
+    const a = await loadAdapter();
+    const first = await a.install({ dryRun: false, force: false });
+    expect(first.kind).toBe("installed");
+
+    const second = await a.install({ dryRun: false, force: false });
+    expect(second.kind).toBe("already-wired");
+  });
+});
+
 describe("agentmemory connect — stub adapters log + return stub", () => {
   it("hermes adapter returns stub regardless of detect", async () => {
     const { adapter } = await import("../src/cli/connect/hermes.js");


### PR DESCRIPTION
## Summary
- make `agentmemory connect codex` install Codex config-layer lifecycle hooks in `~/.codex/hooks.json`, alongside the existing MCP config
- prefer the installed Codex plugin cache for hook script paths, with the bundled package plugin as a fallback
- preserve unrelated user hooks, dedupe prior agentmemory hook entries, and allow the Codex connect path on Windows
- update README guidance so users know plugin-local hooks may install without being dispatched on current Codex builds

## Why
Current Codex builds can install plugin-local hooks without dispatching them, so users see the plugin/MCP as installed while normal Codex tool calls create no observations. The config-layer hook fallback gives AgentMemory a working automatic capture path until upstream plugin hook discovery is available.

Fixes #509. Related to openai/codex#16430.

## Testing
- `npm test -- test/cli-connect.test.ts test/codex-plugin.test.ts`
- `npm run build`
- `npm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an explicit "agentmemory connect codex" installation step; Windows now supports automated Codex connect (Codex only).

* **Documentation**
  * Clarified installation and hook discovery flow, including config-layer hook fallback behavior and lifecycle event notes.

* **Tests**
  * Added comprehensive Codex adapter tests covering hook installation, backfill, idempotence, and filesystem scenarios.

* **Bug Fixes**
  * Improved hook wiring to avoid stale entries and preserve user hooks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/537?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
