### PR TITLE
feat(graph): backfill graph from stored memories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,7 @@ Hook scripts in `src/hooks/` are standalone Node.js scripts (no iii-sdk import).
 ## Current Stats (v0.9.16)
 
 - 53 MCP tools (8 visible by default, `AGENTMEMORY_TOOLS=all` for all)
-- 124 REST endpoints
+- 125 REST endpoints
 - 6 MCP resources, 3 MCP prompts
 - 12 hooks, 4 skills
 - 50+ iii functions

--- a/GRAPH_BACKFILL_IMPLEMENTATION_REPORT.md
+++ b/GRAPH_BACKFILL_IMPLEMENTATION_REPORT.md
@@ -1,0 +1,518 @@
+# AgentMemory Graph Backfill 实现报告
+
+日期：2026-05-19  
+仓库：`E:\works\dtudy\agentmemory-pr`  
+目标：让 `http://localhost:3113/#graph` 能从现有历史 memories / observations 回填知识图谱，并用当前 146 条 memory 做只读验证。
+
+## 1. 背景与问题描述
+
+当前运行中的 AgentMemory viewer 在 `#graph` 页面显示：
+
+- `0 nodes`
+- `0 edges`
+- 但 `/agentmemory/memories?latest=true` 返回 `146` 条 latest memories
+
+进一步确认：
+
+- `/agentmemory/graph/stats` 返回 `totalNodes=0,totalEdges=0`
+- `/agentmemory/graph/query` 返回空图
+- 旧运行实例中 `/agentmemory/graph/build` 不存在或不可用
+- `/agentmemory/graph/extract` 已存在，但它只接受调用方传入 observations，并不会主动扫描历史 memories / observations
+
+因此，根因不是 memory 数据缺失，而是上游 v0.9.20 缺少历史数据批量回填 graph 的实现入口。
+
+## 2. 上游结论
+
+结合上游 repo / changelog / issue / PR 信息：
+
+- Issue #210 / PR #215 只解决了 session end 后自动触发 graph extraction 的一部分问题。
+- Issue #505 指出 viewer 的 `Rebuild Graph` 调用了缺失的 `/graph/build`。
+- PR #502 仍显示 session end 到 graph extraction 的触发链有缺口。
+- v0.9.20 的行为没有提供“把已有 146 条 memories 批量变成 graph”的功能。
+
+结论：上游实现的是“新 session 结束后可能增量抽取”，不是“历史 memory / observation backfill”。
+
+## 3. Agent Team 分工
+
+- `agent1: analyzing`
+  - 复现空图。
+  - 阅读本地源码和上游信息。
+  - 定位缺失点：没有 `mem::graph-build`，没有 `POST /agentmemory/graph/build`，viewer 调用的是缺失 endpoint。
+
+- `agent2: verifier`
+  - 挑刺并指出关键风险：
+    - 只回填 observations 不够，必须支持 memories。
+    - 不能打开页面就写真实 state store。
+    - `graph-extract` 合并已有 node 后，edge 可能仍指向临时 node id。
+    - API 参数需要校验，避免非法 limit / batchSize / offset。
+
+- `agent3: testing`
+  - 只读复现真实环境：
+    - latest memories: 146
+    - sessions: 44
+    - observations: 209
+    - graph nodes/edges: 0/0
+  - 验证真实 store 不应在测试阶段被写入。
+
+- Leader 审核
+  - 合并方案。
+  - 补齐 memory source。
+  - 确保默认 dry-run。
+  - 加测试、打包验证和真实数据离线 dry-run。
+
+## 4. 技术方案
+
+### 4.1 新增 graph build/backfill 管线
+
+新增 `mem::graph-build`，职责是扫描历史数据并分批调用已有 `mem::graph-extract`。
+
+核心策略：
+
+- 默认 `dryRun: true`，只计算计划，不写 graph。
+- 支持 source：
+  - `observations`
+  - `memories`
+  - `all`
+- 默认 source 为 `all`。
+- 默认 memories 只取 `isLatest=true`，避免同一 memory 多版本重复回填。
+- 默认 observations 只取 completed sessions，避免 active session 尚未稳定的数据进入 graph。
+- 支持 `force`，需要重跑时可以忽略已处理 source id。
+- 支持 `batchSize`、`limit`、`offset`、`sessionId`，方便灰度、分批和小范围测试。
+
+### 4.2 graph-extract 合并修复
+
+旧逻辑：
+
+- LLM 解析出 node / edge。
+- 如果 node 已存在，会 merge 到已有 node。
+- 但 edge 仍可能引用刚解析出来的临时 node id。
+
+修复后：
+
+- 建立 `resolvedNodeIds` 映射。
+- 对每个 parsed node，记录它最终落到哪个 persisted node id。
+- 写 edge 前，把 `sourceNodeId` / `targetNodeId` remap 到真实 persisted node id。
+- 新增真实创建/更新计数：
+  - `nodesCreated`
+  - `nodesUpdated`
+  - `edgesCreated`
+  - `edgesUpdated`
+
+### 4.3 新增 REST API
+
+新增：
+
+```http
+POST /agentmemory/graph/build
+```
+
+行为：
+
+- 默认 dry-run。
+- `dryRun=false` 时才写入 graph。
+- 支持 query/body 参数：
+  - `source`
+  - `batchSize`
+  - `limit`
+  - `offset`
+  - `sessionId`
+  - `force`
+  - `includeActiveSessions`
+  - `latestMemoriesOnly`
+
+参数校验：
+
+- `batchSize` 必须为正整数。
+- `limit` 必须为正整数。
+- `offset` 必须为非负整数。
+
+### 4.4 新增 CLI
+
+新增命令：
+
+```powershell
+agentmemory graph-build
+```
+
+默认 dry-run。
+
+写入 graph 需要显式：
+
+```powershell
+agentmemory graph-build --source all --apply
+```
+
+支持参数：
+
+```powershell
+--source observations|memories|all
+--batch-size <N>
+--limit <N>
+--offset <N>
+--session-id <id>
+--include-active
+--force
+```
+
+### 4.5 Viewer 行为调整
+
+`#graph` 页面空图时：
+
+- 只调用 dry-run。
+- 不自动写真实 graph。
+
+点击 `Rebuild Graph` 按钮时：
+
+- 调用 `{ dryRun: false }`。
+- 由用户显式触发真实写入。
+
+## 5. 具体修改文件与代码位置
+
+### 5.1 `src/functions/graph.ts`
+
+文件：`E:\works\dtudy\agentmemory-pr\src\functions\graph.ts`
+
+主要改动：
+
+- 新增 `GraphBuildOptions`
+- 新增 `GraphBuildResult`
+- 新增 `isGraphBuildSource`
+- 新增 `isEligibleObservation`
+- 新增 `collectProcessedSourceIds`
+- 新增 `mem::graph-build`
+- 修复 `mem::graph-extract` 的 edge id remap
+
+关键位置：
+
+- `GraphBuildOptions`：约第 22 行
+- `mem::graph-build`：约第 154 行
+- `resolvedNodeIds`：约第 342 行
+- `nodesCreated` / `edgesCreated` 计数：约第 343 行后
+- edge remap：约第 377 行后
+
+### 5.2 `src/triggers/api.ts`
+
+文件：`E:\works\dtudy\agentmemory-pr\src\triggers\api.ts`
+
+主要改动：
+
+- 新增 `api::graph-build`
+- 注册 `POST /agentmemory/graph/build`
+- 增加 batchSize / limit / offset 参数校验
+- 透传 source / force / includeActiveSessions / latestMemoriesOnly
+
+关键位置：
+
+- `api::graph-build`：约第 1251 行
+- `/agentmemory/graph/build` trigger：约第 1335 行
+
+### 5.3 `src/cli.ts`
+
+文件：`E:\works\dtudy\agentmemory-pr\src\cli.ts`
+
+主要改动：
+
+- help 中加入 `graph-build`
+- `postJsonStrict` 增加 `AGENTMEMORY_SECRET` bearer token
+- 新增 option helper：
+  - `optionValue`
+  - `positiveIntOption`
+  - `nonNegativeIntOption`
+- 新增 `runGraphBuild`
+- 命令表中注册 `"graph-build": runGraphBuild`
+
+关键位置：
+
+- help：约第 141 行
+- `runGraphBuild`：约第 2436 行
+- command registry：约第 2694 行
+
+### 5.4 `src/viewer/index.html`
+
+文件：`E:\works\dtudy\agentmemory-pr\src\viewer\index.html`
+
+主要改动：
+
+- 空图自动检测调用：
+
+```js
+apiPost('graph/build', { dryRun: true })
+```
+
+- Rebuild Graph 按钮调用：
+
+```js
+apiPost('graph/build', { dryRun: false })
+```
+
+关键位置：
+
+- dry-run 探测：约第 1603 行
+- apply rebuild：约第 1959 行
+
+### 5.5 `test/graph.test.ts`
+
+文件：`E:\works\dtudy\agentmemory-pr\test\graph.test.ts`
+
+新增覆盖：
+
+- `graph-build` 默认 dry-run
+- `graph-build` apply 分批执行
+- `graph-build` 默认包含 latest memories
+- `graph-extract` 复用 persisted node id
+- `api::graph-build` 默认 dry-run
+
+关键位置：
+
+- dry-run test：约第 198 行
+- memory source test：约第 260 行
+- edge merge id test：约第 285 行
+- API dry-run test：约第 301 行
+
+## 6. 测量方案
+
+### 6.1 基线测量
+
+运行中实例基线：
+
+```powershell
+Invoke-RestMethod http://localhost:3113/agentmemory/graph/stats
+```
+
+结果：
+
+```json
+{
+  "totalNodes": 0,
+  "totalEdges": 0,
+  "nodesByType": {},
+  "edgesByType": {}
+}
+```
+
+memory 数量：
+
+```powershell
+(Invoke-RestMethod "http://localhost:3113/agentmemory/memories?latest=true").memories.Count
+```
+
+结果：
+
+```text
+146
+```
+
+### 6.2 Dry-run 测量
+
+使用真实 localhost 数据，但写入临时 mock KV，不写真实 state store。
+
+测量结果：
+
+```json
+{
+  "liveMemories": 146,
+  "liveSessions": 44,
+  "seededObservations": 209,
+  "plan": {
+    "success": true,
+    "dryRun": true,
+    "source": "all",
+    "sessionsScanned": 8,
+    "memoriesScanned": 146,
+    "observationsFound": 153,
+    "observationsEligible": 153,
+    "observationsSkippedExisting": 0,
+    "observationsSelected": 153,
+    "batchesPlanned": 20,
+    "batchesProcessed": 0,
+    "nodes": 0,
+    "edges": 0,
+    "nodesAdded": 0,
+    "edgesAdded": 0,
+    "errors": []
+  }
+}
+```
+
+解释：
+
+- 146 条 latest memories 会进入回填候选。
+- observations 默认只从 completed sessions 读取。
+- 默认排除 active sessions，所以 sessionsScanned 是 8，不是 44。
+- 最终会形成 153 个候选源项，按 batchSize=8 计划为 20 个批次。
+
+### 6.3 Apply 测量建议
+
+部署新代码并重启 agentmemory 后，建议按以下顺序测量：
+
+1. 先 dry-run：
+
+```powershell
+agentmemory graph-build --source all
+```
+
+2. 确认候选数量、批次数、错误数。
+
+3. 再 apply：
+
+```powershell
+agentmemory graph-build --source all --apply
+```
+
+4. 查看 graph stats：
+
+```powershell
+Invoke-RestMethod http://localhost:3113/agentmemory/graph/stats
+```
+
+5. 打开：
+
+```text
+http://localhost:3113/#graph
+```
+
+预期：
+
+- nodes > 0
+- edges > 0
+- viewer graph 不再为空
+
+## 7. 测试报告
+
+### 7.1 单元测试
+
+命令：
+
+```powershell
+npm test -- test/graph.test.ts
+```
+
+结果：
+
+```text
+Test Files  1 passed (1)
+Tests       10 passed (10)
+```
+
+### 7.2 打包测试
+
+命令：
+
+```powershell
+npx tsdown
+```
+
+结果：
+
+```text
+Build complete
+```
+
+说明：
+
+- `tsdown` 核心打包通过。
+- `npm run build` 在 Windows 下脚本尾部的 `cp ... || true` 会失败，这是仓库既有跨平台脚本问题，不是本次 graph 代码引入。
+
+### 7.3 Diff 检查
+
+命令：
+
+```powershell
+git diff --check
+```
+
+结果：
+
+- 无 whitespace error。
+- 只有 Windows 下 LF/CRLF 提示。
+
+### 7.4 真实数据安全验证
+
+验证目标：
+
+- 读取真实 localhost 数据。
+- 不写真实 `C:\Users\Lenovo\data\state_store.db`。
+- 确认 146 条 latest memories 能被 build plan 识别。
+
+结果：
+
+- latest memories: 146
+- sessions: 44
+- observations: 209
+- graph build dry-run selected: 153
+- planned batches: 20
+- writes to real store: 0
+
+## 8. 当前限制与注意事项
+
+1. 当前 `localhost:3113` 仍运行旧版本。
+   - 所以现在 viewer graph 仍然是 0/0。
+   - 需要把本仓库新代码部署/安装到正在运行的 agentmemory 后才能生效。
+
+2. 没有在真实 store 上执行 apply。
+   - 这是有意为之，避免测试阶段污染你的真实 memory 数据。
+   - apply 应由你确认后执行。
+
+3. Graph extraction 依赖 LLM provider。
+   - dry-run 不调用 provider。
+   - apply 会调用 `mem::graph-extract`，需要当前 graph extraction provider 可用。
+
+4. 默认不处理 active sessions。
+   - 这是为了避免仍在写入中的 session 造成重复或不稳定 graph。
+   - 如需纳入，可使用 `--include-active`。
+
+## 9. 后续任务推荐
+
+1. 部署并重启本地 agentmemory。
+   - 用新源码替换当前运行版本。
+   - 再执行 dry-run 和 apply。
+
+2. 修复 Windows build script。
+   - 把 `cp ... || true` 替换成跨平台 Node copy 脚本。
+
+3. Viewer 增加 graph-build preview。
+   - 空图时显示“可回填 N 条，预计 M 批次”。
+   - 避免用户误以为系统卡住。
+
+4. Viewer 增加进度条。
+   - apply 时显示当前 batch / total batches。
+   - 显示 nodesCreated / edgesCreated。
+
+5. 增加 graph-build integration test。
+   - 使用临时 state store。
+   - 从 memories 到 graph stats 做完整闭环。
+
+6. 增加失败恢复能力。
+   - batch 失败后记录失败 observation ids。
+   - 支持从 offset 或 failed ids 继续。
+
+7. 上游提交 PR。
+   - 本实现正好覆盖 Issue #505 的 `/graph/build` 缺口。
+   - 同时补齐历史 memories backfill，解决用户已有 memory 但 graph 空的问题。
+
+## 10. 建议执行命令
+
+部署新代码后，先运行：
+
+```powershell
+agentmemory graph-build --source all
+```
+
+确认 dry-run 输出合理后，再运行：
+
+```powershell
+agentmemory graph-build --source all --apply
+```
+
+然后验证：
+
+```powershell
+Invoke-RestMethod http://localhost:3113/agentmemory/graph/stats
+```
+
+最后打开：
+
+```text
+http://localhost:3113/#graph
+```
+

--- a/README.md
+++ b/README.md
@@ -1163,7 +1163,7 @@ Create `~/.agentmemory/.env`:
 
 <h2 id="api"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/section-api.svg"><img src="assets/tags/section-api.svg" alt="API" height="32" /></picture></h2>
 
-124 endpoints on port `3111`. The REST API binds to `127.0.0.1` by default. Protected endpoints require `Authorization: Bearer <secret>` when `AGENTMEMORY_SECRET` is set, and mesh sync endpoints require `AGENTMEMORY_SECRET` on both peers.
+125 endpoints on port `3111`. The REST API binds to `127.0.0.1` by default. Protected endpoints require `Authorization: Bearer <secret>` when `AGENTMEMORY_SECRET` is set, and mesh sync endpoints require `AGENTMEMORY_SECRET` on both peers.
 
 <details>
 <summary>Key endpoints</summary>

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "agentmemory": "dist/cli.mjs"
   },
   "scripts": {
-    "build": "tsdown && (cp iii-config.yaml dist/ 2>/dev/null || true) && (cp iii-config.docker.yaml dist/ 2>/dev/null || true) && (cp docker-compose.yml dist/ 2>/dev/null || true) && (cp .env.example dist/ 2>/dev/null || true) && mkdir -p dist/viewer && cp src/viewer/index.html dist/viewer/ && cp src/viewer/favicon.svg dist/viewer/",
+    "build": "tsdown && node scripts/copy-build-assets.mjs",
     "dev": "tsx src/index.ts",
     "start": "node dist/cli.mjs",
     "migrate": "node dist/functions/migrate.js",

--- a/plugin/hooks/hooks.codex.json
+++ b/plugin/hooks/hooks.codex.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/session-start.mjs",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/session-start.mjs\"",
             "statusMessage": "agentmemory: loading session context"
           }
         ]
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/prompt-submit.mjs",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/prompt-submit.mjs\"",
             "statusMessage": "agentmemory: recalling relevant memories"
           }
         ]
@@ -28,7 +28,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/pre-tool-use.mjs"
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/pre-tool-use.mjs\""
           }
         ]
       }
@@ -38,7 +38,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/post-tool-use.mjs"
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/post-tool-use.mjs\""
           }
         ]
       }
@@ -48,7 +48,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/pre-compact.mjs"
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/pre-compact.mjs\""
           }
         ]
       }
@@ -58,7 +58,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/stop.mjs"
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/stop.mjs\""
           }
         ]
       }

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/session-start.mjs"
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/session-start.mjs\""
           }
         ]
       }
@@ -15,7 +15,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/prompt-submit.mjs"
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/prompt-submit.mjs\""
           }
         ]
       }
@@ -26,7 +26,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/pre-tool-use.mjs"
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/pre-tool-use.mjs\""
           }
         ]
       }
@@ -36,7 +36,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/post-tool-use.mjs"
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/post-tool-use.mjs\""
           }
         ]
       }
@@ -46,7 +46,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/post-tool-failure.mjs"
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/post-tool-failure.mjs\""
           }
         ]
       }
@@ -56,7 +56,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/pre-compact.mjs"
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/pre-compact.mjs\""
           }
         ]
       }
@@ -66,7 +66,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/subagent-start.mjs"
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/subagent-start.mjs\""
           }
         ]
       }
@@ -76,7 +76,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/subagent-stop.mjs"
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/subagent-stop.mjs\""
           }
         ]
       }
@@ -86,7 +86,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/notification.mjs"
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/notification.mjs\""
           }
         ]
       }
@@ -96,7 +96,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/task-completed.mjs"
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/task-completed.mjs\""
           }
         ]
       }
@@ -106,7 +106,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/stop.mjs"
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/stop.mjs\""
           }
         ]
       }
@@ -116,7 +116,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/session-end.mjs"
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/session-end.mjs\""
           }
         ]
       }

--- a/scripts/copy-build-assets.mjs
+++ b/scripts/copy-build-assets.mjs
@@ -1,0 +1,25 @@
+import { cp, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+
+const root = process.cwd();
+const dist = join(root, "dist");
+
+async function copyIfPresent(from, to) {
+  try {
+    await cp(join(root, from), join(root, to));
+  } catch (err) {
+    if (err && err.code === "ENOENT") return;
+    throw err;
+  }
+}
+
+await mkdir(join(dist, "viewer"), { recursive: true });
+
+await Promise.all([
+  copyIfPresent("iii-config.yaml", "dist/iii-config.yaml"),
+  copyIfPresent("iii-config.docker.yaml", "dist/iii-config.docker.yaml"),
+  copyIfPresent("docker-compose.yml", "dist/docker-compose.yml"),
+  copyIfPresent(".env.example", "dist/.env.example"),
+  copyIfPresent("src/viewer/index.html", "dist/viewer/index.html"),
+  copyIfPresent("src/viewer/favicon.svg", "dist/viewer/favicon.svg"),
+]);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -138,6 +138,10 @@ Commands:
   import-jsonl [p]   Import Claude Code JSONL transcripts (default: ~/.claude/projects)
                      --max-files <N> | --max-files=<N>: override scan cap (default 200, max 1000;
                      out-of-range is rejected; for trees >1000 files, batch by subdirectory)
+  graph-build        Backfill the knowledge graph from stored observations.
+                     Defaults to dry-run. Use --apply to write graph nodes/edges.
+                     --source observations|memories|all --batch-size <N>
+                     --session-id <id> --limit <N> --offset <N>
 
 Options:
   --help, -h         Show this help
@@ -1707,9 +1711,12 @@ async function postJsonStrict<T = unknown>(
   body: unknown,
   timeoutMs = 5000,
 ): Promise<T | null> {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  const secret = process.env["AGENTMEMORY_SECRET"];
+  if (secret) headers["Authorization"] = `Bearer ${secret}`;
   const res = await fetch(url, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers,
     body: JSON.stringify(body),
     signal: AbortSignal.timeout(timeoutMs),
   });
@@ -1719,6 +1726,35 @@ async function postJsonStrict<T = unknown>(
     throw new Error(`POST ${url} failed: ${res.status} ${res.statusText}${suffix}`);
   }
   return (await res.json().catch(() => null)) as T | null;
+}
+
+function optionValue(name: string): string | undefined {
+  const eq = args.find((a) => a.startsWith(`${name}=`));
+  if (eq) return eq.slice(name.length + 1);
+  const idx = args.indexOf(name);
+  return idx !== -1 ? args[idx + 1] : undefined;
+}
+
+function positiveIntOption(name: string): number | undefined {
+  const raw = optionValue(name);
+  if (raw === undefined) return undefined;
+  const parsed = parseInt(raw, 10);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    p.log.error(`${name} expects a positive integer`);
+    process.exit(1);
+  }
+  return parsed;
+}
+
+function nonNegativeIntOption(name: string): number | undefined {
+  const raw = optionValue(name);
+  if (raw === undefined) return undefined;
+  const parsed = parseInt(raw, 10);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    p.log.error(`${name} expects a non-negative integer`);
+    process.exit(1);
+  }
+  return parsed;
 }
 
 async function seedDemoSession(
@@ -2397,6 +2433,111 @@ async function runImportJsonl(): Promise<void> {
   }
 }
 
+async function runGraphBuild(): Promise<void> {
+  const port = getRestPort();
+  const base = getBaseUrl();
+  const dryRun = !args.includes("--apply");
+  const body: Record<string, unknown> = {
+    dryRun,
+  };
+  const batchSize = positiveIntOption("--batch-size");
+  const limit = positiveIntOption("--limit");
+  const offset = nonNegativeIntOption("--offset");
+  const sessionId = optionValue("--session-id");
+  const source = optionValue("--source");
+  if (source && !["observations", "memories", "all"].includes(source)) {
+    p.log.error("--source expects one of: observations, memories, all");
+    process.exit(1);
+  }
+  if (batchSize !== undefined) body["batchSize"] = batchSize;
+  if (limit !== undefined) body["limit"] = limit;
+  if (offset !== undefined) body["offset"] = offset;
+  if (sessionId) body["sessionId"] = sessionId;
+  if (source) body["source"] = source;
+  if (args.includes("--include-active")) body["includeActiveSessions"] = true;
+  if (args.includes("--force")) body["force"] = true;
+
+  p.intro(`agentmemory graph-build${dryRun ? " (dry-run)" : " (apply)"}`);
+
+  let probeOk = false;
+  let probeDetail = "";
+  try {
+    const probe = await fetch(`${base}/agentmemory/livez`, {
+      signal: AbortSignal.timeout(2000),
+    });
+    probeOk = probe.ok;
+    if (!probeOk) probeDetail = `HTTP ${probe.status}`;
+  } catch (err) {
+    probeDetail = err instanceof Error ? err.message : String(err);
+  }
+  if (!probeOk) {
+    p.log.error(
+      `agentmemory livez probe failed on port ${port}: ${probeDetail || "unreachable"}. Start it with \`npx @agentmemory/agentmemory\` first.`,
+    );
+    process.exit(1);
+  }
+
+  const spinner = p.spinner();
+  spinner.start(dryRun ? "planning graph backfill" : "building graph");
+  try {
+    const result = await postJsonStrict<{
+      success?: boolean;
+      dryRun?: boolean;
+      source?: string;
+      sessionsScanned?: number;
+      memoriesScanned?: number;
+      observationsFound?: number;
+      observationsEligible?: number;
+      observationsSkippedExisting?: number;
+      observationsSelected?: number;
+      batchesPlanned?: number;
+      batchesProcessed?: number;
+      nodes?: number;
+      edges?: number;
+      nodesAdded?: number;
+      edgesAdded?: number;
+      errors?: Array<{ batch: number; error: string }>;
+    }>(`${base}/agentmemory/graph/build`, body, 120_000);
+    spinner.stop(dryRun ? "plan ready" : "build finished");
+
+    if (!result?.success) {
+      p.log.error(`Graph build failed${result?.errors?.length ? ` (${result.errors.length} batch error(s))` : ""}`);
+      for (const err of result?.errors || []) {
+        p.log.error(`batch ${err.batch}: ${err.error}`);
+      }
+      process.exit(1);
+    }
+
+    p.note(
+      [
+        `Mode: ${result.dryRun ? "dry-run" : "apply"}`,
+        `Source: ${result.source ?? "all"}`,
+        `Sessions scanned: ${result.sessionsScanned ?? 0}`,
+        `Memories scanned: ${result.memoriesScanned ?? 0}`,
+        `Source items found: ${result.observationsFound ?? 0}`,
+        `Eligible items: ${result.observationsEligible ?? result.observationsSelected ?? 0}`,
+        `Skipped existing: ${result.observationsSkippedExisting ?? 0}`,
+        `Observations selected: ${result.observationsSelected ?? 0}`,
+        `Batches planned: ${result.batchesPlanned ?? 0}`,
+        `Batches processed: ${result.batchesProcessed ?? 0}`,
+        `Nodes created: ${result.nodesAdded ?? 0}`,
+        `Edges created: ${result.edgesAdded ?? 0}`,
+        `Graph now: ${result.nodes ?? 0} nodes, ${result.edges ?? 0} edges`,
+      ].join("\n"),
+      "graph backfill",
+    );
+
+    if (dryRun) {
+      p.log.info("Re-run with --apply to call mem::graph-extract and write graph data.");
+    }
+    p.outro("Done.");
+  } catch (err) {
+    spinner.stop("failed");
+    p.log.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // `agentmemory remove` — clean uninstall.
 //
@@ -2550,6 +2691,7 @@ const commands: Record<string, () => Promise<void>> = {
   remove: runRemove,
   mcp: runMcp,
   "import-jsonl": runImportJsonl,
+  "graph-build": runGraphBuild,
 };
 
 const handler = commands[args[0] ?? ""] ?? main;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -142,6 +142,7 @@ Commands:
                      Defaults to dry-run. Use --apply to write graph nodes/edges.
                      --source observations|memories|all --batch-size <N>
                      --session-id <id> --limit <N> --offset <N>
+                     Apply without --limit/--offset resumes in chunks to avoid long request timeouts.
 
 Options:
   --help, -h         Show this help
@@ -2480,7 +2481,7 @@ async function runGraphBuild(): Promise<void> {
   const spinner = p.spinner();
   spinner.start(dryRun ? "planning graph backfill" : "building graph");
   try {
-    const result = await postJsonStrict<{
+    type GraphBuildCliResult = {
       success?: boolean;
       dryRun?: boolean;
       source?: string;
@@ -2497,7 +2498,61 @@ async function runGraphBuild(): Promise<void> {
       nodesAdded?: number;
       edgesAdded?: number;
       errors?: Array<{ batch: number; error: string }>;
-    }>(`${base}/agentmemory/graph/build`, body, 120_000);
+    };
+    let result: GraphBuildCliResult | null;
+    if (
+      !dryRun &&
+      limit === undefined &&
+      offset === undefined &&
+      !sessionId &&
+      !args.includes("--force")
+    ) {
+      const chunkLimit = 20;
+      let chunk = 0;
+      let totalSelected = 0;
+      let totalBatchesPlanned = 0;
+      let totalBatchesProcessed = 0;
+      let totalNodesAdded = 0;
+      let totalEdgesAdded = 0;
+      let last: GraphBuildCliResult | null = null;
+      let failure: GraphBuildCliResult | null = null;
+      for (;;) {
+        chunk++;
+        spinner.message(`building graph chunk ${chunk}`);
+        const next = await postJsonStrict<GraphBuildCliResult>(
+          `${base}/agentmemory/graph/build`,
+          { ...body, limit: chunkLimit },
+          300_000,
+        );
+        if (!next?.success) {
+          failure = next;
+          break;
+        }
+        last = next;
+        totalSelected += next.observationsSelected ?? 0;
+        totalBatchesPlanned += next.batchesPlanned ?? 0;
+        totalBatchesProcessed += next.batchesProcessed ?? 0;
+        totalNodesAdded += next.nodesAdded ?? 0;
+        totalEdgesAdded += next.edgesAdded ?? 0;
+        if ((next.observationsSelected ?? 0) === 0) break;
+      }
+      result = failure ?? (last
+        ? {
+            ...last,
+            observationsSelected: totalSelected,
+            batchesPlanned: totalBatchesPlanned,
+            batchesProcessed: totalBatchesProcessed,
+            nodesAdded: totalNodesAdded,
+            edgesAdded: totalEdgesAdded,
+          }
+        : null);
+    } else {
+      result = await postJsonStrict<GraphBuildCliResult>(
+        `${base}/agentmemory/graph/build`,
+        body,
+        dryRun ? 120_000 : 300_000,
+      );
+    }
     spinner.stop(dryRun ? "plan ready" : "build finished");
 
     if (!result?.success) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -159,6 +159,10 @@ export function getEnvVar(key: string): string | undefined {
   return getMergedEnv()[key];
 }
 
+export function isDropStaleIndexEnabled(): boolean {
+  return getMergedEnv()["AGENTMEMORY_DROP_STALE_INDEX"] === "true";
+}
+
 export function detectLlmProviderKind(): "llm" | "noop" {
   const env = getMergedEnv();
   if (

--- a/src/functions/graph.ts
+++ b/src/functions/graph.ts
@@ -5,15 +5,82 @@ import type {
   GraphQueryResult,
   CompressedObservation,
   MemoryProvider,
+  Session,
+  Memory,
 } from "../types.js";
 import { KV, generateId } from "../state/schema.js";
 import type { StateKV } from "../state/kv.js";
+import { memoryToObservation } from "../state/memory-utils.js";
+import { getGraphBatchSize } from "../config.js";
 import {
   GRAPH_EXTRACTION_SYSTEM,
   buildGraphExtractionPrompt,
 } from "../prompts/graph-extraction.js";
 import { recordAudit } from "./audit.js";
 import { logger } from "../logger.js";
+
+export type GraphBuildOptions = {
+  dryRun?: boolean;
+  source?: "observations" | "memories" | "all";
+  force?: boolean;
+  batchSize?: number;
+  sessionId?: string;
+  includeActiveSessions?: boolean;
+  latestMemoriesOnly?: boolean;
+  limit?: number;
+  offset?: number;
+};
+
+export type GraphBuildResult = {
+  success: boolean;
+  dryRun: boolean;
+  source: "observations" | "memories" | "all";
+  sessionsScanned: number;
+  memoriesScanned: number;
+  observationsFound: number;
+  observationsEligible: number;
+  observationsSkippedExisting: number;
+  observationsSelected: number;
+  batchesPlanned: number;
+  batchesProcessed: number;
+  nodes: number;
+  edges: number;
+  nodesAdded: number;
+  edgesAdded: number;
+  errors: Array<{ batch: number; error: string }>;
+};
+
+function isGraphBuildSource(value: unknown): value is GraphBuildOptions["source"] {
+  return value === "observations" || value === "memories" || value === "all";
+}
+
+function isEligibleObservation(value: unknown): value is CompressedObservation {
+  const obs = value as Partial<CompressedObservation>;
+  return (
+    typeof obs.id === "string" &&
+    obs.id.trim().length > 0 &&
+    typeof obs.title === "string" &&
+    obs.title.trim().length > 0 &&
+    typeof obs.narrative === "string" &&
+    typeof obs.type === "string" &&
+    Array.isArray(obs.concepts) &&
+    Array.isArray(obs.files)
+  );
+}
+
+function collectProcessedSourceIds(
+  nodes: GraphNode[],
+  edges: GraphEdge[],
+): Set<string> {
+  const ids = new Set<string>();
+  for (const node of nodes) {
+    for (const id of node.sourceObservationIds || []) ids.add(id);
+  }
+  for (const edge of edges) {
+    for (const id of edge.sourceObservationIds || []) ids.add(id);
+  }
+  return ids;
+}
 
 function parseGraphXml(
   xml: string,
@@ -84,6 +151,167 @@ export function registerGraphFunction(
   kv: StateKV,
   provider: MemoryProvider,
 ): void {
+  sdk.registerFunction("mem::graph-build",
+    async (data: GraphBuildOptions = {}): Promise<GraphBuildResult> => {
+      const source = isGraphBuildSource(data.source) ? data.source : "all";
+      const dryRun = data.dryRun !== false;
+      const force = data.force === true;
+      const includeActiveSessions = data.includeActiveSessions === true;
+      const latestMemoriesOnly = data.latestMemoriesOnly !== false;
+      const parsedBatchSize =
+        typeof data.batchSize === "number"
+          ? data.batchSize
+          : getGraphBatchSize();
+      const batchSize = Math.max(
+        1,
+        Math.min(50, Number.isFinite(parsedBatchSize) ? parsedBatchSize : 8),
+      );
+      const offset =
+        typeof data.offset === "number" && Number.isFinite(data.offset)
+          ? Math.max(0, Math.floor(data.offset))
+          : 0;
+      const limit =
+        typeof data.limit === "number" && Number.isFinite(data.limit)
+          ? Math.max(0, Math.floor(data.limit))
+          : undefined;
+
+      const existingNodes = await kv.list<GraphNode>(KV.graphNodes);
+      const existingEdges = await kv.list<GraphEdge>(KV.graphEdges);
+      const processedIds = force
+        ? new Set<string>()
+        : collectProcessedSourceIds(existingNodes, existingEdges);
+
+      const observations: CompressedObservation[] = [];
+      let sessionsScanned = 0;
+      let memoriesScanned = 0;
+      let observationsFound = 0;
+
+      if (source === "observations" || source === "all") {
+        const allSessions = await kv.list<Session>(KV.sessions);
+        const sessions = allSessions.filter((s) => {
+          if (data.sessionId && s.id !== data.sessionId) return false;
+          if (!includeActiveSessions && s.status === "active") return false;
+          return true;
+        });
+        sessionsScanned = sessions.length;
+
+        for (const session of sessions) {
+          const sessionObservations = await kv
+            .list<CompressedObservation>(KV.observations(session.id))
+            .catch(() => []);
+          observationsFound += sessionObservations.length;
+          observations.push(...sessionObservations.filter(isEligibleObservation));
+        }
+      }
+
+      if (!data.sessionId && (source === "memories" || source === "all")) {
+        const allMemories = await kv.list<Memory>(KV.memories);
+        const memories = latestMemoriesOnly
+          ? allMemories.filter((m) => m.isLatest)
+          : allMemories;
+        memoriesScanned = memories.length;
+        observationsFound += memories.length;
+        observations.push(
+          ...memories
+            .map((memory) => memoryToObservation(memory))
+            .filter(isEligibleObservation),
+        );
+      }
+
+      observations.sort((a, b) =>
+        String(a.timestamp || "").localeCompare(String(b.timestamp || "")),
+      );
+      const eligible = observations.filter((observation) => {
+        if (force) return true;
+        return !processedIds.has(observation.id);
+      });
+      const selected = eligible.slice(
+        offset,
+        limit === undefined ? undefined : offset + limit,
+      );
+      const batches: CompressedObservation[][] = [];
+      for (let i = 0; i < selected.length; i += batchSize) {
+        batches.push(selected.slice(i, i + batchSize));
+      }
+
+      const result: GraphBuildResult = {
+        success: true,
+        dryRun,
+        source,
+        sessionsScanned,
+        memoriesScanned,
+        observationsFound,
+        observationsEligible: eligible.length,
+        observationsSkippedExisting: observations.length - eligible.length,
+        observationsSelected: selected.length,
+        batchesPlanned: batches.length,
+        batchesProcessed: 0,
+        nodes: existingNodes.length,
+        edges: existingEdges.length,
+        nodesAdded: 0,
+        edgesAdded: 0,
+        errors: [],
+      };
+
+      if (dryRun) return result;
+
+      for (let i = 0; i < batches.length; i++) {
+        try {
+          const extracted = (await sdk.trigger({
+            function_id: "mem::graph-extract",
+            payload: { observations: batches[i] },
+          })) as {
+            success?: boolean;
+            nodesAdded?: number;
+            edgesAdded?: number;
+            nodesCreated?: number;
+            edgesCreated?: number;
+            error?: string;
+          };
+          if (extracted?.success === false) {
+            result.errors.push({
+              batch: i,
+              error: extracted.error || "graph extraction failed",
+            });
+            continue;
+          }
+          result.batchesProcessed++;
+          result.nodesAdded += extracted?.nodesCreated ?? extracted?.nodesAdded ?? 0;
+          result.edgesAdded += extracted?.edgesCreated ?? extracted?.edgesAdded ?? 0;
+        } catch (err) {
+          result.errors.push({
+            batch: i,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+
+      result.success = result.errors.length === 0;
+      const [nodes, edges] = await Promise.all([
+        kv.list<GraphNode>(KV.graphNodes),
+        kv.list<GraphEdge>(KV.graphEdges),
+      ]);
+      result.nodes = nodes.length;
+      result.edges = edges.length;
+      await recordAudit(
+        kv,
+        "observe",
+        "mem::graph-build",
+        selected.map((observation) => observation.id),
+        {
+          source,
+          dryRun,
+          force,
+          batches: result.batchesProcessed,
+          nodes: result.nodes,
+          edges: result.edges,
+          errors: result.errors.length,
+        },
+      );
+      return result;
+    },
+  );
+
   sdk.registerFunction("mem::graph-extract", 
     async (data: { observations: CompressedObservation[] }) => {
       if (!data.observations || data.observations.length === 0) {
@@ -111,6 +339,11 @@ export function registerGraphFunction(
 
         const existingNodes = await kv.list<GraphNode>(KV.graphNodes);
         const existingEdges = await kv.list<GraphEdge>(KV.graphEdges);
+        const resolvedNodeIds = new Map<string, string>();
+        let nodesCreated = 0;
+        let nodesUpdated = 0;
+        let edgesCreated = 0;
+        let edgesUpdated = 0;
 
         for (const node of nodes) {
           const existing = existingNodes.find(
@@ -127,13 +360,28 @@ export function registerGraphFunction(
             await kv.set(KV.graphNodes, existing.id, merged);
             const idx = existingNodes.findIndex((n) => n.id === existing.id);
             if (idx !== -1) existingNodes[idx] = merged;
+            resolvedNodeIds.set(`${node.type}:${node.name}`, existing.id);
+            nodesUpdated++;
           } else {
             await kv.set(KV.graphNodes, node.id, node);
             existingNodes.push(node);
+            resolvedNodeIds.set(`${node.type}:${node.name}`, node.id);
+            nodesCreated++;
           }
         }
 
         for (const edge of edges) {
+          const sourceParsedNode = nodes.find((n) => n.id === edge.sourceNodeId);
+          const targetParsedNode = nodes.find((n) => n.id === edge.targetNodeId);
+          const sourceNodeId = sourceParsedNode
+            ? resolvedNodeIds.get(`${sourceParsedNode.type}:${sourceParsedNode.name}`)
+            : edge.sourceNodeId;
+          const targetNodeId = targetParsedNode
+            ? resolvedNodeIds.get(`${targetParsedNode.type}:${targetParsedNode.name}`)
+            : edge.targetNodeId;
+          if (!sourceNodeId || !targetNodeId) continue;
+          edge.sourceNodeId = sourceNodeId;
+          edge.targetNodeId = targetNodeId;
           const edgeKey = `${edge.sourceNodeId}|${edge.targetNodeId}|${edge.type}`;
           const existingEdge = existingEdges.find(
             (e) => `${e.sourceNodeId}|${e.targetNodeId}|${e.type}` === edgeKey,
@@ -143,9 +391,11 @@ export function registerGraphFunction(
               ...new Set([...existingEdge.sourceObservationIds, ...obsIds]),
             ];
             await kv.set(KV.graphEdges, existingEdge.id, existingEdge);
+            edgesUpdated++;
           } else {
             await kv.set(KV.graphEdges, edge.id, edge);
             existingEdges.push(edge);
+            edgesCreated++;
           }
         }
 
@@ -162,6 +412,12 @@ export function registerGraphFunction(
           success: true,
           nodesAdded: nodes.length,
           edgesAdded: edges.length,
+          nodesParsed: nodes.length,
+          edgesParsed: edges.length,
+          nodesCreated,
+          nodesUpdated,
+          edgesCreated,
+          edgesUpdated,
         };
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);

--- a/src/functions/graph.ts
+++ b/src/functions/graph.ts
@@ -94,12 +94,12 @@ function parseGraphXml(
   const now = new Date().toISOString();
 
   const entityRegex =
-    /<entity\s+type="([^"]+)"\s+name="([^"]+)"[^>]*>([\s\S]*?)<\/entity>/g;
+    /<entity\s+type="([^"]+)"\s+name="([^"]+)"[^/>]*(?:\/>|>([\s\S]*?)<\/entity>)/g;
   let match;
   while ((match = entityRegex.exec(xml)) !== null) {
     const type = match[1] as GraphNode["type"];
     const name = match[2];
-    const propsBlock = match[3];
+    const propsBlock = match[3] ?? "";
     const properties: Record<string, string> = {};
 
     const propRegex = /<property\s+key="([^"]+)">([^<]*)<\/property>/g;

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import {
   isAutoCompressEnabled,
   isConsolidationEnabled,
   isContextInjectionEnabled,
+  isDropStaleIndexEnabled,
 } from "./config.js";
 import {
   createProvider,
@@ -376,8 +377,7 @@ async function main() {
         .map((m) => `${m.obsId} (dim=${m.dim})`)
         .join(", ");
       const distinct = Array.from(seenDimensions).sort((a, b) => a - b).join(", ");
-      const dropStale =
-        process.env["AGENTMEMORY_DROP_STALE_INDEX"] === "true";
+      const dropStale = isDropStaleIndexEnabled();
       if (dropStale) {
         console.warn(
           `[agentmemory] Persisted vector index has ${mismatches.length} of ` +

--- a/src/index.ts
+++ b/src/index.ts
@@ -473,7 +473,7 @@ async function main() {
     `Ready. ${embeddingProvider ? "Triple-stream (BM25+Vector+Graph)" : "BM25+Graph"} search active.`,
   );
   bootLog(
-    `REST API: 124 endpoints at http://localhost:${config.restPort}/agentmemory/*`,
+    `REST API: 125 endpoints at http://localhost:${config.restPort}/agentmemory/*`,
   );
   bootLog(
     `MCP surface (opt-in via \`npx @agentmemory/mcp\`): ${getAllTools().length} tools · 6 resources · 3 prompts`,

--- a/src/mcp/standalone.ts
+++ b/src/mcp/standalone.ts
@@ -89,6 +89,8 @@ interface Validated {
   files?: string[];
   query?: string;
   limit?: number;
+  format?: string;
+  tokenBudget?: number;
   memoryIds?: string[];
   reason?: string;
 }
@@ -118,6 +120,17 @@ function validate(toolName: string, args: Record<string, unknown>): Validated {
       }
       v.query = query.trim();
       v.limit = parseLimit(args["limit"]);
+      const fmt = args["format"];
+      if (typeof fmt === "string" && fmt.trim()) {
+        v.format = fmt.trim().toLowerCase();
+      }
+      const budget = args["token_budget"];
+      if (typeof budget === "number" && Number.isFinite(budget) && budget > 0) {
+        v.tokenBudget = Math.floor(budget);
+      } else if (typeof budget === "string" && budget.trim()) {
+        const n = Number(budget);
+        if (Number.isFinite(n) && n > 0) v.tokenBudget = Math.floor(n);
+      }
       return v;
     }
     case "memory_sessions": {
@@ -159,11 +172,26 @@ async function handleProxy(
       });
       return textResponse(result);
     }
-    case "memory_recall":
+    case "memory_recall": {
+      const body: Record<string, unknown> = {
+        query: v.query,
+        limit: v.limit,
+        format: v.format ?? "full",
+      };
+      if (v.tokenBudget != null) body["token_budget"] = v.tokenBudget;
+      const result = await handle.call("/agentmemory/search", {
+        method: "POST",
+        body: JSON.stringify(body),
+      });
+      return textResponse(result, true);
+    }
     case "memory_smart_search": {
+      const body: Record<string, unknown> = { query: v.query, limit: v.limit };
+      if (v.format != null) body["format"] = v.format;
+      if (v.tokenBudget != null) body["token_budget"] = v.tokenBudget;
       const result = await handle.call("/agentmemory/smart-search", {
         method: "POST",
-        body: JSON.stringify({ query: v.query, limit: v.limit }),
+        body: JSON.stringify(body),
       });
       return textResponse(result, true);
     }

--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -1248,6 +1248,93 @@ export function registerApiTriggers(
     config: { api_path: "/agentmemory/graph/extract", http_method: "POST" },
   });
 
+  sdk.registerFunction("api::graph-build",
+    async (
+      req: ApiRequest<{
+        dryRun?: boolean;
+        source?: string;
+        force?: boolean;
+        batchSize?: number;
+        sessionId?: string;
+        includeActiveSessions?: boolean;
+        latestMemoriesOnly?: boolean;
+        limit?: number;
+        offset?: number;
+      }>,
+    ): Promise<Response> => {
+      const authErr = checkAuth(req, secret);
+      if (authErr) return authErr;
+      try {
+        const body = req.body || {};
+        const queryBatchSize = parseOptionalPositiveInt(req.query_params?.["batchSize"]);
+        const queryLimit = parseOptionalPositiveInt(req.query_params?.["limit"]);
+        const queryOffset = parseOptionalInt(req.query_params?.["offset"]);
+        if (queryBatchSize === null || queryLimit === null) {
+          return {
+            status_code: 400,
+            body: { error: "batchSize and limit must be positive integers" },
+          };
+        }
+        if (queryOffset !== undefined && queryOffset < 0) {
+          return {
+            status_code: 400,
+            body: { error: "offset must be a non-negative integer" },
+          };
+        }
+        const dryRun =
+          req.query_params?.["dryRun"] === "false"
+            ? false
+            : req.query_params?.["dryRun"] === "true"
+              ? true
+              : body.dryRun;
+        const source =
+          req.query_params?.["source"] ||
+          (typeof body.source === "string" ? body.source : undefined);
+        const result = await sdk.trigger({
+          function_id: "mem::graph-build",
+          payload: {
+            ...body,
+            dryRun,
+            source,
+            batchSize:
+              queryBatchSize ?? body.batchSize,
+            limit: queryLimit ?? body.limit,
+            offset: queryOffset ?? body.offset,
+            sessionId:
+              asNonEmptyString(req.query_params?.["sessionId"]) ??
+              body.sessionId,
+            force:
+              req.query_params?.["force"] === "true"
+                ? true
+                : req.query_params?.["force"] === "false"
+                  ? false
+                  : body.force,
+            includeActiveSessions:
+              req.query_params?.["includeActiveSessions"] === "true"
+                ? true
+                : req.query_params?.["includeActiveSessions"] === "false"
+                  ? false
+                  : body.includeActiveSessions,
+            latestMemoriesOnly:
+              req.query_params?.["latestMemoriesOnly"] === "true"
+                ? true
+                : req.query_params?.["latestMemoriesOnly"] === "false"
+                  ? false
+                  : body.latestMemoriesOnly,
+          },
+        });
+        return { status_code: 200, body: result };
+      } catch {
+        return graphDisabledResponse();
+      }
+    },
+  );
+  sdk.registerTrigger({
+    type: "http",
+    function_id: "api::graph-build",
+    config: { api_path: "/agentmemory/graph/build", http_method: "POST" },
+  });
+
   sdk.registerFunction("api::consolidate-pipeline", 
     async (req: ApiRequest<{ tier?: string }>): Promise<Response> => {
       const authErr = checkAuth(req, secret);

--- a/src/viewer/index.html
+++ b/src/viewer/index.html
@@ -1563,8 +1563,16 @@
 
       if (state.graph.nodes.length === 0) {
         var sb = document.getElementById('graph-sidebar');
-        if (sb) sb.innerHTML = '<h3>Graph</h3><p style="font-size:12px;color:var(--ink-faint);margin:8px 0;font-style:italic;">No graph data yet. Building from observations and memories...</p>';
+        if (sb) sb.innerHTML = '<h3>Graph</h3><p style="font-size:12px;color:var(--ink-faint);margin:8px 0;font-style:italic;">No graph data yet. Checking stored observations and memories...</p>';
         var buildResult = await apiPost('graph/build', { dryRun: true });
+        if (sb && buildResult && buildResult.success) {
+          sb.innerHTML = '<h3>Graph</h3>' +
+            '<p style="font-size:12px;color:var(--ink-faint);margin:8px 0;font-style:italic;">No graph data yet.</p>' +
+            '<div style="font-size:11px;line-height:1.7;color:var(--ink-muted);border-top:1px solid var(--border-light);border-bottom:1px solid var(--border-light);padding:8px 0;margin:8px 0;">' +
+            graphBuildSummary(buildResult) +
+            '</div>' +
+            '<button class="btn" style="margin-top:8px;width:100%;font-size:11px;padding:8px;letter-spacing:0.06em;" data-action="rebuild-graph">↻ Rebuild Graph</button>';
+        }
         if (buildResult && buildResult.success && buildResult.dryRun === false && buildResult.nodesAdded > 0) {
           var freshResults = await Promise.all([
             apiPost('graph/query', {}),
@@ -1917,10 +1925,51 @@
       graphSim.raf = requestAnimationFrame(runSimulation);
     }
 
+    function graphBuildSummary(result) {
+      return [
+        '<div><strong>Source</strong> ' + esc(result.source || 'all') + '</div>',
+        '<div><strong>Memories</strong> ' + (result.memoriesScanned || 0) + '</div>',
+        '<div><strong>Sessions</strong> ' + (result.sessionsScanned || 0) + '</div>',
+        '<div><strong>Eligible</strong> ' + (result.observationsEligible || 0) + '</div>',
+        '<div><strong>Skipped</strong> ' + (result.observationsSkippedExisting || 0) + '</div>',
+        '<div><strong>Batches</strong> ' + (result.batchesPlanned || 0) + '</div>'
+      ].join('');
+    }
+
     async function rebuildGraph() {
       var sb = document.getElementById('graph-sidebar');
-      if (sb) sb.innerHTML = '<h3>Graph</h3><p style="font-size:12px;color:var(--ink-faint);font-style:italic;">Rebuilding graph from observations...</p>';
-      await apiPost('graph/build', { dryRun: false });
+      if (sb) sb.innerHTML = '<h3>Graph</h3><p style="font-size:12px;color:var(--ink-faint);font-style:italic;">Checking graph backfill plan...</p>';
+      var plan = await apiPost('graph/build', { dryRun: true, source: 'all', batchSize: 5 });
+      if (!plan || !plan.success) {
+        if (sb) sb.innerHTML = '<h3>Graph</h3><p style="font-size:12px;color:var(--danger);font-style:italic;">Graph rebuild plan failed.</p>';
+        return;
+      }
+      if ((plan.observationsSelected || 0) === 0) {
+        if (sb) sb.innerHTML = '<h3>Graph</h3><p style="font-size:12px;color:var(--ink-faint);font-style:italic;">Graph is already up to date.</p>';
+        return;
+      }
+      var ok = window.confirm(
+        'Build graph from ' + (plan.observationsSelected || 0) +
+        ' stored observations/memories in ' + (plan.batchesPlanned || 0) +
+        ' batches? This writes graph nodes and edges.'
+      );
+      if (!ok) {
+        renderGraphSidebar();
+        return;
+      }
+      var totalSelected = 0;
+      var totalBatches = 0;
+      for (var chunk = 1; ; chunk++) {
+        if (sb) sb.innerHTML = '<h3>Graph</h3><p style="font-size:12px;color:var(--ink-faint);font-style:italic;">Building graph chunk ' + chunk + '...</p><p style="font-size:11px;color:var(--ink-muted);line-height:1.7;">Processed ' + totalSelected + ' source item(s), ' + totalBatches + ' batch(es).</p>';
+        var result = await apiPost('graph/build', { dryRun: false, source: 'all', limit: 20, batchSize: 5 });
+        if (!result || !result.success) {
+          if (sb) sb.innerHTML = '<h3>Graph</h3><p style="font-size:12px;color:var(--danger);font-style:italic;">Graph rebuild failed. Try again to resume from completed items.</p>';
+          return;
+        }
+        totalSelected += result.observationsSelected || 0;
+        totalBatches += result.batchesProcessed || 0;
+        if ((result.observationsSelected || 0) === 0) break;
+      }
       state.graph.loaded = false;
       loadGraph();
     }

--- a/src/viewer/index.html
+++ b/src/viewer/index.html
@@ -1564,8 +1564,8 @@
       if (state.graph.nodes.length === 0) {
         var sb = document.getElementById('graph-sidebar');
         if (sb) sb.innerHTML = '<h3>Graph</h3><p style="font-size:12px;color:var(--ink-faint);margin:8px 0;font-style:italic;">No graph data yet. Building from observations and memories...</p>';
-        var buildResult = await apiPost('graph/build', {});
-        if (buildResult && buildResult.success && buildResult.nodes > 0) {
+        var buildResult = await apiPost('graph/build', { dryRun: true });
+        if (buildResult && buildResult.success && buildResult.dryRun === false && buildResult.nodesAdded > 0) {
           var freshResults = await Promise.all([
             apiPost('graph/query', {}),
             apiGet('graph/stats')
@@ -1920,7 +1920,7 @@
     async function rebuildGraph() {
       var sb = document.getElementById('graph-sidebar');
       if (sb) sb.innerHTML = '<h3>Graph</h3><p style="font-size:12px;color:var(--ink-faint);font-style:italic;">Rebuilding graph from observations...</p>';
-      await apiPost('graph/build', {});
+      await apiPost('graph/build', { dryRun: false });
       state.graph.loaded = false;
       loadGraph();
     }

--- a/test/codex-plugin.test.ts
+++ b/test/codex-plugin.test.ts
@@ -9,6 +9,29 @@ function readJson<T = unknown>(path: string): T {
   return JSON.parse(readFileSync(path, "utf-8")) as T;
 }
 
+type HookHandler = { type: string; command: string };
+type HookEntry = { hooks: HookHandler[] };
+
+function hookCommands(path: string): string[] {
+  const manifest = readJson<{ hooks: Record<string, HookEntry[]> }>(path);
+  return Object.values(manifest.hooks).flatMap((entries) =>
+    entries.flatMap((entry) => entry.hooks.map((handler) => handler.command)),
+  );
+}
+
+describe("Plugin hook manifests", () => {
+  it("quote plugin script paths so roots with spaces stay intact", () => {
+    for (const manifest of ["hooks.json", "hooks.codex.json"]) {
+      const commands = hookCommands(join(pluginRoot, "hooks", manifest));
+      expect(commands.length, `${manifest} should contain hook commands`).toBeGreaterThan(0);
+
+      for (const command of commands) {
+        expect(command).toMatch(/^node "\$\{CLAUDE_PLUGIN_ROOT\}\/scripts\/[^\s"]+\.mjs"$/);
+      }
+    }
+  });
+});
+
 describe("Codex plugin manifest (developers.openai.com/codex/plugins)", () => {
   it("ships .codex-plugin/plugin.json with kebab-case name + version + references", () => {
     const manifestPath = join(pluginRoot, ".codex-plugin/plugin.json");
@@ -72,8 +95,6 @@ describe("Codex plugin manifest (developers.openai.com/codex/plugins)", () => {
   });
 
   it("hook command scripts referenced in hooks.codex.json exist on disk", () => {
-    type HookHandler = { type: string; command: string };
-    type HookEntry = { hooks: HookHandler[] };
     const hooks = readJson<{ hooks: Record<string, HookEntry[]> }>(
       join(pluginRoot, "hooks/hooks.codex.json"),
     );
@@ -81,7 +102,7 @@ describe("Codex plugin manifest (developers.openai.com/codex/plugins)", () => {
     for (const entries of Object.values(hooks.hooks)) {
       for (const entry of entries) {
         for (const handler of entry.hooks) {
-          const match = handler.command.match(/\$\{CLAUDE_PLUGIN_ROOT\}\/(scripts\/[^\s]+)/);
+          const match = handler.command.match(/\$\{CLAUDE_PLUGIN_ROOT\}\/(scripts\/[^\s"]+)/);
           if (match) scriptRefs.add(match[1]);
         }
       }

--- a/test/env-loader.test.ts
+++ b/test/env-loader.test.ts
@@ -25,6 +25,7 @@ describe("loadEnvFile", () => {
     process.env["HOME"] = sandboxHome;
     process.env["USERPROFILE"] = sandboxHome;
     delete process.env["AGENTMEMORY_AUTO_COMPRESS"];
+    delete process.env["AGENTMEMORY_DROP_STALE_INDEX"];
     delete process.env["CONSOLIDATION_ENABLED"];
     delete process.env["GRAPH_EXTRACTION_ENABLED"];
     delete process.env["TOKEN"];
@@ -81,5 +82,11 @@ describe("loadEnvFile", () => {
     writeEnv("TOKEN='abc' # trailing comment");
     const cfg = await freshConfig();
     expect(cfg.getEnvVar("TOKEN")).toBe("abc");
+  });
+
+  it("reads AGENTMEMORY_DROP_STALE_INDEX from the env file", async () => {
+    writeEnv("AGENTMEMORY_DROP_STALE_INDEX=true");
+    const cfg = await freshConfig();
+    expect(cfg.isDropStaleIndexEnabled()).toBe(true);
   });
 });

--- a/test/graph.test.ts
+++ b/test/graph.test.ts
@@ -5,11 +5,14 @@ vi.mock("../src/logger.js", () => ({
 }));
 
 import { registerGraphFunction } from "../src/functions/graph.js";
+import { registerApiTriggers } from "../src/triggers/api.js";
 import type {
   CompressedObservation,
   GraphNode,
   GraphEdge,
   GraphQueryResult,
+  Session,
+  Memory,
 } from "../src/types.js";
 
 function mockKV() {
@@ -74,6 +77,39 @@ const testObs: CompressedObservation = {
   concepts: ["typescript", "entry-point"],
   files: ["src/index.ts"],
   importance: 7,
+};
+
+const secondObs: CompressedObservation = {
+  ...testObs,
+  id: "obs_2",
+  timestamp: "2026-02-01T10:01:00Z",
+  title: "Edit graph file",
+  narrative: "Updated graph.ts with build support",
+  files: ["src/functions/graph.ts"],
+};
+
+const testSession: Session = {
+  id: "ses_1",
+  project: "agentmemory",
+  cwd: "/repo",
+  startedAt: "2026-02-01T10:00:00Z",
+  status: "completed",
+  observationCount: 2,
+};
+
+const testMemory: Memory = {
+  id: "mem_1",
+  createdAt: "2026-02-01T10:02:00Z",
+  updatedAt: "2026-02-01T10:02:00Z",
+  type: "workflow",
+  title: "Graph build uses memories",
+  content: "Graph backfill should build entities from durable memories.",
+  concepts: ["graph", "memory"],
+  files: ["src/functions/graph.ts"],
+  sessionIds: [],
+  strength: 7,
+  version: 1,
+  isLatest: true,
 };
 
 describe("Graph Functions", () => {
@@ -157,5 +193,125 @@ describe("Graph Functions", () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toContain("No observations");
+  });
+
+  it("graph-build defaults to dry-run and plans batches without extracting", async () => {
+    await kv.set("mem:sessions", testSession.id, testSession);
+    await kv.set("mem:obs:ses_1", testObs.id, testObs);
+    await kv.set("mem:obs:ses_1", secondObs.id, secondObs);
+
+    const result = (await sdk.trigger("mem::graph-build", {
+      batchSize: 1,
+    })) as {
+      success: boolean;
+      dryRun: boolean;
+      sessionsScanned: number;
+      observationsFound: number;
+      observationsSelected: number;
+      batchesPlanned: number;
+      batchesProcessed: number;
+    };
+
+    expect(result).toMatchObject({
+      success: true,
+      dryRun: true,
+      sessionsScanned: 1,
+      observationsFound: 2,
+      observationsSelected: 2,
+      batchesPlanned: 2,
+      batchesProcessed: 0,
+    });
+    expect(mockProvider.compress).not.toHaveBeenCalled();
+  });
+
+  it("graph-build applies batches through mem::graph-extract when dryRun is false", async () => {
+    await kv.set("mem:sessions", testSession.id, testSession);
+    await kv.set("mem:obs:ses_1", testObs.id, testObs);
+    await kv.set("mem:obs:ses_1", secondObs.id, secondObs);
+
+    const result = (await sdk.trigger("mem::graph-build", {
+      dryRun: false,
+      batchSize: 1,
+      limit: 2,
+    })) as {
+      success: boolean;
+      dryRun: boolean;
+      batchesProcessed: number;
+      nodesAdded: number;
+      edgesAdded: number;
+    };
+
+    expect(result.success).toBe(true);
+    expect(result.dryRun).toBe(false);
+    expect(result.batchesProcessed).toBe(2);
+    expect(result.nodesAdded).toBe(2);
+    expect(result.edgesAdded).toBe(1);
+    expect(mockProvider.compress).toHaveBeenCalledTimes(2);
+
+    const nodes = await kv.list<GraphNode>("mem:graph:nodes");
+    const edges = await kv.list<GraphEdge>("mem:graph:edges");
+    expect(nodes).toHaveLength(2);
+    expect(edges).toHaveLength(1);
+    expect(nodes.every((n) => n.sourceObservationIds.includes("obs_1"))).toBe(true);
+    expect(nodes.every((n) => n.sourceObservationIds.includes("obs_2"))).toBe(true);
+    expect(edges[0].sourceObservationIds).toEqual(["obs_1", "obs_2"]);
+  });
+
+  it("graph-build includes latest memories by default", async () => {
+    await kv.set("mem:memories", testMemory.id, testMemory);
+
+    const result = (await sdk.trigger("mem::graph-build", {
+      source: "all",
+      batchSize: 8,
+    })) as {
+      success: boolean;
+      dryRun: boolean;
+      memoriesScanned: number;
+      observationsFound: number;
+      observationsEligible: number;
+      observationsSelected: number;
+    };
+
+    expect(result).toMatchObject({
+      success: true,
+      dryRun: true,
+      memoriesScanned: 1,
+      observationsFound: 1,
+      observationsEligible: 1,
+      observationsSelected: 1,
+    });
+  });
+
+  it("graph-extract reuses persisted node ids when merging edges", async () => {
+    await sdk.trigger("mem::graph-extract", { observations: [testObs] });
+    const firstNodes = await kv.list<GraphNode>("mem:graph:nodes");
+    const firstEdges = await kv.list<GraphEdge>("mem:graph:edges");
+
+    await sdk.trigger("mem::graph-extract", { observations: [secondObs] });
+    const secondNodes = await kv.list<GraphNode>("mem:graph:nodes");
+    const secondEdges = await kv.list<GraphEdge>("mem:graph:edges");
+
+    expect(secondNodes.length).toBe(firstNodes.length);
+    expect(secondEdges.length).toBe(firstEdges.length);
+    const nodeIds = new Set(secondNodes.map((node) => node.id));
+    expect(nodeIds.has(secondEdges[0].sourceNodeId)).toBe(true);
+    expect(nodeIds.has(secondEdges[0].targetNodeId)).toBe(true);
+  });
+
+  it("api graph-build exposes a safe dry-run default", async () => {
+    registerApiTriggers(sdk as never, kv as never);
+    await kv.set("mem:sessions", testSession.id, testSession);
+    await kv.set("mem:obs:ses_1", testObs.id, testObs);
+
+    const response = (await sdk.trigger("api::graph-build", {
+      query_params: {},
+      body: {},
+      headers: {},
+    })) as { status_code: number; body: { dryRun?: boolean; batchesPlanned?: number } };
+
+    expect(response.status_code).toBe(200);
+    expect(response.body.dryRun).toBe(true);
+    expect(response.body.batchesPlanned).toBe(1);
+    expect(mockProvider.compress).not.toHaveBeenCalled();
   });
 });

--- a/test/graph.test.ts
+++ b/test/graph.test.ts
@@ -257,6 +257,32 @@ describe("Graph Functions", () => {
     expect(edges[0].sourceObservationIds).toEqual(["obs_1", "obs_2"]);
   });
 
+  it("graph-build skips observations that already contributed graph records", async () => {
+    await kv.set("mem:sessions", testSession.id, testSession);
+    await kv.set("mem:obs:ses_1", testObs.id, testObs);
+    await kv.set("mem:obs:ses_1", secondObs.id, secondObs);
+
+    await sdk.trigger("mem::graph-build", {
+      dryRun: false,
+      batchSize: 1,
+      limit: 2,
+    });
+
+    const result = (await sdk.trigger("mem::graph-build", {
+      batchSize: 1,
+    })) as {
+      dryRun: boolean;
+      observationsEligible: number;
+      observationsSkippedExisting: number;
+      observationsSelected: number;
+    };
+
+    expect(result.dryRun).toBe(true);
+    expect(result.observationsEligible).toBe(0);
+    expect(result.observationsSkippedExisting).toBe(2);
+    expect(result.observationsSelected).toBe(0);
+  });
+
   it("graph-build includes latest memories by default", async () => {
     await kv.set("mem:memories", testMemory.id, testMemory);
 

--- a/test/mcp-standalone-proxy.test.ts
+++ b/test/mcp-standalone-proxy.test.ts
@@ -75,6 +75,61 @@ describe("@agentmemory/mcp standalone — server proxy (issue #159)", () => {
     expect(body.results[0].id).toBe("m1");
   });
 
+  it("proxies memory_recall to POST /agentmemory/search and forwards format/token_budget (#507)", async () => {
+    const calls: Array<{ url: string; body?: unknown }> = [];
+    installFetch((url, init) => {
+      if (url.endsWith("/agentmemory/livez")) return new Response("ok", { status: 200 });
+      const body = init?.body ? JSON.parse(init.body as string) : undefined;
+      calls.push({ url, body });
+      if (url.endsWith("/agentmemory/search")) {
+        return new Response(
+          JSON.stringify({
+            mode: "full",
+            facts: [{ id: "m1" }],
+            narrative: "n",
+            concepts: ["c"],
+            files: ["f"],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    });
+    const res = await handleToolCall("memory_recall", {
+      query: "auth bug",
+      limit: 5,
+      format: "full",
+      token_budget: 800,
+    });
+    const body = JSON.parse(res.content[0].text);
+    expect(body.mode).toBe("full");
+    expect(body.facts[0].id).toBe("m1");
+    const searchCall = calls.find((c) => c.url.endsWith("/agentmemory/search"));
+    expect(searchCall).toBeDefined();
+    expect(searchCall?.body).toEqual({
+      query: "auth bug",
+      limit: 5,
+      format: "full",
+      token_budget: 800,
+    });
+    expect(calls.find((c) => c.url.endsWith("/agentmemory/smart-search"))).toBeUndefined();
+  });
+
+  it("memory_recall defaults format to 'full' when omitted (#507)", async () => {
+    let recallBody: Record<string, unknown> | undefined;
+    installFetch((url, init) => {
+      if (url.endsWith("/agentmemory/livez")) return new Response("ok", { status: 200 });
+      if (url.endsWith("/agentmemory/search")) {
+        recallBody = init?.body ? JSON.parse(init.body as string) : undefined;
+        return new Response(JSON.stringify({ mode: "full", facts: [] }), { status: 200 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+    await handleToolCall("memory_recall", { query: "x" });
+    expect(recallBody?.["format"]).toBe("full");
+    expect(recallBody).not.toHaveProperty("token_budget");
+  });
+
   it("proxies memory_governance_delete to the DELETE REST endpoint", async () => {
     const calls: Array<{ url: string; method: string; body?: unknown }> = [];
     installFetch((url, init) => {

--- a/website/lib/generated-meta.json
+++ b/website/lib/generated-meta.json
@@ -2,7 +2,7 @@
   "version": "0.9.20",
   "mcpTools": 53,
   "hooks": 12,
-  "restEndpoints": 124,
+  "restEndpoints": 125,
   "testsPassing": 1055,
   "generatedAt": "2026-05-18T20:08:39.354Z"
 }


### PR DESCRIPTION
## Summary

Adds a real graph backfill path for existing AgentMemory data, so users with historical memories/observations can populate the viewer graph instead of seeing `0 nodes / 0 edges` forever.

This addresses the missing `/agentmemory/graph/build` path surfaced by the viewer rebuild flow and complements the existing session-end extraction path by adding historical backfill.

Fixes #505 — the viewer "Rebuild Graph" button now has a real backing endpoint instead of 404'ing. Confirmed by @code2tan to still be broken on v0.9.20.

## What changed

- Add `mem::graph-build` to scan stored observations and latest memories, plan/apply in batches, skip already-processed source IDs, and default to safe dry-run.
- Add `POST /agentmemory/graph/build` with query/body validation.
- Add `agentmemory graph-build` CLI, default dry-run; `--apply` writes graph records.
- Make CLI apply resumable in bounded chunks to avoid long HTTP request timeouts.
- Fix `mem::graph-extract` edge merging so edges point to persisted node IDs after duplicate node merges.
- Update viewer graph rebuild UX with dry-run preview, confirmation, chunked apply, and resume-friendly failure text.
- Replace Unix-only build asset copy commands with a cross-platform Node script.
- Add focused graph tests and a local implementation report.

## Verification

- `npm test -- test/graph.test.ts` -> 11 tests passed
- `npm run build` -> passed on Windows
- `git diff --check` -> no whitespace errors
- Local deployed dry-run before apply:
  - memories scanned: 157
  - source items found: 164
  - eligible items: 164
  - batches planned: 17
  - graph before: 0 nodes / 0 edges
- Local apply result after resumable chunks:
  - graph after: 395 nodes / 46 edges
  - follow-up dry-run: eligible items 0, skipped existing 164

## Notes

The viewer's empty-graph auto path remains read-only: it only performs a dry-run preview. A write happens only after explicit rebuild confirmation or CLI `--apply`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add graph-build REST endpoint and CLI with dry-run/apply, batching, per-chunk progress, and detailed build stats; viewer shows dry-run plan and guided “Rebuild Graph” flow.
* **Bug Fixes**
  * Fixes to graph extraction/edge remapping and XML entity parsing for more reliable graph imports.
* **Chores**
  * Simplified build pipeline with a robust asset-copy script; hook command strings quoted; new config toggle for stale index handling; proxy tool now forwards format/token budget.
* **Documentation**
  * Updated README, agents docs, and site metadata to reflect endpoint count.
* **Tests**
  * Expanded coverage for graph build/extract, hooks, env config, and proxy behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/538?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
