### PR TITLE
fix(hooks): stop also closes session for Codex (closes #493)

### DIFF
--- a/plugin/scripts/stop.mjs
+++ b/plugin/scripts/stop.mjs
@@ -31,6 +31,14 @@ async function main() {
 			signal: AbortSignal.timeout(12e4)
 		});
 	} catch {}
+	try {
+		await fetch(`${REST_URL}/agentmemory/session/end`, {
+			method: "POST",
+			headers: authHeaders(),
+			body: JSON.stringify({ sessionId }),
+			signal: AbortSignal.timeout(5e3)
+		});
+	} catch {}
 }
 main();
 

--- a/src/hooks/stop.ts
+++ b/src/hooks/stop.ts
@@ -49,6 +49,24 @@ async function main() {
   } catch {
     // summarize is best-effort
   }
+
+  // Claude Code fires a separate `SessionEnd` hook that closes the
+  // viewer session lifecycle. Codex does not have a SessionEnd event,
+  // so the only signal we get when a Codex session ends is this Stop
+  // hook (#493). Always best-effort POST /agentmemory/session/end here
+  // so the viewer shows `completed` for Codex sessions; for Claude Code
+  // this is a harmless idempotent second call (session-end.mjs runs on
+  // SessionEnd and sets the same fields).
+  try {
+    await fetch(`${REST_URL}/agentmemory/session/end`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ sessionId }),
+      signal: AbortSignal.timeout(5000),
+    });
+  } catch {
+    // session/end is best-effort
+  }
 }
 
 main();


### PR DESCRIPTION
## Summary

Closes #493.

Codex sessions stayed `status: "active"` in the viewer forever because Codex doesn't fire a separate `SessionEnd` hook and the existing `Stop` handler only called `/agentmemory/summarize`.

`session-end.mjs` already POSTs `/agentmemory/session/end`, but it's only wired to Claude Code's `SessionEnd` event. Codex has no equivalent.

## Fix

`src/hooks/stop.ts` now also POSTs `/agentmemory/session/end` after the summarize call, best-effort with a 5s timeout. For Claude Code this is a harmless idempotent second call (the dedicated `SessionEnd` hook still runs and sets the same `endedAt` + `status` fields). For Codex it's the only path that closes the lifecycle.

## Diff

- `src/hooks/stop.ts` — `+18` adds the second fetch
- `plugin/scripts/stop.mjs` — `+8` regenerated by tsdown

## Validation

- `npm test` → 97/97 test files, 1081/1081 tests pass
- `npm run build` → bundle clean

## Notes on idempotency

`POST /agentmemory/session/end` is a `kv.update` with two `{type: "set"}` ops on `endedAt` and `status`. Repeating it is safe and overwrites with the current time + `"completed"` — desired behavior since Stop fires after the user-visible session is over.

If a follow-up sets a stricter "don't overwrite endedAt if already set" guard at the server side, that's orthogonal and won't regress this fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Sessions are now properly terminated when stopping the agent, with enhanced reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/579?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->