### PR TITLE
[codex] Fix graph XML parsing for reordered attributes

### DIFF
--- a/src/functions/graph.ts
+++ b/src/functions/graph.ts
@@ -26,19 +26,22 @@ function parseGraphXml(
   const edges: GraphEdge[] = [];
   const now = new Date().toISOString();
 
-  // Lazy `[^>]*?` so the self-closing alternation gets a chance before
-  // greedy attribute matching consumes the trailing `/` and the regex
-  // falls through to the explicit-close branch, which then runs ahead to
-  // the *next* entity's `</entity>` and silently drops a node (#494
-  // follow-up: greedy `[^>]*` was eating the `/` and merging two entity
-  // declarations into one match).
-  const entityRegex =
-    /<entity\s+type="([^"]+)"\s+name="([^"]+)"[^>]*?(?:\/>|>([\s\S]*?)<\/entity>)/g;
-  let match;
-  while ((match = entityRegex.exec(xml)) !== null) {
-    const type = match[1] as GraphNode["type"];
-    const name = match[2];
-    const propsBlock = match[3] ?? "";
+  const parseAttrs = (raw: string): Record<string, string> => {
+    const attrs: Record<string, string> = {};
+    const attrRegex = /([A-Za-z_][\w:-]*)="([^"]*)"/g;
+    let attrMatch;
+    while ((attrMatch = attrRegex.exec(raw)) !== null) {
+      attrs[attrMatch[1]] = attrMatch[2];
+    }
+    return attrs;
+  };
+
+  const addNode = (rawAttrs: string, propsBlock = ""): void => {
+    const attrs = parseAttrs(rawAttrs);
+    const type = attrs.type as GraphNode["type"] | undefined;
+    const name = attrs.name;
+    if (!type || !name) return;
+
     const properties: Record<string, string> = {};
 
     const propRegex = /<property\s+key="([^"]+)">([^<]*)<\/property>/g;
@@ -55,15 +58,27 @@ function parseGraphXml(
       sourceObservationIds: observationIds,
       createdAt: now,
     });
+  };
+
+  const entityRegex = /<entity\b([^>]*[^/])>([\s\S]*?)<\/entity>/g;
+  let match;
+  while ((match = entityRegex.exec(xml)) !== null) {
+    addNode(match[1], match[2]);
   }
 
-  const relRegex =
-    /<relationship\s+type="([^"]+)"\s+source="([^"]+)"\s+target="([^"]+)"\s+weight="([^"]+)"\s*\/>/g;
+  const selfClosingEntityRegex = /<entity\b([^>]*)\/>/g;
+  while ((match = selfClosingEntityRegex.exec(xml)) !== null) {
+    addNode(match[1]);
+  }
+
+  const relRegex = /<relationship\b([^>]*)\/>/g;
   while ((match = relRegex.exec(xml)) !== null) {
-    const type = match[1] as GraphEdge["type"];
-    const sourceName = match[2];
-    const targetName = match[3];
-    const parsedWeight = parseFloat(match[4]);
+    const attrs = parseAttrs(match[1]);
+    const type = attrs.type as GraphEdge["type"] | undefined;
+    const sourceName = attrs.source;
+    const targetName = attrs.target;
+    if (!type || !sourceName || !targetName) continue;
+    const parsedWeight = parseFloat(attrs.weight ?? "0.5");
     const weight = Number.isNaN(parsedWeight) ? 0.5 : parsedWeight;
 
     const sourceNode = nodes.find((n) => n.name === sourceName);

--- a/test/graph.test.ts
+++ b/test/graph.test.ts
@@ -132,6 +132,32 @@ describe("Graph Functions", () => {
     expect(edges[0].type).toBe("uses");
   });
 
+  it("graph-extract accepts XML attributes in any order", async () => {
+    mockProvider.compress.mockResolvedValueOnce(`<entities>
+<entity name="src/index.ts" type="file"/>
+<entity name="main" type="function"><property key="lang">typescript</property></entity>
+</entities>
+<relationships>
+<relationship target="main" weight="0.9" source="src/index.ts" type="uses"/>
+</relationships>`);
+
+    const result = (await sdk.trigger("mem::graph-extract", {
+      observations: [testObs],
+    })) as { success: boolean; nodesAdded: number; edgesAdded: number };
+
+    expect(result.success).toBe(true);
+    expect(result.nodesAdded).toBe(2);
+    expect(result.edgesAdded).toBe(1);
+
+    const nodes = await kv.list<GraphNode>("mem:graph:nodes");
+    expect(nodes.some((n) => n.name === "src/index.ts")).toBe(true);
+    expect(nodes.some((n) => n.name === "main")).toBe(true);
+
+    const edges = await kv.list<GraphEdge>("mem:graph:edges");
+    expect(edges).toHaveLength(1);
+    expect(edges[0].type).toBe("uses");
+  });
+
   it("graph-query with search returns matching nodes", async () => {
     await sdk.trigger("mem::graph-extract", { observations: [testObs] });
 


### PR DESCRIPTION
## Summary

This PR makes `mem::graph-extract` tolerate XML attributes in any order for both `<entity>` and `<relationship>` tags.

## Problem

The graph extraction prompt asks an LLM to return XML like this:

```xml
<entity type="file" name="src/index.ts"/>
<relationship type="uses" source="src/index.ts" target="main" weight="0.9"/>
```

The current parser accepts self-closing entity tags, but it still assumes a fixed attribute order:

- entities must be `type="..."` followed by `name="..."`
- relationships must be `type="..."`, then `source="..."`, then `target="..."`, then `weight="..."`

Real model output does not always preserve that order. For example, Qwen/OpenRouter can emit valid XML like:

```xml
<entity name="src/index.ts" type="file"/>
<relationship target="main" weight="0.9" source="src/index.ts" type="uses"/>
```

That output is semantically valid, but the parser silently drops it. The API call can return `success: true` with `nodesAdded: 0` and `edgesAdded: 0`, leaving the dashboard in the "No graph data yet" state even when `GRAPH_EXTRACTION_ENABLED=true` and the LLM provider is working.

## Fix

The parser now extracts XML attributes into a small key/value map before reading `type`, `name`, `source`, `target`, and `weight`. This keeps support for:

- explicit entity tags with properties
- self-closing entity tags
- relationship tags
- arbitrary attribute ordering

It also defaults missing relationship `weight` to the existing fallback of `0.5`, while continuing to skip malformed tags that lack required fields.

## Validation

- Added a regression test covering reordered attributes on both entity and relationship tags.
- Ran `npm test -- test/graph.test.ts`.
- Ran `npm run build`.

Both checks pass locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced XML parsing to correctly handle entity and relationship attributes regardless of their order in the document.
  * Improved graph extraction robustness by supporting multiple XML tag formats.
* **Tests**
  * Added test coverage to verify XML parsing handles attributes in any order.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/635?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->