### PR TITLE
revert: drop GH Packages mirror, keep single canonical install path

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,19 +11,14 @@ on:
         default: "agentmemory,mcp,fs-watcher"
 
 # Workflow-level permissions stay minimal — only `contents: read`
-# is required to check out the repo. Write scopes (`id-token: write`
-# for npm provenance, `packages: write` for the GH Packages mirror)
-# are granted per-job below so neither job inherits a scope it
-# doesn't need.
+# is required to check out the repo. `id-token: write` is granted on
+# the publish job for npm's --provenance Sigstore OIDC mint.
 permissions:
   contents: read
 
 jobs:
   publish:
     runs-on: ubuntu-latest
-    # `id-token: write` is required for npm publish --provenance to
-    # mint a Sigstore OIDC token on this run. Scoped to this job only
-    # so the GH Packages mirror job doesn't inherit it.
     permissions:
       contents: read
       id-token: write
@@ -127,49 +122,3 @@ jobs:
           done
           echo "ERROR: fs-watcher never propagated after 2 minutes" >&2
           exit 1
-
-  publish-github-packages:
-    # Mirror the same artifacts to GitHub Packages so the repo's
-    # right-sidebar "Packages" widget surfaces them. Scoped to
-    # @rohitg00 since GH Packages requires the org/user to match the
-    # repo owner. Public npm registry remains the canonical install
-    # source; this is purely a discovery surface on the repo page.
-    needs: publish
-    runs-on: ubuntu-latest
-    # `packages: write` only here — the public-npm publish job
-    # doesn't need it. `contents: read` for the checkout.
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          # Same posture as the publish job — no push back to the
-          # repo, so don't persist the token to `.git/config`.
-          persist-credentials: false
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 22
-          registry-url: https://npm.pkg.github.com
-          scope: "@rohitg00"
-
-      - run: npm install --package-lock-only --legacy-peer-deps --no-audit --no-fund
-      - run: npm ci --legacy-peer-deps --no-audit --no-fund
-      - run: npm run build
-
-      - name: Publish @rohitg00/agentmemory to GitHub Packages
-        run: |
-          VERSION=$(node -p "require('./package.json').version")
-          # Save original package.json, rewrite scope for GH Packages,
-          # publish, restore. Avoids a permanent scope change in main.
-          cp package.json package.json.bak
-          node -e "const p=require('./package.json');p.name='@rohitg00/agentmemory';p.publishConfig={registry:'https://npm.pkg.github.com'};require('fs').writeFileSync('package.json',JSON.stringify(p,null,2));"
-          if npm view "@rohitg00/agentmemory@$VERSION" version --registry=https://npm.pkg.github.com >/dev/null 2>&1; then
-            echo "GH Packages version already published, skipping"
-          else
-            npm publish --access public || echo "GH Packages publish failed (non-fatal)"
-          fi
-          mv package.json.bak package.json
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@
 <p align="center">
   <a href="https://www.npmjs.com/package/@agentmemory/agentmemory"><img src="https://img.shields.io/npm/v/@agentmemory/agentmemory?color=CB3837&label=npm&style=for-the-badge&logo=npm" alt="npm version" /></a>
   <a href="https://www.npmjs.com/package/@agentmemory/agentmemory"><img src="https://img.shields.io/npm/dm/@agentmemory/agentmemory?color=CB3837&label=downloads&style=for-the-badge&logo=npm" alt="npm downloads" /></a>
-  <a href="https://github.com/rohitg00/agentmemory/pkgs/npm/agentmemory"><img src="https://img.shields.io/badge/GitHub_Packages-mirror-181717?style=for-the-badge&logo=github&logoColor=white" alt="GitHub Packages mirror" /></a>
   <a href="https://github.com/rohitg00/agentmemory/actions"><img src="https://img.shields.io/github/actions/workflow/status/rohitg00/agentmemory/ci.yml?label=tests&style=for-the-badge&logo=github" alt="CI" /></a>
   <a href="https://github.com/rohitg00/agentmemory/blob/main/LICENSE"><img src="https://img.shields.io/github/license/rohitg00/agentmemory?color=blue&style=for-the-badge" alt="License" /></a>
   <a href="https://github.com/rohitg00/agentmemory/stargazers"><img src="https://img.shields.io/github/stars/rohitg00/agentmemory?style=for-the-badge&color=yellow&logo=github" alt="Stars" /></a>


### PR DESCRIPTION
Reverts the GH Packages publish from #545.

## Why

GitHub Packages is a **separate registry** from npmjs.com. Installing `@rohitg00/agentmemory` from `npm.pkg.github.com` requires the user to point their registry there + authenticate — that's real friction users don't hit on the canonical `@agentmemory/agentmemory` install from public npm.

The right-sidebar **Packages** widget on the repo page was the only motivation for the mirror. Better DX = single canonical install path. Sidebar widget stays empty; acceptable trade.

## Diff

```diff
- publish-github-packages job in .github/workflows/publish.yml
- packages: write permission references in the workflow comment block
- GitHub Packages mirror badge from README
```

`+2 / -54` across 2 files.

## Manual follow-up post-merge

Delete the already-published `@rohitg00/agentmemory@0.9.20` from GH Packages so the URL stops resolving:

- https://github.com/users/rohitg00/packages/npm/agentmemory/settings → **Manage versions** → delete `0.9.20`
- Or delete the package entirely → **Settings** → **Delete this package**

## Out of scope

Sponsor button surface (FUNDING.yml + #547) stays as-is — that part of #545 is unrelated and working.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README status badges to reflect npm registry distribution focus

* **Chores**
  * Streamlined publishing workflow to consolidate on npm registry as primary distribution channel

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/548?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->