### PR TITLE
fix: iii reconnect route loss + Voyage env config + heap calc against actual ceiling

### DIFF
--- a/src/health/thresholds.ts
+++ b/src/health/thresholds.ts
@@ -1,3 +1,4 @@
+import { getHeapStatistics } from "node:v8";
 import type { HealthSnapshot } from "../types.js";
 
 interface ThresholdConfig {
@@ -23,7 +24,11 @@ const DEFAULTS: ThresholdConfig = {
 export function evaluateHealth(
   snapshot: HealthSnapshot,
   config: Partial<ThresholdConfig> = {},
-): { status: "healthy" | "degraded" | "critical"; alerts: string[]; notes: string[] } {
+): {
+  status: "healthy" | "degraded" | "critical";
+  alerts: string[];
+  notes: string[];
+} {
   const cfg = { ...DEFAULTS, ...config };
   const alerts: string[] = [];
   const notes: string[] = [];
@@ -59,10 +64,33 @@ export function evaluateHealth(
     degraded = true;
   }
 
+  // Compute memPercent against the actual V8 heap ceiling (--max-old-space-size or v8's
+  // heap_size_limit), not heapTotal which V8 grows lazily — heapUsed/heapTotal hits 95%+
+  // even when there's 5x headroom remaining, firing spurious memory_heap_tight notes.
+  // Fallback to heapTotal preserves prior behavior when no cap is set.
+  let heapCapBytes = 0;
+  const argMatch = (process.execArgv || []).find(
+    (a) => typeof a === "string" && a.startsWith("--max-old-space-size="),
+  );
+  if (argMatch)
+    heapCapBytes = (parseInt(argMatch.split("=")[1], 10) || 0) * 1024 * 1024;
+  if (!heapCapBytes) {
+    const envMatch = (process.env.NODE_OPTIONS || "").match(
+      /--max-old-space-size=(\d+)/,
+    );
+    if (envMatch) heapCapBytes = (parseInt(envMatch[1], 10) || 0) * 1024 * 1024;
+  }
+  if (!heapCapBytes) {
+    try {
+      heapCapBytes = getHeapStatistics().heap_size_limit || 0;
+    } catch {
+      // not available — fall through to heapTotal
+    }
+  }
+  const heapCeiling =
+    heapCapBytes > 0 ? heapCapBytes : snapshot.memory.heapTotal;
   const memPercent =
-    snapshot.memory.heapTotal > 0
-      ? (snapshot.memory.heapUsed / snapshot.memory.heapTotal) * 100
-      : 0;
+    heapCeiling > 0 ? (snapshot.memory.heapUsed / heapCeiling) * 100 : 0;
   const rss = snapshot.memory.rss ?? 0;
   const rssAboveFloor = rss >= cfg.memoryRssFloorBytes;
   const memMb = Math.round(rss / (1024 * 1024));

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,11 @@ import { registerPrivacyFunction } from "./functions/privacy.js";
 import { registerObserveFunction } from "./functions/observe.js";
 import { registerImageQuotaCleanup } from "./functions/image-quota-cleanup.js";
 import { registerVisionSearchFunctions } from "./functions/vision-search.js";
-import { registerSlotsFunctions, isSlotsEnabled, isReflectEnabled } from "./functions/slots.js";
+import {
+  registerSlotsFunctions,
+  isSlotsEnabled,
+  isReflectEnabled,
+} from "./functions/slots.js";
 import { registerDiskSizeManager } from "./functions/disk-size-manager.js";
 import { registerCompressFunction } from "./functions/compress.js";
 import {
@@ -124,7 +128,9 @@ process.on("unhandledRejection", (reason) => {
   const r = reason as { code?: string; function_id?: string; message?: string };
   console.warn(
     `[agentmemory] unhandledRejection (suppressed):`,
-    r?.code ? `${r.code} ${r.function_id ?? ""} ${r.message ?? ""}`.trim() : reason,
+    r?.code
+      ? `${r.code} ${r.function_id ?? ""} ${r.message ?? ""}`.trim()
+      : reason,
   );
 });
 
@@ -143,9 +149,7 @@ async function main() {
 
   bootLog(`Starting worker v${VERSION}...`);
   bootLog(`Engine: ${config.engineUrl}`);
-  bootLog(
-    `Provider: ${config.provider.provider} (${config.provider.model})`,
-  );
+  bootLog(`Provider: ${config.provider.provider} (${config.provider.model})`);
   if (embeddingProvider) {
     bootLog(
       `Embedding provider: ${embeddingProvider.name} (${embeddingProvider.dimensions} dims)`,
@@ -158,9 +162,7 @@ async function main() {
       `Image embedding provider: ${imageEmbeddingProvider.name} (${imageEmbeddingProvider.dimensions} dims) — vision-search active`,
     );
   }
-  bootLog(
-    `REST API: http://localhost:${config.restPort}/agentmemory/*`,
-  );
+  bootLog(`REST API: http://localhost:${config.restPort}/agentmemory/*`);
   bootLog(`Streams: ws://localhost:${config.streamsPort}`);
 
   const sdk = registerWorker(config.engineUrl, {
@@ -199,147 +201,187 @@ async function main() {
     ? (sdk.getMeter.bind(sdk) as (name: string) => unknown)
     : undefined;
 
-  initMetrics(meterAccessor as ((name: string) => import("@opentelemetry/api").Meter) | undefined);
-
-  registerPrivacyFunction(sdk);
-  registerObserveFunction(sdk, kv, dedupMap, config.maxObservationsPerSession);
-  registerImageQuotaCleanup(sdk, kv);
-  registerVisionSearchFunctions(sdk, kv, imageEmbeddingProvider);
-  if (isSlotsEnabled()) {
-    registerSlotsFunctions(sdk, kv);
-  }
-  registerDiskSizeManager(sdk, kv);
-  registerCompressFunction(sdk, kv, provider, metricsStore);
-  registerSearchFunction(sdk, kv);
-  registerContextFunction(sdk, kv, config.tokenBudget);
-  registerSummarizeFunction(sdk, kv, provider, metricsStore);
-  registerMigrateFunction(sdk, kv);
-  registerFileIndexFunction(sdk, kv);
-  registerConsolidateFunction(sdk, kv, provider);
-  registerPatternsFunction(sdk, kv);
-  registerRememberFunction(sdk, kv);
-  registerEvictFunction(sdk, kv);
-
-  registerRelationsFunction(sdk, kv);
-  registerTimelineFunction(sdk, kv);
-  registerProfileFunction(sdk, kv);
-  registerAutoForgetFunction(sdk, kv);
-  registerExportImportFunction(sdk, kv);
-  registerEnrichFunction(sdk, kv);
-
-  const claudeBridgeConfig = loadClaudeBridgeConfig();
-  if (claudeBridgeConfig.enabled) {
-    registerClaudeBridgeFunction(sdk, kv, claudeBridgeConfig);
-    bootLog(
-      `Claude bridge: syncing to ${claudeBridgeConfig.memoryFilePath}`,
-    );
-  }
-
-  if (isGraphExtractionEnabled()) {
-    registerGraphFunction(sdk, kv, provider);
-    bootLog(`Knowledge graph: extraction enabled`);
-  }
-
-  registerConsolidationPipelineFunction(sdk, kv, provider);
-  bootLog(`Consolidation pipeline: registered (CONSOLIDATION_ENABLED=${isConsolidationEnabled() ? "true" : "false"})`);
-
-  if (isAutoCompressEnabled()) {
-    bootLog(
-      `WARNING: AGENTMEMORY_AUTO_COMPRESS=true — every PostToolUse observation will be sent to your LLM provider for compression. This spends API tokens proportional to your session tool-use frequency (see #138). Set AGENTMEMORY_AUTO_COMPRESS=false to disable.`,
-    );
-  } else {
-    bootLog(
-      `Auto-compress: OFF (default, #138) — observations indexed via zero-LLM synthetic compression. Set AGENTMEMORY_AUTO_COMPRESS=true to opt-in to LLM-powered summaries (uses your API key).`,
-    );
-  }
-
-  if (isContextInjectionEnabled()) {
-    bootLog(
-      `WARNING: AGENTMEMORY_INJECT_CONTEXT=true — the PreToolUse and SessionStart hooks will inject up to ~4000 chars of memory context into every tool turn. On Claude Pro this burns session tokens proportional to your tool-call frequency (see #143). Set AGENTMEMORY_INJECT_CONTEXT=false to disable.`,
-    );
-  } else {
-    bootLog(
-      `Context injection: OFF (default, #143) — hooks capture observations but do not inject context into Claude Code's conversation. Set AGENTMEMORY_INJECT_CONTEXT=true to opt-in (warning: expect your Claude Pro allocation to drain faster).`,
-    );
-  }
-
-  const teamConfig = loadTeamConfig();
-  if (teamConfig) {
-    registerTeamFunction(sdk, kv, teamConfig);
-    bootLog(
-      `Team memory: ${teamConfig.teamId} (${teamConfig.mode})`,
-    );
-  }
-
-  registerGovernanceFunction(sdk, kv);
-
-  registerActionsFunction(sdk, kv);
-  registerFrontierFunction(sdk, kv);
-  registerLeasesFunction(sdk, kv);
-  registerRoutinesFunction(sdk, kv);
-  registerSignalsFunction(sdk, kv);
-  registerCheckpointsFunction(sdk, kv);
-  registerMeshFunction(sdk, kv, secret);
-  registerBranchAwareFunction(sdk, kv);
-  registerFlowCompressFunction(sdk, kv, provider);
-  registerSentinelsFunction(sdk, kv);
-  registerSketchesFunction(sdk, kv);
-  registerCrystallizeFunction(sdk, kv, provider);
-  registerDiagnosticsFunction(sdk, kv);
-  registerFacetsFunction(sdk, kv);
-  registerVerifyFunction(sdk, kv);
-  registerLessonsFunctions(sdk, kv);
-  registerObsidianExportFunction(sdk, kv);
-  registerReflectFunctions(sdk, kv, provider);
-  registerWorkingMemoryFunctions(sdk, kv, config.tokenBudget);
-  registerSkillExtractFunctions(sdk, kv, provider);
-  registerCascadeFunction(sdk, kv);
-
-  registerSlidingWindowFunction(sdk, kv, provider);
-  registerQueryExpansionFunction(sdk, provider);
-  registerTemporalGraphFunctions(sdk, kv, provider);
-  registerRetentionFunctions(sdk, kv);
-  registerCompressFileFunction(sdk, kv, provider);
-  registerReplayFunctions(sdk, kv);
-  bootLog(
-    `v0.6 advanced retrieval: sliding-window, query-expansion, temporal-graph, retention-scoring`,
+  initMetrics(
+    meterAccessor as
+      | ((name: string) => import("@opentelemetry/api").Meter)
+      | undefined,
   );
-  bootLog(
-    `Orchestration layer: actions, frontier, leases, routines, signals, checkpoints, flow-compress, mesh, branch-aware, sentinels, sketches, crystallize, diagnostics, facets`,
-  );
-  if (isSlotsEnabled()) {
-    bootLog(
-      `Slots: enabled (pinned editable memory). Reflect on Stop hook: ${isReflectEnabled() ? "on" : "off"}`,
-    );
-  }
 
-  const snapshotConfig = loadSnapshotConfig();
-  if (snapshotConfig.enabled) {
-    registerSnapshotFunction(sdk, kv, snapshotConfig.dir);
-    bootLog(
-      `Git snapshots: ${snapshotConfig.dir} (every ${snapshotConfig.interval}s)`,
-    );
-  }
-
+  // Hoist bm25Index so IndexPersistence + restoreFrom + rebuild loop (all after the
+  // registerAllFunctions closure below) can see it. The inner declaration inside the
+  // closure shadows this but resolves to the same singleton from getSearchIndex().
   const bm25Index = getSearchIndex();
-  const graphWeight = parseFloat(getEnvVar("AGENTMEMORY_GRAPH_WEIGHT") || "0.3");
-  const hybridSearch = new HybridSearch(
-    bm25Index,
-    vectorIndex,
-    embeddingProvider,
-    kv,
-    embeddingConfig.bm25Weight,
-    embeddingConfig.vectorWeight,
-    graphWeight,
-  );
 
-  registerSmartSearchFunction(sdk, kv, (query, limit) =>
-    hybridSearch.search(query, limit),
-  );
+  // Wrap register* block in a re-runnable function so it can replay on iii reconnect.
+  // Without this, when iii restarts (and unregisters all /agentmemory/* routes during
+  // its startup cleanup), the warm AM worker stays connected but has zero registered
+  // routes — livez 404 → MCP shim falls to local-fallback mode permanently.
+  const registerAllFunctions = (): void => {
+    registerPrivacyFunction(sdk);
+    registerObserveFunction(
+      sdk,
+      kv,
+      dedupMap,
+      config.maxObservationsPerSession,
+    );
+    registerImageQuotaCleanup(sdk, kv);
+    registerVisionSearchFunctions(sdk, kv, imageEmbeddingProvider);
+    if (isSlotsEnabled()) {
+      registerSlotsFunctions(sdk, kv);
+    }
+    registerDiskSizeManager(sdk, kv);
+    registerCompressFunction(sdk, kv, provider, metricsStore);
+    registerSearchFunction(sdk, kv);
+    registerContextFunction(sdk, kv, config.tokenBudget);
+    registerSummarizeFunction(sdk, kv, provider, metricsStore);
+    registerMigrateFunction(sdk, kv);
+    registerFileIndexFunction(sdk, kv);
+    registerConsolidateFunction(sdk, kv, provider);
+    registerPatternsFunction(sdk, kv);
+    registerRememberFunction(sdk, kv);
+    registerEvictFunction(sdk, kv);
 
-  registerApiTriggers(sdk, kv, secret, metricsStore, provider);
-  registerEventTriggers(sdk, kv);
-  registerMcpEndpoints(sdk, kv, secret);
+    registerRelationsFunction(sdk, kv);
+    registerTimelineFunction(sdk, kv);
+    registerProfileFunction(sdk, kv);
+    registerAutoForgetFunction(sdk, kv);
+    registerExportImportFunction(sdk, kv);
+    registerEnrichFunction(sdk, kv);
+
+    const claudeBridgeConfig = loadClaudeBridgeConfig();
+    if (claudeBridgeConfig.enabled) {
+      registerClaudeBridgeFunction(sdk, kv, claudeBridgeConfig);
+      bootLog(`Claude bridge: syncing to ${claudeBridgeConfig.memoryFilePath}`);
+    }
+
+    if (isGraphExtractionEnabled()) {
+      registerGraphFunction(sdk, kv, provider);
+      bootLog(`Knowledge graph: extraction enabled`);
+    }
+
+    registerConsolidationPipelineFunction(sdk, kv, provider);
+    bootLog(
+      `Consolidation pipeline: registered (CONSOLIDATION_ENABLED=${isConsolidationEnabled() ? "true" : "false"})`,
+    );
+
+    if (isAutoCompressEnabled()) {
+      bootLog(
+        `WARNING: AGENTMEMORY_AUTO_COMPRESS=true — every PostToolUse observation will be sent to your LLM provider for compression. This spends API tokens proportional to your session tool-use frequency (see #138). Set AGENTMEMORY_AUTO_COMPRESS=false to disable.`,
+      );
+    } else {
+      bootLog(
+        `Auto-compress: OFF (default, #138) — observations indexed via zero-LLM synthetic compression. Set AGENTMEMORY_AUTO_COMPRESS=true to opt-in to LLM-powered summaries (uses your API key).`,
+      );
+    }
+
+    if (isContextInjectionEnabled()) {
+      bootLog(
+        `WARNING: AGENTMEMORY_INJECT_CONTEXT=true — the PreToolUse and SessionStart hooks will inject up to ~4000 chars of memory context into every tool turn. On Claude Pro this burns session tokens proportional to your tool-call frequency (see #143). Set AGENTMEMORY_INJECT_CONTEXT=false to disable.`,
+      );
+    } else {
+      bootLog(
+        `Context injection: OFF (default, #143) — hooks capture observations but do not inject context into Claude Code's conversation. Set AGENTMEMORY_INJECT_CONTEXT=true to opt-in (warning: expect your Claude Pro allocation to drain faster).`,
+      );
+    }
+
+    const teamConfig = loadTeamConfig();
+    if (teamConfig) {
+      registerTeamFunction(sdk, kv, teamConfig);
+      bootLog(`Team memory: ${teamConfig.teamId} (${teamConfig.mode})`);
+    }
+
+    registerGovernanceFunction(sdk, kv);
+
+    registerActionsFunction(sdk, kv);
+    registerFrontierFunction(sdk, kv);
+    registerLeasesFunction(sdk, kv);
+    registerRoutinesFunction(sdk, kv);
+    registerSignalsFunction(sdk, kv);
+    registerCheckpointsFunction(sdk, kv);
+    registerMeshFunction(sdk, kv, secret);
+    registerBranchAwareFunction(sdk, kv);
+    registerFlowCompressFunction(sdk, kv, provider);
+    registerSentinelsFunction(sdk, kv);
+    registerSketchesFunction(sdk, kv);
+    registerCrystallizeFunction(sdk, kv, provider);
+    registerDiagnosticsFunction(sdk, kv);
+    registerFacetsFunction(sdk, kv);
+    registerVerifyFunction(sdk, kv);
+    registerLessonsFunctions(sdk, kv);
+    registerObsidianExportFunction(sdk, kv);
+    registerReflectFunctions(sdk, kv, provider);
+    registerWorkingMemoryFunctions(sdk, kv, config.tokenBudget);
+    registerSkillExtractFunctions(sdk, kv, provider);
+    registerCascadeFunction(sdk, kv);
+
+    registerSlidingWindowFunction(sdk, kv, provider);
+    registerQueryExpansionFunction(sdk, provider);
+    registerTemporalGraphFunctions(sdk, kv, provider);
+    registerRetentionFunctions(sdk, kv);
+    registerCompressFileFunction(sdk, kv, provider);
+    registerReplayFunctions(sdk, kv);
+    bootLog(
+      `v0.6 advanced retrieval: sliding-window, query-expansion, temporal-graph, retention-scoring`,
+    );
+    bootLog(
+      `Orchestration layer: actions, frontier, leases, routines, signals, checkpoints, flow-compress, mesh, branch-aware, sentinels, sketches, crystallize, diagnostics, facets`,
+    );
+    if (isSlotsEnabled()) {
+      bootLog(
+        `Slots: enabled (pinned editable memory). Reflect on Stop hook: ${isReflectEnabled() ? "on" : "off"}`,
+      );
+    }
+
+    const snapshotConfig = loadSnapshotConfig();
+    if (snapshotConfig.enabled) {
+      registerSnapshotFunction(sdk, kv, snapshotConfig.dir);
+      bootLog(
+        `Git snapshots: ${snapshotConfig.dir} (every ${snapshotConfig.interval}s)`,
+      );
+    }
+
+    const bm25Index = getSearchIndex();
+    const graphWeight = parseFloat(
+      getEnvVar("AGENTMEMORY_GRAPH_WEIGHT") || "0.3",
+    );
+    const hybridSearch = new HybridSearch(
+      bm25Index,
+      vectorIndex,
+      embeddingProvider,
+      kv,
+      embeddingConfig.bm25Weight,
+      embeddingConfig.vectorWeight,
+      graphWeight,
+    );
+
+    registerSmartSearchFunction(sdk, kv, (query, limit) =>
+      hybridSearch.search(query, limit),
+    );
+
+    registerApiTriggers(sdk, kv, secret, metricsStore, provider);
+    registerEventTriggers(sdk, kv);
+    registerMcpEndpoints(sdk, kv, secret);
+  }; // end registerAllFunctions
+  registerAllFunctions();
+  // On iii reconnect after disconnect, replay registrations so /agentmemory/* HTTP
+  // routes survive iii restarts. iii-sdk's own reconnect logic doesn't currently
+  // re-send registerFunction/registerTrigger payloads (#mcp-shim-regression).
+  if (typeof sdk.on === "function") {
+    let _prevConnState: string = "connected";
+    sdk.on("connection_state", (state: string) => {
+      if (_prevConnState !== "connected" && state === "connected") {
+        bootLog("iii reconnected — re-registering all functions/triggers");
+        try {
+          registerAllFunctions();
+        } catch (err) {
+          process.stderr.write(
+            `[agentmemory] re-registration on reconnect failed: ${err instanceof Error ? err.message : String(err)}\n`,
+          );
+        }
+      }
+      _prevConnState = state;
+    });
+  }
 
   const healthMonitor = registerHealthMonitor(sdk, kv);
 
@@ -351,9 +393,7 @@ async function main() {
   });
   if (loaded?.bm25 && loaded.bm25.size > 0) {
     bm25Index.restoreFrom(loaded.bm25);
-    bootLog(
-      `Loaded persisted BM25 index (${bm25Index.size} docs)`,
-    );
+    bootLog(`Loaded persisted BM25 index (${bm25Index.size} docs)`);
   }
   if (loaded?.vector && vectorIndex && loaded.vector.size > 0) {
     // Persisted vectors carry whatever dimension the provider had when
@@ -376,7 +416,9 @@ async function main() {
         .slice(0, 5)
         .map((m) => `${m.obsId} (dim=${m.dim})`)
         .join(", ");
-      const distinct = Array.from(seenDimensions).sort((a, b) => a - b).join(", ");
+      const distinct = Array.from(seenDimensions)
+        .sort((a, b) => a - b)
+        .join(", ");
       const dropStale = isDropStaleIndexEnabled();
       if (dropStale) {
         console.warn(
@@ -403,9 +445,7 @@ async function main() {
       }
     } else {
       vectorIndex.restoreFrom(loaded.vector);
-      bootLog(
-        `Loaded persisted vector index (${vectorIndex.size} vectors)`,
-      );
+      bootLog(`Loaded persisted vector index (${vectorIndex.size} vectors)`);
     }
   }
 
@@ -466,10 +506,7 @@ async function main() {
         indexPersistence.scheduleSave();
       }
     } catch (err) {
-      console.warn(
-        `[agentmemory] Failed to backfill memories into BM25:`,
-        err,
-      );
+      console.warn(`[agentmemory] Failed to backfill memories into BM25:`, err);
     }
   }
 
@@ -496,13 +533,22 @@ async function main() {
     config.restPort,
   );
 
-  const autoForgetIntervalMs = parseInt(process.env.AUTO_FORGET_INTERVAL_MS || "3600000", 10);
-  const consolidationIntervalMs = parseInt(process.env.CONSOLIDATION_INTERVAL_MS || "7200000", 10);
+  const autoForgetIntervalMs = parseInt(
+    process.env.AUTO_FORGET_INTERVAL_MS || "3600000",
+    10,
+  );
+  const consolidationIntervalMs = parseInt(
+    process.env.CONSOLIDATION_INTERVAL_MS || "7200000",
+    10,
+  );
 
   if (process.env.AUTO_FORGET_ENABLED !== "false") {
     const autoForgetTimer = setInterval(async () => {
       try {
-        await sdk.trigger({ function_id: "mem::auto-forget", payload: { dryRun: false } });
+        await sdk.trigger({
+          function_id: "mem::auto-forget",
+          payload: { dryRun: false },
+        });
       } catch {}
     }, autoForgetIntervalMs);
     autoForgetTimer.unref();
@@ -512,7 +558,10 @@ async function main() {
   if (process.env.LESSON_DECAY_ENABLED !== "false") {
     const lessonDecayTimer = setInterval(async () => {
       try {
-        await sdk.trigger({ function_id: "mem::lesson-decay-sweep", payload: {} });
+        await sdk.trigger({
+          function_id: "mem::lesson-decay-sweep",
+          payload: {},
+        });
       } catch {}
     }, 86400000);
     lessonDecayTimer.unref();
@@ -522,7 +571,10 @@ async function main() {
   if (process.env.INSIGHT_DECAY_ENABLED !== "false") {
     const insightDecayTimer = setInterval(async () => {
       try {
-        await sdk.trigger({ function_id: "mem::insight-decay-sweep", payload: {} });
+        await sdk.trigger({
+          function_id: "mem::insight-decay-sweep",
+          payload: {},
+        });
       } catch {}
     }, 86400000);
     insightDecayTimer.unref();
@@ -531,11 +583,16 @@ async function main() {
   if (isConsolidationEnabled()) {
     const consolidationTimer = setInterval(async () => {
       try {
-        await sdk.trigger({ function_id: "mem::consolidate-pipeline", payload: {} });
+        await sdk.trigger({
+          function_id: "mem::consolidate-pipeline",
+          payload: {},
+        });
       } catch {}
     }, consolidationIntervalMs);
     consolidationTimer.unref();
-    bootLog(`Auto-consolidation: enabled (every ${consolidationIntervalMs / 60000}m)`);
+    bootLog(
+      `Auto-consolidation: enabled (every ${consolidationIntervalMs / 60000}m)`,
+    );
   }
 
   const shutdown = async () => {

--- a/src/providers/embedding/voyage.ts
+++ b/src/providers/embedding/voyage.ts
@@ -6,7 +6,13 @@ const API_URL = "https://api.voyageai.com/v1/embeddings";
 
 export class VoyageEmbeddingProvider implements EmbeddingProvider {
   readonly name = "voyage";
-  readonly dimensions = 1024;
+  // Respect VOYAGE_EMBEDDING_MODEL + VOYAGE_OUTPUT_DIMENSION env vars instead of hardcoding model + dims.
+  // Voyage 3 supports {256, 512, 1024, 2048} via output_dimension. Default behavior preserved when envs unset.
+  readonly model = getEnvVar("VOYAGE_EMBEDDING_MODEL") || "voyage-code-3";
+  readonly dimensions = parseInt(
+    getEnvVar("VOYAGE_OUTPUT_DIMENSION") || "1024",
+    10,
+  );
   private apiKey: string;
 
   constructor(apiKey?: string) {
@@ -20,17 +26,19 @@ export class VoyageEmbeddingProvider implements EmbeddingProvider {
   }
 
   async embedBatch(texts: string[]): Promise<Float32Array[]> {
+    const body: Record<string, unknown> = {
+      model: this.model,
+      input: texts,
+      input_type: "document",
+    };
+    if (this.dimensions !== 1024) body.output_dimension = this.dimensions;
     const response = await fetchWithTimeout(API_URL, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${this.apiKey}`,
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({
-        model: "voyage-code-3",
-        input: texts,
-        input_type: "document",
-      }),
+      body: JSON.stringify(body),
     });
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary

Three independent fixes discovered while running agentmemory at the Orbit/Devotel project. Submitting as one PR because they all live in the same dist hot-path and the regression diagnosis links them.

### 1. iii reconnect → /agentmemory/* routes lost (`src/index.ts`)

When iii engine restarts, it unregisters all worker-registered HTTP routes during its startup cleanup pass. iii-sdk's reconnect logic on the AM worker side re-establishes the WebSocket but does **NOT** re-send the `registerFunction`/`registerTrigger` payloads.

**Symptom:** AM worker stays alive, but `GET /agentmemory/livez` returns 404 indefinitely. The `@agentmemory/mcp` shim's livez probe then fails forever and the shim falls into permanent local-fallback mode (7-tool subset), making the daemon look broken when only the routes are gone.

**Fix:** wrap the register-everything block in a re-runnable `registerAllFunctions()` closure + hook `sdk.on("connection_state")` to replay it when the connection transitions from reconnecting back to connected. `bm25Index` is hoisted out of the closure so `IndexPersistence` + `restoreFrom` code below the closure can still see it.

### 2. Voyage env-configurable model + dimensions (`src/providers/embedding/voyage.ts`)

`VoyageEmbeddingProvider` currently hardcodes `model: "voyage-code-3"` in the `embedBatch` POST body, so `VOYAGE_EMBEDDING_MODEL` env is silently ignored.

**Fix:** read model from `getEnvVar("VOYAGE_EMBEDDING_MODEL")` falling back to `voyage-code-3` (preserves default). Add `VOYAGE_OUTPUT_DIMENSION` env that overrides the readonly dimensions field; when non-1024, attach `output_dimension` to the API payload so Voyage 3 large can emit 2048-dim embeddings.

### 3. memory_heap_tight calc uses heap ceiling, not heapTotal (`src/health/thresholds.ts`)

`evaluateHealth`'s `memPercent = heapUsed/heapTotal` hits 95%+ even when V8 has 5× headroom under `--max-old-space-size`, because heapTotal is V8's lazy current allocation, not the configured ceiling. Result: chronic spurious `memory_heap_tight` notes in healthy daemons.

**Fix:** read cap from `process.execArgv` → `NODE_OPTIONS` env → `v8.getHeapStatistics().heap_size_limit` (in that priority), fall back to heapTotal preserving prior behavior when no cap is set. Now memPercent reflects actual headroom.

## Test plan

- [x] Patches applied to installed v0.9.21 dist bundle in production-like setup
- [x] Killed iii daemon while AM worker stays alive → livez returns 200 within shim's 30s livez TTL cycle, no manual AM restart needed
- [x] Set VOYAGE_EMBEDDING_MODEL=voyage-3-large + VOYAGE_OUTPUT_DIMENSION=2048 → 430 old 1024-dim vectors discarded via AGENTMEMORY_DROP_STALE_INDEX, new embeds at 2048-dim
- [x] heap calc: notes:[] empty at heapUsed=17% of 512MB cap (was firing at 95%+ against heapTotal pre-patch)
- [ ] Upstream CI / lint
- [ ] Add a regression test (would need to instrument iii-sdk reconnect in test harness)

## Discovered at

Devotel/Orbit CPaaS production daemon during an extended diagnostic session. Detailed root-cause analysis preserved in our internal audit docs:
- iii-reconnect symptom diagnosis
- Voyage hardcoded-model discovery
- Heap calc misleading-warning analysis

Happy to add tests or split into 3 separate PRs if you'd prefer that — these were diagnosed together so submitting together felt natural.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Memory-based alerts now compute pressure using effective V8 heap ceiling for improved accuracy.

* **New Features**
  * Agent memory routes now survive service restarts via automatic re-registration on reconnection.
  * Embedding model and dimensions are now configurable via environment variables.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/610?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->