### PR TITLE
feat(connect): add Kilo CLI adapter

### DIFF
--- a/src/cli/connect/index.ts
+++ b/src/cli/connect/index.ts
@@ -9,6 +9,7 @@ import { adapter as hermes } from "./hermes.js";
 import { adapter as openclaw } from "./openclaw.js";
 import { adapter as openhuman } from "./openhuman.js";
 import { adapter as pi } from "./pi.js";
+import { adapter as kilo } from "./kilo.js";
 
 export const ADAPTERS: readonly ConnectAdapter[] = [
   claudeCode,
@@ -19,6 +20,7 @@ export const ADAPTERS: readonly ConnectAdapter[] = [
   hermes,
   pi,
   openhuman,
+  kilo,
 ];
 
 export function resolveAdapter(name: string): ConnectAdapter | null {

--- a/src/cli/connect/kilo.ts
+++ b/src/cli/connect/kilo.ts
@@ -1,0 +1,112 @@
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { ConnectAdapter, ConnectOptions, ConnectResult } from "./types.js";
+import {
+  backupFile,
+  logAlreadyWired,
+  logBackup,
+  logInstalled,
+  readJsonSafe,
+  writeJsonAtomic,
+} from "./util.js";
+
+type McpEntry = {
+  type: string;
+  command: string[];
+  environment?: Record<string, string>;
+  enabled?: boolean;
+};
+
+type KiloConfig = {
+  mcp?: Record<string, McpEntry>;
+  [key: string]: unknown;
+};
+
+// Env values use ${VAR} expansion so the wired MCP entry inherits
+// AGENTMEMORY_URL / AGENTMEMORY_SECRET from the user's shell.
+const AGENTMEMORY_MCP_BLOCK: McpEntry = {
+  type: "local",
+  command: ["npx", "-y", "@agentmemory/mcp"],
+  environment: {
+    AGENTMEMORY_URL: "${AGENTMEMORY_URL}",
+    AGENTMEMORY_SECRET: "${AGENTMEMORY_SECRET}",
+  },
+  enabled: true,
+};
+
+function entryMatches(entry: unknown): boolean {
+  if (!entry || typeof entry !== "object") return false;
+  const e = entry as Record<string, unknown>;
+  const cmd = Array.isArray(e["command"]) ? (e["command"] as string[]) : [];
+  return cmd.some((c) => c.includes("@agentmemory/mcp"));
+}
+
+const configDir = join(homedir(), ".config", "kilo");
+const configFiles = ["kilo.jsonc", "kilo.json", "opencode.jsonc", "opencode.json"];
+
+function findConfigFile(): string | null {
+  for (const file of configFiles) {
+    const fullPath = join(configDir, file);
+    if (existsSync(fullPath)) return fullPath;
+  }
+  return null;
+}
+
+export const adapter: ConnectAdapter = {
+  name: "kilo",
+  displayName: "Kilo",
+  docs: "https://github.com/rohitg00/agentmemory/tree/main/integrations/kilo",
+  protocolNote: "→ Using MCP. Kilo implements memory hooks natively in its codebase.",
+
+  detect(): boolean {
+    return existsSync(configDir) || findConfigFile() !== null;
+  },
+
+  async install(opts: ConnectOptions): Promise<ConnectResult> {
+    const configPath = findConfigFile() ?? join(configDir, "kilo.json");
+    const existing = readJsonSafe<KiloConfig>(configPath);
+    const next: KiloConfig = existing ? { ...existing } : {};
+    const mcp: Record<string, McpEntry> = {
+      ...((next.mcp as Record<string, McpEntry>) ?? {}),
+    };
+
+    const alreadyHas = entryMatches(mcp["agentmemory"]);
+    if (alreadyHas && !opts.force) {
+      logAlreadyWired("Kilo", configPath);
+      return { kind: "already-wired", mutatedPath: configPath };
+    }
+
+    if (opts.dryRun) {
+      console.log(
+        `[dry-run] Would ${alreadyHas ? "overwrite" : "add"} mcp.agentmemory in ${configPath}`,
+      );
+      return { kind: "installed", mutatedPath: configPath };
+    }
+
+    let backupPath: string | undefined;
+    if (existsSync(configPath)) {
+      backupPath = backupFile(configPath, "kilo");
+      logBackup(backupPath);
+    }
+
+    mcp["agentmemory"] = AGENTMEMORY_MCP_BLOCK;
+    next.mcp = mcp;
+    writeJsonAtomic(configPath, next);
+
+    const verify = readJsonSafe<KiloConfig>(configPath);
+    if (!entryMatches(verify?.mcp?.["agentmemory"])) {
+      console.error(
+        `Verification failed: ${configPath} did not contain mcp.agentmemory after write.`,
+      );
+      return { kind: "skipped", reason: "verification-failed" };
+    }
+
+    logInstalled("Kilo", configPath);
+    return {
+      kind: "installed",
+      mutatedPath: configPath,
+      ...(backupPath !== undefined && { backupPath }),
+    };
+  },
+};


### PR DESCRIPTION
## Summary

- Adds a `connect` adapter for **Kilo** (kilo-code), a fork of OpenCode with 17k+ GitHub stars
- Kilo uses the OpenCode MCP config shape: top-level `mcp` key with command as array (not the standard `mcpServers` object)
- Kilo implements memory hooks natively in its codebase, so no plugin installation is needed — MCP wiring is the only step

## Config shape

```json
{
  "mcp": {
    "agentmemory": {
      "type": "local",
      "command": ["npx", "-y", "@agentmemory/mcp"],
      "environment": {
        "AGENTMEMORY_URL": "${AGENTMEMORY_URL}",
        "AGENTMEMORY_SECRET": "${AGENTMEMORY_SECRET}"
      },
      "enabled": true
    }
  }
}
```

## Detection

Checks for `~/.config/kilo/` directory or any of: `kilo.jsonc`, `kilo.json`, `opencode.jsonc`, `opencode.json` in that directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kilo integration for agent connectivity
  * Automatic detection and installation with dry-run mode
  * Force-overwrite option for existing configurations
  * Automatic backup creation before configuration changes
  * Built-in verification of successful installation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/630?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->