### PR TITLE
revert: drop --next workaround for iii-console installer (upstream #1660 shipped)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -497,17 +497,8 @@ function detectIiiConsole(): IiiConsoleState {
   return { kind: "missing" };
 }
 
-// install.iii.dev/console/main/install.sh has a bug in its release-tag
-// filter that rejects every stable release for iii-hq/iii: the jq
-// predicate uses `startswith("v")` while the actual tags are
-// `iii/v0.12.0` (slash-prefixed). The `--next` path uses a regex
-// without the startswith constraint and therefore works today,
-// installing the most recent prerelease (e.g. iii/v0.14.0-next.1).
-//
-// Pass `--next` until the upstream fix lands (iii-hq/iii#1652).
-// Switch back to the bare invocation once the script is patched.
 const III_CONSOLE_INSTALL_CMD =
-  "curl -fsSL https://install.iii.dev/console/main/install.sh | bash -s -- --next";
+  "curl -fsSL https://install.iii.dev/console/main/install.sh | sh";
 
 async function ensureIiiConsole(): Promise<IiiConsoleState> {
   const state = detectIiiConsole();


### PR DESCRIPTION
## Why now

v0.9.19 routed first-run iii-console install through `bash -s -- --next` ([commit bb259ac](https://github.com/rohitg00/agentmemory/commit/bb259ac)) to work around iii-hq/iii's installer tag-prefix bug: `startswith("v")` filter rejected the actual `iii/v0.12.0` slash-prefixed tags, leaving every stable release invisible and the script bailing with `no stable iii release found`.

Upstream [iii-hq/iii#1660](https://github.com/iii-hq/iii/pull/1660) shipped the fix on 2026-05-19. Installer's jq predicate now reads `test("^(iii/)?v")` and the explicit-version path falls back from `iii/v${ver}` → `v${ver}` cleanly.

`install.iii.dev/console/main/install.sh` is a CDN proxy serving `raw.githubusercontent.com/iii-hq/iii/main/console/install.sh` with a 5-minute cache — no iii release tag required to propagate the fix. Verified live URL = upstream main HEAD byte-for-byte.

## Change

```diff
- // install.iii.dev/console/main/install.sh has a bug in its release-tag
- // filter that rejects every stable release for iii-hq/iii: the jq
- // predicate uses `startswith("v")` while the actual tags are
- // `iii/v0.12.0` (slash-prefixed). The `--next` path uses a regex
- // without the startswith constraint and therefore works today,
- // installing the most recent prerelease (e.g. iii/v0.14.0-next.1).
- //
- // Pass `--next` until the upstream fix lands (iii-hq/iii#1652).
- // Switch back to the bare invocation once the script is patched.
- const III_CONSOLE_INSTALL_CMD =
-   "curl -fsSL https://install.iii.dev/console/main/install.sh | bash -s -- --next";
+ const III_CONSOLE_INSTALL_CMD =
+   "curl -fsSL https://install.iii.dev/console/main/install.sh | sh";
```

One file, -10 +1. Drops the workaround + the explanatory comment block (no longer load-bearing).

## Backwards compat

v0.9.19/v0.9.20 users on `bash -s -- --next` continue to resolve a valid release — upstream #1660's regex update also fixes the `-next.*` lookup, so they're not stranded. New users / fresh installs after this PR ships get the canonical bare path.

## Verification

```bash
npm run build && npm test   # 1038/1038 pass locally
```

Manual probe of the live installer is included as a follow-up:

```bash
$ curl -sSL https://install.iii.dev/console/main/install.sh | grep -c 'iii/v'
# returns >0 — fix is live
$ curl -fsSL https://install.iii.dev/console/main/install.sh | sh   # plain path works
```

Closes the agentmemory side of the iii-hq/iii#1652 + #1660 trail.

## Related

- iii-hq/iii#1652 — tag-prefix bug (upstream, fixed by #1660)
- iii-hq/iii#1660 — installer fix (merged 2026-05-19)
- iii-hq/iii#1663 — separate 403 rate-limit bug, still open upstream, not addressed here

## Out of scope

The 403 rate-limit issue at iii-hq/iii#1663 (GitHub anonymous API limit on the installer's `releases?per_page=20` call) is unrelated — installer still uses no `Authorization` header. Affected users can pre-fetch the binary tarball directly from the releases page or splice a `GITHUB_TOKEN` into the API headers via a `sed` shim. Tracking separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the console installer command execution for improved reliability across different environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/546?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->