### PR TITLE
feat(context,smart-search): inject insights into session context and smart search results (#457)

### DIFF
--- a/src/functions/context.ts
+++ b/src/functions/context.ts
@@ -7,6 +7,7 @@ import type {
   ProjectProfile,
   MemorySlot,
   Lesson,
+  Insight,
 } from "../types.js";
 import { KV } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
@@ -40,7 +41,7 @@ export function registerContextFunction(
       const budget = data.budget || tokenBudget;
       const blocks: ContextBlock[] = [];
 
-      const [pinnedSlots, profile, lessons] = await Promise.all([
+      const [pinnedSlots, profile, lessons, insights] = await Promise.all([
         isSlotsEnabled()
           ? listPinnedSlots(kv).catch(() => [] as MemorySlot[])
           : Promise.resolve([] as MemorySlot[]),
@@ -48,6 +49,7 @@ export function registerContextFunction(
           .get<ProjectProfile>(KV.profiles, data.project)
           .catch(() => null),
         kv.list<Lesson>(KV.lessons).catch(() => [] as Lesson[]),
+        kv.list<Insight>(KV.insights).catch(() => [] as Insight[]),
       ]);
 
       const slotContent = renderPinnedContext(pinnedSlots);
@@ -129,6 +131,36 @@ export function registerContextFunction(
           tokens: estimateTokens(lessonsContent),
           recency: mostRecent,
           sourceIds: relevantLessons.map((l) => l.id),
+        });
+      }
+
+      // Insights — higher-order reflections synthesised from patterns
+      // across memories, lessons, and crystals by mem::reflect. Capped at
+      // 8 to keep the block bounded; token-budget loop below drops the
+      // block if it doesn't fit. #457
+      const relevantInsights = insights
+        .filter((i) => !i.deleted && (!i.project || i.project === data.project))
+        .sort((a, b) => b.confidence - a.confidence)
+        .slice(0, 8);
+
+      if (relevantInsights.length > 0) {
+        const items = relevantInsights
+          .map(
+            (i) =>
+              `- (${i.confidence.toFixed(2)}) ${i.title}: ${i.content.slice(0, 160)}`,
+          )
+          .join("\n");
+        const insightsContent = `## Insights\n${items}`;
+        const mostRecentI = relevantInsights.reduce((acc, i) => {
+          const t = new Date(i.lastReinforcedAt || i.updatedAt).getTime();
+          return t > acc ? t : acc;
+        }, 0);
+        blocks.push({
+          type: "memory",
+          content: insightsContent,
+          tokens: estimateTokens(insightsContent),
+          recency: mostRecentI,
+          sourceIds: relevantInsights.map((i) => i.id),
         });
       }
 

--- a/src/functions/smart-search.ts
+++ b/src/functions/smart-search.ts
@@ -4,6 +4,7 @@ import type {
   CompactSearchResult,
   CompressedObservation,
   HybridSearchResult,
+  Insight,
   Lesson,
 } from "../types.js";
 import { KV } from "../state/schema.js";
@@ -81,15 +82,16 @@ export function registerSmartSearchFunction(
       const lessonLimit = Math.min(limit, 10);
       const includeLessons = data.includeLessons !== false;
 
-      // Run observation hybrid-search and lesson recall in parallel so the
-      // extra lesson lookup adds no wallclock when the underlying calls
-      // can overlap. Lesson recall is best-effort: if mem::lesson-recall
+      // Run observation hybrid-search, lesson recall, and insight recall
+      // in parallel so the extra lookups add no wallclock when the
+      // underlying calls can overlap. All are best-effort: if a call
       // fails or returns unexpected shape, log + fall back to empty.
-      const [hybridResults, lessons] = await Promise.all([
+      const [hybridResults, lessons, insights] = await Promise.all([
         searchFn(data.query, limit),
         includeLessons
           ? recallLessons(sdk, data.query, lessonLimit, data.project)
           : Promise.resolve([]),
+        recallInsights(sdk, data.query, lessonLimit, data.project),
       ]);
 
       const compact: CompactSearchResult[] = hybridResults.map((r) => ({
@@ -110,13 +112,16 @@ export function registerSmartSearchFunction(
         query: data.query,
         results: compact.length,
         lessons: lessons.length,
+        insights: insights.length,
       });
       const response: {
         mode: "compact";
         results: CompactSearchResult[];
         lessons?: CompactLessonResult[];
+        insights?: CompactLessonResult[];
       } = { mode: "compact", results: compact };
       if (includeLessons) response.lessons = lessons;
+      if (insights.length > 0) response.insights = insights;
       return response;
     },
   );
@@ -148,6 +153,38 @@ async function recallLessons(
     }));
   } catch (err) {
     logger.warn("Smart search: mem::lesson-recall failed; returning empty lesson list", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return [];
+  }
+}
+
+async function recallInsights(
+  sdk: ISdk,
+  query: string,
+  limit: number,
+  project?: string,
+): Promise<CompactLessonResult[]> {
+  try {
+    const result = (await sdk.trigger({
+      function_id: "mem::insight-search",
+      payload: { query, limit, project, minConfidence: 0.3 },
+    })) as { success?: boolean; insights?: Array<Insight & { score?: number }> };
+    if (!result?.success || !Array.isArray(result.insights)) return [];
+    return result.insights.map((i) => ({
+      lessonId: i.id,
+      content:
+        i.content.length > LESSON_CONTENT_PREVIEW_CHARS
+          ? i.content.slice(0, LESSON_CONTENT_PREVIEW_CHARS) + "…"
+          : i.content,
+      confidence: i.confidence,
+      score: i.score ?? i.confidence,
+      createdAt: i.createdAt,
+      project: i.project,
+      tags: i.tags ?? [],
+    }));
+  } catch (err) {
+    logger.warn("Smart search: mem::insight-search failed; returning empty insight list", {
       error: err instanceof Error ? err.message : String(err),
     });
     return [];


### PR DESCRIPTION
## Summary
`mem::context` (SessionStart injection) and `mem::smart-search` (hybrid
search) loaded lessons but skipped insights — the higher-order reflections
synthesised by `mem::reflect`. Insights sat in KV reachable only via the
explicit `memory_insight_list` / `memory_insight_search` MCP tools, never
surfacing automatically in context or search results.

## Diff
- **src/functions/context.ts** (+34/-1): parallel-load `KV.insights`
  alongside lessons; filter non-deleted, project-scoped; sort by
  confidence descending; cap at 8; render as `## Insights` block.
- **src/functions/smart-search.ts** (+41/-4): add `recallInsights()`
  helper calling `mem::insight-search` with minConfidence 0.3; run in
  parallel with hybrid search and lesson recall; attach results as
  `insights` field on the compact response. Reuses `CompactLessonResult`
  type.

Both follow the existing lessons pattern exactly: same cap strategy,
token-budget loop, recency sort, and best-effort catch semantics.

## Validation
- Type safety verified: `Insight` interface fields all match; `KV.insights`
  scope defined; `mem::insight-search` payload signature matches handler.
- Reviewed: 0 Critical, 0 Major findings.
- npm install blocked by pre-existing arborist bug on Windows (`@node-rs/jieba`
  + `@anthropic-ai/claude-agent-sdk` optional deps trigger npm 10/11
  canDedupe crash). Unrelated to this change. CI runs ubuntu+macos only.
- Existing tests do not reference insights — this is additive, no test
  assertion changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Insights are now integrated into agent memory context, retrieved and displayed with confidence ratings, titles, and content previews (capped at 8 results, sorted by confidence)
* Smart search now includes insight-based recall alongside observation and lesson searches, with results returned in a unified format

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/615?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->