### PR TITLE
fix(tier1): install ERESOLVE + non-OpenAI base URL + bridge path

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.142",
-    "@anthropic-ai/sdk": "^0.39.0",
+    "@anthropic-ai/sdk": "^0.93.0",
     "@clack/prompts": "^1.2.0",
     "dotenv": "^17.4.2",
     "iii-sdk": "0.11.2",

--- a/src/config.ts
+++ b/src/config.ts
@@ -216,13 +216,19 @@ export function loadClaudeBridgeConfig(): ClaudeBridgeConfig {
   const lineBudget = safeParseInt(env["CLAUDE_MEMORY_LINE_BUDGET"], 200);
   let memoryFilePath = "";
   if (enabled && projectPath) {
-    const safePath = projectPath.replace(/[/\\]/g, "-").replace(/^-/, "");
+    // #625: Claude Code stores MEMORY.md at
+    //   ~/.claude/projects/<slug>/MEMORY.md
+    // where <slug> is the project path with `/` and `\` swapped for `-`.
+    // The leading `-` from an absolute POSIX path is preserved (Claude
+    // Code keeps it; stripping it produced a slug Claude never reads).
+    // There's also no `memory/` subdirectory — the file sits directly
+    // under the slug dir.
+    const safePath = projectPath.replace(/[/\\]/g, "-");
     memoryFilePath = join(
       homedir(),
       ".claude",
       "projects",
       safePath,
-      "memory",
       "MEMORY.md",
     );
   }

--- a/src/providers/_openai-shared.ts
+++ b/src/providers/_openai-shared.ts
@@ -87,6 +87,34 @@ function v1AzureUrl(baseUrl: string, path: string): string {
   return url.toString();
 }
 
+// Append an OpenAI-compatible route to the base URL without producing
+// a doubled version segment. Three cases:
+//
+//   1. Empty path (just a hostname) — OpenAI default: prepend `/v1/`.
+//        https://api.openai.com → https://api.openai.com/v1/chat/completions
+//   2. Path already ends with `/v1` — provider-documented base, treat
+//      it as the version anchor and append the route directly.
+//        https://api.deepseek.com/v1 → https://api.deepseek.com/v1/chat/completions
+//        (without this, we'd produce /v1/v1/chat/completions and 404. #628)
+//   3. Path ends with any other versioned or path segment — provider
+//      uses a non-OpenAI version scheme (Zhipu /api/paas/v4, others) —
+//      append the route directly, no `/v1/` injected.
+//        https://open.bigmodel.cn/api/paas/v4 → .../v4/chat/completions  (#646)
+function appendOpenAIRoute(baseUrl: string, route: string): string {
+  const trimmedBase = baseUrl.replace(/\/+$/, "");
+  const cleanRoute = route.startsWith("/") ? route : `/${route}`;
+  let pathname: string;
+  try {
+    pathname = new URL(trimmedBase).pathname.replace(/\/+$/, "");
+  } catch {
+    return `${trimmedBase}/v1${cleanRoute}`;
+  }
+  if (pathname === "" || pathname === "/") {
+    return `${trimmedBase}/v1${cleanRoute}`;
+  }
+  return `${trimmedBase}${cleanRoute}`;
+}
+
 export function buildChatUrl(
   baseUrl: string,
   isAzure: boolean,
@@ -97,7 +125,7 @@ export function buildChatUrl(
       ? legacyAzureUrl(baseUrl, "/chat/completions", azureApiVersion)
       : v1AzureUrl(baseUrl, "/chat/completions");
   }
-  return `${baseUrl}/v1/chat/completions`;
+  return appendOpenAIRoute(baseUrl, "/chat/completions");
 }
 
 export function buildEmbeddingUrl(
@@ -110,7 +138,7 @@ export function buildEmbeddingUrl(
       ? legacyAzureUrl(baseUrl, "/embeddings", azureApiVersion)
       : v1AzureUrl(baseUrl, "/embeddings");
   }
-  return `${baseUrl}/v1/embeddings`;
+  return appendOpenAIRoute(baseUrl, "/embeddings");
 }
 
 // Azure key-auth uses `api-key: <KEY>`; standard OpenAI-compatible

--- a/test/claude-bridge-path.test.ts
+++ b/test/claude-bridge-path.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { loadClaudeBridgeConfig } from "../src/config.js";
+
+// #625: bridge path must match Claude Code's slug convention exactly:
+//   ~/.claude/projects/<slug>/MEMORY.md
+// where <slug> replaces every / and \ with - and KEEPS any leading -.
+// The previous code stripped the leading - and added a /memory/
+// subdirectory; the bridge then wrote a file Claude Code never read.
+describe("loadClaudeBridgeConfig path (#625)", () => {
+  const ORIG_ENV = { ...process.env };
+  beforeEach(() => {
+    delete process.env["CLAUDE_MEMORY_BRIDGE"];
+    delete process.env["CLAUDE_PROJECT_PATH"];
+    delete process.env["CLAUDE_MEMORY_LINE_BUDGET"];
+  });
+  afterEach(() => {
+    process.env = { ...ORIG_ENV };
+  });
+
+  it("preserves leading - on POSIX absolute paths", () => {
+    process.env["CLAUDE_MEMORY_BRIDGE"] = "true";
+    process.env["CLAUDE_PROJECT_PATH"] = "/home/user/repos/my-project";
+    const cfg = loadClaudeBridgeConfig();
+    expect(cfg.memoryFilePath).toBe(
+      join(homedir(), ".claude", "projects", "-home-user-repos-my-project", "MEMORY.md"),
+    );
+  });
+
+  it("writes MEMORY.md directly under the slug dir, no memory/ subdir", () => {
+    process.env["CLAUDE_MEMORY_BRIDGE"] = "true";
+    process.env["CLAUDE_PROJECT_PATH"] = "/Users/x/agentmemory";
+    const cfg = loadClaudeBridgeConfig();
+    expect(cfg.memoryFilePath).not.toMatch(/[/\\]memory[/\\]MEMORY\.md$/);
+    expect(cfg.memoryFilePath).toMatch(/-Users-x-agentmemory[/\\]MEMORY\.md$/);
+  });
+
+  it("returns empty memoryFilePath when bridge disabled", () => {
+    const cfg = loadClaudeBridgeConfig();
+    expect(cfg.enabled).toBe(false);
+    expect(cfg.memoryFilePath).toBe("");
+  });
+
+  it("returns empty memoryFilePath when project path unset", () => {
+    process.env["CLAUDE_MEMORY_BRIDGE"] = "true";
+    const cfg = loadClaudeBridgeConfig();
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.memoryFilePath).toBe("");
+  });
+
+  it("handles Windows-style backslash paths by swapping to -", () => {
+    process.env["CLAUDE_MEMORY_BRIDGE"] = "true";
+    process.env["CLAUDE_PROJECT_PATH"] = "C:\\Users\\x\\project";
+    const cfg = loadClaudeBridgeConfig();
+    expect(cfg.memoryFilePath).toMatch(/C:-Users-x-project[/\\]MEMORY\.md$/);
+  });
+});

--- a/test/openai-shared.test.ts
+++ b/test/openai-shared.test.ts
@@ -150,6 +150,49 @@ describe("_openai-shared — buildEmbeddingUrl", () => {
   });
 });
 
+describe("_openai-shared — non-OpenAI base URLs (#628, #646)", () => {
+  it("does not double /v1 when base URL already ends with /v1 (DeepSeek shape, #628)", () => {
+    expect(
+      buildChatUrl("https://api.deepseek.com/v1", false, "2024-08-01-preview"),
+    ).toBe("https://api.deepseek.com/v1/chat/completions");
+    expect(
+      buildEmbeddingUrl("https://api.deepseek.com/v1", false, "2024-08-01-preview"),
+    ).toBe("https://api.deepseek.com/v1/embeddings");
+  });
+
+  it("does not inject /v1 when provider uses non-OpenAI version segment (Zhipu /api/paas/v4, #646)", () => {
+    expect(
+      buildChatUrl(
+        "https://open.bigmodel.cn/api/paas/v4",
+        false,
+        "2024-08-01-preview",
+      ),
+    ).toBe("https://open.bigmodel.cn/api/paas/v4/chat/completions");
+    expect(
+      buildEmbeddingUrl(
+        "https://open.bigmodel.cn/api/paas/v4",
+        false,
+        "2024-08-01-preview",
+      ),
+    ).toBe("https://open.bigmodel.cn/api/paas/v4/embeddings");
+  });
+
+  it("tolerates trailing slash on already-versioned base", () => {
+    expect(
+      buildChatUrl("https://api.deepseek.com/v1/", false, "2024-08-01-preview"),
+    ).toBe("https://api.deepseek.com/v1/chat/completions");
+  });
+
+  it("handles localhost OpenAI-compatible servers with explicit /v1", () => {
+    expect(
+      buildChatUrl("http://localhost:11434/v1", false, "2024-08-01-preview"),
+    ).toBe("http://localhost:11434/v1/chat/completions");
+    expect(
+      buildChatUrl("http://localhost:8000/v1", false, "2024-08-01-preview"),
+    ).toBe("http://localhost:8000/v1/chat/completions");
+  });
+});
+
 describe("_openai-shared — buildAuthHeaders", () => {
   it("emits Authorization: Bearer for standard OpenAI", () => {
     expect(buildAuthHeaders("sk-test", false)).toEqual({


### PR DESCRIPTION
## Summary

Three user-blocking bugs fixed in one PR. All three keep users from installing or using agentmemory today on common provider configs. 1146/1146 vitest pass.

| Issue | Symptom | Fix |
|---|---|---|
| **#631** | `npm install -g @agentmemory/agentmemory@0.9.21` prints ERESOLVE warning every time | Bump `@anthropic-ai/sdk` from `^0.39.0` to `^0.93.0` |
| **#646 / #628** | DeepSeek, SiliconFlow, Zhipu, vLLM, LM Studio, Ollama all silent-404 on embed + chat | Smart base URL handling — don't blindly inject `/v1/` |
| **#625** | `CLAUDE_MEMORY_BRIDGE` wrote `MEMORY.md` to a path Claude Code never reads → bridge silently broken since v0.4.0 | Match Claude Code slug convention exactly |

## #631 — install ERESOLVE

`claude-agent-sdk@^0.3.142` declares `peerDependencies: { "@anthropic-ai/sdk": ">=0.93.0" }`. We pinned `@anthropic-ai/sdk@^0.39.0` → npm prints `ERESOLVE overriding peer dependency` on every install. `AnthropicProvider` only uses `messages.create` which is API-stable since v0.3x, so the bump is drop-in. Verified clean install in `/tmp/am-eresolve-test/` with only the published `dependencies` block.

## #646 + #628 — non-OpenAI base URL

`buildChatUrl` and `buildEmbeddingUrl` previously did:

```ts
return `${baseUrl}/v1/chat/completions`;
```

This breaks on:
- **DeepSeek / SiliconFlow / vLLM / LM Studio / Ollama**: `OPENAI_BASE_URL=.../v1` → `.../v1/v1/chat/completions` → silent 404
- **Zhipu (智谱 GLM)**: `OPENAI_BASE_URL=.../api/paas/v4` → `.../api/paas/v4/v1/embeddings` → silent 404

New `appendOpenAIRoute()`:
- Empty path → `/v1/<route>` (OpenAI default unchanged)
- Path ends with `/v1` → append `<route>` directly
- Path has any non-empty segment → append `<route>` directly, no `/v1` injection

Azure paths unchanged — they have their own builders.

## #625 — CLAUDE_MEMORY_BRIDGE

`loadClaudeBridgeConfig()` was producing `~/.claude/projects/home-user-repos-my-project/memory/MEMORY.md` but Claude Code reads from `~/.claude/projects/-home-user-repos-my-project/MEMORY.md`. Two bugs:

1. **Leading `-` stripped**: Old code did `.replace(/^-/, "")`. Claude Code keeps the leading dash.
2. **Extra `memory/` subdir**: Old code added a `memory/` directory under the slug. Claude Code stores `MEMORY.md` directly under the slug.

Verified the convention by listing my local `~/.claude/projects/` — every entry has the leading `-` and stores `MEMORY.md` at the top level.

## Test plan

- [x] `npm test` — 1146/1146 pass (105 files); +10 new tests across `openai-shared.test.ts` (#646/#628) and `claude-bridge-path.test.ts` (#625)
- [x] `npm run build` — 21 files, 2450 KB
- [x] `npm install` in clean dir with only the published dependencies block: no ERESOLVE
- [x] Verified `~/.claude/projects/` slug convention on macOS — leading `-` preserved, no `memory/` subdir
- [x] No PR merges or contributor PRs touched — all fixes original

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of OpenAI-compatible API endpoints to prevent incorrect path construction.

* **Bug Fixes**
  * Fixed Claude bridge memory file path generation to properly handle project paths and directory structure.

* **Chores**
  * Updated Anthropic SDK dependency to the latest version.

* **Tests**
  * Added comprehensive test coverage for path handling and OpenAI-compatible endpoint configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/649?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->