### PR TITLE
fix: resolve 15 open issues — buffer pool, graph extraction, sessions, audit, pagination, and more

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,12 @@
 
 # OPENROUTER_EMBEDDING_MODEL=openai/text-embedding-3-small  # When EMBEDDING_PROVIDER=openrouter
 
+# Volcengine (Doubao) — OpenAI-compatible embedding API (#439)
+# VOLCENGINE_API_KEY=...                          # Auto-selects openai provider + Volcengine base URL
+# VOLCENGINE_BASE_URL=https://ark.cn-beijing.volces.com/api/coding/v3
+# VOLCENGINE_EMBEDDING_MODEL=doubao-embedding-vision
+# OPENAI_EMBEDDING_DIMENSIONS=2048               # Set to actual doubao model output size
+
 # -----------------------------------------------------------------------------
 # 3. Auth & security
 # -----------------------------------------------------------------------------

--- a/.env.example
+++ b/.env.example
@@ -119,7 +119,7 @@
 # 6. CLI / runtime knobs
 # -----------------------------------------------------------------------------
 
-# AGENTMEMORY_TOOLS=all                          # core (7 tools, default) | all (51 tools) — surface exposed to MCP clients
+# AGENTMEMORY_TOOLS=all                          # core (8 tools, default) | all (53 tools) — surface exposed to MCP clients
 # AGENTMEMORY_SLOTS=memory                       # Comma-separated plugin slot names the CLI should claim
 # AGENTMEMORY_DEBUG=1                            # Trace MCP shim probe + standalone fallback decisions to stderr
 # AGENTMEMORY_FORCE_PROXY=1                      # Skip the MCP shim livez probe and trust AGENTMEMORY_URL (for sandboxed MCP clients that can't reach localhost)

--- a/README.md
+++ b/README.md
@@ -839,6 +839,8 @@ npm install @xenova/transformers
 | `memory_timeline` | Chronological observations |
 | `memory_relations` | Query relationship graph |
 | `memory_graph_query` | Knowledge graph traversal |
+| `memory_lesson_save` | Save a lesson with confidence score; auto-reinforces duplicates; decays when unused |
+| `memory_lesson_recall` | Search lessons by query, filtered by confidence and project |
 | `memory_consolidate` | Run 4-tier consolidation |
 | `memory_claude_bridge_sync` | Sync with MEMORY.md |
 | `memory_team_share` | Share with team members |

--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ codex plugin install agentmemory
 
 The Codex plugin ships from the same `plugin/` directory as the Claude Code plugin. It registers:
 
-- `@agentmemory/mcp` as an MCP server (proxies all 51 tools when `AGENTMEMORY_URL` points at a running agentmemory server; falls back to 7 tools locally when no server is reachable)
+- `@agentmemory/mcp` as an MCP server (proxies all 53 tools when `AGENTMEMORY_URL` points at a running agentmemory server; falls back to 7 tools locally when no server is reachable)
 - 6 lifecycle hooks: `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `PreCompact`, `Stop`
 - 4 skills: `/recall`, `/remember`, `/session-history`, `/forget`
 
@@ -807,9 +807,9 @@ npm install @xenova/transformers
 
 53 tools, 6 resources, 3 prompts, and 4 skills — the most comprehensive MCP memory toolkit for any agent.
 
-> **MCP shim vs full server:** the published `@agentmemory/mcp` package is a thin shim. It exposes the full 51-tool surface **only when it can reach a running agentmemory server** via `AGENTMEMORY_URL` (proxy mode). With no server reachable, the shim falls back to a 7-tool local set (`memory_save`, `memory_recall`, `memory_smart_search`, `memory_sessions`, `memory_export`, `memory_audit`, `memory_governance_delete`). The `AGENTMEMORY_TOOLS=core|all` env var is a *server-side* flag — setting it in the shim's `env` block has no effect. If you see only 7 tools in Cursor / OpenCode / Gemini CLI, start `npx @agentmemory/agentmemory` (or the Docker stack) and set `AGENTMEMORY_URL=http://localhost:3111`.
+> **MCP shim vs full server:** the published `@agentmemory/mcp` package is a thin shim. It exposes the full 53-tool surface **only when it can reach a running agentmemory server** via `AGENTMEMORY_URL` (proxy mode). With no server reachable, the shim falls back to a 7-tool local set (`memory_save`, `memory_recall`, `memory_smart_search`, `memory_sessions`, `memory_export`, `memory_audit`, `memory_governance_delete`). The `AGENTMEMORY_TOOLS=core|all` env var is a *server-side* flag — setting it in the shim's `env` block has no effect. If you see only 7 tools in Cursor / OpenCode / Gemini CLI, start `npx @agentmemory/agentmemory` (or the Docker stack) and set `AGENTMEMORY_URL=http://localhost:3111`.
 
-### 51 Tools
+### 53 Tools
 
 <details>
 <summary>Core tools (always available)</summary>
@@ -1222,7 +1222,7 @@ Create `~/.agentmemory/.env`:
 # USER_ID=
 # TEAM_MODE=private
 
-# Tool visibility: "core" (8 tools) or "all" (51 tools)
+# Tool visibility: "core" (8 tools) or "all" (53 tools)
 # AGENTMEMORY_TOOLS=core
 ```
 

--- a/iii-config.docker.yaml
+++ b/iii-config.docker.yaml
@@ -40,7 +40,7 @@ workers:
       enabled: true
       service_name: agentmemory
       exporter: memory
-      sampling_ratio: 1.0
+      sampling_ratio: 0.1
       metrics_enabled: true
       logs_enabled: true
       logs_console_output: true

--- a/iii-config.yaml
+++ b/iii-config.yaml
@@ -40,7 +40,11 @@ workers:
       enabled: true
       service_name: agentmemory
       exporter: memory
-      sampling_ratio: 1.0
+      # Sampling ratio reduced from 1.0 to break the subscriber-lag → WARN
+      # feedback loop that caused runaway daemon.log.new growth (#519).
+      # At 1.0, every lagged-subscriber WARN was itself logged, feeding the
+      # same backed-up subscriber and pegging CPU at ~99%.
+      sampling_ratio: 0.1
       metrics_enabled: true
       logs_enabled: true
       logs_console_output: true

--- a/integrations/openclaw/plugin.mjs
+++ b/integrations/openclaw/plugin.mjs
@@ -179,9 +179,24 @@ const plugin = {
       if (!cfg.enabled) return;
       const prompt = typeof event?.prompt === "string" ? event.prompt.trim() : "";
       if (!prompt) return;
+      const sessionId =
+        event.sessionId ||
+        event.sessionKey ||
+        event.runId ||
+        `openclaw-${Date.now()}`;
+      const project = event.cwd || event.projectPath || process.cwd();
+      const userId = event.userId || event.principal || undefined;
+      // Register the session so it appears in the viewer and query surfaces (#522)
+      await client.postJson("/agentmemory/session/start", {
+        sessionId,
+        project,
+        cwd: project,
+        ...(userId ? { userId } : {}),
+      });
       const result = await client.postJson("/agentmemory/smart-search", {
         query: prompt,
         limit: 5,
+        ...(userId ? { userId } : {}),
       });
       const block = formatResults(result?.results || []);
       if (!block) return;
@@ -200,16 +215,23 @@ const plugin = {
         event.sessionKey ||
         event.runId ||
         `openclaw-${Date.now()}`;
+      const project = event.cwd || event.projectPath || process.cwd();
+      const userId = event.userId || event.principal || undefined;
       await client.postJson("/agentmemory/observe", {
         hookType: "post_tool_use",
         sessionId,
+        project,
+        cwd: project,
         timestamp: new Date().toISOString(),
+        ...(userId ? { userId } : {}),
         data: {
           tool_name: "conversation",
           tool_input: userText.slice(0, 1000),
           tool_output: assistantText.slice(0, 4000),
         },
       });
+      // Close the session so status and viewer reflect the completed state (#522)
+      await client.postJson("/agentmemory/session/end", { sessionId });
     });
   },
 };

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agentmemory",
   "version": "0.9.21",
-  "description": "Persistent memory for AI coding agents -- captures tool usage, compresses via LLM, injects context into future sessions. 12 hooks, 51 MCP tools, 4 skills, real-time viewer.",
+  "description": "Persistent memory for AI coding agents -- captures tool usage, compresses via LLM, injects context into future sessions. 12 hooks, 53 MCP tools, 4 skills, real-time viewer.",
   "author": {
     "name": "Rohit Ghumare",
     "url": "https://github.com/rohitg00"

--- a/src/config.ts
+++ b/src/config.ts
@@ -202,6 +202,14 @@ export function detectEmbeddingProvider(
   if (forced) return forced;
 
   if (source["GEMINI_API_KEY"]) return "gemini";
+  // Volcengine (Doubao) uses an OpenAI-compatible API (#439).
+  // When VOLCENGINE_API_KEY is set, configure the OpenAI provider to use it.
+  if (source["VOLCENGINE_API_KEY"]) {
+    process.env["OPENAI_API_KEY"] = process.env["OPENAI_API_KEY"] || source["VOLCENGINE_API_KEY"];
+    process.env["OPENAI_BASE_URL"] = process.env["OPENAI_BASE_URL"] || source["VOLCENGINE_BASE_URL"] || "https://ark.cn-beijing.volces.com/api/coding/v3";
+    process.env["OPENAI_EMBEDDING_MODEL"] = process.env["OPENAI_EMBEDDING_MODEL"] || source["VOLCENGINE_EMBEDDING_MODEL"] || "doubao-embedding-vision";
+    return "openai";
+  }
   if (source["OPENAI_API_KEY"]) return "openai";
   if (source["VOYAGE_API_KEY"]) return "voyage";
   if (source["COHERE_API_KEY"]) return "cohere";

--- a/src/functions/audit.ts
+++ b/src/functions/audit.ts
@@ -39,12 +39,14 @@ export async function recordAudit(
   details: Record<string, unknown> = {},
   qualityScore?: number,
   userId?: string,
+  sessionId?: string,
 ): Promise<AuditEntry> {
   const entry: AuditEntry = {
     id: generateId("aud"),
     timestamp: new Date().toISOString(),
     operation,
     userId,
+    sessionId,
     functionId,
     targetIds,
     details,
@@ -62,9 +64,10 @@ export async function safeAudit(
   details: Record<string, unknown> = {},
   qualityScore?: number,
   userId?: string,
+  sessionId?: string,
 ): Promise<void> {
   try {
-    await recordAudit(kv, operation, functionId, targetIds, details, qualityScore, userId);
+    await recordAudit(kv, operation, functionId, targetIds, details, qualityScore, userId, sessionId);
   } catch (err) {
     try {
       logger.warn("audit write failed", {
@@ -81,6 +84,7 @@ export async function queryAudit(
   kv: StateKV,
   filter?: {
     operation?: AuditEntry["operation"];
+    sessionId?: string;
     dateFrom?: string;
     dateTo?: string;
     limit?: number;
@@ -93,6 +97,9 @@ export async function queryAudit(
 
   if (filter?.operation) {
     entries = entries.filter((e) => e.operation === filter.operation);
+  }
+  if (filter?.sessionId) {
+    entries = entries.filter((e) => e.sessionId === filter.sessionId);
   }
   if (filter?.dateFrom) {
     const from = new Date(filter.dateFrom).getTime();

--- a/src/functions/context.ts
+++ b/src/functions/context.ts
@@ -7,6 +7,8 @@ import type {
   ProjectProfile,
   MemorySlot,
   Lesson,
+  Insight,
+  SemanticMemory,
 } from "../types.js";
 import { KV } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
@@ -40,7 +42,7 @@ export function registerContextFunction(
       const budget = data.budget || tokenBudget;
       const blocks: ContextBlock[] = [];
 
-      const [pinnedSlots, profile, lessons] = await Promise.all([
+      const [pinnedSlots, profile, lessons, insights, semanticFacts] = await Promise.all([
         isSlotsEnabled()
           ? listPinnedSlots(kv).catch(() => [] as MemorySlot[])
           : Promise.resolve([] as MemorySlot[]),
@@ -48,6 +50,8 @@ export function registerContextFunction(
           .get<ProjectProfile>(KV.profiles, data.project)
           .catch(() => null),
         kv.list<Lesson>(KV.lessons).catch(() => [] as Lesson[]),
+        kv.list<Insight>(KV.insights).catch(() => [] as Insight[]),
+        kv.list<SemanticMemory>(KV.semantic).catch(() => [] as SemanticMemory[]),
       ]);
 
       const slotContent = renderPinnedContext(pinnedSlots);
@@ -129,6 +133,51 @@ export function registerContextFunction(
           tokens: estimateTokens(lessonsContent),
           recency: mostRecent,
           sourceIds: relevantLessons.map((l) => l.id),
+        });
+      }
+
+      // Insights — produced by consolidation pipeline; surface top project-scoped
+      // ones so agents benefit from curated cross-session patterns (#590).
+      const relevantInsights = insights
+        .filter((ins) => !ins.deleted && (!ins.project || ins.project === data.project))
+        .sort((a, b) => b.confidence - a.confidence)
+        .slice(0, 5);
+
+      if (relevantInsights.length > 0) {
+        const items = relevantInsights
+          .map((ins) => `- (${ins.confidence.toFixed(2)}) ${ins.title}: ${ins.content}`)
+          .join("\n");
+        const insightsContent = `## Key Insights\n${items}`;
+        blocks.push({
+          type: "memory",
+          content: insightsContent,
+          tokens: estimateTokens(insightsContent),
+          recency: relevantInsights.reduce((acc, ins) => {
+            const t = new Date(ins.lastReinforcedAt || ins.updatedAt).getTime();
+            return t > acc ? t : acc;
+          }, 0),
+          sourceIds: relevantInsights.map((ins) => ins.id),
+        });
+      }
+
+      // Semantic facts — distilled from consolidation; rank by confidence × strength (#590).
+      const topSemanticFacts = semanticFacts
+        .sort((a, b) => b.confidence * b.strength - a.confidence * a.strength)
+        .slice(0, 5);
+
+      if (topSemanticFacts.length > 0) {
+        const items = topSemanticFacts
+          .map((f) => `- ${f.fact}`)
+          .join("\n");
+        const semanticContent = `## Semantic Memory\n${items}`;
+        blocks.push({
+          type: "memory",
+          content: semanticContent,
+          tokens: estimateTokens(semanticContent),
+          recency: topSemanticFacts.reduce((acc, f) => {
+            const t = new Date(f.lastAccessedAt || f.updatedAt).getTime();
+            return t > acc ? t : acc;
+          }, 0),
         });
       }
 

--- a/src/functions/governance.ts
+++ b/src/functions/governance.ts
@@ -155,9 +155,10 @@ export function registerGovernanceFunction(sdk: ISdk, kv: StateKV): void {
     },
   );
 
-  sdk.registerFunction("mem::audit-query", 
+  sdk.registerFunction("mem::audit-query",
     async (data?: {
       operation?: AuditEntry["operation"];
+      sessionId?: string;
       dateFrom?: string;
       dateTo?: string;
       limit?: number;

--- a/src/functions/replay.ts
+++ b/src/functions/replay.ts
@@ -452,6 +452,13 @@ export function registerReplayFunctions(sdk: ISdk, kv: StateKV): void {
         observations: observationCount,
       });
 
+      // Kick off consolidation pipeline for the imported observations (#518).
+      // Without this, observations land in KV but the compression/consolidation
+      // pipeline never processes them since they arrived outside the live hook flow.
+      if (sessionIds.length > 0) {
+        sdk.triggerVoid("mem::consolidate-pipeline", {});
+      }
+
       return {
         success: true,
         imported: files.length,

--- a/src/hooks/stop.ts
+++ b/src/hooks/stop.ts
@@ -49,6 +49,19 @@ async function main() {
   } catch {
     // summarize is best-effort
   }
+
+  if (sessionId !== "unknown") {
+    try {
+      await fetch(`${REST_URL}/agentmemory/session/end`, {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({ sessionId }),
+        signal: AbortSignal.timeout(10000),
+      });
+    } catch {
+      // session end is best-effort
+    }
+  }
 }
 
 main();

--- a/src/state/vector-index.ts
+++ b/src/state/vector-index.ts
@@ -1,9 +1,10 @@
 function float32ToBase64(arr: Float32Array): string {
-  return Buffer.from(arr.buffer).toString("base64");
+  return Buffer.from(arr.buffer, arr.byteOffset, arr.byteLength).toString("base64");
 }
 
 function base64ToFloat32(b64: string): Float32Array {
-  return new Float32Array(Buffer.from(b64, "base64").buffer);
+  const buf = Buffer.from(b64, "base64");
+  return new Float32Array(buf.buffer, buf.byteOffset, buf.byteLength / 4);
 }
 
 function cosineSimilarity(a: Float32Array, b: Float32Array): number {

--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -536,9 +536,24 @@ export function registerApiTriggers(
         };
       }
       const title = typeof body.title === "string" ? body.title.trim() : undefined;
+      // Normalize project to main repo root when cwd is a git worktree (#515).
+      // Worktree paths (e.g. ~/.codex/worktrees/<hash>/my-repo) would otherwise
+      // create a new project identity per worktree, fragmenting context.
+      let canonicalProject = project;
+      try {
+        const wt = await sdk.trigger<
+          { cwd: string },
+          { success: boolean; isWorktree: boolean; mainRepoRoot: string }
+        >({ function_id: "mem::detect-worktree", payload: { cwd } });
+        if (wt.success && wt.isWorktree && wt.mainRepoRoot) {
+          canonicalProject = wt.mainRepoRoot;
+        }
+      } catch {
+        // worktree detection is best-effort; fall back to the caller-supplied project
+      }
       const session: Session = {
         id: sessionId,
-        project,
+        project: canonicalProject,
         cwd,
         startedAt: new Date().toISOString(),
         status: "active",
@@ -1397,6 +1412,9 @@ export function registerApiTriggers(
       const parsedLimit = parseOptionalInt(req.query_params?.["limit"]);
       const entries = await sdk.trigger({ function_id: "mem::audit-query", payload: {
         operation: req.query_params?.["operation"],
+        sessionId: req.query_params?.["sessionId"] || undefined,
+        dateFrom: req.query_params?.["dateFrom"] || undefined,
+        dateTo: req.query_params?.["dateTo"] || undefined,
         limit: parsedLimit ?? 50,
       } });
       return { status_code: 200, body: { entries, success: true } };

--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -580,6 +580,17 @@ export function registerApiTriggers(
         { type: "set", path: "endedAt", value: new Date().toISOString() },
         { type: "set", path: "status", value: "completed" },
       ]);
+      if (isGraphExtractionEnabled()) {
+        try {
+          const observations = await kv.list<CompressedObservation>(KV.observations(sessionId));
+          const compressed = observations.filter((o) => o.title);
+          if (compressed.length > 0) {
+            sdk.triggerVoid("mem::graph-extract", { observations: compressed });
+          }
+        } catch {
+          // graph extraction is best-effort
+        }
+      }
       return { status_code: 200, body: { success: true } };
     },
   );
@@ -1252,6 +1263,45 @@ export function registerApiTriggers(
     type: "http",
     function_id: "api::graph-extract",
     config: { api_path: "/agentmemory/graph/extract", http_method: "POST" },
+  });
+
+  sdk.registerFunction("api::graph-build",
+    async (req: ApiRequest<Record<string, unknown>>): Promise<Response> => {
+      const authErr = checkAuth(req, secret);
+      if (authErr) return authErr;
+      if (!isGraphExtractionEnabled()) return graphDisabledResponse();
+      try {
+        const sessions = await kv.list<Session>(KV.sessions);
+        let totalNodes = 0;
+        let totalEdges = 0;
+        const BATCH_SIZE = 50;
+        for (const session of sessions) {
+          const observations = await kv.list<CompressedObservation>(KV.observations(session.id));
+          const compressed = observations.filter((o) => o.title);
+          for (let i = 0; i < compressed.length; i += BATCH_SIZE) {
+            const batch = compressed.slice(i, i + BATCH_SIZE);
+            try {
+              const result = await sdk.trigger<{ observations: CompressedObservation[] }, { nodesAdded?: number; edgesAdded?: number }>({
+                function_id: "mem::graph-extract",
+                payload: { observations: batch },
+              });
+              totalNodes += result.nodesAdded ?? 0;
+              totalEdges += result.edgesAdded ?? 0;
+            } catch {
+              // batch failure is non-fatal; continue with remaining sessions
+            }
+          }
+        }
+        return { status_code: 200, body: { success: true, nodes: totalNodes, edges: totalEdges } };
+      } catch {
+        return graphDisabledResponse();
+      }
+    },
+  );
+  sdk.registerTrigger({
+    type: "http",
+    function_id: "api::graph-build",
+    config: { api_path: "/agentmemory/graph/build", http_method: "POST" },
   });
 
   sdk.registerFunction("api::consolidate-pipeline", 

--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -1523,7 +1523,10 @@ export function registerApiTriggers(
       const memories = await kv.list<import("../types.js").Memory>(KV.memories);
       const latest = req.query_params?.["latest"] === "true";
       const filtered = latest ? memories.filter((m) => m.isLatest) : memories;
-      return { status_code: 200, body: { memories: filtered } };
+      const limit = parseOptionalInt(req.query_params?.["limit"]);
+      const offset = parseOptionalInt(req.query_params?.["offset"]) ?? 0;
+      const paginated = limit != null ? filtered.slice(offset, offset + limit) : filtered;
+      return { status_code: 200, body: { memories: paginated, total: filtered.length, offset, limit: limit ?? filtered.length } };
     },
   );
   sdk.registerTrigger({

--- a/src/types.ts
+++ b/src/types.ts
@@ -548,6 +548,7 @@ export interface AuditEntry {
     | "slot_delete"
     | "slot_reflect";
   userId?: string;
+  sessionId?: string;
   functionId: string;
   targetIds: string[];
   details: Record<string, unknown>;

--- a/src/viewer/index.html
+++ b/src/viewer/index.html
@@ -1723,6 +1723,7 @@
       });
       graphSim.edges = state.graph.edges.slice();
       graphSim.running = true;
+      graphSim.tick = 0;
       graphSim.dragNode = null;
 
       setupGraphInteraction(canvas);
@@ -1901,9 +1902,23 @@
       var edges = graphSim.edges;
       var nodeCount = nodes.length;
       var damping = 0.9;
-      var repulsion = nodeCount > 100 ? 2000 : nodeCount > 50 ? 1200 : 800;
-      var attraction = nodeCount > 100 ? 0.002 : 0.005;
-      var centerGravity = nodeCount > 100 ? 0.005 : 0.01;
+      var repulsion = nodeCount > 500 ? 4000 : nodeCount > 100 ? 2000 : nodeCount > 50 ? 1200 : 800;
+      var attraction = nodeCount > 500 ? 0.001 : nodeCount > 100 ? 0.002 : 0.005;
+      var centerGravity = nodeCount > 500 ? 0.008 : nodeCount > 100 ? 0.005 : 0.01;
+
+      // Alpha decay: simulation cools over time so it always settles (#563)
+      if (!graphSim.tick) graphSim.tick = 0;
+      graphSim.tick++;
+      var maxTicks = nodeCount > 1000 ? 300 : nodeCount > 500 ? 400 : 500;
+      var alpha = Math.max(0, 1 - graphSim.tick / maxTicks);
+      // Node-count-aware velocity cap tightens as graph grows
+      var maxV = nodeCount > 1000 ? 2 : nodeCount > 500 ? 4 : nodeCount > 100 ? 6 : 10;
+
+      if (alpha <= 0) {
+        graphSim.running = false;
+        renderGraph();
+        return;
+      }
 
       var nodeMap = {};
       nodes.forEach(function(n) { nodeMap[n.id] = n; });
@@ -1923,8 +1938,11 @@
         }
         fx -= n.x * centerGravity;
         fy -= n.y * centerGravity;
-        n.vx = (n.vx + fx) * damping;
-        n.vy = (n.vy + fy) * damping;
+        n.vx = (n.vx + fx * alpha) * damping;
+        n.vy = (n.vy + fy * alpha) * damping;
+        // Velocity cap prevents runaway oscillation on dense graphs
+        var speed = Math.sqrt(n.vx * n.vx + n.vy * n.vy);
+        if (speed > maxV) { n.vx = (n.vx / speed) * maxV; n.vy = (n.vy / speed) * maxV; }
       }
 
       edges.forEach(function(e) {
@@ -1934,7 +1952,7 @@
         var dx = t.x - s.x;
         var dy = t.y - s.y;
         var dist = Math.sqrt(dx * dx + dy * dy) || 1;
-        var f = (dist - 100) * attraction;
+        var f = (dist - 100) * attraction * alpha;
         var fx = (dx / dist) * f;
         var fy = (dy / dist) * f;
         if (graphSim.dragNode !== s) { s.vx += fx; s.vy += fy; }


### PR DESCRIPTION
## Summary

This PR resolves 15 open issues across multiple areas of the codebase:

### Bug Fixes

- **#587 / #584 — Vector index buffer pool corruption**: `Buffer.from(b64, 'base64').buffer` returns the entire 8192-byte Node.js pool buffer, causing phantom reads of 2048 floats instead of the correct 384. Fixed with `byteOffset`/`byteLength` in both `float32ToBase64` and `base64ToFloat32`.

- **#600 — Graph extraction never triggered on session end**: `api::session::end` updated KV but never fired the `agentmemory.session.stopped` event topic that would trigger graph extraction. Added direct `sdk.triggerVoid("mem::graph-extract", ...)` call after session is persisted.

- **#505 — Viewer graph/build endpoint missing**: The viewer called `POST /agentmemory/graph/build` which didn't exist. Added a new `api::graph-build` function that iterates all sessions and batch-extracts graph nodes.

- **#563 — Force-directed graph simulation never settles**: Canvas graph ran indefinitely without alpha decay. Added tick counter, adaptive alpha decay, velocity cap per node count, and auto-stop when alpha reaches 0.

- **#519 — iii-observability log feedback loop (137 GB log files)**: At `sampling_ratio: 1.0`, subscriber-lag WARNs were re-logged into the same backed-up subscriber, creating a positive feedback loop. Reduced to `0.1` in both `iii-config.yaml` and `iii-config.docker.yaml`.

- **#518 — `import-jsonl` doesn't trigger consolidation pipeline**: Observations were stored in KV but never enqueued for compression/consolidation. Added `sdk.triggerVoid("mem::consolidate-pipeline", {})` after successful imports.

- **#590 — Context injection missing insights and semantic memories**: `getContext()` only loaded episodic memories. Added `KV.insights` and `KV.semantic` queries with top-5 ranked results included in the context payload.

- **#493 — Codex Stop hook doesn't close the session**: `stop.ts` called `summarize` but never called `session/end`, leaving sessions stuck as `active`. Added a `POST /agentmemory/session/end` call after summarization.

### Features / Improvements

- **#544 — Pagination for memories list**: Added `limit` and `offset` query parameters to `GET /agentmemory/memories`. Response now includes `total`, `offset`, and `limit` fields.

- **#515 — Worktree fragmentation splits project memory**: `api::session::start` now calls `mem::detect-worktree` and uses `mainRepoRoot` as the canonical project path when inside a git worktree.

- **#433 — Audit log missing sessionId + no session filter**: Added `sessionId` field to `AuditEntry`, threaded it through `recordAudit`/`safeAudit`, and added `sessionId` filter support to `queryAudit` and `mem::audit-query`.

- **#522 / #596 — OpenClaw plugin missing session lifecycle**: `before_agent_start` now calls `POST /agentmemory/session/start`; `agent_end` now calls `POST /agentmemory/session/end` with proper project/cwd/userId propagation.

- **#439 — Volcengine (Doubao) embedding support**: Added `VOLCENGINE_API_KEY` / `VOLCENGINE_BASE_URL` / `VOLCENGINE_EMBEDDING_MODEL` detection in `detectEmbeddingProvider()`, routing through the existing OpenAI-compatible embedding provider.

- **#565 — Tool count stale in docs/plugin metadata**: Updated all references from `51 tools` → `53 tools`. Added missing `memory_lesson_save` and `memory_lesson_recall` to the README tools table.

- **#552 — `memory_lesson_save` / `memory_lesson_recall` undocumented**: Added both tools to the extended tools table in README.md.

## Test plan

- [ ] Vector search: store and recall a memory; verify embedding dimensions match exactly (384 for local, 1536 for OpenAI)
- [ ] Graph extraction: end a session with `GRAPH_EXTRACTION_ENABLED=true`; verify nodes appear in viewer
- [ ] Viewer graph: open graph tab with 100+ nodes; verify simulation settles within ~500 ticks
- [ ] JSONL import: run `mem::replay::import-jsonl`; verify consolidation pipeline runs afterwards
- [ ] Pagination: `GET /agentmemory/memories?limit=10&offset=0`; verify `total` > `limit` when applicable
- [ ] Worktree: start session inside a git worktree; verify project is set to main repo root
- [ ] Audit: call `mem::audit-query` with `sessionId` filter; verify only matching entries returned
- [ ] Volcengine: set `VOLCENGINE_API_KEY`; verify embedding provider resolves to `openai`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Volcengine (Doubao) embedding provider support
  * Enhanced agent memory context with Key Insights and Semantic Memory blocks
  * Implemented session lifecycle tracking for improved agent interactions

* **Bug Fixes**
  * Fixed vector embedding serialization for typed arrays

* **Chores**
  * Updated available tools count to 53
  * Optimized observability sampling for improved stability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/602?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->