### PR TITLE
fix(observe): auto-create session row + surface session/start HTTP errors (closes #522)

### DIFF
--- a/plugin/scripts/session-start.mjs
+++ b/plugin/scripts/session-start.mjs
@@ -41,6 +41,8 @@ async function main() {
 		fetch(url, {
 			...init,
 			signal: AbortSignal.timeout(REGISTER_TIMEOUT_MS)
+		}).then((res) => {
+			if (!res.ok) process.stderr.write(`[agentmemory] session/start returned ${res.status} for ${sessionId}\n`);
 		}).catch(() => {});
 		return;
 	}
@@ -52,7 +54,7 @@ async function main() {
 		if (res.ok) {
 			const result = await res.json();
 			if (result.context) process.stdout.write(result.context);
-		}
+		} else process.stderr.write(`[agentmemory] session/start returned ${res.status} for ${sessionId}\n`);
 	} catch {}
 }
 main();

--- a/src/functions/observe.ts
+++ b/src/functions/observe.ts
@@ -214,6 +214,28 @@ export function registerObserveFunction(
             }
           }
           await kv.update(KV.sessions, payload.sessionId, updates);
+        } else {
+          // Auto-create the session row when an observation arrives before
+          // (or instead of) a successful session/start call. The hook
+          // scripts call session/start as fire-and-forget; on transient
+          // server unavailability that POST is silently dropped, leaving
+          // observations orphaned from GET /agentmemory/sessions even
+          // though they're present on disk. Re-creating here closes the
+          // data-loss hole permanently; session/start remains the fast
+          // path (it also returns the injected context).
+          const firstPrompt =
+            typeof raw.userPrompt === "string"
+              ? raw.userPrompt.replace(/\s+/g, " ").trim().slice(0, 200)
+              : undefined;
+          await kv.set(KV.sessions, payload.sessionId, {
+            id: payload.sessionId,
+            project: payload.project,
+            cwd: payload.cwd,
+            startedAt: payload.timestamp,
+            status: "active",
+            observationCount: 1,
+            ...(firstPrompt ? { firstPrompt } : {}),
+          });
         }
 
         // Per-observation LLM compression is opt-in as of 0.8.8 (#138).

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -62,11 +62,24 @@ async function main() {
   if (!INJECT_CONTEXT) {
     // Pure telemetry path: caller never reads the response, so don't
     // block on it. AbortSignal.timeout caps the wait the event loop
-    // gives the pending socket before exit.
+    // gives the pending socket before exit. Server-side observe now
+    // auto-creates a session row when one is missing (#522), so a
+    // dropped POST here is a missed context-inject, not data loss.
     fetch(url, {
       ...init,
       signal: AbortSignal.timeout(REGISTER_TIMEOUT_MS),
-    }).catch(() => {});
+    })
+      .then((res) => {
+        // Surface HTTP errors so wiring problems (wrong URL, auth)
+        // don't stay invisible. Network/timeout errors fall through
+        // to .catch() and stay quiet — those are common on cold-start.
+        if (!res.ok) {
+          process.stderr.write(
+            `[agentmemory] session/start returned ${res.status} for ${sessionId}\n`,
+          );
+        }
+      })
+      .catch(() => {});
     return;
   }
 
@@ -80,9 +93,14 @@ async function main() {
       if (result.context) {
         process.stdout.write(result.context);
       }
+    } else {
+      process.stderr.write(
+        `[agentmemory] session/start returned ${res.status} for ${sessionId}\n`,
+      );
     }
   } catch {
-    // silently fail -- don't block Claude Code startup
+    // network/timeout — don't block Claude Code startup; observe-side
+    // will still pick up the session via auto-upsert (#522).
   }
 }
 


### PR DESCRIPTION
## Summary

Closes #522.

Silent data-loss path: when a client posts to `POST /agentmemory/observe` before (or instead of) a successful `POST /agentmemory/session/start`, observations land in `KV.observations(sessionId)` but `KV.sessions` never gets the parent row. `GET /agentmemory/sessions` then returns an empty list even though the underlying observation files are on disk.

Root cause from the issue + confirmed by @huyzhui222:
- Hook script `session-start.mjs` POSTs `/agentmemory/session/start` as fire-and-forget (`fetch(...).catch(() => {})`).
- When that POST fails silently (transient server unavailability on cold-start, wrong URL, auth, …), the session record is never written.
- `observe` still writes its observation, leaving orphaned rows.

## Two complementary changes

### 1. Server-side: `observe` upserts the session row if missing

`src/functions/observe.ts` — when `observe` lands and `kv.get(KV.sessions, sessionId)` returns nothing, insert it inline using the `project` / `cwd` / `timestamp` / first-prompt fields already present on the payload. `session/start` stays the fast path (it also returns the inject-context block) but is no longer load-bearing for durability.

### 2. Hook-side: surface HTTP errors

`src/hooks/session-start.ts` — explicit `process.stderr.write` when `session/start` returns a non-2xx status, on both the fire-and-forget and inject-context paths. Network/timeout errors stay quiet (common on cold-start); HTTP errors surface so wiring problems (wrong URL, auth, etc.) become visible. The compiled `plugin/scripts/session-start.mjs` is regenerated by tsdown.

## Diff

- `src/functions/observe.ts` — `+22` server-side auto-upsert in the `else` branch where session is missing
- `src/hooks/session-start.ts` — `+24/-3` `.then(res => res.ok || log)` on both paths
- `plugin/scripts/session-start.mjs` — `+3/-1` regenerated by tsdown

Total 46 insertions, 4 deletions across 3 files.

## Validation

- `npm test` → 97/97 test files, 1081/1081 tests pass
- `npm run build` → bundle clean

## Backwards compatibility

- `session/start` keeps returning the same response shape.
- Existing session rows are untouched; only the `else` branch (session missing) gains behavior.
- Hooks that previously swallowed all errors now log non-2xx — this is the desired behavior per the issue, and is consistent with the no-data-loss promise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sessions are now automatically created when observations are received, preventing data loss.

* **Improvements**
  * Session start failures are now logged for better visibility and debugging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/576?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->