### PR TITLE
fix: read Claude Code tool_response in PostToolUse hook

### DIFF
--- a/plugin/scripts/post-tool-use.mjs
+++ b/plugin/scripts/post-tool-use.mjs
@@ -23,7 +23,8 @@ async function main() {
 	}
 	if (isSdkChildContext(data)) return;
 	const sessionId = data.session_id || "unknown";
-	const { imageData, cleanOutput } = extractImageData(data.tool_output);
+	const toolOutput = data.tool_response ?? data.tool_output;
+	const { imageData, cleanOutput } = extractImageData(toolOutput);
 	try {
 		await fetch(`${REST_URL}/agentmemory/observe`, {
 			method: "POST",

--- a/src/hooks/post-tool-use.ts
+++ b/src/hooks/post-tool-use.ts
@@ -31,8 +31,9 @@ async function main() {
   if (isSdkChildContext(data)) return;
 
   const sessionId = (data.session_id as string) || "unknown";
+  const toolOutput = data.tool_response ?? data.tool_output;
 
-  const { imageData, cleanOutput } = extractImageData(data.tool_output);
+  const { imageData, cleanOutput } = extractImageData(toolOutput);
 
   try {
     await fetch(`${REST_URL}/agentmemory/observe`, {

--- a/test/post-tool-use-hook.test.ts
+++ b/test/post-tool-use-hook.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import { spawn } from "node:child_process";
+import { createServer, type IncomingMessage } from "node:http";
+import { join } from "node:path";
+
+const HOOK = join(
+  import.meta.dirname,
+  "..",
+  "plugin",
+  "scripts",
+  "post-tool-use.mjs",
+);
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let body = "";
+    req.setEncoding("utf8");
+    req.on("data", (chunk) => {
+      body += chunk;
+    });
+    req.on("end", () => resolve(body));
+    req.on("error", reject);
+  });
+}
+
+async function runHook(payload: Record<string, unknown>) {
+  let received: unknown;
+  const server = createServer(async (req, res) => {
+    const body = await readBody(req);
+    received = JSON.parse(body);
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ ok: true }));
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("test server did not bind to a TCP port");
+  }
+
+  const result = await new Promise<{
+    exitCode: number | null;
+    stderr: string;
+    stdout: string;
+  }>((resolve, reject) => {
+    const child = spawn(process.execPath, [HOOK], {
+      env: {
+        PATH: process.env["PATH"] ?? "",
+        AGENTMEMORY_URL: `http://127.0.0.1:${address.port}`,
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", reject);
+    child.on("close", (exitCode) => {
+      resolve({ exitCode, stderr, stdout });
+    });
+    child.stdin.end(JSON.stringify(payload));
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+
+  return { ...result, received };
+}
+
+describe("post-tool-use hook", () => {
+  it("stores Claude Code tool_response as tool_output", async () => {
+    const result = await runHook({
+      session_id: "ses_tool_response",
+      cwd: "/tmp/project",
+      tool_name: "Read",
+      tool_input: { file_path: "src/foo.ts" },
+      tool_response: "file contents from Claude Code",
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    expect(result.received).toMatchObject({
+      hookType: "post_tool_use",
+      sessionId: "ses_tool_response",
+      data: {
+        tool_name: "Read",
+        tool_input: { file_path: "src/foo.ts" },
+        tool_output: "file contents from Claude Code",
+      },
+    });
+  });
+
+  it("keeps legacy tool_output fallback", async () => {
+    const result = await runHook({
+      session_id: "ses_tool_output",
+      cwd: "/tmp/project",
+      tool_name: "Bash",
+      tool_input: { command: "pwd" },
+      tool_output: "/tmp/project",
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.received).toMatchObject({
+      hookType: "post_tool_use",
+      sessionId: "ses_tool_output",
+      data: {
+        tool_name: "Bash",
+        tool_input: { command: "pwd" },
+        tool_output: "/tmp/project",
+      },
+    });
+  });
+});

--- a/test/post-tool-use-hook.test.ts
+++ b/test/post-tool-use-hook.test.ts
@@ -36,44 +36,46 @@ async function runHook(payload: Record<string, unknown>) {
     server.listen(0, "127.0.0.1", resolve);
   });
 
-  const address = server.address();
-  if (!address || typeof address === "string") {
-    throw new Error("test server did not bind to a TCP port");
+  try {
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("test server did not bind to a TCP port");
+    }
+
+    const result = await new Promise<{
+      exitCode: number | null;
+      stderr: string;
+      stdout: string;
+    }>((resolve, reject) => {
+      const child = spawn(process.execPath, [HOOK], {
+        env: {
+          PATH: process.env["PATH"] ?? "",
+          AGENTMEMORY_URL: `http://127.0.0.1:${address.port}`,
+        },
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+
+      let stdout = "";
+      let stderr = "";
+      child.stdout.on("data", (chunk) => {
+        stdout += chunk.toString();
+      });
+      child.stderr.on("data", (chunk) => {
+        stderr += chunk.toString();
+      });
+      child.on("error", reject);
+      child.on("close", (exitCode) => {
+        resolve({ exitCode, stderr, stdout });
+      });
+      child.stdin.end(JSON.stringify(payload));
+    });
+
+    return { ...result, received };
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
   }
-
-  const result = await new Promise<{
-    exitCode: number | null;
-    stderr: string;
-    stdout: string;
-  }>((resolve, reject) => {
-    const child = spawn(process.execPath, [HOOK], {
-      env: {
-        PATH: process.env["PATH"] ?? "",
-        AGENTMEMORY_URL: `http://127.0.0.1:${address.port}`,
-      },
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", (chunk) => {
-      stdout += chunk.toString();
-    });
-    child.stderr.on("data", (chunk) => {
-      stderr += chunk.toString();
-    });
-    child.on("error", reject);
-    child.on("close", (exitCode) => {
-      resolve({ exitCode, stderr, stdout });
-    });
-    child.stdin.end(JSON.stringify(payload));
-  });
-
-  await new Promise<void>((resolve, reject) => {
-    server.close((err) => (err ? reject(err) : resolve()));
-  });
-
-  return { ...result, received };
 }
 
 describe("post-tool-use hook", () => {


### PR DESCRIPTION
  ## Summary

  - prefer `tool_response` for Claude Code `PostToolUse` payloads
  - keep the legacy `tool_output` fallback for existing hook payloads
  - add regression coverage for both payload shapes

  Closes #539

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prioritizes the newer response field over the legacy field when extracting image data and constructing observation payloads, with a fallback to maintain compatibility.
* **Tests**
  * Adds integration tests that validate payload mapping and successful execution for both the new response field and the legacy fallback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/578?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->