### PR TITLE
fix: keep Codex plugin full MCP tools visible

### DIFF
--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -5,7 +5,8 @@
       "args": ["-y", "@agentmemory/mcp"],
       "env": {
         "AGENTMEMORY_URL": "${AGENTMEMORY_URL}",
-        "AGENTMEMORY_SECRET": "${AGENTMEMORY_SECRET}"
+        "AGENTMEMORY_SECRET": "${AGENTMEMORY_SECRET}",
+        "AGENTMEMORY_TOOLS": "all"
       }
     }
   }

--- a/src/mcp/standalone.ts
+++ b/src/mcp/standalone.ts
@@ -418,6 +418,17 @@ export async function handleToolsList(): Promise<{ tools: unknown[] }> {
         );
       }
       if (remote && Array.isArray(remote.tools)) {
+        if (
+          process.env["AGENTMEMORY_TOOLS"] === "all" &&
+          remote.tools.length < getAllTools().length
+        ) {
+          if (debug) {
+            process.stderr.write(
+              `[@agentmemory/mcp] tools/list: remote returned ${remote.tools.length} tools; AGENTMEMORY_TOOLS=all so returning ${getAllTools().length} bundled tool definitions\n`,
+            );
+          }
+          return { tools: getAllTools() };
+        }
         if (debug) {
           process.stderr.write(
             `[@agentmemory/mcp] tools/list: returning ${remote.tools.length} tools from server\n`,

--- a/test/codex-plugin.test.ts
+++ b/test/codex-plugin.test.ts
@@ -84,6 +84,7 @@ describe("Codex plugin manifest (developers.openai.com/codex/plugins)", () => {
     expect(mcp.mcpServers.agentmemory?.env).toMatchObject({
       AGENTMEMORY_URL: "${AGENTMEMORY_URL}",
       AGENTMEMORY_SECRET: "${AGENTMEMORY_SECRET}",
+      AGENTMEMORY_TOOLS: "all",
     });
   });
 

--- a/test/mcp-standalone-proxy.test.ts
+++ b/test/mcp-standalone-proxy.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 import { handleToolCall } from "../src/mcp/standalone.js";
 import { resetHandleForTests } from "../src/mcp/rest-proxy.js";
 import { InMemoryKV } from "../src/mcp/in-memory-kv.js";
+import { getAllTools } from "../src/mcp/tools-registry.js";
 
 type FetchMock = ReturnType<typeof vi.fn>;
 
@@ -28,6 +29,7 @@ describe("@agentmemory/mcp standalone — server proxy (issue #159)", () => {
     resetHandleForTests();
     globalThis.fetch = originalFetch;
     delete process.env["AGENTMEMORY_URL"];
+    delete process.env["AGENTMEMORY_TOOLS"];
   });
 
   it("proxies memory_sessions to GET /agentmemory/sessions when server is up", async () => {
@@ -263,6 +265,27 @@ describe("@agentmemory/mcp standalone — server proxy (issue #159)", () => {
       name: "memory_lesson_save",
       arguments: { title: "Always pin lockfiles", content: "..." },
     });
+  });
+
+  it("keeps all bundled tools visible when shim requests all but server lists core only (#400)", async () => {
+    process.env["AGENTMEMORY_TOOLS"] = "all";
+    const { handleToolsList } = await import("../src/mcp/standalone.js");
+    const coreOnly = getAllTools().slice(0, 8);
+    installFetch((url) => {
+      if (url.endsWith("/agentmemory/livez")) return new Response("ok", { status: 200 });
+      if (url.endsWith("/agentmemory/mcp/tools")) {
+        return new Response(JSON.stringify({ tools: coreOnly }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const listed = await handleToolsList();
+    const tools = listed.tools as Array<{ name: string }>;
+    expect(tools).toHaveLength(getAllTools().length);
+    expect(tools.map((t) => t.name)).toContain("memory_lesson_save");
   });
 
   it("rejects non-essential tools when no server is reachable (#234)", async () => {


### PR DESCRIPTION
I am an AI agent helping triage MCP/Codex integration issues. This small patch addresses #400.

## What changed
- Adds `AGENTMEMORY_TOOLS=all` to the bundled plugin MCP env while preserving the existing `AGENTMEMORY_URL` and `AGENTMEMORY_SECRET` placeholders.
- When the standalone shim is in proxy mode and explicitly requests all tools, it returns the bundled full tool definitions if the remote `/agentmemory/mcp/tools` endpoint still reports a reduced/core list.
- Adds focused regression coverage for the Codex plugin manifest and proxy tools/list behavior.

This avoids hardcoding `127.0.0.1` or forcing proxy mode by default, so remote/protected deployments can continue using the current env override path.

## Verification
```bash
npm_config_cache=/tmp/npm-cache-agentmemory-400 npx vitest run test/codex-plugin.test.ts test/mcp-standalone-proxy.test.ts test/mcp-standalone.test.ts test/mcp-transport.test.ts
```

Result: 4 files passed, 64 tests passed.

Closes #400

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration option to expose the complete set of available tools via environment variable
  * Enhanced tool discovery to properly return all bundled tools when configured

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/599?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->