### PR TITLE
perf(summarize): skip mem::summarize when a fresh summary exists

### DIFF
--- a/src/functions/summarize.ts
+++ b/src/functions/summarize.ts
@@ -50,6 +50,15 @@ function getChunkConcurrency(): number {
   return Number.isFinite(n) && n > 0 ? n : CHUNK_CONCURRENCY_DEFAULT;
 }
 
+const DEDUP_WINDOW_MS_DEFAULT = 90_000;
+
+function getDedupWindowMs(): number {
+  const raw = process.env["SUMMARIZE_DEDUP_WINDOW_MS"];
+  if (raw === undefined) return DEDUP_WINDOW_MS_DEFAULT;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? n : DEDUP_WINDOW_MS_DEFAULT;
+}
+
 // One chunk call with retry-once. Returns null when both attempts fail —
 // whether by parse failure, provider 4xx (content rejected by upstream
 // filters), or transient network/5xx errors that didn't recover on retry.
@@ -248,15 +257,9 @@ export function registerSummarizeFunction(
         return { success: false, error: "session_not_found" };
       }
 
-      // Skip the LLM call when an existing summary is younger than
-      // SUMMARIZE_DEDUP_WINDOW_MS (default 90s, set to 0 to disable).
-      // Stop hooks fire on every assistant turn — at sub-minute
-      // granularity the observation delta rarely justifies a new summary.
-      const dedupRaw = process.env["SUMMARIZE_DEDUP_WINDOW_MS"];
-      const dedupWindowMs =
-        dedupRaw !== undefined && Number.isFinite(Number(dedupRaw))
-          ? Math.max(0, Number(dedupRaw))
-          : 90_000;
+      // Stop hooks fire on every assistant turn; at sub-minute granularity
+      // the observation delta rarely justifies a fresh LLM summary.
+      const dedupWindowMs = getDedupWindowMs();
       if (dedupWindowMs > 0) {
         const existing = await kv
           .get<SessionSummary>(KV.summaries, sessionId)

--- a/src/functions/summarize.ts
+++ b/src/functions/summarize.ts
@@ -248,13 +248,10 @@ export function registerSummarizeFunction(
         return { success: false, error: "session_not_found" };
       }
 
-      // Fresh-summary dedup: Stop hooks fire summarize on every assistant
-      // turn. For chatty sessions that produce one summary every few
-      // seconds, re-running the full LLM-driven summarize is wasted work
-      // — observation deltas at sub-minute granularity rarely justify
-      // re-summarizing. If an existing summary is younger than the
-      // window below, skip without LLM work. Tunable via
+      // Skip the LLM call when an existing summary is younger than
       // SUMMARIZE_DEDUP_WINDOW_MS (default 90s, set to 0 to disable).
+      // Stop hooks fire on every assistant turn — at sub-minute
+      // granularity the observation delta rarely justifies a new summary.
       const dedupRaw = process.env["SUMMARIZE_DEDUP_WINDOW_MS"];
       const dedupWindowMs =
         dedupRaw !== undefined && Number.isFinite(Number(dedupRaw))

--- a/src/functions/summarize.ts
+++ b/src/functions/summarize.ts
@@ -248,6 +248,44 @@ export function registerSummarizeFunction(
         return { success: false, error: "session_not_found" };
       }
 
+      // Fresh-summary dedup: Stop hooks fire summarize on every assistant
+      // turn. For chatty sessions that produce one summary every few
+      // seconds, re-running the full LLM-driven summarize is wasted work
+      // — observation deltas at sub-minute granularity rarely justify
+      // re-summarizing. If an existing summary is younger than the
+      // window below, skip without LLM work. Tunable via
+      // SUMMARIZE_DEDUP_WINDOW_MS (default 90s, set to 0 to disable).
+      const dedupRaw = process.env["SUMMARIZE_DEDUP_WINDOW_MS"];
+      const dedupWindowMs =
+        dedupRaw !== undefined && Number.isFinite(Number(dedupRaw))
+          ? Math.max(0, Number(dedupRaw))
+          : 90_000;
+      if (dedupWindowMs > 0) {
+        const existing = await kv
+          .get<SessionSummary>(KV.summaries, sessionId)
+          .catch(() => null);
+        if (existing && existing.createdAt) {
+          const ageMs = Date.now() - Date.parse(existing.createdAt);
+          if (Number.isFinite(ageMs) && ageMs >= 0 && ageMs < dedupWindowMs) {
+            logger.info("Summarize skipped — fresh summary present", {
+              sessionId,
+              ageMs,
+              dedupWindowMs,
+            });
+            const latencyMs = Date.now() - startMs;
+            if (metricsStore) {
+              await metricsStore.record("mem::summarize", latencyMs, true);
+            }
+            return {
+              success: true,
+              skipped: "fresh",
+              ageMs,
+              summary: existing,
+            };
+          }
+        }
+      }
+
       const observations = await kv.list<CompressedObservation>(
         KV.observations(sessionId),
       );


### PR DESCRIPTION
## Summary

Stop hooks fire \`mem::summarize\` on every assistant turn. For chatty sessions, summarize completes successfully every few seconds — and the next turn fires another full LLM-driven summarize pass. On serverless / rate-limited LLM providers, these stack: by the time one summarize finishes, the next is already in flight, both contending for the same provider rate budget.

This adds a freshness gate at the top of \`mem::summarize\`: if an existing \`SessionSummary\` for the requested sessionId is younger than \`SUMMARIZE_DEDUP_WINDOW_MS\` (default 90,000 ms / 90 s, set to \`0\` to disable), return the cached summary with \`skipped: "fresh"\` and skip the LLM work entirely.

## Smoke-validated

| Call | Wall-clock | Result |
|---|---|---|
| First call (small session, 6 obs) | **6.4 s** | real LLM run, qualityScore 100 → summary stored |
| Second call within 90 s | **0.02 s** | \`skipped: "fresh"\`, \`ageMs: 77\`, **zero LLM calls** |

\`MetricsStore\` is still pinged on the dedup path (as a successful call) so per-function latency stats stay accurate.

## Why now

This complements:
- **#472** (chunk large sessions) — already merged, reduced per-call LLM tokens but didn't address the per-turn re-summarize.
- The Stop-hook fire-and-forget work (separate PR) — server-side dedup means even when the hook does block briefly, the work is trivial.

Combined effect: typical Stop-hook → /agentmemory/summarize → dedup-hit chain is now ~50 ms server-side instead of a multi-LLM-call cycle.

## Test plan

- [x] \`npm test\` passes
- [x] Manual smoke against a small session: first call ran, second call within 90 s returned \`skipped: "fresh"\` with \`ageMs\` populated
- [x] \`SUMMARIZE_DEDUP_WINDOW_MS=0\` disables the gate
- [x] Default 90 s tunable per environment

## Notes

The window is env-configurable but not currently exposed in any config schema. Bump to \`600000\` (10 min) for very chatty long-running sessions if the default feels too aggressive.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Summary generation now reuses a recent summary when one exists within a configurable freshness window, skipping repeated reprocessing.
  * Faster summary retrieval and reduced resource use for a more responsive experience; freshness window can be adjusted (or disabled) to control skipping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
