### PR TITLE
fix(docs): correct codex plugin install command (closes #476)

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ npx @agentmemory/agentmemory
 
 # 2. register the agentmemory marketplace and install the plugin
 codex plugin marketplace add rohitg00/agentmemory
-codex plugin install agentmemory
+codex plugin add agentmemory@agentmemory
 ```
 
 The Codex plugin ships from the same `plugin/` directory as the Claude Code plugin. It registers:
@@ -516,7 +516,7 @@ The agentmemory entry is the **same MCP server block** across every host that us
 | **Gemini CLI** | `~/.gemini/settings.json` | `gemini mcp add agentmemory npx -y @agentmemory/mcp --scope user` (auto-merges). |
 | **OpenClaw** | OpenClaw MCP config | Same `mcpServers` block, or use the deeper [memory plugin](integrations/openclaw/). |
 | **Codex CLI (MCP only)** | `.codex/config.toml` | TOML shape: `codex mcp add agentmemory -- npx -y @agentmemory/mcp`, or add `[mcp_servers.agentmemory]` manually. |
-| **Codex CLI (full plugin)** | Codex plugin marketplace | `codex plugin marketplace add rohitg00/agentmemory` then `codex plugin install agentmemory`. Registers MCP + 6 lifecycle hooks (SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, PreCompact, Stop) + 4 skills. On Codex Desktop, also run `agentmemory connect codex --with-hooks` until [openai/codex#16430](https://github.com/openai/codex/issues/16430) lands — plugin hooks are currently silent there. |
+| **Codex CLI (full plugin)** | Codex plugin marketplace | `codex plugin marketplace add rohitg00/agentmemory` then `codex plugin add agentmemory@agentmemory`. Registers MCP + 6 lifecycle hooks (SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, PreCompact, Stop) + 4 skills. On Codex Desktop, also run `agentmemory connect codex --with-hooks` until [openai/codex#16430](https://github.com/openai/codex/issues/16430) lands — plugin hooks are currently silent there. |
 | **OpenCode (MCP only)** | `opencode.json` | Different shape — top-level `mcp` key, command as array: `{"mcp": {"agentmemory": {"type": "local", "command": ["npx", "-y", "@agentmemory/mcp"], "enabled": true}}}`. |
 | **OpenCode (full plugin)** | `plugin/opencode/` | 22 auto-capture hooks covering session lifecycle, messages, tools, errors. Two slash commands (`/recall`, `/remember`). Copy `plugin/opencode/` into your OpenCode workspace and add the plugin entry to `opencode.json`. See [`plugin/opencode/README.md`](plugin/opencode/README.md) for the full hook table + gap analysis. |
 | **pi** | `~/.pi/agent/extensions/agentmemory` | Copy [`integrations/pi`](integrations/pi/) and restart pi. |

--- a/src/cli/connect/codex.ts
+++ b/src/cli/connect/codex.ts
@@ -112,7 +112,7 @@ export const adapter: ConnectAdapter = {
 
     logInstalled("Codex CLI", CODEX_TOML);
     p.log.info(
-      "Codex picks up MCP servers on next launch. For the deeper plugin install, run: codex plugin marketplace add rohitg00/agentmemory && codex plugin install agentmemory",
+      "Codex picks up MCP servers on next launch. For the deeper plugin install, run: codex plugin marketplace add rohitg00/agentmemory && codex plugin add agentmemory@agentmemory",
     );
 
     if (opts.withHooks) {


### PR DESCRIPTION
## Summary

Closes #476.

Codex's plugin CLI exposes `codex plugin add / list / remove / marketplace`, not `install`. Verified against [`codex-rs/cli/src/plugin_cmd.rs`](https://github.com/openai/codex/blob/main/codex-rs/cli/src/plugin_cmd.rs):

```
pub enum PluginSubcommand {
    Add(...)         // codex plugin add <PLUGIN>[@<MARKETPLACE>]
    List(...)        // codex plugin list
    Remove(...)      // codex plugin remove <PLUGIN>
    Marketplace(...) // codex plugin marketplace <add|upgrade|remove>
}
```

Users following the current README hit:

```
$ codex plugin install agentmemory
error: unrecognized subcommand 'install'
```

## Fix

Two callsites corrected to use `codex plugin add agentmemory@agentmemory`:

- `README.md` — top-level Codex install snippet
- `README.md` — agent matrix row
- `src/cli/connect/codex.ts` — final info hint printed after `agentmemory connect codex`

CHANGELOG entries are left alone (those reference what the README said at the time; rewriting history isn't the right call). Slash-command references like `/plugin install agentmemory` inside Claude Code are Claude's own slash API and remain correct.

## Diff

3 lines across 2 files.

## Validation

- `npm test` → 1081/1081 tests pass
- `npm run build` → clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated plugin installation command syntax from `codex plugin install agentmemory` to `codex plugin add agentmemory@agentmemory` in setup instructions and user-facing messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/580?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->