### PR TITLE
feat(graph): auto-trigger mem::graph-extract on mem::remember

### DIFF
--- a/src/functions/remember.ts
+++ b/src/functions/remember.ts
@@ -7,7 +7,7 @@ import { memoryToObservation } from "../state/memory-utils.js";
 import { deleteAccessLog } from "./access-tracker.js";
 import { recordAudit } from "./audit.js";
 import { getSearchIndex, vectorIndexAddGuarded, vectorIndexRemove, flushIndexSave } from "./search.js";
-import { getAgentId } from "../config.js";
+import { isGraphExtractionEnabled, getAgentId } from "../config.js";
 import { logger } from "../logger.js";
 
 export function registerRememberFunction(sdk: ISdk, kv: StateKV): void {
@@ -146,6 +146,37 @@ export function registerRememberFunction(sdk: ISdk, kv: StateKV): void {
           memory.title + " " + memory.content,
           { kind: "memory", logId: memory.id },
         );
+
+        // Feed the knowledge graph from saved memories the same way
+        // observation writes do (event::session::compressed in
+        // triggers/events.ts). Without this, Memory records — including
+        // bulk imports like in-repo doc ingestion or post-hoc lesson
+        // crystallization — never populate KV.graphNodes/Edges, so
+        // mem::reflect's graph-clustering path doesn't see them and
+        // ends up synthesizing only from lessons + semantic facts +
+        // crystals. Gated on the same GRAPH_EXTRACTION_ENABLED flag
+        // that the observation path already honors. Fire-and-forget;
+        // graph-extract is an LLM call that can take seconds and must
+        // not block the remember response.
+        if (isGraphExtractionEnabled()) {
+          // Fire-and-forget graph extraction. The Void action enqueues
+          // the work without returning a promise, so there's no async
+          // rejection to leak (the engine queue owns downstream
+          // failures); the try/catch guards only a synchronous enqueue
+          // throw. v3-d; replaces the removed sdk.triggerVoid (#773).
+          try {
+            sdk.trigger({
+              function_id: "mem::graph-extract",
+              payload: { observations: [memoryToObservation(memory)] },
+              action: TriggerAction.Void(),
+            });
+          } catch (err) {
+            logger.warn("graph-extract enqueue threw on remember", {
+              memId: memory.id,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }
 
         if (supersededId) {
           await sdk.trigger({

--- a/test/cross-project-isolation.test.ts
+++ b/test/cross-project-isolation.test.ts
@@ -20,6 +20,7 @@ vi.mock("../src/functions/access-tracker.js", () => ({
 vi.mock("../src/config.js", () => ({
   getAgentId: () => undefined,
   isAgentScopeIsolated: () => false,
+  isGraphExtractionEnabled: () => false,
 }));
 
 import { registerRememberFunction } from "../src/functions/remember.js";


### PR DESCRIPTION
## Summary

`mem::remember` (the explicit memory-save path used by `memory_save` MCP calls, plugin Stop hooks, JSONL imports, etc.) does NOT auto-trigger `mem::graph-extract`. Observations *do* auto-trigger extraction when `GRAPH_EXTRACTION_ENABLED=true`, but memories don't — so the knowledge graph grows from observation traffic only, leaving curated memories invisible to graph queries.

This wires the same auto-trigger pattern on the memory write path: after a successful `mem::remember`, fire `mem::graph-extract` against the newly-saved memory id when `GRAPH_EXTRACTION_ENABLED=true`. Best-effort; failure is logged-and-continued so a slow/down LLM provider can't block the save.

## Impact

Closes the gap between observation-driven and memory-driven graph growth. After this:

- `mem::lineage` (with `includeGraph: true`) sees the same node set whether a concept was extracted from observation traffic or written as a memory.
- `mem::smart-search` graph-score component lights up for curated memories.
- `agentmemory graph-build` (#538, if/when it lands) becomes a backfill tool for old data, not the only path for new data.

## Related

- Complements #502 (graph extraction on manual session end) — same auto-trigger pattern, different event.
- Independent of #538 (graph backfill) — that handles historical data, this handles new writes.

## Test plan

- [x] Existing tests pass (\`npm test\`)
- [x] \`GRAPH_EXTRACTION_ENABLED=true mem::remember\` produces graph nodes within the configured concurrency window
- [x] \`GRAPH_EXTRACTION_ENABLED=false\` (default) no-ops the trigger


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Memory saves can now optionally trigger background knowledge-graph extraction when the feature flag is enabled. Extraction runs asynchronously after a save so the save remains fast; extraction errors are logged as warnings and do not block or revert the original save.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
