### PR TITLE
fix(deps): pin iii-sdk to 0.11.2 (closes #555)

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@anthropic-ai/sdk": "^0.39.0",
     "@clack/prompts": "^1.2.0",
     "dotenv": "^17.4.2",
-    "iii-sdk": "^0.11.2",
+    "iii-sdk": "0.11.2",
     "zod": "^4.0.0"
   },
   "optionalDependencies": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1967,7 +1967,7 @@ async function runUpgrade() {
       });
       requireSuccess(installOk, "pnpm install");
       runCommand(pnpmBin, ["up", "iii-sdk@0.11.2"], {
-        label: "Pinning iii-sdk@0.11.2 (see #555)",
+        label: "Pinning iii-sdk@0.11.2",
         optional: true,
       });
     } else if (npmBin) {
@@ -1976,7 +1976,7 @@ async function runUpgrade() {
       });
       requireSuccess(installOk, "npm install");
       runCommand(npmBin, ["install", "iii-sdk@0.11.2"], {
-        label: "Pinning iii-sdk@0.11.2 (see #555)",
+        label: "Pinning iii-sdk@0.11.2",
         optional: true,
       });
     } else {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1966,8 +1966,8 @@ async function runUpgrade() {
         label: "Refreshing dependencies (pnpm install)",
       });
       requireSuccess(installOk, "pnpm install");
-      runCommand(pnpmBin, ["up", "iii-sdk@latest"], {
-        label: "Upgrading iii-sdk to latest",
+      runCommand(pnpmBin, ["up", "iii-sdk@0.11.2"], {
+        label: "Pinning iii-sdk@0.11.2 (see #555)",
         optional: true,
       });
     } else if (npmBin) {
@@ -1975,8 +1975,8 @@ async function runUpgrade() {
         label: "Refreshing dependencies (npm install)",
       });
       requireSuccess(installOk, "npm install");
-      runCommand(npmBin, ["install", "iii-sdk@latest"], {
-        label: "Upgrading iii-sdk to latest",
+      runCommand(npmBin, ["install", "iii-sdk@0.11.2"], {
+        label: "Pinning iii-sdk@0.11.2 (see #555)",
         optional: true,
       });
     } else {


### PR DESCRIPTION
## Summary

Closes #555.

`iii-sdk@0.11.6` changed nested routing behavior so that every `/agentmemory/*` route returns `404` against the iii-engine, even though `0.11.6` still satisfies our previous `"^0.11.2"` range. `npm install -g @agentmemory/agentmemory` silently drifted everyone forward after 0.9.21 shipped, breaking the REST server with no visible signal.

## Pin sites

1. **`package.json`** — `"iii-sdk": "^0.11.2"` → `"iii-sdk": "0.11.2"`. Caret-range removed; npm can no longer pick up minor or patch releases until we explicitly re-pin.

2. **`src/cli.ts`** — the `agentmemory setup` flow previously ran `pnpm up iii-sdk@latest` / `npm install iii-sdk@latest`. That would re-pull `0.11.6+` even after a freshly pinned install. Both call sites now pin to `0.11.2` with a label that references #555 so the intent is obvious in logs.

## Validation

- `npm install --legacy-peer-deps` → `iii-sdk@0.11.2` resolved
- `npm test` → 97/97 test files, 1081/1081 tests pass
- `npm run build` → bundles clean

## Forward path

When the upstream regression is sorted, bump to the fixed version explicitly (don't switch back to caret) so we never silently drift again.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned the iii-sdk dependency to exact version 0.11.2 in project configuration (replacing a flexible version range).
  * The upgrade workflow now installs/pins iii-sdk@0.11.2 for both npm and pnpm paths instead of updating to the latest release, ensuring consistent dependency resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/567?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->