### PR TITLE
feat(cli): allow AGENTMEMORY_IMPORT_TIMEOUT_MS override for import-jsonl

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2333,12 +2333,30 @@ async function runImportJsonl(): Promise<void> {
   const spinner = p.spinner();
   spinner.start("scanning files");
 
+  // Large ~/.claude/projects trees can take >2 min to scan + ingest.
+  // 120s was previously hardcoded, which made the CLI surface a fake
+  // "timeout" while the server kept ingesting in the background. Allow
+  // operators to extend the client-side timeout via env var without
+  // patching the binary. Default stays 120s for backward compatibility.
+  const rawTimeout = process.env["AGENTMEMORY_IMPORT_TIMEOUT_MS"];
+  const importTimeoutMs = (() => {
+    if (!rawTimeout) return 120_000;
+    const parsed = Number.parseInt(rawTimeout, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      p.log.warn(
+        `AGENTMEMORY_IMPORT_TIMEOUT_MS=${rawTimeout} is not a positive integer — falling back to default 120000ms.`,
+      );
+      return 120_000;
+    }
+    return parsed;
+  })();
+
   try {
     const res = await fetch(`${base}/agentmemory/replay/import-jsonl`, {
       method: "POST",
       headers,
       body: JSON.stringify(body),
-      signal: AbortSignal.timeout(120_000),
+      signal: AbortSignal.timeout(importTimeoutMs),
     });
     const text = await res.text();
     let json: {


### PR DESCRIPTION
## Summary

Makes the `import-jsonl` CLI command timeout configurable via the `AGENTMEMORY_IMPORT_TIMEOUT_MS` environment variable, replacing the hardcoded 120s ceiling.

## Why

The current 120s timeout in `import-jsonl` is hardcoded and fails for large jsonl imports (real-world scenario: 100 files / 25→59 sessions in a single batch hits the wall at 120s and aborts mid-flight).

Letting operators set their own ceiling — without touching source — enables larger batch imports on slower disks/networks while keeping the safe default.

## Test plan

- [x] Default behavior unchanged: when `AGENTMEMORY_IMPORT_TIMEOUT_MS` is unset, the original 120000ms ceiling applies
- [x] Override works: `AGENTMEMORY_IMPORT_TIMEOUT_MS=300000` raises the ceiling to 5 minutes
- [x] Invalid values (non-numeric) fall back to the default safely
- [x] Rebased onto upstream/main directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `import-jsonl` operation timeout is now configurable via the `AGENTMEMORY_IMPORT_TIMEOUT_MS` environment variable, with a default of 120 seconds if not specified or invalid.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/607?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->