### PR TITLE
fix(mcp): honor AGENTMEMORY_TOOLS from .env in getVisibleTools

### DIFF
--- a/src/mcp/tools-registry.ts
+++ b/src/mcp/tools-registry.ts
@@ -1,3 +1,5 @@
+import { getEnvVar } from "../config.js";
+
 export type McpToolDef = {
   name: string;
   description: string;
@@ -942,7 +944,7 @@ export function getAllTools(): McpToolDef[] {
 }
 
 export function getVisibleTools(): McpToolDef[] {
-  const mode = process.env["AGENTMEMORY_TOOLS"] || "core";
+  const mode = getEnvVar("AGENTMEMORY_TOOLS") || "core";
   if (mode === "all") return getAllTools();
   return getAllTools().filter((t) => ESSENTIAL_TOOLS.has(t.name));
 }

--- a/test/tools-visibility-env.test.ts
+++ b/test/tools-visibility-env.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const ORIGINAL_HOME = process.env["HOME"];
+const ORIGINAL_USERPROFILE = process.env["USERPROFILE"];
+const ORIGINAL_TOOLS = process.env["AGENTMEMORY_TOOLS"];
+
+let sandboxHome: string;
+
+async function freshTools() {
+  vi.resetModules();
+  return await import("../src/mcp/tools-registry.js");
+}
+
+function writeEnv(contents: string) {
+  const dir = join(sandboxHome, ".agentmemory");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, ".env"), contents);
+}
+
+describe("getVisibleTools env resolution", () => {
+  beforeEach(() => {
+    sandboxHome = mkdtempSync(join(tmpdir(), "agentmemory-tools-"));
+    process.env["HOME"] = sandboxHome;
+    process.env["USERPROFILE"] = sandboxHome;
+    delete process.env["AGENTMEMORY_TOOLS"];
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_HOME === undefined) delete process.env["HOME"];
+    else process.env["HOME"] = ORIGINAL_HOME;
+    if (ORIGINAL_USERPROFILE === undefined) delete process.env["USERPROFILE"];
+    else process.env["USERPROFILE"] = ORIGINAL_USERPROFILE;
+    if (ORIGINAL_TOOLS === undefined) delete process.env["AGENTMEMORY_TOOLS"];
+    else process.env["AGENTMEMORY_TOOLS"] = ORIGINAL_TOOLS;
+    rmSync(sandboxHome, { recursive: true, force: true });
+  });
+
+  it("exposes the full tool surface when AGENTMEMORY_TOOLS=all is set in the .env file", async () => {
+    writeEnv("AGENTMEMORY_TOOLS=all");
+    const reg = await freshTools();
+    const visible = reg.getVisibleTools();
+    expect(visible.length).toBe(reg.getAllTools().length);
+    expect(visible.map((t) => t.name)).toContain("memory_graph_query");
+  });
+
+  it("falls back to the core subset when AGENTMEMORY_TOOLS is unset", async () => {
+    writeEnv("");
+    const reg = await freshTools();
+    const names = reg.getVisibleTools().map((t) => t.name);
+    expect(names).toContain("memory_save");
+    expect(names).not.toContain("memory_graph_query");
+    expect(names.length).toBeLessThan(reg.getAllTools().length);
+  });
+
+  it("lets process.env override the .env file value", async () => {
+    writeEnv("AGENTMEMORY_TOOLS=core");
+    process.env["AGENTMEMORY_TOOLS"] = "all";
+    const reg = await freshTools();
+    expect(reg.getVisibleTools().length).toBe(reg.getAllTools().length);
+  });
+});


### PR DESCRIPTION
## What

`getVisibleTools()` in `src/mcp/tools-registry.ts` read `process.env["AGENTMEMORY_TOOLS"]` directly, bypassing `getMergedEnv()` — the `{ ...fileEnv, ...process.env }` helper that every other config reader reaches through `getEnvVar()`. This routes the lookup through `getEnvVar()` instead.

## Why

`AGENTMEMORY_TOOLS=all` set in `~/.agentmemory/.env` was silently ignored. The MCP tool surface stayed at the 8-tool core set instead of the full surface, even though `.env.example` documents that variable as the way to opt in:

```
AGENTMEMORY_TOOLS=all   # core (default) | all — surface exposed to MCP clients
```

Because `getMergedEnv()` is `{ ...fileEnv, ...process.env }`, `process.env` (shell export, the `--tools` flag) still takes precedence over the file — only the missing `.env` fallback is restored.

This is the root cause behind #553: the "8 tools, not 51" state is the server returning its `core` surface over a *working* proxy — not a probe/proxy failure. It may also explain #400 (Codex full-surface) where a healthy server still serves the reduced set.

To be clear about scope: this does **not** address #510, which is the distinct "literal `${AGENTMEMORY_URL}` placeholder breaks the shim's localhost fallback" connection bug — that one is already handled on `main` by the `resolveEnvOrEmpty` guard in #588.

## How to verify

```bash
# with AGENTMEMORY_TOOLS=all only in ~/.agentmemory/.env (not exported):
# before — server reports 8 core tools; after — full surface
```

Automated coverage added in `test/tools-visibility-env.test.ts` (hermetic; sandboxes `HOME` and writes a temp `.env`):
- `AGENTMEMORY_TOOLS=all` in `.env` → full surface (`getAllTools().length`, incl. `memory_graph_query`)
- unset → core subset (regression guard)
- `process.env` overrides the `.env` value (precedence preserved)

`npm run build` is clean and the suite passes (the 5 unrelated `auto-compress` / `embedding-provider` failures only occur when a real `~/.agentmemory/.env` is present in the test environment; they pass with a clean `HOME`).

Fixes #553
