### PR TITLE
fix: read tool_response instead of tool_output in PostToolUse hook

### DIFF
--- a/plugin/scripts/post-tool-use.mjs
+++ b/plugin/scripts/post-tool-use.mjs
@@ -23,7 +23,7 @@ async function main() {
 	}
 	if (isSdkChildContext(data)) return;
 	const sessionId = data.session_id || "unknown";
-	const { imageData, cleanOutput } = extractImageData(data.tool_output);
+	const { imageData, cleanOutput } = extractImageData(data.tool_response ?? data.tool_output);
 	try {
 		await fetch(`${REST_URL}/agentmemory/observe`, {
 			method: "POST",

--- a/src/hooks/post-tool-use.ts
+++ b/src/hooks/post-tool-use.ts
@@ -32,7 +32,11 @@ async function main() {
 
   const sessionId = (data.session_id as string) || "unknown";
 
-  const { imageData, cleanOutput } = extractImageData(data.tool_output);
+  // Claude Code's PostToolUse payload uses `tool_response`; fall back to
+  // `tool_output` for older integrations that may use the legacy field name.
+  const { imageData, cleanOutput } = extractImageData(
+    data.tool_response ?? data.tool_output,
+  );
 
   try {
     await fetch(`${REST_URL}/agentmemory/observe`, {

--- a/src/hooks/post-tool-use.ts
+++ b/src/hooks/post-tool-use.ts
@@ -32,8 +32,6 @@ async function main() {
 
   const sessionId = (data.session_id as string) || "unknown";
 
-  // Claude Code's PostToolUse payload uses `tool_response`; fall back to
-  // `tool_output` for older integrations that may use the legacy field name.
   const { imageData, cleanOutput } = extractImageData(
     data.tool_response ?? data.tool_output,
   );


### PR DESCRIPTION
## Root cause

`src/hooks/post-tool-use.ts` (and its compiled counterpart `plugin/scripts/post-tool-use.mjs`) read the tool output from `data.tool_output`:

```ts
const { imageData, cleanOutput } = extractImageData(data.tool_output);
```

But Claude Code's PostToolUse hook payload uses `tool_response`, not `tool_output`. This means `cleanOutput` is always `undefined`, the observe request reaches the server with no output value, and `mem::compress` fails schema validation on every real tool call — `narrative` and `facts` are empty so the XML schema check fails.

Captured real PostToolUse payload from Claude Code (from #539):

```json
{
  "hook_event_name": "PostToolUse",
  "tool_name": "Bash",
  "tool_input": { "command": "echo hi" },
  "tool_response": { "stdout": "hi\n", "stderr": "", "interrupted": false }
}
```

## Fix

Read `data.tool_response` with `data.tool_output` as a fallback so any older integration still using the legacy field name keeps working:

```ts
const { imageData, cleanOutput } = extractImageData(
  data.tool_response ?? data.tool_output,
);
```

Same one-liner applied to the compiled `plugin/scripts/post-tool-use.mjs`.

## Impact

Without this fix `mem::compress` silently fails on ~100% of real Claude Code tool calls, degrading `memory_recall` output and starving the consolidation pipeline of compressed observations.

Fixes #539

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool response processing to prefer the newer response field when present, falling back to legacy output otherwise.
  * Ensures image data and cleaned output are correctly extracted and included in downstream observations, improving compatibility and reliability across response formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/561?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->