### PR TITLE
Add optional external_id metadata passthrough for memory retrieval results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Optional `external_id` and metadata passthrough for saved memories and retrieval results, intended for import/export, deduplication, observability, debugging, and deterministic evaluation workflows.
+
 ## [0.9.20] — 2026-05-18
 
 Hotfix: revert the Codex Stop → session-end chain shipped in v0.9.19.

--- a/README.md
+++ b/README.md
@@ -527,6 +527,23 @@ iii.trigger({
 
 Worked example: [`examples/python/`](examples/python/) (quickstart + observation/recall flow). REST on `:3111` remains available for hosts without an iii runtime.
 
+When importing memories from another system, callers can optionally attach a stable `external_id` and metadata. These fields are stored with the memory and returned in search results, so integrations can map retrieved memories back to their source records:
+
+```bash
+curl -X POST http://localhost:3111/agentmemory/remember \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "content": "The auth service rotates refresh tokens on every use.",
+    "external_id": "source-system:memory-42",
+    "metadata": { "source": "import", "conversation_id": "conv-1", "turn_index": 3 }
+  }'
+
+curl -X POST http://localhost:3111/agentmemory/search \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"refresh tokens"}'
+# Results include observation.id plus observation.external_id and observation.metadata when present.
+```
+
 ### From source
 
 ```bash

--- a/src/functions/remember.ts
+++ b/src/functions/remember.ts
@@ -9,6 +9,10 @@ import { recordAudit } from "./audit.js";
 import { getSearchIndex, vectorIndexAddGuarded } from "./search.js";
 import { logger } from "../logger.js";
 
+function isMetadataRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 export function registerRememberFunction(sdk: ISdk, kv: StateKV): void {
   sdk.registerFunction("mem::remember", 
     async (data: {
@@ -18,6 +22,8 @@ export function registerRememberFunction(sdk: ISdk, kv: StateKV): void {
       files?: string[];
       ttlDays?: number;
       sourceObservationIds?: string[];
+      external_id?: string;
+      metadata?: Record<string, unknown>;
     }) => {
       if (
         !data.content ||
@@ -34,6 +40,12 @@ export function registerRememberFunction(sdk: ISdk, kv: StateKV): void {
       }
       if (data.sourceObservationIds && !Array.isArray(data.sourceObservationIds)) {
         return { success: false, error: "sourceObservationIds must be an array" };
+      }
+      if (data.external_id !== undefined && typeof data.external_id !== "string") {
+        return { success: false, error: "external_id must be a string" };
+      }
+      if (data.metadata !== undefined && !isMetadataRecord(data.metadata)) {
+        return { success: false, error: "metadata must be an object" };
       }
       const validTypes = new Set([
         "pattern",
@@ -88,6 +100,9 @@ export function registerRememberFunction(sdk: ISdk, kv: StateKV): void {
           ),
           isLatest: true,
         };
+
+        if (data.external_id) memory.external_id = data.external_id;
+        if (data.metadata) memory.metadata = data.metadata;
 
         if (data.ttlDays && typeof data.ttlDays === "number" && data.ttlDays > 0) {
           memory.forgetAfter = new Date(Date.now() + data.ttlDays * 86400000).toISOString();

--- a/src/functions/search.ts
+++ b/src/functions/search.ts
@@ -297,6 +297,8 @@ export function registerSearchFunction(sdk: ISdk, kv: StateKV): void {
           type: r.observation.type,
           score: r.score,
           timestamp: r.observation.timestamp,
+          external_id: r.observation.external_id,
+          metadata: r.observation.metadata,
         }))
         const packed = applyTokenBudget(compactResults)
         return {
@@ -316,6 +318,8 @@ export function registerSearchFunction(sdk: ISdk, kv: StateKV): void {
           narrative: r.observation.narrative,
           score: r.score,
           timestamp: r.observation.timestamp,
+          external_id: r.observation.external_id,
+          metadata: r.observation.metadata,
         }))
         const packed = applyTokenBudget(narrativeResults)
         const text = packed.items

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -39,6 +39,13 @@ function parseCsvList(value: unknown): string[] {
   return [];
 }
 
+function asMetadataRecord(value: unknown): Record<string, unknown> | undefined {
+  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return undefined;
+}
+
 export function registerMcpEndpoints(
   sdk: ISdk,
   kv: StateKV,
@@ -172,11 +179,15 @@ export function registerMcpEndpoints(
                 ? args.files.split(",").map((f: string) => f.trim()).filter(Boolean)
                 : [];
 
+            const external_id = asNonEmptyString(args.external_id);
+            const metadata = asMetadataRecord(args.metadata);
             const result = await sdk.trigger({ function_id: "mem::remember", payload: {
               content: args.content,
               type,
               concepts,
               files,
+              external_id,
+              metadata,
             } });
             return {
               status_code: 200,

--- a/src/mcp/standalone.ts
+++ b/src/mcp/standalone.ts
@@ -87,6 +87,8 @@ interface Validated {
   type?: string;
   concepts?: string[];
   files?: string[];
+  external_id?: string;
+  metadata?: Record<string, unknown>;
   query?: string;
   limit?: number;
   format?: string;
@@ -110,6 +112,12 @@ function validate(toolName: string, args: Record<string, unknown>): Validated {
       v.type = (args["type"] as string) || "fact";
       v.concepts = normalizeList(args["concepts"]);
       v.files = normalizeList(args["files"]);
+      if (typeof args["external_id"] === "string" && args["external_id"].trim()) {
+        v.external_id = args["external_id"].trim();
+      }
+      if (typeof args["metadata"] === "object" && args["metadata"] !== null && !Array.isArray(args["metadata"])) {
+        v.metadata = args["metadata"] as Record<string, unknown>;
+      }
       return v;
     }
     case "memory_recall":
@@ -168,6 +176,8 @@ async function handleProxy(
           type: v.type,
           concepts: v.concepts,
           files: v.files,
+          external_id: v.external_id,
+          metadata: v.metadata,
         }),
       });
       return textResponse(result);
@@ -246,6 +256,8 @@ async function handleLocal(
         version: 1,
         isLatest: true,
         sessionIds: [],
+        external_id: v.external_id,
+        metadata: v.metadata,
       });
       kvInstance.persist();
       return textResponse({ saved: id });

--- a/src/mcp/tools-registry.ts
+++ b/src/mcp/tools-registry.ts
@@ -75,6 +75,14 @@ export const CORE_TOOLS: McpToolDef[] = [
           type: "string",
           description: "Comma-separated relevant file paths",
         },
+        external_id: {
+          type: "string",
+          description: "Optional stable source identifier for imported memories",
+        },
+        metadata: {
+          type: "object",
+          description: "Optional caller-provided metadata to return with retrieval results",
+        },
       },
       required: ["content"],
     },

--- a/src/state/memory-utils.ts
+++ b/src/state/memory-utils.ts
@@ -20,5 +20,7 @@ export function memoryToObservation(memory: Memory): CompressedObservation {
     concepts: memory.concepts,
     files: memory.files,
     importance: memory.strength,
+    external_id: memory.external_id,
+    metadata: memory.metadata,
   };
 }

--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -93,6 +93,13 @@ function asNonEmptyString(value: unknown): string | null {
   return trimmed ? trimmed : null;
 }
 
+function asMetadataRecord(value: unknown): Record<string, unknown> | undefined {
+  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return undefined;
+}
+
 function parseOptionalFiniteNumber(value: unknown): number | undefined | null {
   if (value === undefined || value === null) return undefined;
   if (typeof value === "number") return Number.isFinite(value) ? value : null;
@@ -842,6 +849,8 @@ export function registerApiTriggers(
         type?: string;
         concepts?: string[];
         files?: string[];
+        external_id?: string;
+        metadata?: Record<string, unknown>;
       }>,
     ): Promise<Response> => {
       const authErr = checkAuth(req, secret);
@@ -853,7 +862,15 @@ export function registerApiTriggers(
       ) {
         return { status_code: 400, body: { error: "content is required" } };
       }
-      const result = await sdk.trigger({ function_id: "mem::remember", payload: req.body });
+      const payload = {
+        content: req.body.content,
+        type: req.body.type,
+        concepts: req.body.concepts,
+        files: req.body.files,
+        external_id: asNonEmptyString(req.body.external_id) ?? undefined,
+        metadata: asMetadataRecord(req.body.metadata),
+      };
+      const result = await sdk.trigger({ function_id: "mem::remember", payload });
       return { status_code: 201, body: result };
     },
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,8 @@ export interface CompressedObservation {
   imageData?: string;
   imageDescription?: string;
   modality?: "text" | "image" | "mixed";
+  external_id?: string;
+  metadata?: Record<string, unknown>;
 
 }
 
@@ -98,6 +100,8 @@ export interface Memory {
   forgetAfter?: string;
   imageRef?: string;
   imageData?: string;
+  external_id?: string;
+  metadata?: Record<string, unknown>;
 }
 
 export interface SessionSummary {
@@ -264,6 +268,8 @@ export interface CompactSearchResult {
   type: ObservationType;
   score: number;
   timestamp: string;
+  external_id?: string;
+  metadata?: Record<string, unknown>;
 }
 
 export interface TimelineEntry {

--- a/test/remember-external-metadata.test.ts
+++ b/test/remember-external-metadata.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, it, expect, vi } from "vitest";
+
+vi.mock("../src/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("../src/state/keyed-mutex.js", () => ({
+  withKeyedLock: <T>(_key: string, fn: () => Promise<T>) => fn(),
+}));
+
+import { registerRememberFunction } from "../src/functions/remember.js";
+import {
+  getSearchIndex,
+  registerSearchFunction,
+} from "../src/functions/search.js";
+
+function mockKV() {
+  const store = new Map<string, Map<string, unknown>>();
+  return {
+    get: async <T>(scope: string, key: string): Promise<T | null> =>
+      (store.get(scope)?.get(key) as T) ?? null,
+    set: async <T>(scope: string, key: string, data: T): Promise<T> => {
+      if (!store.has(scope)) store.set(scope, new Map());
+      store.get(scope)!.set(key, data);
+      return data;
+    },
+    delete: async (scope: string, key: string): Promise<void> => {
+      store.get(scope)?.delete(key);
+    },
+    list: async <T>(scope: string): Promise<T[]> => {
+      const entries = store.get(scope);
+      return entries ? (Array.from(entries.values()) as T[]) : [];
+    },
+  };
+}
+
+function mockSdk() {
+  const functions = new Map<string, Function>();
+  return {
+    registerFunction: (id: string, handler: Function) => {
+      functions.set(id, handler);
+    },
+    registerTrigger: () => {},
+    trigger: async (input: { function_id: string; payload: unknown }) => {
+      const fn = functions.get(input.function_id);
+      if (!fn && input.function_id === "mem::cascade-update") return undefined;
+      if (!fn) throw new Error(`unknown fn ${input.function_id}`);
+      return fn(input.payload);
+    },
+  };
+}
+
+describe("memory external_id and metadata passthrough", () => {
+  beforeEach(() => {
+    getSearchIndex().clear();
+  });
+
+  it("keeps duplicate-content memories distinguishable by external_id in search results", async () => {
+    const sdk = mockSdk();
+    const kv = mockKV();
+    registerRememberFunction(sdk as never, kv as never);
+    registerSearchFunction(sdk as never, kv as never);
+
+    const content = "Imported duplicate source memory about stable IDs";
+    await sdk.trigger({
+      function_id: "mem::remember",
+      payload: { content, external_id: "source-a" },
+    });
+    await sdk.trigger({
+      function_id: "mem::remember",
+      payload: { content, external_id: "source-b" },
+    });
+
+    const result = (await sdk.trigger({
+      function_id: "mem::search",
+      payload: { query: "stable IDs", limit: 5 },
+    })) as { results: Array<{ observation: { external_id?: string } }> };
+
+    expect(result.results.map((r) => r.observation.external_id).sort()).toEqual(
+      ["source-a", "source-b"],
+    );
+  });
+
+  it("returns saved metadata unchanged in search results", async () => {
+    const sdk = mockSdk();
+    const kv = mockKV();
+    registerRememberFunction(sdk as never, kv as never);
+    registerSearchFunction(sdk as never, kv as never);
+
+    const metadata = {
+      source: "locomo",
+      conversation_id: "conv-1",
+      turn_index: 3,
+    };
+    await sdk.trigger({
+      function_id: "mem::remember",
+      payload: {
+        content: "Imported LOCOMO turn about metadata passthrough",
+        external_id: "locomo-conv-1-turn-3",
+        metadata,
+      },
+    });
+
+    const result = (await sdk.trigger({
+      function_id: "mem::search",
+      payload: { query: "metadata passthrough", limit: 5 },
+    })) as {
+      results: Array<{
+        observation: {
+          external_id?: string;
+          metadata?: Record<string, unknown>;
+        };
+      }>;
+    };
+
+    expect(result.results[0].observation.external_id).toBe(
+      "locomo-conv-1-turn-3",
+    );
+    expect(result.results[0].observation.metadata).toEqual(metadata);
+  });
+});


### PR DESCRIPTION
Hi! This PR adds optional `external_id` and metadata passthrough support for saved memories and retrieval results.

The motivation is to make integrations easier when memories originate from another system or dataset and need stable source identifiers. This helps with import/export workflows, deduplication, observability, debugging, and deterministic evaluation where callers need to know exactly which source memory was retrieved.

The change is additive: existing callers can ignore the new fields, and default behavior should remain unchanged.

Included:
- optional `external_id` on memory save/create
- optional metadata passthrough
- retrieval/search results include the stored `external_id` and metadata
- regression test for duplicate content with distinct external IDs
- docs/example update

Validation run locally:
- `npm test -- test/remember-external-metadata.test.ts`
- `npm test`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `external_id` and `metadata` fields when saving memories. These fields are persisted and returned in search results, supporting deduplication, observability, and deterministic evaluation.

* **Documentation**
  * Updated documentation with examples of the new optional fields in memory save and retrieval workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/583?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->