### PR TITLE
fix(cli): pass Authorization Bearer header in CLI helpers (closes #518)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1716,6 +1716,13 @@ function buildDemoSessions(): DemoSession[] {
   ];
 }
 
+function jsonAuthHeaders(): Record<string, string> {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  const secret = process.env["AGENTMEMORY_SECRET"];
+  if (secret) headers["Authorization"] = `Bearer ${secret}`;
+  return headers;
+}
+
 async function postJson<T = unknown>(
   url: string,
   body: unknown,
@@ -1724,7 +1731,7 @@ async function postJson<T = unknown>(
   try {
     const res = await fetch(url, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: jsonAuthHeaders(),
       body: JSON.stringify(body),
       signal: AbortSignal.timeout(timeoutMs),
     });
@@ -1742,7 +1749,7 @@ async function postJsonStrict<T = unknown>(
 ): Promise<T | null> {
   const res = await fetch(url, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: jsonAuthHeaders(),
     body: JSON.stringify(body),
     signal: AbortSignal.timeout(timeoutMs),
   });


### PR DESCRIPTION
## Summary

Closes #518.

When `AGENTMEMORY_SECRET` is set, the server enables the `api-auth` middleware on every mutating REST route (including `/agentmemory/session/start`). The CLI's own HTTP helpers — `postJson` and `postJsonStrict` — were not passing the `Authorization: Bearer ${AGENTMEMORY_SECRET}` header, so `agentmemory demo` and any other internal CLI HTTP call would `401 unauthorized` the moment a secret was configured.

This matches exactly what @victorbjuliani found:
```
■  POST http://localhost:3111/agentmemory/session/start failed:
   401 Unauthorized — {"error":"unauthorized"}
```

Plugin scripts (`plugin/scripts/*.mjs`) already pass the Bearer correctly via `authHeaders()`. This PR brings the CLI helpers in line.

## Diff

- `src/cli.ts` — `+9/-2` adds `jsonAuthHeaders()` helper and routes both `postJson` + `postJsonStrict` through it.

## Validation

- `npm test` → 97/97 test files, 1081/1081 tests pass
- `npm run build` → bundle clean

## Note on import-jsonl + consolidation pipeline

The issue body originally framed the symptom as "consolidation pipeline halts after `import-jsonl`". `import-jsonl` itself does pass the Bearer (`src/cli.ts:2329-2330`) and writes sessions + observations directly via the replay function, which by current design uses synthetic compression inline rather than fanning out through the live `mem::observe` consolidation triggers.

If `import-jsonl` should also enqueue flow-compress / consolidate / graph-extract on imported observations, that's a separate behavior change worth a dedicated issue — please open a follow-up if so. This PR addresses the auth gap that was blocking `demo` and any other CLI HTTP path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * POST requests in the CLI now properly authenticate with the server secret when configured.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/577?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->