### PR TITLE
fix(windows): make agentmemory actually start on Windows (watch path + IPv4 engine WS + configurable timeout)

### DIFF
--- a/iii-config.docker.yaml
+++ b/iii-config.docker.yaml
@@ -46,7 +46,8 @@ workers:
       logs_console_output: true
   - name: iii-exec
     config:
+      # See iii-config.yaml: watch the shipped artifact, not the source.
       watch:
-        - src/**/*.ts
+        - dist/**/*.mjs
       exec:
         - node dist/index.mjs

--- a/iii-config.yaml
+++ b/iii-config.yaml
@@ -46,7 +46,11 @@ workers:
       logs_console_output: true
   - name: iii-exec
     config:
+      # Watch the shipped artifact, not the source tree. The npm package
+      # ships only `dist/` — `src/**/*.ts` resolves to nothing for end
+      # users, and on some platforms an empty watch glob causes iii-exec
+      # to abort startup before it ever spawns the node child.
       watch:
-        - src/**/*.ts
+        - dist/**/*.mjs
       exec:
         - node dist/index.mjs

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -74,6 +74,21 @@ const IS_RESET = args.includes("--reset");
 const IIPINNED_VERSION =
   process.env["AGENTMEMORY_III_VERSION"] || "0.11.2";
 
+// How long the wrapper waits for iii-engine's REST API to start responding
+// before giving up and printing the "REST API never responded" error.
+// The default 15s is too tight on Windows: iii spawns the `iii-exec` worker
+// (`node dist/index.mjs`), which has to reconnect over WebSocket and
+// register HTTP triggers before the REST surface answers — and Windows cold
+// node startup + native deps regularly push that past 15s. Bumping to 60s
+// makes Windows installs work out of the box; AGENTMEMORY_READY_TIMEOUT_MS
+// lets users tune it further (e.g. CI containers, slow disks).
+const READY_TIMEOUT_MS = (() => {
+  const raw = process.env["AGENTMEMORY_READY_TIMEOUT_MS"];
+  if (!raw) return 60000;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 60000;
+})();
+
 // Map Node platform/arch → the asset name iii-hq/iii ships under
 // https://github.com/iii-hq/iii/releases/download/iii/v<version>/<asset>
 function iiiReleaseAsset(): string | null {
@@ -153,6 +168,10 @@ Environment:
   AGENTMEMORY_USE_DOCKER=1     Prefer the bundled docker-compose path over the
                                native iii-engine binary on first run.
   AGENTMEMORY_III_VERSION      Override pinned iii-engine version (default ${IIPINNED_VERSION}).
+  AGENTMEMORY_READY_TIMEOUT_MS How long to wait for iii-engine's REST API to
+                               come up before giving up (default 60000).
+                               Raise on slow disks / CI; lower for fast-fail
+                               smoke tests.
 
 Quick start:
   npx @agentmemory/agentmemory          # start with local iii-engine or Docker
@@ -1037,10 +1056,10 @@ async function main() {
   const s = p.spinner();
   s.start("Waiting for iii-engine to be ready...");
 
-  const ready = await waitForEngine(15000);
+  const ready = await waitForEngine(READY_TIMEOUT_MS);
   if (!ready) {
     const port = getRestPort();
-    s.stop("iii-engine did not become ready within 15s");
+    s.stop(`iii-engine did not become ready within ${Math.round(READY_TIMEOUT_MS / 1000)}s`);
 
     if (startupFailure?.kind === "engine-crashed" || startupFailure?.kind === "docker-crashed") {
       p.log.error("The iii-engine process crashed on startup.");
@@ -1384,10 +1403,12 @@ function buildDoctorEffects(): DoctorEffects {
       try {
         const started = await startEngine();
         if (!started) return { ok: false, message: "startEngine() returned false" };
-        const ready = await waitForEngine(15000);
+        const ready = await waitForEngine(READY_TIMEOUT_MS);
         return {
           ok: ready,
-          message: ready ? "Engine ready" : "Engine did not become ready within 15s",
+          message: ready
+            ? "Engine ready"
+            : `Engine did not become ready within ${Math.round(READY_TIMEOUT_MS / 1000)}s`,
         };
       } catch (err) {
         return {

--- a/src/config.ts
+++ b/src/config.ts
@@ -137,7 +137,11 @@ export function loadConfig(): AgentMemoryConfig {
   const provider = detectProvider(env);
 
   return {
-    engineUrl: env["III_ENGINE_URL"] || "ws://localhost:49134",
+    // Use 127.0.0.1 (not "localhost") so we force IPv4. On Windows,
+    // `localhost` prefers IPv6 (::1) but iii-engine binds IPv4 only, so
+    // resolving via "localhost" leads to an ECONNREFUSED reconnect loop
+    // and the iii-exec worker never registers its HTTP triggers.
+    engineUrl: env["III_ENGINE_URL"] || "ws://127.0.0.1:49134",
     restPort: parseInt(env["III_REST_PORT"] || "3111", 10) || 3111,
     streamsPort: parseInt(env["III_STREAMS_PORT"] || "3112", 10) || 3112,
     provider,


### PR DESCRIPTION
## Problem

On Windows, `agentmemory` (v0.9.21) cannot complete startup. The wrapper prints "The engine process started but the REST API never responded" and exits, leaving an orphaned `iii.exe` listening on `:3111` with **zero agentmemory routes registered**. Every subsequent REST/MCP call gets a 404 from the dead backend.

## Root causes (two latent bugs, one papered-over symptom)

### 1. `iii-exec` watches a path that doesn't exist in shipped packages

`iii-config.yaml` and `iii-config.docker.yaml` configure the `iii-exec` worker to watch `src/**/*.ts`. The published npm package ships only `dist/` — that glob resolves to zero files for every end user. On some platforms (Windows reproducibly), an empty watch glob causes `iii-exec` to abort startup **before it ever spawns** `node dist/index.mjs`, which is the process that actually registers the REST HTTP triggers.

Fix: watch `dist/**/*.mjs` so the watcher targets the shipped artifact.

### 2. Engine WS default resolves to IPv6 on Windows, but iii binds IPv4 only

`src/config.ts:140` defaults `engineUrl` to `ws://localhost:49134`. On Windows, `localhost` prefers `::1` (IPv6), but iii-engine binds IPv4 only — so the node child enters an `ECONNREFUSED` reconnect loop indefinitely and never finishes registering its HTTP triggers, even when `iii-exec` did manage to spawn it.

Fix: default to `ws://127.0.0.1:49134`. `III_ENGINE_URL` overrides are unchanged.

### 3. (Defensive) Hardcoded 15 s readiness timeout

`waitForEngine(15000)` at `src/cli.ts:1040` and `:1387` is too tight: even after bugs 1 & 2 are fixed, cold-start of the Node child + native deps + WebSocket handshake + trigger registration can push past 15 s on slow disks / CI / first-run installs. Introduce `AGENTMEMORY_READY_TIMEOUT_MS` (default 60 000) and templatize the "did not become ready within Ns" message.

## Verification

Tested on Windows 11 / Node 22.12 / iii v0.11.2:

- **Before**: `node dist/cli.mjs` → "REST API never responded" after 15 s, every time. Confirmed via direct probe (`curl http://127.0.0.1:3111/agentmemory/health` → 404).
- **After this PR**: `node dist/cli.mjs` →
  ```
  curl -s http://127.0.0.1:3111/agentmemory/health
  {"status":"healthy","version":"0.9.21","viewerPort":3113, ...}
  ```
  Engine reaches healthy state in ~1.3 s. All 124 REST endpoints registered. MCP shim (`@agentmemory/mcp`) connects and tool calls succeed end-to-end against Codex CLI / Gemini CLI / Antigravity CLI / Claude Code.

Other checks:
- `npm run build` ✓
- `npx tsc --noEmit` ✓ (no errors)
- `npm test` → 1081 / 1096 passing. The 15 pre-existing failures are Windows-specific path-comparison issues in `obsidian-export.test.ts` etc.; none touch any file in this PR.
- `node dist/cli.mjs --help` shows the new env var under `Environment:`.

## Files changed

- `src/cli.ts` — add `AGENTMEMORY_READY_TIMEOUT_MS` constant, replace both `waitForEngine(15000)` call sites, templatize the timeout message, document the env var in `--help`.
- `src/config.ts` — default `engineUrl` to `ws://127.0.0.1:49134` instead of `ws://localhost:...`.
- `iii-config.yaml`, `iii-config.docker.yaml` — watch `dist/**/*.mjs` instead of `src/**/*.ts`.

## Why the (2) and (3) splits are worth keeping separate

(2) and (3) compound: even on a machine where IPv6 happens to fall through to IPv4 quickly, the hardcoded 15 s ceiling sometimes wasn't enough. Fixing only the timeout would have masked the real bugs (and Docker mode would still have been broken because `AGENTMEMORY_USE_DOCKER=1` doesn't help when `iii-exec` itself can't find files to watch). Fixing only the watch path would have left Windows users in the reconnect loop. All three are needed for a clean Windows install.

## Credit

Root cause of (1) and (2) identified in collaboration with another agent run by the same user, who patched these the same way in their local `node_modules` to get a working server before this PR was opened.