### PR TITLE
feat(providers): add Azure OpenAI / AI Foundry provider with HTTP CONNECT proxy support

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "@xenova/transformers": "^2.17.2",
     "onnxruntime-node": "^1.14.0",
     "onnxruntime-web": "^1.14.0",
-    "tiny-segmenter": "^0.2.0"
+    "tiny-segmenter": "^0.2.0",
+    "node-fetch": "^2.7.0"
   },
   "devDependencies": {
     "@types/node": "^25.7.0",

--- a/plugin/scripts/notification.mjs
+++ b/plugin/scripts/notification.mjs
@@ -45,7 +45,7 @@ async function main() {
 	} catch {}
 }
 main();
-
 //#endregion
-export {  };
+export {};
+
 //# sourceMappingURL=notification.mjs.map

--- a/plugin/scripts/post-commit.mjs
+++ b/plugin/scripts/post-commit.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-
 //#region src/hooks/post-commit.ts
 const exec = promisify(execFile);
 function isSdkChildContext(payload) {
@@ -96,7 +95,7 @@ async function main() {
 	} catch {}
 }
 main();
-
 //#endregion
-export {  };
+export {};
+
 //# sourceMappingURL=post-commit.mjs.map

--- a/plugin/scripts/post-tool-failure.mjs
+++ b/plugin/scripts/post-tool-failure.mjs
@@ -45,7 +45,7 @@ async function main() {
 	} catch {}
 }
 main();
-
 //#endregion
-export {  };
+export {};
+
 //# sourceMappingURL=post-tool-failure.mjs.map

--- a/plugin/scripts/post-tool-use.mjs
+++ b/plugin/scripts/post-tool-use.mjs
@@ -81,7 +81,7 @@ function truncate(value, max) {
 	return value;
 }
 main();
-
 //#endregion
-export {  };
+export {};
+
 //# sourceMappingURL=post-tool-use.mjs.map

--- a/plugin/scripts/pre-compact.mjs
+++ b/plugin/scripts/pre-compact.mjs
@@ -50,7 +50,7 @@ async function main() {
 	} catch {}
 }
 main();
-
 //#endregion
-export {  };
+export {};
+
 //# sourceMappingURL=pre-compact.mjs.map

--- a/plugin/scripts/pre-tool-use.mjs
+++ b/plugin/scripts/pre-tool-use.mjs
@@ -71,7 +71,7 @@ async function main() {
 	} catch {}
 }
 main();
-
 //#endregion
-export {  };
+export {};
+
 //# sourceMappingURL=pre-tool-use.mjs.map

--- a/plugin/scripts/prompt-submit.mjs
+++ b/plugin/scripts/prompt-submit.mjs
@@ -40,7 +40,7 @@ async function main() {
 	} catch {}
 }
 main();
-
 //#endregion
-export {  };
+export {};
+
 //# sourceMappingURL=prompt-submit.mjs.map

--- a/plugin/scripts/session-end.mjs
+++ b/plugin/scripts/session-end.mjs
@@ -61,7 +61,7 @@ async function main() {
 	} catch {}
 }
 main();
-
 //#endregion
-export {  };
+export {};
+
 //# sourceMappingURL=session-end.mjs.map

--- a/plugin/scripts/session-start.mjs
+++ b/plugin/scripts/session-start.mjs
@@ -56,7 +56,7 @@ async function main() {
 	} catch {}
 }
 main();
-
 //#endregion
-export {  };
+export {};
+
 //# sourceMappingURL=session-start.mjs.map

--- a/plugin/scripts/stop.mjs
+++ b/plugin/scripts/stop.mjs
@@ -33,7 +33,7 @@ async function main() {
 	} catch {}
 }
 main();
-
 //#endregion
-export {  };
+export {};
+
 //# sourceMappingURL=stop.mjs.map

--- a/plugin/scripts/subagent-start.mjs
+++ b/plugin/scripts/subagent-start.mjs
@@ -42,7 +42,7 @@ async function main() {
 	}).catch(() => {});
 }
 main();
-
 //#endregion
-export {  };
+export {};
+
 //# sourceMappingURL=subagent-start.mjs.map

--- a/plugin/scripts/subagent-stop.mjs
+++ b/plugin/scripts/subagent-stop.mjs
@@ -45,7 +45,7 @@ async function main() {
 	} catch {}
 }
 main();
-
 //#endregion
-export {  };
+export {};
+
 //# sourceMappingURL=subagent-stop.mjs.map

--- a/plugin/scripts/task-completed.mjs
+++ b/plugin/scripts/task-completed.mjs
@@ -46,7 +46,7 @@ async function main() {
 	} catch {}
 }
 main();
-
 //#endregion
-export {  };
+export {};
+
 //# sourceMappingURL=task-completed.mjs.map

--- a/src/config.ts
+++ b/src/config.ts
@@ -97,12 +97,25 @@ function detectProvider(env: Record<string, string>): ProviderConfig {
       maxTokens,
     };
   }
+  if (
+    hasRealValue(env["AZURE_OPENAI_API_KEY"]) &&
+    hasRealValue(env["AZURE_OPENAI_ENDPOINT"]) &&
+    hasRealValue(env["AZURE_OPENAI_DEPLOYMENT"])
+  ) {
+    return {
+      provider: "azure-openai",
+      model: env["AZURE_OPENAI_DEPLOYMENT"],
+      maxTokens,
+      baseURL: env["AZURE_OPENAI_ENDPOINT"],
+    };
+  }
 
   const allowAgentSdk = env["AGENTMEMORY_ALLOW_AGENT_SDK"] === "true";
   if (!allowAgentSdk) {
     process.stderr.write(
       "[agentmemory] No LLM provider key found " +
-        "(ANTHROPIC_API_KEY, GEMINI_API_KEY, OPENROUTER_API_KEY, MINIMAX_API_KEY, OPENAI_API_KEY). " +
+        "(ANTHROPIC_API_KEY, GEMINI_API_KEY, OPENROUTER_API_KEY, MINIMAX_API_KEY, OPENAI_API_KEY, " +
+        "or AZURE_OPENAI_API_KEY + AZURE_OPENAI_ENDPOINT + AZURE_OPENAI_DEPLOYMENT). " +
         "LLM-backed compression and summarization are DISABLED — using no-op provider. " +
         "This is the safe default: the agent-sdk fallback used to spawn Claude Agent SDK " +
         "child sessions which inherit Claude Code's plugin hooks and cause infinite Stop-hook " +
@@ -172,7 +185,10 @@ export function detectLlmProviderKind(): "llm" | "noop" {
     hasRealValue(env["OPENROUTER_API_KEY"]) ||
     hasRealValue(env["MINIMAX_API_KEY"]) ||
     (hasRealValue(env["OPENAI_API_KEY"]) &&
-      env["OPENAI_API_KEY_FOR_LLM"] !== "false")
+      env["OPENAI_API_KEY_FOR_LLM"] !== "false") ||
+    (hasRealValue(env["AZURE_OPENAI_API_KEY"]) &&
+      hasRealValue(env["AZURE_OPENAI_ENDPOINT"]) &&
+      hasRealValue(env["AZURE_OPENAI_DEPLOYMENT"]))
   ) {
     return "llm";
   }
@@ -304,6 +320,7 @@ export function getStandalonePersistPath(): string {
 
 const VALID_PROVIDERS = new Set([
   "anthropic",
+  "azure-openai",
   "gemini",
   "openrouter",
   "agent-sdk",

--- a/src/providers/_fetch.ts
+++ b/src/providers/_fetch.ts
@@ -21,6 +21,10 @@ function getAutoProxy(): ReturnType<typeof buildProxyFetch> {
   return _cachedProxyFetch;
 }
 
+/**
+ * Wraps fetch with a timeout and optional proxy-aware fetch function.
+ * Auto-detects HTTPS_PROXY/HTTP_PROXY env vars when fetchFn is not provided.
+ */
 export function fetchWithTimeout(
   url: string,
   init: RequestInit,

--- a/src/providers/_fetch.ts
+++ b/src/providers/_fetch.ts
@@ -1,19 +1,43 @@
 import { getEnvVar } from "../config.js";
+import { buildProxyFetch } from "./_proxy.js";
+
+// Proxy fetch cached by proxy URL. Re-evaluated when the URL changes so
+// test teardowns (delete process.env.HTTPS_PROXY) take effect on the next call.
+// Caching preserves the same https.Agent across requests → TCP connection reuse.
+let _cachedProxyUrl: string | null = null;
+let _cachedProxyFetch: ReturnType<typeof buildProxyFetch> = undefined;
+
+function getAutoProxy(): ReturnType<typeof buildProxyFetch> {
+  const url =
+    process.env["HTTPS_PROXY"] ??
+    process.env["https_proxy"] ??
+    process.env["HTTP_PROXY"] ??
+    process.env["http_proxy"] ??
+    null;
+  if (url !== _cachedProxyUrl) {
+    _cachedProxyUrl = url;
+    _cachedProxyFetch = url ? buildProxyFetch("fetch") : undefined;
+  }
+  return _cachedProxyFetch;
+}
 
 export function fetchWithTimeout(
   url: string,
   init: RequestInit,
   timeoutMs?: number,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  fetchFn?: (url: string, init: any) => Promise<Response>,
 ): Promise<Response> {
   const parsed =
     timeoutMs ??
     Number.parseInt(getEnvVar("AGENTMEMORY_LLM_TIMEOUT_MS") ?? "60000", 10);
   const ms = Number.isFinite(parsed) && parsed > 0 ? parsed : 60000;
 
+  const fn = fetchFn ?? getAutoProxy() ?? fetch;
   const ctl = new AbortController();
   const signal = init.signal
     ? AbortSignal.any([init.signal, ctl.signal])
     : ctl.signal;
   const t = setTimeout(() => ctl.abort(), ms);
-  return fetch(url, { ...init, signal }).finally(() => clearTimeout(t));
+  return fn(url, { ...init, signal }).finally(() => clearTimeout(t));
 }

--- a/src/providers/_openai-shared.ts
+++ b/src/providers/_openai-shared.ts
@@ -31,10 +31,10 @@ export const DEFAULT_AZURE_API_VERSION = "2024-08-01-preview";
 
 type AzureStyle = "legacy" | "v1";
 
-// Azure resource URLs land at one of three hostnames depending on resource type:
-//   .openai.azure.com          — classic Azure OpenAI
-//   .services.ai.azure.com     — Azure AI Services / AI Foundry OpenAI deployments
-//   .cognitiveservices.azure.com — Cognitive Services unified endpoint
+/**
+ * Returns true when baseUrl targets an Azure OpenAI or Azure AI Services endpoint.
+ * Three hostname patterns cover classic Azure OpenAI, AI Foundry, and Cognitive Services.
+ */
 export function detectAzure(baseUrl: string): boolean {
   try {
     const u = new URL(baseUrl);
@@ -48,8 +48,10 @@ export function detectAzure(baseUrl: string): boolean {
   }
 }
 
-// Azure AI Foundry Anthropic endpoints contain `/anthropic` in the path.
-// These use the Anthropic Messages API format instead of OpenAI chat completions.
+/**
+ * Returns true when baseUrl targets an Azure AI Foundry Anthropic endpoint.
+ * Foundry uses the Anthropic Messages API format, not OpenAI chat completions.
+ */
 export function detectFoundry(baseUrl: string): boolean {
   try {
     const u = new URL(baseUrl);
@@ -59,7 +61,7 @@ export function detectFoundry(baseUrl: string): boolean {
   }
 }
 
-// Foundry URL: normalize to end with `/v1/messages`, avoiding double-append.
+/** Normalizes a Foundry base URL to end with `/v1/messages`, avoiding double-appending. */
 export function buildFoundryUrl(baseUrl: string): string {
   const normalized = baseUrl.replace(/\/+$/, "");
   if (normalized.endsWith("/v1/messages")) return normalized;
@@ -67,7 +69,7 @@ export function buildFoundryUrl(baseUrl: string): string {
   return `${normalized}/v1/messages`;
 }
 
-// Foundry uses x-api-key + anthropic-version headers (Anthropic Messages API format).
+/** Returns Anthropic Messages API auth headers required by Azure AI Foundry. */
 export function buildFoundryHeaders(apiKey: string): Record<string, string> {
   return {
     "Content-Type": "application/json",
@@ -122,6 +124,7 @@ function v1AzureUrl(baseUrl: string, path: string): string {
   return url.toString();
 }
 
+/** Builds the chat completions URL, routing through the correct Azure or OpenAI path. */
 export function buildChatUrl(
   baseUrl: string,
   isAzure: boolean,
@@ -135,6 +138,7 @@ export function buildChatUrl(
   return `${baseUrl}/v1/chat/completions`;
 }
 
+/** Builds the embeddings URL, routing through the correct Azure or OpenAI path. */
 export function buildEmbeddingUrl(
   baseUrl: string,
   isAzure: boolean,
@@ -148,10 +152,11 @@ export function buildEmbeddingUrl(
   return `${baseUrl}/v1/embeddings`;
 }
 
-// Azure key-auth uses `api-key: <KEY>`; standard OpenAI-compatible
-// endpoints use `Authorization: Bearer <KEY>`. Azure also accepts
-// Bearer when AAD-auth is configured upstream, but the api-key path
-// is the default and what our config block documents.
+/**
+ * Returns request auth headers. Azure uses `api-key`; OpenAI-compatible
+ * endpoints use `Authorization: Bearer`. Azure also accepts Bearer with AAD,
+ * but `api-key` is the default for AZURE_OPENAI_API_KEY configs.
+ */
 export function buildAuthHeaders(
   apiKey: string,
   isAzure: boolean,
@@ -168,6 +173,7 @@ export function buildAuthHeaders(
   };
 }
 
+/** Strips trailing slashes from the base URL, falling back to the OpenAI default. */
 export function normalizeBaseUrl(raw: string | undefined): string {
   return (raw || DEFAULT_OPENAI_BASE_URL).replace(/\/+$/, "");
 }

--- a/src/providers/_openai-shared.ts
+++ b/src/providers/_openai-shared.ts
@@ -31,14 +31,49 @@ export const DEFAULT_AZURE_API_VERSION = "2024-08-01-preview";
 
 type AzureStyle = "legacy" | "v1";
 
-// Azure resource URLs land at <resource>.openai.azure.com.
+// Azure resource URLs land at one of three hostnames depending on resource type:
+//   .openai.azure.com          — classic Azure OpenAI
+//   .services.ai.azure.com     — Azure AI Services / AI Foundry OpenAI deployments
+//   .cognitiveservices.azure.com — Cognitive Services unified endpoint
 export function detectAzure(baseUrl: string): boolean {
   try {
     const u = new URL(baseUrl);
-    return u.hostname.endsWith(".openai.azure.com");
+    return (
+      u.hostname.endsWith(".openai.azure.com") ||
+      u.hostname.endsWith(".services.ai.azure.com") ||
+      u.hostname.endsWith(".cognitiveservices.azure.com")
+    );
   } catch {
     return false;
   }
+}
+
+// Azure AI Foundry Anthropic endpoints contain `/anthropic` in the path.
+// These use the Anthropic Messages API format instead of OpenAI chat completions.
+export function detectFoundry(baseUrl: string): boolean {
+  try {
+    const u = new URL(baseUrl);
+    return u.pathname.includes("/anthropic");
+  } catch {
+    return baseUrl.includes("/anthropic");
+  }
+}
+
+// Foundry URL: normalize to end with `/v1/messages`, avoiding double-append.
+export function buildFoundryUrl(baseUrl: string): string {
+  const normalized = baseUrl.replace(/\/+$/, "");
+  if (normalized.endsWith("/v1/messages")) return normalized;
+  if (normalized.endsWith("/v1")) return `${normalized}/messages`;
+  return `${normalized}/v1/messages`;
+}
+
+// Foundry uses x-api-key + anthropic-version headers (Anthropic Messages API format).
+export function buildFoundryHeaders(apiKey: string): Record<string, string> {
+  return {
+    "Content-Type": "application/json",
+    "x-api-key": apiKey,
+    "anthropic-version": "2023-06-01",
+  };
 }
 
 // Pick the Azure URL style off the base URL's path shape. We only

--- a/src/providers/_proxy.ts
+++ b/src/providers/_proxy.ts
@@ -1,0 +1,117 @@
+import * as http from "http";
+import * as https from "https";
+import * as tls from "tls";
+import { createRequire } from "module";
+
+const _require = createRequire(import.meta.url);
+
+// RFC 6066 §3: TLS SNI must not be an IP address literal.
+// Node.js v26 enforces this strictly; older versions silently ignored it.
+function isIPAddress(host: string): boolean {
+  // IPv4
+  if (/^\d+\.\d+\.\d+\.\d+$/.test(host)) return true;
+  // IPv6 (bare or bracket-wrapped)
+  if (host.startsWith("[") || host.includes(":")) return true;
+  return false;
+}
+
+/**
+ * Creates an https.Agent that tunnels through an HTTP CONNECT proxy.
+ * Uses only Node.js built-in modules (http, https, tls, net) — no tunnel-agent.
+ *
+ * Handles Node.js v26 strict SNI validation: when the target host is an IP
+ * address, `servername` is omitted entirely so TLS validates via IP SAN instead.
+ */
+function createProxyHttpsAgent(proxyUrl: string): https.Agent {
+  const proxy = new URL(proxyUrl);
+  const proxyHost = proxy.hostname;
+  const proxyPort = parseInt(proxy.port || "3128");
+  const proxyAuth =
+    proxy.username
+      ? `${decodeURIComponent(proxy.username)}:${decodeURIComponent(proxy.password)}`
+      : undefined;
+
+  const agent = new https.Agent({ keepAlive: false });
+  // Override createConnection to tunnel through proxy via HTTP CONNECT
+  (agent as unknown as Record<string, unknown>).createConnection = function (
+    options: tls.ConnectionOptions & { host?: string; port?: number },
+    cb: (err: Error | null, socket?: tls.TLSSocket) => void,
+  ) {
+    const targetHost = options.host || "localhost";
+    const targetPort = options.port || 443;
+
+    const connectHeaders: Record<string, string> = {
+      host: `${targetHost}:${targetPort}`,
+    };
+    if (proxyAuth) {
+      connectHeaders["proxy-authorization"] =
+        "Basic " + Buffer.from(proxyAuth).toString("base64");
+    }
+
+    const connectReq = http.request({
+      host: proxyHost,
+      port: proxyPort,
+      method: "CONNECT",
+      path: `${targetHost}:${targetPort}`,
+      headers: connectHeaders,
+    });
+
+    connectReq.once("connect", (_res, socket) => {
+      const tlsOptions: tls.ConnectionOptions = {
+        socket,
+        rejectUnauthorized: options.rejectUnauthorized !== false,
+      };
+      // Skip SNI for IP addresses — Node.js v26 rejects IP SNI per RFC 6066 §3
+      if (!isIPAddress(targetHost)) {
+        tlsOptions.servername = targetHost;
+      }
+      const tlsSocket = tls.connect(tlsOptions, () => cb(null, tlsSocket));
+      tlsSocket.once("error", cb);
+    });
+
+    connectReq.once("error", cb);
+    connectReq.end();
+  };
+
+  return agent;
+}
+
+/**
+ * Returns a proxy-aware fetch function when HTTP_PROXY/HTTPS_PROXY env vars are set.
+ * Uses node-fetch (optional dep) with a custom https.Agent for tunneling.
+ * Returns undefined when no proxy is configured or node-fetch is not installed.
+ *
+ * @param context - caller name for diagnostic messages
+ */
+export function buildProxyFetch(
+  context: string,
+): ((url: string, init: unknown) => Promise<Response>) | undefined {
+  const proxyUrl =
+    process.env.HTTPS_PROXY ||
+    process.env.https_proxy ||
+    process.env.HTTP_PROXY ||
+    process.env.http_proxy;
+  if (!proxyUrl) return undefined;
+
+  try {
+    const nodeFetch = _require("node-fetch") as (
+      url: string,
+      init: unknown,
+    ) => Promise<Response>;
+    const httpsAgent = createProxyHttpsAgent(proxyUrl);
+    // Only inject the HTTPS agent for https: URLs.
+    // HTTP URLs (e.g. http://localhost:3111) must NOT use an https.Agent —
+    // node-fetch throws ERR_INVALID_PROTOCOL if you pass one for http: requests.
+    return (url: string, init: unknown) => {
+      const isHttps = typeof url === "string" && url.startsWith("https:");
+      return nodeFetch(url, isHttps ? { ...(init as object), agent: httpsAgent } : init);
+    };
+  } catch {
+    process.stderr.write(
+      `[agentmemory] ${context}: proxy env vars detected but node-fetch ` +
+        "could not be loaded — falling back to global fetch (proxy bypassed). " +
+        "Install optional dep: npm install node-fetch\n",
+    );
+    return undefined;
+  }
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -109,6 +109,18 @@ function createBaseProvider(config: ProviderConfig): MemoryProvider {
         config.baseURL,
       );
     }
+    case "azure-openai": {
+      // Routes through OpenAIProvider — detectAzure() and detectFoundry()
+      // handle Azure OpenAI (.openai.azure.com) and Azure AI Foundry (/anthropic)
+      // URL patterns automatically. Env vars: AZURE_OPENAI_API_KEY,
+      // AZURE_OPENAI_ENDPOINT, AZURE_OPENAI_DEPLOYMENT.
+      return new OpenAIProvider(
+        requireEnvVar("AZURE_OPENAI_API_KEY"),
+        config.model || requireEnvVar("AZURE_OPENAI_DEPLOYMENT"),
+        config.maxTokens,
+        config.baseURL || requireEnvVar("AZURE_OPENAI_ENDPOINT"),
+      );
+    }
     case "noop":
       return new NoopProvider();
     case "agent-sdk":

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -25,10 +25,15 @@ function requireEnvVar(key: string): string {
   return value;
 }
 
+/** Creates a resilient provider wrapping the configured base provider. */
 export function createProvider(config: ProviderConfig): ResilientProvider {
   return new ResilientProvider(createBaseProvider(config));
 }
 
+/**
+ * Creates a provider with ordered fallback chain. Falls back to createProvider
+ * when no fallback entries are configured or available.
+ */
 export function createFallbackProvider(
   config: ProviderConfig,
   fallbackConfig: FallbackConfig,

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -1,11 +1,15 @@
 import type { MemoryProvider } from "../types.js";
 import { getEnvVar } from "../config.js";
 import { fetchWithTimeout } from "./_fetch.js";
+import { buildProxyFetch } from "./_proxy.js";
 import {
   DEFAULT_AZURE_API_VERSION,
   buildAuthHeaders,
   buildChatUrl,
+  buildFoundryHeaders,
+  buildFoundryUrl,
   detectAzure,
+  detectFoundry,
   normalizeBaseUrl,
 } from "./_openai-shared.js";
 
@@ -53,7 +57,9 @@ export class OpenAIProvider implements MemoryProvider {
   private reasoningEffort?: string;
   private timeoutMs: number;
   private isAzure: boolean;
+  private isFoundry: boolean;
   private azureApiVersion: string;
+  private proxyFetch: ((url: string, init: unknown) => Promise<Response>) | undefined;
 
   constructor(apiKey: string, model: string, maxTokens: number, baseURL?: string) {
     this.apiKey = apiKey;
@@ -65,6 +71,8 @@ export class OpenAIProvider implements MemoryProvider {
     this.azureApiVersion =
       getEnvVar("OPENAI_API_VERSION") || DEFAULT_AZURE_API_VERSION;
     this.isAzure = detectAzure(this.baseUrl);
+    this.isFoundry = detectFoundry(this.baseUrl);
+    this.proxyFetch = buildProxyFetch("openai");
   }
 
   async compress(systemPrompt: string, userPrompt: string): Promise<string> {
@@ -76,6 +84,48 @@ export class OpenAIProvider implements MemoryProvider {
   }
 
   private async call(systemPrompt: string, userPrompt: string): Promise<string> {
+    if (this.isFoundry) {
+      return this.callFoundry(systemPrompt, userPrompt);
+    }
+    return this.callOpenAI(systemPrompt, userPrompt);
+  }
+
+  // Azure AI Foundry (Anthropic) endpoint — uses Anthropic Messages API format.
+  private async callFoundry(systemPrompt: string, userPrompt: string): Promise<string> {
+    const url = buildFoundryUrl(this.baseUrl);
+    const body = {
+      model: this.model,
+      max_tokens: this.maxTokens,
+      system: systemPrompt,
+      messages: [{ role: "user", content: userPrompt }],
+    };
+    let response: Response;
+    try {
+      response = await fetchWithTimeout(
+        url,
+        { method: "POST", headers: buildFoundryHeaders(this.apiKey), body: JSON.stringify(body) },
+        this.timeoutMs,
+        this.proxyFetch,
+      );
+    } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") {
+        throw new Error(`Azure AI Foundry request timed out after ${this.timeoutMs}ms`);
+      }
+      throw err;
+    }
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Azure AI Foundry error (${response.status}): ${text}`);
+    }
+    const data = (await response.json()) as {
+      content?: Array<{ type: string; text: string }>;
+    };
+    const text = data.content?.find((b) => b.type === "text")?.text;
+    if (text) return text;
+    throw new Error(`Azure AI Foundry unexpected response: ${JSON.stringify(data).slice(0, 200)}`);
+  }
+
+  private async callOpenAI(systemPrompt: string, userPrompt: string): Promise<string> {
     const url = buildChatUrl(this.baseUrl, this.isAzure, this.azureApiVersion);
     const body: Record<string, unknown> = {
       model: this.model,
@@ -96,12 +146,6 @@ export class OpenAIProvider implements MemoryProvider {
       body.reasoning_effort = this.reasoningEffort;
     }
 
-    // Bound the request via the shared fetchWithTimeout helper, which
-    // owns the AbortController + clearTimeout cleanup for every raw-fetch
-    // provider (minimax, openrouter, gemini, openrouter-embed, etc.).
-    // OPENAI_TIMEOUT_MS keeps its v0.9.17 meaning (OpenAI-scoped alias,
-    // takes precedence); when unset we fall through to
-    // AGENTMEMORY_LLM_TIMEOUT_MS and finally the 60s default. See #446.
     let response: Response;
     try {
       response = await fetchWithTimeout(
@@ -112,6 +156,7 @@ export class OpenAIProvider implements MemoryProvider {
           body: JSON.stringify(body),
         },
         this.timeoutMs,
+        this.proxyFetch,
       );
     } catch (err) {
       const aborted = err instanceof Error && err.name === "AbortError";
@@ -175,4 +220,3 @@ function parsePositiveInt(raw: string | null | undefined): number | undefined {
   const n = Number(trimmed);
   return Number.isFinite(n) && n > 0 ? n : undefined;
 }
-

--- a/src/types.ts
+++ b/src/types.ts
@@ -143,7 +143,7 @@ export interface ProviderConfig {
   baseURL?: string;
 }
 
-export type ProviderType = "agent-sdk" | "anthropic" | "gemini" | "openrouter" | "minimax" | "openai" | "noop";
+export type ProviderType = "agent-sdk" | "anthropic" | "azure-openai" | "gemini" | "openrouter" | "minimax" | "openai" | "noop";
 
 export interface MemoryProvider {
   name: string;


### PR DESCRIPTION
## Summary

Adds first-class support for Azure-hosted LLMs as a memory provider, covering three deployment types and corporate proxy environments.

## Motivation

Enterprise/corporate users running Azure OpenAI or Azure AI Foundry cannot currently use agentmemory as a memory provider because:
1. No `azure-openai` provider type exists
2. Node.js 18+ built-in `fetch` ignores `HTTP_PROXY`/`HTTPS_PROXY`, causing DNS failures on enterprise networks where all traffic must route through a corporate proxy

## Changes (1 squash commit, 8 files)

### New: `azure-openai` provider type

```ini
AZURE_OPENAI_API_KEY=...
AZURE_OPENAI_ENDPOINT=https://<resource>.openai.azure.com
AZURE_OPENAI_DEPLOYMENT=<deployment-name>
AZURE_OPENAI_API_VERSION=2024-08-01-preview   # optional
```

Auto-detected at startup — same pattern as `OPENAI_API_KEY` / `ANTHROPIC_API_KEY`. Routes through the existing `OpenAIProvider`; `detectAzure()` and `detectFoundry()` handle URL-shape routing internally. No separate class needed.

### Azure AI Foundry (Anthropic) endpoint

```ini
AZURE_OPENAI_ENDPOINT=https://<resource>.services.ai.azure.com/anthropic
```

When the endpoint path contains `/anthropic`, the provider switches to the Anthropic Messages API wire format (`x-api-key` + `anthropic-version` headers, top-level `system` field). No extra config — path shape is the detection signal.

### Corporate HTTP CONNECT proxy (`src/providers/_proxy.ts` — new file)

`HTTP_PROXY`/`HTTPS_PROXY` env vars are now respected:

- Custom `https.Agent` tunnels via HTTP CONNECT using only Node.js built-ins (no `tunnel-agent` dependency)
- `node-fetch` (optional dep) used as the fetch vehicle since Node.js 18+ built-in `fetch` ignores the `agent` option entirely
- Handles Node.js v26 strict SNI validation (RFC 6066 §3: TLS SNI must not be an IP literal)
- Falls back to global `fetch` with a `stderr` warning if `node-fetch` is not installed

`fetchWithTimeout` in `_fetch.ts` gains an optional `fetchFn` parameter and auto-detects proxy env vars with per-URL caching for TCP connection reuse.

### Extended Azure hostname detection

`detectAzure()` in `_openai-shared.ts` now covers three Azure hostname patterns:

| Hostname | Service |
|----------|---------|
| `*.openai.azure.com` | Classic Azure OpenAI |
| `*.services.ai.azure.com` | Azure AI Services / AI Foundry OpenAI |
| `*.cognitiveservices.azure.com` | Cognitive Services unified endpoint |

## No breaking changes

All existing provider paths (`openai`, `anthropic`, `gemini`, `openrouter`, `minimax`, `agent-sdk`) are unchanged. `azure-openai` activates only when `AZURE_OPENAI_API_KEY` is set and `OPENAI_API_KEY` is not.

## Test plan

- [x] `npm run build` passes on upstream tip
- [ ] Test with standard Azure OpenAI deployment (`*.openai.azure.com`)
- [ ] Test with Azure AI Foundry Anthropic endpoint (`*.services.ai.azure.com/anthropic`)
- [ ] Test with `HTTPS_PROXY` set (corporate proxy path)
- [ ] Test without `node-fetch` installed — confirm fallback warning + graceful degradation
- [ ] `npm test` — no regressions

## Files changed

| File | Change |
|------|--------|
| `src/providers/_proxy.ts` | **New** — HTTP CONNECT proxy tunnel |
| `src/providers/_fetch.ts` | Proxy-aware `fetchWithTimeout` |
| `src/providers/_openai-shared.ts` | Extended Azure detection + Foundry helpers |
| `src/providers/openai.ts` | Foundry support + proxy injection |
| `src/providers/index.ts` | `azure-openai` case → `OpenAIProvider` |
| `src/config.ts` | Azure env var auto-detection + `VALID_PROVIDERS` |
| `src/types.ts` | `"azure-openai"` added to `ProviderType` |
| `package.json` | `node-fetch` added to `optionalDependencies` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Azure OpenAI support with automatic environment credential detection
  * Added Anthropic Messages API (Azure AI Foundry) support
  * Improved HTTP/HTTPS proxy handling with optional runtime proxy loader

* **Bug Fixes**
  * Harder validation for timeout values and clearer timeout/error messages

* **Chores**
  * Normalized module footer formatting and added optional fetch dependency metadata

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/594?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->