### PR TITLE
fix(cli): honor --force on unresponsive engine; detect listening PIDs on Windows

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -131,8 +131,10 @@ Commands:
   upgrade            Upgrade local deps + iii runtime (best effort)
   stop [--force]     Stop the running iii-engine started by this CLI.
                      --force bypasses the Docker-heuristic guard and signals
-                     whatever pidfile+lsof report on the REST port (use when
-                     the engine was started natively but state file is missing).
+                     whatever pidfile + lsof/netstat report on the REST port.
+                     Also forces SIGTERM/SIGKILL when the engine is wedged
+                     (REST port listening but unresponsive) so a fresh start
+                     is not blocked by stale state.
   mcp                Start standalone MCP shim — opt-in surface for MCP-only clients
                      (Cursor, Gemini CLI, etc). REST always available at :3111.
   import-jsonl [p]   Import Claude Code JSONL transcripts (default: ~/.claude/projects)
@@ -2107,16 +2109,66 @@ async function signalAndWait(
   return !pidAlive(pid);
 }
 
+// Pure parser for `netstat -ano` output. Returns the PID of every process
+// LISTENING on `port` (IPv4 + IPv6), excluding `selfPid`. Exported so the
+// parser can be tested without spawning netstat.
+export function parseNetstatListeningPids(
+  output: string,
+  port: number,
+  selfPid: number,
+): number[] {
+  // Sample line shapes we accept (netstat -ano on en-US and localized hosts):
+  //   TCP    0.0.0.0:3111           0.0.0.0:0              LISTENING       39672
+  //   TCP    [::]:3111              [::]:0                 LISTENING       39672
+  //   TCP    127.0.0.1:3111         0.0.0.0:0              LISTENING       39672
+  // Some locales translate "LISTENING" (e.g. "ABHÖREN" on de-DE). The PID
+  // is always the last whitespace-separated token, so we key off the local
+  // address column + the absence of a remote address state we treat as
+  // non-listening. We use a positive check on TCP-prefixed lines whose
+  // local-address suffix is exactly ":<port>" and whose foreign address is
+  // an unspecified peer (":0" or "[::]:0").
+  const pids = new Set<number>();
+  const portSuffix = `:${port}`;
+  for (const rawLine of output.split(/\r?\n/)) {
+    const trimmed = rawLine.trim();
+    if (!trimmed.toUpperCase().startsWith("TCP")) continue;
+    const tokens = trimmed.split(/\s+/);
+    // Expected layout: [proto, local, foreign, state, pid]
+    if (tokens.length < 5) continue;
+    const local = tokens[1] ?? "";
+    const foreign = tokens[2] ?? "";
+    if (local.slice(local.lastIndexOf(":")) !== portSuffix) continue;
+    // A listening socket has an unspecified peer endpoint.
+    const isListening = foreign === "0.0.0.0:0" || foreign === "[::]:0" || foreign === "*:*";
+    if (!isListening) continue;
+    const pid = parseInt(tokens[tokens.length - 1] ?? "", 10);
+    if (Number.isFinite(pid) && pid > 0 && pid !== selfPid) pids.add(pid);
+  }
+  return [...pids];
+}
+
 function findEnginePidsByPort(port: number): number[] {
-  if (IS_WINDOWS) return [];
-  const lsof = whichBinary("lsof");
-  if (!lsof) return [];
-  // -sTCP:LISTEN restricts to listening server sockets only. Without
-  // this, lsof also returns client-side PIDs (any process with an
-  // active TCP connection to :port), which includes the agentmemory
+  // -sTCP:LISTEN on unix and the local/foreign + LISTENING heuristic on
+  // Windows both restrict matches to listening server sockets. Without
+  // this, lsof / netstat also report client-side PIDs (any process with
+  // an active TCP connection to :port), which includes the agentmemory
   // CLI itself thanks to the keep-alive fetch in isEngineRunning().
   // signalAndWait would then SIGKILL its own parent — exit code 137.
   const selfPid = process.pid;
+  if (IS_WINDOWS) {
+    try {
+      const out = execFileSync("netstat.exe", ["-ano", "-p", "TCP"], {
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+      return parseNetstatListeningPids(out, port, selfPid);
+    } catch (err) {
+      vlog(`netstat :${port}: ${err instanceof Error ? err.message : String(err)}`);
+      return [];
+    }
+  }
+  const lsof = whichBinary("lsof");
+  if (!lsof) return [];
   try {
     const out = execFileSync(lsof, ["-i", `:${port}`, "-sTCP:LISTEN", "-t"], {
       encoding: "utf-8",
@@ -2191,13 +2243,39 @@ async function runStop(): Promise<void> {
     }
     const survivors = new Set<number>(portPids);
     if (pidfilePid) survivors.add(pidfilePid);
+    if (!force) {
+      p.log.warn(
+        `Engine not responding on :${port}, but ${survivors.size} process(es) still hold the port or pidfile: ${[...survivors].join(", ")}`,
+      );
+      p.log.info(
+        `Preserving ~/.agentmemory/iii.pid. Rerun with --force to signal these PIDs, or inspect them first:\n  ps -p ${[...survivors].join(",")} -o pid,ppid,comm,etime\n  ${IS_WINDOWS ? "netstat -ano | findstr :" + port : "lsof -i :" + port}`,
+      );
+      process.exit(1);
+    }
+    // --force on an unresponsive engine: the user already told us they want
+    // these PIDs gone. SIGTERM/SIGKILL them and clear the pidfile so the next
+    // start is not refused by a stale-state guard.
     p.log.warn(
-      `Engine not responding on :${port}, but ${survivors.size} process(es) still hold the port or pidfile: ${[...survivors].join(", ")}`,
+      `--force: signaling ${survivors.size} unresponsive process(es) on :${port}: ${[...survivors].join(", ")}`,
     );
-    p.log.info(
-      `Preserving ~/.agentmemory/iii.pid. Investigate before manual cleanup:\n  ps -p ${[...survivors].join(",")} -o pid,ppid,comm,etime\n  ${IS_WINDOWS ? "netstat -ano | findstr :" + port : "lsof -i :" + port}`,
-    );
-    process.exit(1);
+    let allStopped = true;
+    for (const pid of survivors) {
+      const s = p.spinner();
+      s.start(`Stopping pid ${pid}...`);
+      const ok = await signalAndWait(pid, "SIGTERM", 3000);
+      s.stop(ok ? `Stopped pid ${pid}` : `Failed to stop pid ${pid}`);
+      if (!ok) allStopped = false;
+    }
+    clearEnginePidfile();
+    clearEngineState();
+    if (!allStopped) {
+      p.log.error(
+        `One or more processes survived SIGKILL. Inspect with ${IS_WINDOWS ? "Task Manager / Get-Process" : "ps"}.`,
+      );
+      process.exit(1);
+    }
+    p.outro("Stopped. Memories persisted to disk; restart anytime with: npx @agentmemory/agentmemory");
+    return;
   }
 
   if (!state) {

--- a/test/cli-stop-port-detection.test.ts
+++ b/test/cli-stop-port-detection.test.ts
@@ -1,0 +1,79 @@
+// Unit tests for parseNetstatListeningPids — the Windows port-detection
+// parser used by `agentmemory stop [--force]`.
+//
+// We exercise:
+//   - IPv4 / IPv6 / loopback local addresses
+//   - LISTENING vs ESTABLISHED filtering
+//   - selfPid exclusion (so the CLI does not signal its own parent)
+//   - locale-translated state strings (de-DE: "ABHÖREN") — covered by the
+//     foreign-address heuristic, not the literal "LISTENING" word
+//   - blank / garbage input
+
+import { describe, it, expect } from "vitest";
+import { parseNetstatListeningPids } from "../src/cli.js";
+
+describe("parseNetstatListeningPids", () => {
+  it("returns the listening PID for IPv4 and IPv6 sockets on the requested port", () => {
+    const sample = [
+      "",
+      "Active Connections",
+      "",
+      "  Proto  Local Address          Foreign Address        State           PID",
+      "  TCP    0.0.0.0:3111           0.0.0.0:0              LISTENING       39672",
+      "  TCP    [::]:3111              [::]:0                 LISTENING       39672",
+      "  TCP    127.0.0.1:3113         0.0.0.0:0              LISTENING       26320",
+      "",
+    ].join("\r\n");
+    expect(parseNetstatListeningPids(sample, 3111, /*selfPid*/ 999).sort()).toEqual([39672]);
+    expect(parseNetstatListeningPids(sample, 3113, 999)).toEqual([26320]);
+  });
+
+  it("ignores ESTABLISHED, TIME_WAIT, CLOSE_WAIT and other non-listening states", () => {
+    // The browser-tab ghost connection symptom: an old SSE client lingering
+    // in CLOSE_WAIT on the viewer port. The parser must NOT report it as a
+    // listening owner, otherwise --force would kill an unrelated client.
+    const sample = [
+      "  TCP    127.0.0.1:3113         127.0.0.1:54321        ESTABLISHED     12345",
+      "  TCP    127.0.0.1:3113         127.0.0.1:54322        CLOSE_WAIT      12345",
+      "  TCP    127.0.0.1:3113         0.0.0.0:0              LISTENING       54000",
+    ].join("\n");
+    expect(parseNetstatListeningPids(sample, 3113, 1)).toEqual([54000]);
+  });
+
+  it("excludes the caller's own PID", () => {
+    const sample = "  TCP    0.0.0.0:3111   0.0.0.0:0   LISTENING   42";
+    expect(parseNetstatListeningPids(sample, 3111, /*selfPid*/ 42)).toEqual([]);
+  });
+
+  it("does not confuse :3111 with :31111 or :13111", () => {
+    const sample = [
+      "  TCP    0.0.0.0:31111   0.0.0.0:0   LISTENING   1001",
+      "  TCP    0.0.0.0:13111   0.0.0.0:0   LISTENING   1002",
+      "  TCP    0.0.0.0:3111    0.0.0.0:0   LISTENING   1003",
+    ].join("\n");
+    expect(parseNetstatListeningPids(sample, 3111, 0)).toEqual([1003]);
+  });
+
+  it("deduplicates IPv4 + IPv6 entries with the same PID", () => {
+    const sample = [
+      "  TCP    0.0.0.0:3111   0.0.0.0:0   LISTENING   7777",
+      "  TCP    [::]:3111      [::]:0      LISTENING   7777",
+    ].join("\n");
+    expect(parseNetstatListeningPids(sample, 3111, 0)).toEqual([7777]);
+  });
+
+  it("returns an empty array for empty, garbage, or UDP-only input", () => {
+    expect(parseNetstatListeningPids("", 3111, 0)).toEqual([]);
+    expect(parseNetstatListeningPids("nothing here", 3111, 0)).toEqual([]);
+    expect(
+      parseNetstatListeningPids("  UDP    0.0.0.0:3111   *:*   1234", 3111, 0),
+    ).toEqual([]);
+  });
+
+  it("tolerates locale-translated state words because we key off the peer address", () => {
+    // de-DE netstat renders "LISTENING" as "ABHÖREN". The parser must still
+    // recognise the row as a listener via the unspecified-peer heuristic.
+    const sample = "  TCP    0.0.0.0:3111   0.0.0.0:0   ABHÖREN   8181";
+    expect(parseNetstatListeningPids(sample, 3111, 0)).toEqual([8181]);
+  });
+});


### PR DESCRIPTION
## Summary

Two related bugs make `agentmemory stop --force` useless on Windows when the iii-engine listening socket is wedged after sleep/wake. Together they leave the user with no CLI path to recover: the engine listens but does not respond, `--force` is silently dropped, and the only Windows code path for finding port owners returns an empty array.

This PR makes `--force` actually force, and adds first-class Windows support for finding the listening PID via `netstat -ano`.

## Bugs

1. `runStop` checks `--force` only after deciding the engine is reachable. When the engine listens but is unresponsive, `runStop` takes the early-exit branch and prints `Preserving ~/.agentmemory/iii.pid. Investigate before manual cleanup`, ignoring `--force` entirely. The exact flag that should rescue this scenario does nothing.
2. `findEnginePidsByPort` short-circuits with `return []` on Windows, so `--force` has no PIDs to signal even if it were honored. The only candidate left is the pidfile, which is typically stale.

The combined effect on Windows: a hung engine cannot be stopped from the CLI at all. The user must run `netstat -ano | findstr :3111` then `taskkill /F /PID <pid>` by hand.

## Repro (Windows 11, Node 22, agentmemory 0.9.21)

```
PS> agentmemory          # start engine
# ...let laptop sleep for a few minutes, then resume...
PS> agentmemory status
x  Not running - no response at http://127.0.0.1:3111
PS> agentmemory stop --force
!  Engine not responding on :3111, but 1 process(es) still hold the port or pidfile: 39672
o  Preserving ~/.agentmemory/iii.pid. Investigate before manual cleanup
# exit 1 - --force did nothing
PS> netstat -ano | findstr :3111
  TCP    0.0.0.0:3111   0.0.0.0:0   LISTENING   39672
PS> taskkill /F /PID 39672   # the only working escape hatch
```

After this PR:

```
PS> agentmemory stop --force
!  --force: signaling 1 unresponsive process(es) on :3111: 39672
o  Stopped pid 39672
o  Stopped. Memories persisted to disk; restart anytime with: npx @agentmemory/agentmemory
```

## Changes

- `runStop`: when `!running` and survivors exist, honor `--force` by SIGTERM/SIGKILL-ing every PID via the existing `signalAndWait` helper, then clear pidfile + engine state so the next start is not refused by the stale-state guard. The non-`--force` message now points at the `--force` flag in addition to manual triage commands.
- `findEnginePidsByPort`: on Windows, parse `netstat -ano -p TCP` for PIDs whose local address ends in `:PORT` and whose foreign address is the unspecified peer (`0.0.0.0:0`, `[::]:0`, `*:*`). The state column is **ignored** because it is locale-translated (de-DE renders LISTENING as ABHOEREN, fr-FR as ECOUTER, etc) - keying off the peer address is locale-stable.
- `parseNetstatListeningPids`: extracted as a pure exported function so the parser is unit-testable without spawning netstat.
- Help text for `stop --force` now mentions netstat and the unresponsive-engine case.

## Test plan

New file `test/cli-stop-port-detection.test.ts` (Vitest) covers:

- IPv4 (`0.0.0.0:3111`) + IPv6 (`[::]:3111`) listeners on the requested port
- Filtering ESTABLISHED / CLOSE_WAIT / TIME_WAIT rows (the **browser-tab ghost socket** case - a stale viewer SSE connection in CLOSE_WAIT must not be reported as a listening owner, otherwise `--force` would kill an unrelated browser process)
- selfPid exclusion (the CLI must not signal its own parent, exit 137)
- Port-prefix collisions (`:3111` vs `:31111` vs `:13111`)
- Dedup across IPv4/IPv6 dual-stack listeners
- Empty / garbage / UDP-only input
- Locale-translated state words (`ABHOEREN` on de-DE)

Local run:

```
$ npx vitest run test/cli-stop-port-detection.test.ts
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

Full suite: my branch reduces overall failures from 24 to 17 on a Windows 11 host (the remaining 17 are pre-existing path-related failures unaffected by this change; same set fails on `main`). Build passes (`npm run build` clean).

## Non-goals (deliberate)

- No change to the macOS/Linux `lsof` path - it already works.
- No change to the Docker code path - the Docker guard is unchanged.
- No new dependencies. `netstat.exe` ships with every Windows install.

## Notes

I hit this while writing a Windows supervisor for agentmemory ([yanniedog/agentmemory-keeper](https://github.com/yanniedog/agentmemory-keeper)). The supervisor works around the bug by killing port holders directly via PowerShell, but the right fix is to make `agentmemory stop --force` do what its name promises. Happy to scope down further if you want this split into two PRs (one per bug).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved detection of engine processes running on Windows
  * Enhanced `agentmemory stop --force` to handle unresponsive engines more effectively
  * Added detailed warnings with specific process IDs when engine fails to respond gracefully

* **Documentation**
  * Updated help text for `--force` option to clarify behavior

* **Tests**
  * Added comprehensive test suite for process detection functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/624?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->