### PR TITLE
feat(visibility): surface insights + semantic facts in mem::context and smart-search

### DIFF
--- a/src/functions/context.ts
+++ b/src/functions/context.ts
@@ -7,6 +7,8 @@ import type {
   ProjectProfile,
   MemorySlot,
   Lesson,
+  Insight,
+  SemanticMemory,
 } from "../types.js";
 import { KV } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
@@ -40,15 +42,20 @@ export function registerContextFunction(
       const budget = data.budget || tokenBudget;
       const blocks: ContextBlock[] = [];
 
-      const [pinnedSlots, profile, lessons] = await Promise.all([
-        isSlotsEnabled()
-          ? listPinnedSlots(kv).catch(() => [] as MemorySlot[])
-          : Promise.resolve([] as MemorySlot[]),
-        kv
-          .get<ProjectProfile>(KV.profiles, data.project)
-          .catch(() => null),
-        kv.list<Lesson>(KV.lessons).catch(() => [] as Lesson[]),
-      ]);
+      const [pinnedSlots, profile, lessons, insights, semanticAll] =
+        await Promise.all([
+          isSlotsEnabled()
+            ? listPinnedSlots(kv).catch(() => [] as MemorySlot[])
+            : Promise.resolve([] as MemorySlot[]),
+          kv
+            .get<ProjectProfile>(KV.profiles, data.project)
+            .catch(() => null),
+          kv.list<Lesson>(KV.lessons).catch(() => [] as Lesson[]),
+          kv.list<Insight>(KV.insights).catch(() => [] as Insight[]),
+          kv
+            .list<SemanticMemory>(KV.semantic)
+            .catch(() => [] as SemanticMemory[]),
+        ]);
 
       const slotContent = renderPinnedContext(pinnedSlots);
       if (slotContent) {
@@ -132,6 +139,44 @@ export function registerContextFunction(
         });
       }
 
+      // Insights — mirrors the lessons round-trip closure. Without this
+      // block, distilled insights produced by mem::reflect sit in KV and
+      // only surface when the agent explicitly calls memory_insight_list,
+      // which agents rarely do unprompted. Same ranking shape as lessons:
+      // project-scoped insights rank above global, then weight by
+      // confidence, cap at 10. #590.
+      const relevantInsights = insights
+        .filter(
+          (i) => !i.deleted && (!i.project || i.project === data.project),
+        )
+        .sort((a, b) => {
+          const scoreA = (a.project === data.project ? 1.5 : 1) * a.confidence;
+          const scoreB = (b.project === data.project ? 1.5 : 1) * b.confidence;
+          return scoreB - scoreA;
+        })
+        .slice(0, 10);
+
+      if (relevantInsights.length > 0) {
+        const items = relevantInsights
+          .map(
+            (i) =>
+              `- (${i.confidence.toFixed(2)}) ${i.title}: ${i.content}`,
+          )
+          .join("\n");
+        const insightsContent = `## Distilled Insights\n${items}`;
+        const mostRecent = relevantInsights.reduce((acc, i) => {
+          const t = new Date(i.lastReinforcedAt || i.updatedAt).getTime();
+          return t > acc ? t : acc;
+        }, 0);
+        blocks.push({
+          type: "memory",
+          content: insightsContent,
+          tokens: estimateTokens(insightsContent),
+          recency: mostRecent,
+          sourceIds: relevantInsights.map((i) => i.id),
+        });
+      }
+
       const allSessions = await kv.list<Session>(KV.sessions);
       const sessions = allSessions
         .filter((s) => s.project === data.project && s.id !== data.sessionId)
@@ -194,6 +239,54 @@ export function registerContextFunction(
             sourceIds: top.map((o) => o.id),
           });
         }
+      }
+
+      // Semantic facts — produced by consolidation-pipeline by clustering
+      // session summaries. They have no direct project field; project
+      // membership is derived from sourceSessionIds. Include a fact when
+      // any source session belongs to the current project, OR when it has
+      // no resolvable source sessions (treat as global cross-project
+      // knowledge). Filter out facts whose sources are entirely in other
+      // projects. Score by strength × confidence × project-relevance boost.
+      const sessionProjectById = new Map<string, string>();
+      for (const s of allSessions) {
+        sessionProjectById.set(s.id, s.project);
+      }
+
+      const relevantSemantic = semanticAll
+        .map((fact) => {
+          const projects = (fact.sourceSessionIds || [])
+            .map((sid) => sessionProjectById.get(sid))
+            .filter((p): p is string => !!p);
+          const matchesProject = projects.includes(data.project);
+          const isGlobal = projects.length === 0;
+          if (!isGlobal && !matchesProject) return null;
+          const boost = matchesProject ? 1.5 : 1;
+          const score = fact.strength * fact.confidence * boost;
+          return { fact, score };
+        })
+        .filter(
+          (x): x is { fact: SemanticMemory; score: number } => x !== null,
+        )
+        .sort((a, b) => b.score - a.score)
+        .slice(0, 10);
+
+      if (relevantSemantic.length > 0) {
+        const items = relevantSemantic
+          .map(({ fact }) => `- (${fact.confidence.toFixed(2)}) ${fact.fact}`)
+          .join("\n");
+        const semanticContent = `## Architectural Facts\n${items}`;
+        const mostRecent = relevantSemantic.reduce((acc, { fact }) => {
+          const t = new Date(fact.updatedAt).getTime();
+          return t > acc ? t : acc;
+        }, 0);
+        blocks.push({
+          type: "memory",
+          content: semanticContent,
+          tokens: estimateTokens(semanticContent),
+          recency: mostRecent,
+          sourceIds: relevantSemantic.map(({ fact }) => fact.id),
+        });
       }
 
       blocks.sort((a, b) => b.recency - a.recency);

--- a/src/functions/smart-search.ts
+++ b/src/functions/smart-search.ts
@@ -1,9 +1,11 @@
 import type { ISdk } from "iii-sdk";
 import type {
+  CompactInsightResult,
   CompactLessonResult,
   CompactSearchResult,
   CompressedObservation,
   HybridSearchResult,
+  Insight,
   Lesson,
 } from "../types.js";
 import { KV } from "../state/schema.js";
@@ -14,6 +16,7 @@ import { logger } from "../logger.js";
 // Compact mode trims each lesson's content for at-a-glance display. The
 // full content is fetched via memory_lesson_recall when the caller needs it.
 const LESSON_CONTENT_PREVIEW_CHARS = 240;
+const INSIGHT_CONTENT_PREVIEW_CHARS = 240;
 
 export function registerSmartSearchFunction(
   sdk: ISdk,
@@ -27,6 +30,7 @@ export function registerSmartSearchFunction(
       limit?: number;
       project?: string;
       includeLessons?: boolean;
+      includeInsights?: boolean;
     }) => {
 
       if (data.expandIds && data.expandIds.length > 0) {
@@ -79,16 +83,23 @@ export function registerSmartSearchFunction(
       // Cap lesson results at a smaller number than observations: lessons
       // are denser (curated insights) so 10 is usually plenty for a recall.
       const lessonLimit = Math.min(limit, 10);
+      const insightLimit = Math.min(limit, 10);
       const includeLessons = data.includeLessons !== false;
+      const includeInsights = data.includeInsights !== false;
 
-      // Run observation hybrid-search and lesson recall in parallel so the
-      // extra lesson lookup adds no wallclock when the underlying calls
-      // can overlap. Lesson recall is best-effort: if mem::lesson-recall
-      // fails or returns unexpected shape, log + fall back to empty.
-      const [hybridResults, lessons] = await Promise.all([
+      // Run observation hybrid-search, lesson recall, and insight search in
+      // parallel so the extra reflection lookups add no wallclock when the
+      // underlying calls can overlap. Both side-channel lookups are
+      // best-effort: if the underlying trigger fails or returns an unexpected
+      // shape, log + fall back to empty so the main search result is never
+      // blocked.
+      const [hybridResults, lessons, insights] = await Promise.all([
         searchFn(data.query, limit),
         includeLessons
           ? recallLessons(sdk, data.query, lessonLimit, data.project)
+          : Promise.resolve([]),
+        includeInsights
+          ? recallInsights(sdk, data.query, insightLimit, data.project)
           : Promise.resolve([]),
       ]);
 
@@ -110,13 +121,16 @@ export function registerSmartSearchFunction(
         query: data.query,
         results: compact.length,
         lessons: lessons.length,
+        insights: insights.length,
       });
       const response: {
         mode: "compact";
         results: CompactSearchResult[];
         lessons?: CompactLessonResult[];
+        insights?: CompactInsightResult[];
       } = { mode: "compact", results: compact };
       if (includeLessons) response.lessons = lessons;
+      if (includeInsights) response.insights = insights;
       return response;
     },
   );
@@ -148,6 +162,39 @@ async function recallLessons(
     }));
   } catch (err) {
     logger.warn("Smart search: mem::lesson-recall failed; returning empty lesson list", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return [];
+  }
+}
+
+async function recallInsights(
+  sdk: ISdk,
+  query: string,
+  limit: number,
+  project?: string,
+): Promise<CompactInsightResult[]> {
+  try {
+    const result = (await sdk.trigger({
+      function_id: "mem::insight-search",
+      payload: { query, limit, project },
+    })) as { success?: boolean; insights?: Array<Insight & { score?: number }> };
+    if (!result?.success || !Array.isArray(result.insights)) return [];
+    return result.insights.map((i) => ({
+      insightId: i.id,
+      title: i.title,
+      content:
+        i.content.length > INSIGHT_CONTENT_PREVIEW_CHARS
+          ? i.content.slice(0, INSIGHT_CONTENT_PREVIEW_CHARS) + "…"
+          : i.content,
+      confidence: i.confidence,
+      score: i.score ?? i.confidence,
+      createdAt: i.createdAt,
+      project: i.project,
+      tags: i.tags ?? [],
+    }));
+  } catch (err) {
+    logger.warn("Smart search: mem::insight-search failed; returning empty insight list", {
       error: err instanceof Error ? err.message : String(err),
     });
     return [];

--- a/src/types.ts
+++ b/src/types.ts
@@ -276,6 +276,17 @@ export interface CompactLessonResult {
   tags: string[];
 }
 
+export interface CompactInsightResult {
+  insightId: string;
+  title: string;
+  content: string;
+  confidence: number;
+  score: number;
+  createdAt: string;
+  project?: string;
+  tags: string[];
+}
+
 export interface TimelineEntry {
   observation: CompressedObservation;
   sessionId: string;

--- a/test/context-insights-semantic.test.ts
+++ b/test/context-insights-semantic.test.ts
@@ -1,0 +1,395 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { registerContextFunction } from "../src/functions/context.js";
+import { KV } from "../src/state/schema.js";
+import type { Insight, SemanticMemory, Session } from "../src/types.js";
+
+function mockKV() {
+  const store = new Map<string, Map<string, unknown>>();
+  return {
+    get: async <T>(scope: string, key: string): Promise<T | null> => {
+      return (store.get(scope)?.get(key) as T) ?? null;
+    },
+    set: async <T>(scope: string, key: string, data: T): Promise<T> => {
+      if (!store.has(scope)) store.set(scope, new Map());
+      store.get(scope)!.set(key, data);
+      return data;
+    },
+    delete: async (scope: string, key: string): Promise<void> => {
+      store.get(scope)?.delete(key);
+    },
+    list: async <T>(scope: string): Promise<T[]> => {
+      if (!store.has(scope)) return [];
+      return Array.from(store.get(scope)!.values()) as T[];
+    },
+  };
+}
+
+type ContextHandler = (data: {
+  sessionId: string;
+  project: string;
+  budget?: number;
+}) => Promise<{ context: string; blocks: number; tokens: number }>;
+
+function wireContext(kv: ReturnType<typeof mockKV>, budget = 4000) {
+  let handler: ContextHandler | undefined;
+  const sdk = {
+    registerFunction: vi.fn((id: string, cb: ContextHandler) => {
+      if (id === "mem::context") handler = cb;
+    }),
+  } as unknown as import("iii-sdk").ISdk;
+  registerContextFunction(sdk, kv as never, budget);
+  if (!handler) throw new Error("mem::context not registered");
+  return handler;
+}
+
+function makeInsight(over: Partial<Insight> = {}): Insight {
+  const now = new Date().toISOString();
+  return {
+    id: over.id ?? `ins_${Math.random().toString(36).slice(2)}`,
+    title: over.title ?? "default insight title",
+    content: over.content ?? "default insight content",
+    confidence: over.confidence ?? 0.7,
+    reinforcements: over.reinforcements ?? 1,
+    sourceConceptCluster: over.sourceConceptCluster ?? [],
+    sourceMemoryIds: over.sourceMemoryIds ?? [],
+    sourceLessonIds: over.sourceLessonIds ?? [],
+    sourceCrystalIds: over.sourceCrystalIds ?? [],
+    project: over.project,
+    tags: over.tags ?? [],
+    createdAt: over.createdAt ?? now,
+    updatedAt: over.updatedAt ?? now,
+    lastReinforcedAt: over.lastReinforcedAt,
+    lastDecayedAt: over.lastDecayedAt,
+    decayRate: over.decayRate ?? 0.05,
+    deleted: over.deleted,
+  };
+}
+
+function makeSemantic(over: Partial<SemanticMemory> = {}): SemanticMemory {
+  const now = new Date().toISOString();
+  return {
+    id: over.id ?? `sem_${Math.random().toString(36).slice(2)}`,
+    fact: over.fact ?? "default semantic fact",
+    confidence: over.confidence ?? 0.9,
+    sourceSessionIds: over.sourceSessionIds ?? [],
+    sourceMemoryIds: over.sourceMemoryIds ?? [],
+    accessCount: over.accessCount ?? 0,
+    lastAccessedAt: over.lastAccessedAt ?? now,
+    strength: over.strength ?? 0.8,
+    createdAt: over.createdAt ?? now,
+    updatedAt: over.updatedAt ?? now,
+  };
+}
+
+function makeSession(over: Partial<Session> = {}): Session {
+  return {
+    id: over.id ?? `ses_${Math.random().toString(36).slice(2)}`,
+    project: over.project ?? "/tmp/proj",
+    cwd: over.cwd ?? over.project ?? "/tmp/proj",
+    startedAt: over.startedAt ?? new Date().toISOString(),
+    status: over.status ?? "completed",
+    observationCount: over.observationCount ?? 0,
+    endedAt: over.endedAt,
+    updatedAt: over.updatedAt,
+  };
+}
+
+async function seedInsight(
+  kv: ReturnType<typeof mockKV>,
+  partial: Partial<Insight>,
+) {
+  const insight = makeInsight(partial);
+  await kv.set(KV.insights, insight.id, insight);
+  return insight;
+}
+
+async function seedSemantic(
+  kv: ReturnType<typeof mockKV>,
+  partial: Partial<SemanticMemory>,
+) {
+  const fact = makeSemantic(partial);
+  await kv.set(KV.semantic, fact.id, fact);
+  return fact;
+}
+
+async function seedSession(
+  kv: ReturnType<typeof mockKV>,
+  partial: Partial<Session>,
+) {
+  const session = makeSession(partial);
+  await kv.set(KV.sessions, session.id, session);
+  return session;
+}
+
+describe("mem::context — insights auto-injection (#590)", () => {
+  let kv: ReturnType<typeof mockKV>;
+  let handler: ContextHandler;
+
+  beforeEach(() => {
+    kv = mockKV();
+    handler = wireContext(kv);
+  });
+
+  it("includes a 'Distilled Insights' block when KV has insights for the project", async () => {
+    await seedInsight(kv, {
+      id: "ins_a",
+      title: "PID 1 masking kills restart policy",
+      content: "When nginx runs as PID 1, supervisor never sees death.",
+      project: "/tmp/proj",
+      confidence: 0.95,
+    });
+
+    const result = await handler({
+      sessionId: "ses_a",
+      project: "/tmp/proj",
+    });
+
+    expect(result.context).toContain("Distilled Insights");
+    expect(result.context).toContain("PID 1 masking kills restart policy");
+    expect(result.blocks).toBeGreaterThan(0);
+  });
+
+  it("omits the insights block entirely when KV has no insights", async () => {
+    const result = await handler({
+      sessionId: "ses_empty",
+      project: "/tmp/proj",
+    });
+
+    expect(result.context).not.toContain("Distilled Insights");
+  });
+
+  it("ranks project-scoped insights above global insights", async () => {
+    await seedInsight(kv, {
+      id: "ins_global",
+      title: "global-insight-marker",
+      content: "global content",
+      project: undefined,
+      confidence: 0.9,
+    });
+    await seedInsight(kv, {
+      id: "ins_project",
+      title: "project-insight-marker",
+      content: "project content",
+      project: "/tmp/proj",
+      confidence: 0.7,
+    });
+
+    const result = await handler({
+      sessionId: "ses_rank",
+      project: "/tmp/proj",
+    });
+
+    const projectIdx = result.context.indexOf("project-insight-marker");
+    const globalIdx = result.context.indexOf("global-insight-marker");
+    expect(projectIdx).toBeGreaterThan(-1);
+    expect(globalIdx).toBeGreaterThan(-1);
+    expect(projectIdx).toBeLessThan(globalIdx);
+  });
+
+  it("excludes insights scoped to a different project", async () => {
+    await seedInsight(kv, {
+      id: "ins_other",
+      title: "other-project-insight",
+      content: "should not appear",
+      project: "/tmp/other-project",
+      confidence: 0.9,
+    });
+
+    const result = await handler({
+      sessionId: "ses_isolate",
+      project: "/tmp/proj",
+    });
+
+    expect(result.context).not.toContain("other-project-insight");
+  });
+
+  it("excludes deleted insights", async () => {
+    await seedInsight(kv, {
+      id: "ins_deleted",
+      title: "tombstoned-insight",
+      content: "should not appear",
+      project: "/tmp/proj",
+      confidence: 0.9,
+      deleted: true,
+    });
+
+    const result = await handler({
+      sessionId: "ses_deleted",
+      project: "/tmp/proj",
+    });
+
+    expect(result.context).not.toContain("tombstoned-insight");
+  });
+
+  it("caps at the top 10 insights by confidence", async () => {
+    for (let i = 0; i < 15; i++) {
+      await seedInsight(kv, {
+        id: `ins_${i}`,
+        title: `insight-marker-${i}`,
+        content: `content ${i}`,
+        project: "/tmp/proj",
+        confidence: i / 100,
+      });
+    }
+
+    const result = await handler({
+      sessionId: "ses_cap",
+      project: "/tmp/proj",
+    });
+
+    const matched = result.context.match(/insight-marker-/g) ?? [];
+    expect(matched.length).toBe(10);
+    expect(result.context).toContain("insight-marker-14");
+    expect(result.context).toContain("insight-marker-5");
+    expect(result.context).not.toContain("insight-marker-0");
+  });
+
+  it("shows insight confidence in the rendered line", async () => {
+    await seedInsight(kv, {
+      id: "ins_conf",
+      title: "confidence-test",
+      content: "test confidence rendering",
+      project: "/tmp/proj",
+      confidence: 0.83,
+    });
+
+    const result = await handler({
+      sessionId: "ses_conf",
+      project: "/tmp/proj",
+    });
+
+    expect(result.context).toContain("(0.83)");
+  });
+});
+
+describe("mem::context — semantic facts auto-injection (#590)", () => {
+  let kv: ReturnType<typeof mockKV>;
+  let handler: ContextHandler;
+
+  beforeEach(() => {
+    kv = mockKV();
+    handler = wireContext(kv);
+  });
+
+  it("includes an 'Architectural Facts' block when KV has semantic facts whose source session is in the current project", async () => {
+    const session = await seedSession(kv, {
+      id: "ses_src",
+      project: "/tmp/proj",
+    });
+    await seedSemantic(kv, {
+      id: "sem_a",
+      fact: "Loki runs in a railway-loki docker container",
+      sourceSessionIds: [session.id],
+      confidence: 0.95,
+      strength: 0.9,
+    });
+
+    const result = await handler({
+      sessionId: "ses_a",
+      project: "/tmp/proj",
+    });
+
+    expect(result.context).toContain("Architectural Facts");
+    expect(result.context).toContain(
+      "Loki runs in a railway-loki docker container",
+    );
+  });
+
+  it("includes facts with no source sessions (treated as global cross-project knowledge)", async () => {
+    await seedSemantic(kv, {
+      id: "sem_global",
+      fact: "global-semantic-marker",
+      sourceSessionIds: [],
+      confidence: 0.9,
+      strength: 0.8,
+    });
+
+    const result = await handler({
+      sessionId: "ses_a",
+      project: "/tmp/proj",
+    });
+
+    expect(result.context).toContain("global-semantic-marker");
+  });
+
+  it("excludes facts whose source sessions are entirely in other projects", async () => {
+    const otherSession = await seedSession(kv, {
+      id: "ses_other_src",
+      project: "/tmp/other-project",
+    });
+    await seedSemantic(kv, {
+      id: "sem_other",
+      fact: "other-project-semantic-marker",
+      sourceSessionIds: [otherSession.id],
+      confidence: 0.95,
+      strength: 0.9,
+    });
+
+    const result = await handler({
+      sessionId: "ses_a",
+      project: "/tmp/proj",
+    });
+
+    expect(result.context).not.toContain("other-project-semantic-marker");
+  });
+
+  it("ranks project-matching facts above pure-global facts", async () => {
+    await seedSemantic(kv, {
+      id: "sem_global_rank",
+      fact: "global-rank-marker",
+      sourceSessionIds: [],
+      confidence: 0.9,
+      strength: 1.0,
+    });
+    const session = await seedSession(kv, {
+      id: "ses_src_rank",
+      project: "/tmp/proj",
+    });
+    await seedSemantic(kv, {
+      id: "sem_project_rank",
+      fact: "project-rank-marker",
+      sourceSessionIds: [session.id],
+      confidence: 0.7,
+      strength: 1.0,
+    });
+
+    const result = await handler({
+      sessionId: "ses_a",
+      project: "/tmp/proj",
+    });
+
+    const projectIdx = result.context.indexOf("project-rank-marker");
+    const globalIdx = result.context.indexOf("global-rank-marker");
+    expect(projectIdx).toBeGreaterThan(-1);
+    expect(globalIdx).toBeGreaterThan(-1);
+    expect(projectIdx).toBeLessThan(globalIdx);
+  });
+
+  it("caps at top 10 facts by score", async () => {
+    const session = await seedSession(kv, {
+      id: "ses_cap_src",
+      project: "/tmp/proj",
+    });
+    for (let i = 0; i < 15; i++) {
+      await seedSemantic(kv, {
+        id: `sem_${i}`,
+        fact: `semantic-marker-${i}`,
+        sourceSessionIds: [session.id],
+        confidence: i / 100,
+        strength: 1,
+      });
+    }
+
+    const result = await handler({
+      sessionId: "ses_a",
+      project: "/tmp/proj",
+      budget: 10000,
+    });
+
+    const matched = result.context.match(/semantic-marker-/g) ?? [];
+    expect(matched.length).toBe(10);
+    expect(result.context).toContain("semantic-marker-14");
+    expect(result.context).toContain("semantic-marker-5");
+    expect(result.context).not.toContain("semantic-marker-0");
+  });
+});

--- a/test/smart-search.test.ts
+++ b/test/smart-search.test.ts
@@ -291,4 +291,131 @@ describe("Smart Search Function", () => {
       expect(result.lessons).toEqual([]);
     });
   });
+
+  describe("insight inclusion (#590)", () => {
+    it("compact mode returns insights array alongside observation results", async () => {
+      sdk.registerFunction("mem::insight-search", async () => ({
+        success: true,
+        insights: [
+          {
+            id: "ins_a",
+            title: "PID 1 masking kills restart policy",
+            content:
+              "When nginx runs as PID 1 with a backgrounded critical process, the supervisor never sees the death.",
+            confidence: 0.95,
+            createdAt: "2026-05-20T13:00:00Z",
+            project: "p",
+            tags: ["loki", "railway"],
+            score: 0.85,
+          },
+          {
+            id: "ins_b",
+            title: "Silent process death",
+            content: "Background processes die invisibly.",
+            confidence: 0.88,
+            createdAt: "2026-05-20T13:01:00Z",
+            project: "p",
+            tags: ["reliability"],
+            score: 0.78,
+          },
+        ],
+      }));
+
+      const result = (await sdk.trigger("mem::smart-search", {
+        query: "process death",
+      })) as { mode: string; results: CompactSearchResult[]; insights?: any[] };
+
+      expect(result.mode).toBe("compact");
+      expect(result.results.length).toBe(2);
+      expect(result.insights).toBeDefined();
+      expect(result.insights!.length).toBe(2);
+      expect(result.insights![0]).toMatchObject({
+        insightId: "ins_a",
+        title: "PID 1 masking kills restart policy",
+        confidence: 0.95,
+        score: 0.85,
+      });
+      expect(result.insights![0].tags).toEqual(["loki", "railway"]);
+    });
+
+    it("compact mode truncates long insight content for preview", async () => {
+      const long = "y".repeat(500);
+      sdk.registerFunction("mem::insight-search", async () => ({
+        success: true,
+        insights: [
+          {
+            id: "ins_long",
+            title: "wordy",
+            content: long,
+            confidence: 0.5,
+            createdAt: "",
+            tags: [],
+            score: 0.4,
+          },
+        ],
+      }));
+
+      const result = (await sdk.trigger("mem::smart-search", {
+        query: "y",
+      })) as { insights: any[] };
+
+      expect(result.insights[0].content.length).toBeLessThan(long.length);
+      expect(result.insights[0].content).toMatch(/…$/);
+    });
+
+    it("includeInsights:false omits the insights array entirely", async () => {
+      const result = (await sdk.trigger("mem::smart-search", {
+        query: "auth",
+        includeInsights: false,
+      })) as { results: CompactSearchResult[]; insights?: unknown };
+
+      expect(result.results.length).toBe(2);
+      expect(result.insights).toBeUndefined();
+    });
+
+    it("forwards project filter to mem::insight-search", async () => {
+      let receivedPayload: any = null;
+      sdk.registerFunction("mem::insight-search", async (payload: any) => {
+        receivedPayload = payload;
+        return { success: true, insights: [] };
+      });
+
+      await sdk.trigger("mem::smart-search", {
+        query: "deploy",
+        project: "compass-app",
+      });
+
+      expect(receivedPayload).toMatchObject({
+        query: "deploy",
+        project: "compass-app",
+      });
+    });
+
+    it("tolerates mem::insight-search failure: returns empty insights, observations unchanged", async () => {
+      sdk.registerFunction("mem::insight-search", async () => {
+        throw new Error("insights store unavailable");
+      });
+
+      const result = (await sdk.trigger("mem::smart-search", {
+        query: "auth",
+      })) as { results: CompactSearchResult[]; insights: any[] };
+
+      expect(result.results.length).toBe(2);
+      expect(result.insights).toEqual([]);
+    });
+
+    it("tolerates non-success insight-search response shape", async () => {
+      sdk.registerFunction("mem::insight-search", async () => ({
+        success: false,
+        error: "query is required",
+      }));
+
+      const result = (await sdk.trigger("mem::smart-search", {
+        query: "auth",
+      })) as { results: CompactSearchResult[]; insights: any[] };
+
+      expect(result.results.length).toBe(2);
+      expect(result.insights).toEqual([]);
+    });
+  });
 });


### PR DESCRIPTION
Closes #590. Same pattern as #458 + #473, applied to `KV.insights` and `KV.semantic`.

**`smart-search`**: new `includeInsights` (default true), parallel `mem::insight-search`, returns `insights` field — direct mirror of the lesson piggyback in #473.

**`mem::context`**: reads `KV.insights` + `KV.semantic` in parallel with existing reads.
- Insights filtered identically to lessons (`!deleted && (!project || project === current)`), ranked `(matching ? 1.5 : 1) × confidence`, top 10, `## Distilled Insights` block.
- Semantic project membership derived from `sourceSessionIds` via the already-fetched `allSessions` map. Cross-project facts surface as global; sources entirely in other projects are excluded. Ranked `strength × confidence × boost`, top 10, `## Architectural Facts` block.

+18 tests (smart-search +6, new `test/context-insights-semantic.test.ts` +12). All pass. No existing test broken.