### PR TITLE
feat: add privacy-safe audit receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -854,7 +854,7 @@ npm install @xenova/transformers
 | `memory_claude_bridge_sync` | Sync with MEMORY.md |
 | `memory_team_share` | Share with team members |
 | `memory_team_feed` | Recent shared items |
-| `memory_audit` | Audit trail of operations |
+| `memory_audit` | Audit trail of operations; pass `receipt: true` for privacy-safe hashed receipts |
 | `memory_governance_delete` | Delete with audit trail |
 | `memory_snapshot_create` | Git-versioned snapshot |
 | `memory_action_create` | Create work items with dependencies |
@@ -1262,7 +1262,7 @@ Create `~/.agentmemory/.env`:
 | `POST` | `/agentmemory/import` | Import from JSON |
 | `POST` | `/agentmemory/graph/query` | Knowledge graph query |
 | `POST` | `/agentmemory/team/share` | Share with team |
-| `GET` | `/agentmemory/audit` | Audit trail |
+| `GET` | `/agentmemory/audit` | Audit trail; add `?receipt=true` for privacy-safe hashed receipts |
 
 Full endpoint list: [`src/triggers/api.ts`](src/triggers/api.ts)
 

--- a/README.md
+++ b/README.md
@@ -854,7 +854,7 @@ npm install @xenova/transformers
 | `memory_claude_bridge_sync` | Sync with MEMORY.md |
 | `memory_team_share` | Share with team members |
 | `memory_team_feed` | Recent shared items |
-| `memory_audit` | Audit trail of operations; pass `receipt: true` for privacy-safe hashed receipts |
+| `memory_audit` | Audit trail of operations; pass `receipt: true` for privacy-safe HMAC-hashed receipts (requires `AGENTMEMORY_RECEIPT_HMAC_KEY`) |
 | `memory_governance_delete` | Delete with audit trail |
 | `memory_snapshot_create` | Git-versioned snapshot |
 | `memory_action_create` | Create work items with dependencies |
@@ -1262,7 +1262,9 @@ Create `~/.agentmemory/.env`:
 | `POST` | `/agentmemory/import` | Import from JSON |
 | `POST` | `/agentmemory/graph/query` | Knowledge graph query |
 | `POST` | `/agentmemory/team/share` | Share with team |
-| `GET` | `/agentmemory/audit` | Audit trail; add `?receipt=true` for privacy-safe hashed receipts |
+| `GET` | `/agentmemory/audit` | Audit trail; add `?receipt=true` for privacy-safe HMAC-hashed receipts |
+
+Audit receipts require `AGENTMEMORY_RECEIPT_HMAC_KEY` when `receipt=true` is requested. The key is used only to derive stable receipt identifiers with HMAC-SHA256 so shared receipts do not expose raw or dictionary-guessable audit, target, or user IDs.
 
 Full endpoint list: [`src/triggers/api.ts`](src/triggers/api.ts)
 

--- a/src/functions/audit.ts
+++ b/src/functions/audit.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHmac } from "node:crypto";
 import type { AuditEntry } from "../types.js";
 import { KV, generateId } from "../state/schema.js";
 import type { StateKV } from "../state/kv.js";
@@ -52,21 +52,33 @@ export interface AuditReceipt {
     rawTargetIdsIncluded: false;
     rawDetailsIncluded: false;
     rawUserIdsIncluded: false;
+    hashAlgorithm: "hmac-sha256";
+    hmacKeySource: "AGENTMEMORY_RECEIPT_HMAC_KEY";
   };
   entryCount: number;
   entries: AuditReceiptEntry[];
 }
 
-function digest(value: string): string {
-  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+function receiptHmacKey(): string {
+  const key = process.env.AGENTMEMORY_RECEIPT_HMAC_KEY;
+  if (!key) {
+    throw new Error("AGENTMEMORY_RECEIPT_HMAC_KEY is required to generate audit receipts");
+  }
+  return key;
 }
 
-function safeDetailKeys(details: Record<string, unknown> | undefined): string[] {
-  if (!details) return [];
+function digest(value: string, key: string): string {
+  return `hmac-sha256:${createHmac("sha256", key).update(value).digest("hex")}`;
+}
+
+function safeDetailKeys(details: unknown): string[] {
+  if (!details || typeof details !== "object" || Array.isArray(details)) return [];
   return Object.keys(details).sort();
 }
 
 export function buildAuditReceipt(entries: AuditEntry[]): AuditReceipt {
+  const hmacKey = receiptHmacKey();
+
   return {
     schema: "agentmemory.audit.receipt.v1",
     generatedAt: new Date().toISOString(),
@@ -74,18 +86,20 @@ export function buildAuditReceipt(entries: AuditEntry[]): AuditReceipt {
       rawTargetIdsIncluded: false,
       rawDetailsIncluded: false,
       rawUserIdsIncluded: false,
+      hashAlgorithm: "hmac-sha256",
+      hmacKeySource: "AGENTMEMORY_RECEIPT_HMAC_KEY",
     },
     entryCount: entries.length,
     entries: entries.map((entry) => ({
-      auditIdHash: digest(entry.id),
+      auditIdHash: digest(entry.id, hmacKey),
       timestamp: entry.timestamp,
       operation: entry.operation,
       functionId: entry.functionId,
       targetCount: entry.targetIds.length,
-      targetIdHashes: entry.targetIds.map(digest),
+      targetIdHashes: entry.targetIds.map((targetId) => digest(targetId, hmacKey)),
       detailKeys: safeDetailKeys(entry.details),
       qualityScore: entry.qualityScore,
-      userIdHash: entry.userId ? digest(entry.userId) : undefined,
+      userIdHash: entry.userId ? digest(entry.userId, hmacKey) : undefined,
     })),
   };
 }

--- a/src/functions/audit.ts
+++ b/src/functions/audit.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type { AuditEntry } from "../types.js";
 import { KV, generateId } from "../state/schema.js";
 import type { StateKV } from "../state/kv.js";
@@ -30,6 +31,64 @@ import { logger } from "../logger.js";
 //
 // When adding a new deletion path, add an explicit recordAudit call
 // BEFORE kv.delete(...) and match one of the two shapes above.
+
+
+export interface AuditReceiptEntry {
+  auditIdHash: string;
+  timestamp: string;
+  operation: AuditEntry["operation"];
+  functionId: string;
+  targetCount: number;
+  targetIdHashes: string[];
+  detailKeys: string[];
+  qualityScore?: number;
+  userIdHash?: string;
+}
+
+export interface AuditReceipt {
+  schema: "agentmemory.audit.receipt.v1";
+  generatedAt: string;
+  privacy: {
+    rawTargetIdsIncluded: false;
+    rawDetailsIncluded: false;
+    rawUserIdsIncluded: false;
+  };
+  entryCount: number;
+  entries: AuditReceiptEntry[];
+}
+
+function digest(value: string): string {
+  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}
+
+function safeDetailKeys(details: Record<string, unknown> | undefined): string[] {
+  if (!details) return [];
+  return Object.keys(details).sort();
+}
+
+export function buildAuditReceipt(entries: AuditEntry[]): AuditReceipt {
+  return {
+    schema: "agentmemory.audit.receipt.v1",
+    generatedAt: new Date().toISOString(),
+    privacy: {
+      rawTargetIdsIncluded: false,
+      rawDetailsIncluded: false,
+      rawUserIdsIncluded: false,
+    },
+    entryCount: entries.length,
+    entries: entries.map((entry) => ({
+      auditIdHash: digest(entry.id),
+      timestamp: entry.timestamp,
+      operation: entry.operation,
+      functionId: entry.functionId,
+      targetCount: entry.targetIds.length,
+      targetIdHashes: entry.targetIds.map(digest),
+      detailKeys: safeDetailKeys(entry.details),
+      qualityScore: entry.qualityScore,
+      userIdHash: entry.userId ? digest(entry.userId) : undefined,
+    })),
+  };
+}
 
 export async function recordAudit(
   kv: StateKV,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -10,6 +10,8 @@ import type {
 } from "../types.js";
 import { getVisibleTools } from "./tools-registry.js";
 import { timingSafeCompare } from "../auth.js";
+import { buildAuditReceipt } from "../functions/audit.js";
+import type { AuditEntry } from "../types.js";
 
 type McpResponse = {
   status_code: number;
@@ -559,12 +561,13 @@ export function registerMcpEndpoints(
               const result = await sdk.trigger({ function_id: "mem::audit-query", payload: {
                 operation: args.operation as string,
                 limit: typeof args.limit === "number" ? args.limit : 50,
-              } });
+              } }) as AuditEntry[];
+              const body = args.receipt === true ? buildAuditReceipt(result) : result;
               return {
                 status_code: 200,
                 body: {
                   content: [
-                    { type: "text", text: JSON.stringify(result, null, 2) },
+                    { type: "text", text: JSON.stringify(body, null, 2) },
                   ],
                 },
               };

--- a/src/mcp/standalone.ts
+++ b/src/mcp/standalone.ts
@@ -6,6 +6,8 @@ import { getAllTools } from "./tools-registry.js";
 import { getStandalonePersistPath } from "../config.js";
 import { VERSION } from "../version.js";
 import { generateId } from "../state/schema.js";
+import { buildAuditReceipt } from "../functions/audit.js";
+import type { AuditEntry } from "../types.js";
 import {
   resolveHandle,
   invalidateHandle,
@@ -104,6 +106,7 @@ interface Validated {
   tokenBudget?: number;
   memoryIds?: string[];
   reason?: string;
+  receipt?: boolean;
 }
 
 function validate(toolName: string, args: Record<string, unknown>): Validated {
@@ -159,6 +162,7 @@ function validate(toolName: string, args: Record<string, unknown>): Validated {
       return v;
     case "memory_audit": {
       v.limit = parseLimit(args["limit"], 50);
+      v.receipt = args["receipt"] === true;
       return v;
     }
     default:
@@ -225,8 +229,10 @@ async function handleProxy(
       return textResponse(result, true);
     }
     case "memory_audit": {
+      const qs = new URLSearchParams({ limit: String(v.limit) });
+      if (v.receipt) qs.set("receipt", "true");
       const result = await handle.call(
-        `/agentmemory/audit?limit=${v.limit}`,
+        `/agentmemory/audit?${qs.toString()}`,
         { method: "GET" },
       );
       return textResponse(result, true);
@@ -319,10 +325,9 @@ async function handleLocal(
     case "memory_audit": {
       const entries = await kvInstance.list("mem:audit");
       const limit = v.limit ?? 50;
+      const selected = (entries as AuditEntry[]).slice(0, limit);
       return textResponse(
-        {
-          entries: (entries as Array<Record<string, unknown>>).slice(0, limit),
-        },
+        v.receipt ? { receipt: buildAuditReceipt(selected) } : { entries: selected },
         true,
       );
     }

--- a/src/mcp/tools-registry.ts
+++ b/src/mcp/tools-registry.ts
@@ -319,6 +319,10 @@ export const V040_TOOLS: McpToolDef[] = [
       properties: {
         operation: { type: "string", description: "Filter by operation type" },
         limit: { type: "number", description: "Max entries (default 50)" },
+        receipt: {
+          type: "boolean",
+          description: "Return a privacy-safe receipt with hashed target/user ids and detail keys only",
+        },
       },
     },
   },

--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -10,6 +10,8 @@ import { VERSION } from "../version.js";
 import { timingSafeCompare } from "../auth.js";
 import { renderViewerDocument } from "../viewer/document.js";
 import { getBoundViewerPort, getViewerSkipped } from "../viewer/server.js";
+import { buildAuditReceipt } from "../functions/audit.js";
+import type { AuditEntry } from "../types.js";
 import { MAX_FILES_UPPER_BOUND } from "../functions/replay.js";
 import {
   isGraphExtractionEnabled,
@@ -1348,7 +1350,13 @@ export function registerApiTriggers(
       const entries = await sdk.trigger({ function_id: "mem::audit-query", payload: {
         operation: req.query_params?.["operation"],
         limit: parsedLimit ?? 50,
-      } });
+      } }) as AuditEntry[];
+      if (req.query_params?.["receipt"] === "true") {
+        return {
+          status_code: 200,
+          body: { receipt: buildAuditReceipt(entries), success: true },
+        };
+      }
       return { status_code: 200, body: { entries, success: true } };
     },
   );

--- a/test/audit.test.ts
+++ b/test/audit.test.ts
@@ -1,10 +1,11 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
 vi.mock("../src/logger.js", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
 import { buildAuditReceipt, recordAudit, queryAudit } from "../src/functions/audit.js";
+import type { AuditEntry } from "../src/types.js";
 
 function mockKV() {
   const store = new Map<string, Map<string, unknown>>();
@@ -29,9 +30,19 @@ function mockKV() {
 
 describe("Audit Functions", () => {
   let kv: ReturnType<typeof mockKV>;
+  let previousReceiptHmacKey: string | undefined;
 
   beforeEach(() => {
     kv = mockKV();
+    previousReceiptHmacKey = process.env.AGENTMEMORY_RECEIPT_HMAC_KEY;
+  });
+
+  afterEach(() => {
+    if (previousReceiptHmacKey === undefined) {
+      delete process.env.AGENTMEMORY_RECEIPT_HMAC_KEY;
+      return;
+    }
+    process.env.AGENTMEMORY_RECEIPT_HMAC_KEY = previousReceiptHmacKey;
   });
 
   it("recordAudit creates an entry with proper fields", async () => {
@@ -132,13 +143,34 @@ describe("Audit Functions", () => {
       hmacKeySource: "AGENTMEMORY_RECEIPT_HMAC_KEY",
     });
     expect(receipt.entries[0].targetCount).toBe(1);
+    expect(receipt.entries[0].auditIdHash).toMatch(/^hmac-sha256:/);
     expect(receipt.entries[0].targetIdHashes[0]).toMatch(/^hmac-sha256:/);
     expect(receipt.entries[0].detailKeys).toEqual(["content", "count", "path"]);
     expect(receipt.entries[0].userIdHash).toMatch(/^hmac-sha256:/);
+    expect(serialized).not.toContain(entry.id);
     expect(serialized).not.toContain("mem_private_customer_ticket");
     expect(serialized).not.toContain("customer secret should not be exported");
     expect(serialized).not.toContain("/private/work/customer");
     expect(serialized).not.toContain("user-private-email@example.com");
+  });
+
+  it("buildAuditReceipt handles malformed legacy details safely", async () => {
+    process.env.AGENTMEMORY_RECEIPT_HMAC_KEY = "test-receipt-hmac-key";
+    const baseEntry = await recordAudit(kv as never, "observe", "mem::legacy", ["mem_legacy"], {});
+    const legacyEntry = {
+      ...baseEntry,
+      id: "aud_malformed_legacy",
+      details: null,
+    } as unknown as AuditEntry;
+
+    const receipt = buildAuditReceipt([legacyEntry]);
+    const serialized = JSON.stringify(receipt);
+
+    expect(receipt.entries[0].detailKeys).toEqual([]);
+    expect(receipt.entries[0].auditIdHash).toMatch(/^hmac-sha256:/);
+    expect(receipt.privacy.rawDetailsIncluded).toBe(false);
+    expect(serialized).not.toContain("aud_malformed_legacy");
+    expect(serialized).not.toContain("mem_legacy");
   });
 
 });

--- a/test/audit.test.ts
+++ b/test/audit.test.ts
@@ -4,7 +4,7 @@ vi.mock("../src/logger.js", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
-import { recordAudit, queryAudit } from "../src/functions/audit.js";
+import { buildAuditReceipt, recordAudit, queryAudit } from "../src/functions/audit.js";
 
 function mockKV() {
   const store = new Map<string, Map<string, unknown>>();
@@ -103,4 +103,39 @@ describe("Audit Functions", () => {
     const entries = await queryAudit(kv as never, { limit: 3 });
     expect(entries.length).toBe(3);
   });
+  it("buildAuditReceipt hashes ids and omits raw details", async () => {
+    const entry = await recordAudit(
+      kv as never,
+      "remember",
+      "mem::remember",
+      ["mem_private_customer_ticket"],
+      {
+        content: "customer secret should not be exported",
+        path: "/private/work/customer",
+        count: 1,
+      },
+      0.91,
+      "user-private-email@example.com",
+    );
+
+    const receipt = buildAuditReceipt([entry]);
+    const serialized = JSON.stringify(receipt);
+
+    expect(receipt.schema).toBe("agentmemory.audit.receipt.v1");
+    expect(receipt.entryCount).toBe(1);
+    expect(receipt.privacy).toEqual({
+      rawTargetIdsIncluded: false,
+      rawDetailsIncluded: false,
+      rawUserIdsIncluded: false,
+    });
+    expect(receipt.entries[0].targetCount).toBe(1);
+    expect(receipt.entries[0].targetIdHashes[0]).toMatch(/^sha256:/);
+    expect(receipt.entries[0].detailKeys).toEqual(["content", "count", "path"]);
+    expect(receipt.entries[0].userIdHash).toMatch(/^sha256:/);
+    expect(serialized).not.toContain("mem_private_customer_ticket");
+    expect(serialized).not.toContain("customer secret should not be exported");
+    expect(serialized).not.toContain("/private/work/customer");
+    expect(serialized).not.toContain("user-private-email@example.com");
+  });
+
 });

--- a/test/audit.test.ts
+++ b/test/audit.test.ts
@@ -118,6 +118,7 @@ describe("Audit Functions", () => {
       "user-private-email@example.com",
     );
 
+    process.env.AGENTMEMORY_RECEIPT_HMAC_KEY = "test-receipt-hmac-key";
     const receipt = buildAuditReceipt([entry]);
     const serialized = JSON.stringify(receipt);
 
@@ -127,11 +128,13 @@ describe("Audit Functions", () => {
       rawTargetIdsIncluded: false,
       rawDetailsIncluded: false,
       rawUserIdsIncluded: false,
+      hashAlgorithm: "hmac-sha256",
+      hmacKeySource: "AGENTMEMORY_RECEIPT_HMAC_KEY",
     });
     expect(receipt.entries[0].targetCount).toBe(1);
-    expect(receipt.entries[0].targetIdHashes[0]).toMatch(/^sha256:/);
+    expect(receipt.entries[0].targetIdHashes[0]).toMatch(/^hmac-sha256:/);
     expect(receipt.entries[0].detailKeys).toEqual(["content", "count", "path"]);
-    expect(receipt.entries[0].userIdHash).toMatch(/^sha256:/);
+    expect(receipt.entries[0].userIdHash).toMatch(/^hmac-sha256:/);
     expect(serialized).not.toContain("mem_private_customer_ticket");
     expect(serialized).not.toContain("customer secret should not be exported");
     expect(serialized).not.toContain("/private/work/customer");

--- a/test/audit.test.ts
+++ b/test/audit.test.ts
@@ -173,4 +173,13 @@ describe("Audit Functions", () => {
     expect(serialized).not.toContain("mem_legacy");
   });
 
+  it("buildAuditReceipt requires an HMAC key", async () => {
+    const entry = await recordAudit(kv as never, "observe", "mem::test", ["mem_1"], {});
+    delete process.env.AGENTMEMORY_RECEIPT_HMAC_KEY;
+
+    expect(() => buildAuditReceipt([entry])).toThrow(
+      "AGENTMEMORY_RECEIPT_HMAC_KEY is required to generate audit receipts",
+    );
+  });
+
 });


### PR DESCRIPTION
## What

Adds an opt-in privacy-safe audit receipt format for existing audit trails.

- `buildAuditReceipt()` converts audit entries to `agentmemory.audit.receipt.v1`
- hashes audit ids, target ids, and user ids with SHA-256
- includes operation/function/timestamp/target counts/detail keys, but not raw `targetIds`, raw `details`, or raw `userId`
- exposes receipts via `GET /agentmemory/audit?receipt=true`
- exposes the same mode through `memory_audit` with `receipt: true`

## Why

Persistent memory tools need a shareable proof that memory operations happened without leaking the memory content, paths, raw ids, prompts, or user identifiers. The normal audit endpoint remains unchanged; the receipt mode is for safe handoff/debug/audit artifacts.

## Verification

- `npm run build`
- `npm test -- --run test/audit.test.ts`
- `npm test` (1097 tests passed)
- `git diff --check`

Note: `npm install` needed `--legacy-peer-deps` locally because the current dependency tree has a peer constraint conflict between `@anthropic-ai/sdk@0.39.0` and `@anthropic-ai/claude-agent-sdk`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Privacy-safe audit receipts: request audit data with `receipt=true` to receive stable hashed identifiers, counts and metadata instead of raw sensitive values (supported by API endpoints, MCP tools, proxy and local modes).

* **Documentation**
  * README and REST docs updated to describe the `receipt` parameter, receipt format, and requirement for a configured HMAC key for stable receipts.

* **Tests**
  * Added tests validating receipt generation, counts, hashed identifiers, privacy flags, and omission of raw sensitive fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/617?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->