### PR TITLE
fix: guard against null sessionIds on Memory objects

### DIFF
--- a/src/functions/export-import.ts
+++ b/src/functions/export-import.ts
@@ -375,6 +375,9 @@ export function registerExportImportFunction(sdk: ISdk, kv: StateKV): void {
             continue;
           }
         }
+        if (!Array.isArray(memory.sessionIds)) {
+          memory.sessionIds = [];
+        }
         await kv.set(KV.memories, memory.id, memory);
         stats.memories++;
       }

--- a/src/functions/remember.ts
+++ b/src/functions/remember.ts
@@ -114,7 +114,7 @@ export function registerRememberFunction(sdk: ISdk, kv: StateKV): void {
         }
         await vectorIndexAddGuarded(
           memory.id,
-          memory.sessionIds[0] ?? "memory",
+          (memory.sessionIds ?? [])[0] ?? "memory",
           memory.title + " " + memory.content,
           { kind: "memory", logId: memory.id },
         );

--- a/src/functions/search.ts
+++ b/src/functions/search.ts
@@ -223,7 +223,7 @@ export async function rebuildIndex(kv: StateKV): Promise<number> {
       idx.add(memoryToObservation(memory))
       await enqueue({
         id: memory.id,
-        sessionId: memory.sessionIds[0] ?? 'memory',
+        sessionId: (memory.sessionIds ?? [])[0] ?? 'memory',
         text: memory.title + ' ' + memory.content,
         context: { kind: "memory", logId: memory.id },
       })

--- a/src/state/memory-utils.ts
+++ b/src/state/memory-utils.ts
@@ -11,7 +11,7 @@ import type { CompressedObservation, Memory } from "../types.js";
 export function memoryToObservation(memory: Memory): CompressedObservation {
   return {
     id: memory.id,
-    sessionId: memory.sessionIds[0] ?? "memory",
+    sessionId: (memory.sessionIds ?? [])[0] ?? "memory",
     timestamp: memory.createdAt,
     type: "decision",
     title: memory.title,


### PR DESCRIPTION
## Problem

`memory.sessionIds[0]` crashes at runtime when `sessionIds` is `null` or `undefined`. This happens when Memory objects are loaded from KV store via import, migration, or corrupted data — the TypeScript type declares `sessionIds: string[]` but runtime doesn't enforce this.

**Error:**
```
TypeError: Cannot read properties of null (reading '0')
```

## Root Cause

`mem::import` writes memory objects directly to KV without normalizing the `sessionIds` field. External data or older export formats may have `sessionIds: null` instead of `sessionIds: []`.

## Fix

Two-pronged approach:

1. **Defensive guards** at all 3 direct access points using `(memory.sessionIds ?? [])[0] ?? "memory"` pattern
2. **Root cause prevention** — normalize `sessionIds` during import to prevent null from persisting in the KV store

## Changed Files

| File | Change |
|------|--------|
| `src/state/memory-utils.ts` | Guard in `memoryToObservation()` |
| `src/functions/search.ts` | Guard in `rebuildIndex()` |
| `src/functions/remember.ts` | Guard in `vectorIndexAddGuarded` call |
| `src/functions/export-import.ts` | Normalize `sessionIds` during import |

## Testing

- Build passes (`npm run build`)
- All existing tests pass (7 pre-existing failures in embedding-provider tests unrelated to this change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of data import to normalize missing session IDs and avoid errors with incomplete or legacy data.
  * Enhanced defensive handling of session identifiers across memory, search, and indexing flows to prevent failures when session info is absent.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/644?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->