### PR TITLE
docs(readme): drop sponsor badge — sidebar widget covers it

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@
   <a href="https://github.com/rohitg00/agentmemory/actions"><img src="https://img.shields.io/github/actions/workflow/status/rohitg00/agentmemory/ci.yml?label=tests&style=for-the-badge&logo=github" alt="CI" /></a>
   <a href="https://github.com/rohitg00/agentmemory/blob/main/LICENSE"><img src="https://img.shields.io/github/license/rohitg00/agentmemory?color=blue&style=for-the-badge" alt="License" /></a>
   <a href="https://github.com/rohitg00/agentmemory/stargazers"><img src="https://img.shields.io/github/stars/rohitg00/agentmemory?style=for-the-badge&color=yellow&logo=github" alt="Stars" /></a>
-  <a href="https://github.com/sponsors/rohitg00"><img src="https://img.shields.io/badge/sponsor-rohitg00-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white" alt="Sponsor rohitg00 on GitHub Sponsors" /></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
GitHub auto-renders the **Sponsor this project** widget in the right sidebar from `.github/FUNDING.yml` (Sponsor button + heart icon + "Learn more about GitHub Sponsors" link). The README badge was redundant noise on the top badge row.

Sidebar widget is the canonical surface — one path, one click.

`-1 line` across 1 file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed GitHub Sponsors badge from the documentation header.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/549?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->