### PR TITLE
fix(funding): tighten FUNDING.yml to canonical single-line form

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,5 +1,1 @@
-# GitHub renders this as the "Sponsor" button at the top of the repo
-# and the Sponsor widget in the right sidebar. Enable GitHub Sponsors
-# on the profile at github.com/sponsors/accounts before merging so the
-# resulting link doesn't 404.
 github: [rohitg00]


### PR DESCRIPTION
Sponsor button missing on the repo page after #545 merged. Diff strips the 4-line comment prefix so the file matches GitHub's documented FUNDING schema exactly.

```yaml
github: [rohitg00]
```

Sponsor profile is enabled (`github.com/sponsors/rohitg00` returns 200 + 'Sponsor @rohitg00' button). The blocker is GitHub's side-bar indexer not picking up the file from #545 yet. Tightening forces a re-parse.

## Companion fix (separate)

The **Packages** sidebar widget is also empty because no release has been published since the `publish-github-packages` job was added. To populate it without cutting v0.9.21:

```bash
gh workflow run publish.yml --repo rohitg00/agentmemory
```

The existing `if npm view ... skipping` guards make this safe — public-npm jobs short-circuit, only the new GH Packages job actually does work. After it completes, `@rohitg00/agentmemory` should appear in the right-sidebar Packages section.

Need maintainer approval to dispatch — happy to run it once you greenlight, or you can fire it from the Actions tab directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified GitHub Sponsors funding configuration by removing unnecessary comments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/547?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->