### PR TITLE
fix(cli): accurately display bound viewer port on splash screen

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -195,9 +195,36 @@ function getBaseUrl(): string {
   return `http://localhost:${getRestPort()}`;
 }
 
+let discoveredViewerPort: number | null = null;
+
+export async function discoverViewerPort(): Promise<void> {
+  if (discoveredViewerPort !== null) return;
+  try {
+    const res = await fetch(`${getBaseUrl()}/agentmemory/livez`, {
+      signal: AbortSignal.timeout(1000),
+    });
+    if (res.ok) {
+      const data = await res.json() as { viewerPort?: number | null };
+      if (typeof data.viewerPort === "number") {
+        discoveredViewerPort = data.viewerPort;
+      }
+    }
+  } catch {}
+}
+
 function getViewerUrl(): string {
   const envUrl = process.env["AGENTMEMORY_VIEWER_URL"];
   if (envUrl) return envUrl.replace(/\/+$/, "");
+  
+  if (discoveredViewerPort !== null) {
+    try {
+      const u = new URL(getBaseUrl());
+      return `${u.protocol}//${u.hostname}:${discoveredViewerPort}`;
+    } catch {
+      return `http://localhost:${discoveredViewerPort}`;
+    }
+  }
+  
   try {
     const u = new URL(getBaseUrl());
     const vPort =
@@ -257,7 +284,18 @@ async function isAgentmemoryReady(): Promise<boolean> {
     const res = await fetch(`${getBaseUrl()}/agentmemory/livez`, {
       signal: AbortSignal.timeout(2000),
     });
-    return res.ok;
+    if (!res.ok) return false;
+    try {
+      const data = await res.json() as { viewerPort?: number | null; viewerSkipped?: boolean };
+      if (typeof data.viewerPort === "number") {
+        discoveredViewerPort = data.viewerPort;
+        return true;
+      }
+      if (data.viewerSkipped) return true;
+      return false;
+    } catch {
+      return false;
+    }
   } catch {
     return false;
   }
@@ -1101,6 +1139,9 @@ async function runStatus() {
       apiFetch<any>(base, "config/flags"),
     ]);
 
+    if (typeof healthRes?.viewerPort === "number") {
+      discoveredViewerPort = healthRes.viewerPort;
+    }
     const h = healthRes?.health;
     const status = healthRes?.status || "unknown";
     const version = healthRes?.version || "?";
@@ -1260,6 +1301,7 @@ function buildDoctorEffects(): DoctorEffects {
     iiiBinaryVersion: (binPath: string) => iiiBinVersion(binPath),
     viewerReachable: async (timeoutMs = 2000) => {
       try {
+        await discoverViewerPort();
         const res = await fetch(getViewerUrl(), {
           signal: AbortSignal.timeout(timeoutMs),
         });

--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -9,6 +9,7 @@ import type { ResilientProvider } from "../providers/resilient.js";
 import { VERSION } from "../version.js";
 import { timingSafeCompare } from "../auth.js";
 import { renderViewerDocument } from "../viewer/document.js";
+import { getBoundViewerPort, getViewerSkipped } from "../viewer/server.js";
 import { MAX_FILES_UPPER_BOUND } from "../functions/replay.js";
 import {
   isGraphExtractionEnabled,
@@ -143,7 +144,7 @@ export function registerApiTriggers(
   sdk.registerFunction("api::liveness",
     async (): Promise<Response> => ({
       status_code: 200,
-      body: { status: "ok", service: "agentmemory" },
+      body: { status: "ok", service: "agentmemory", viewerPort: getBoundViewerPort(), viewerSkipped: getViewerSkipped() },
     }),
   );
   sdk.registerTrigger({
@@ -244,6 +245,8 @@ export function registerApiTriggers(
           health: health || null,
           functionMetrics,
           circuitBreaker,
+          viewerPort: getBoundViewerPort(),
+          viewerSkipped: getViewerSkipped(),
         },
       };
     },

--- a/src/viewer/server.ts
+++ b/src/viewer/server.ts
@@ -131,6 +131,16 @@ function readBody(req: IncomingMessage): Promise<string> {
 
 const MAX_VIEWER_PORT_RETRIES = 10;
 
+let boundViewerPort: number | null = null;
+let viewerSkipped = false;
+
+export function getBoundViewerPort(): number | null {
+  return boundViewerPort;
+}
+export function getViewerSkipped(): boolean {
+  return viewerSkipped;
+}
+
 export function startViewerServer(
   port: number,
   _kv: unknown,
@@ -227,6 +237,7 @@ export function startViewerServer(
   };
 
   server.on("listening", () => {
+    boundViewerPort = currentPort;
     if (currentPort === requestedPort) {
       console.log(`[agentmemory] Viewer: http://localhost:${currentPort}`);
     } else {
@@ -244,10 +255,12 @@ export function startViewerServer(
       return;
     }
     if (err.code === "EADDRINUSE") {
+      viewerSkipped = true;
       console.warn(
         `[agentmemory] Viewer ports ${requestedPort}-${requestedPort + MAX_VIEWER_PORT_RETRIES} all in use, skipping viewer.`,
       );
     } else {
+      viewerSkipped = true;
       console.error(`[agentmemory] Viewer error:`, err.message);
     }
   });

--- a/src/viewer/server.ts
+++ b/src/viewer/server.ts
@@ -148,6 +148,10 @@ export function startViewerServer(
   secret?: string,
   restPort?: number,
 ): Server {
+  // Reset exported runtime state for each start attempt.
+  boundViewerPort = null;
+  viewerSkipped = false;
+
   const resolvedRestPort = restPort ?? port - 2;
   const requestedPort = port;
   // Computed lazily on first request — `port` may be 0 here (OS-assigned)
@@ -237,7 +241,12 @@ export function startViewerServer(
   };
 
   server.on("listening", () => {
-    boundViewerPort = currentPort;
+    const addr = server.address();
+    boundViewerPort =
+      addr && typeof addr === "object" && "port" in addr
+        ? addr.port
+        : currentPort;
+    viewerSkipped = false;
     if (currentPort === requestedPort) {
       console.log(`[agentmemory] Viewer: http://localhost:${currentPort}`);
     } else {
@@ -255,11 +264,13 @@ export function startViewerServer(
       return;
     }
     if (err.code === "EADDRINUSE") {
+      boundViewerPort = null;
       viewerSkipped = true;
       console.warn(
         `[agentmemory] Viewer ports ${requestedPort}-${requestedPort + MAX_VIEWER_PORT_RETRIES} all in use, skipping viewer.`,
       );
     } else {
+      boundViewerPort = null;
       viewerSkipped = true;
       console.error(`[agentmemory] Viewer error:`, err.message);
     }


### PR DESCRIPTION
- Expose viewerPort and viewerSkipped state in /agentmemory/livez endpoint.
- Update CLI readiness check to poll until the viewer port is bound or explicitly skipped.
- Prevents misleading default port (3113) display on splash screen when the viewer falls back to another port.

**Fixes #521**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now auto-discovers the viewer port from the running server and uses it to build viewer URLs.
  * Health and liveness endpoints include viewer server status, port, and a "viewer skipped" indicator.
  * Readiness and diagnostics now honor discovered viewer port and treat skipped-viewer signals as ready, improving reachability checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/560?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->