### PR TITLE
Add Copilot CLI connect wiring and hook compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,17 @@ agentmemory connect codex --with-hooks
 
 This adds an idempotent block to `~/.codex/hooks.json` referencing absolute paths to the bundled scripts (no `${CLAUDE_PLUGIN_ROOT}` expansion needed at user-scope). Re-run the same command after upgrading agentmemory to refresh paths. User entries in the same file are preserved; only previous agentmemory entries are replaced.
 
+### GitHub Copilot CLI
+
+```bash
+npm install -g @agentmemory/agentmemory
+agentmemory                            # start server
+agentmemory connect copilot-cli        # wire hooks + MCP
+# restart copilot so it picks up the new hooks
+```
+
+Copilot reloads hooks only on process start, so wiring changes do not apply to already-running sessions. For customization details, see the official hooks docs: https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/use-hooks.
+
 <details>
 <summary><b>OpenClaw (paste this prompt)</b></summary>
 
@@ -536,6 +547,7 @@ The agentmemory entry is the **same MCP server block** across every host that us
 | **OpenClaw** | OpenClaw MCP config | Same `mcpServers` block, or use the deeper [memory plugin](integrations/openclaw/). |
 | **Codex CLI (MCP only)** | `.codex/config.toml` | TOML shape: `codex mcp add agentmemory -- npx -y @agentmemory/mcp`, or add `[mcp_servers.agentmemory]` manually. |
 | **Codex CLI (full plugin)** | Codex plugin marketplace | `codex plugin marketplace add rohitg00/agentmemory` then `codex plugin add agentmemory@agentmemory`. Registers MCP + 6 lifecycle hooks (SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, PreCompact, Stop) + 4 skills. On Codex Desktop, also run `agentmemory connect codex --with-hooks` until [openai/codex#16430](https://github.com/openai/codex/issues/16430) lands — plugin hooks are currently silent there. |
+| **Copilot CLI** | `~/.copilot/hooks/agentmemory.json` + `~/.copilot/mcp-config.json` | Use `agentmemory connect copilot-cli`. Restart `copilot` after connect/remove so hook changes load. |
 | **OpenCode (MCP only)** | `opencode.json` | Different shape — top-level `mcp` key, command as array: `{"mcp": {"agentmemory": {"type": "local", "command": ["npx", "-y", "@agentmemory/mcp"], "enabled": true}}}`. |
 | **OpenCode (full plugin)** | `plugin/opencode/` | 22 auto-capture hooks covering session lifecycle, messages, tools, errors. Two slash commands (`/recall`, `/remember`). Copy `plugin/opencode/` into your OpenCode workspace and add the plugin entry to `opencode.json`. See [`plugin/opencode/README.md`](plugin/opencode/README.md) for the full hook table + gap analysis. |
 | **pi** | `~/.pi/agent/extensions/agentmemory` | Copy [`integrations/pi`](integrations/pi/) and restart pi. |

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "./package.json": "./package.json"
   },
   "bin": {
-    "agentmemory": "dist/cli.mjs"
+    "agentmemory": "dist/cli.mjs",
+    "agentmemory-hook": "dist/hook-shim.mjs"
   },
   "scripts": {
     "build": "tsdown && (cp iii-config.yaml dist/ 2>/dev/null || true) && (cp iii-config.docker.yaml dist/ 2>/dev/null || true) && (cp docker-compose.yml dist/ 2>/dev/null || true) && (cp .env.example dist/ 2>/dev/null || true) && mkdir -p dist/viewer && cp src/viewer/index.html dist/viewer/ && cp src/viewer/favicon.svg dist/viewer/",

--- a/plugin/.copilot-plugin/plugin.json
+++ b/plugin/.copilot-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "agentmemory",
+  "version": "0.9.21",
+  "description": "Persistent memory for AI coding agents -- captures tool usage, compresses via LLM, injects context into future sessions. 11 hooks, 51 MCP tools, 4 skills, real-time viewer.",
+  "author": {
+    "name": "Rohit Ghumare",
+    "url": "https://github.com/rohitg00"
+  },
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/rohitg00/agentmemory",
+  "repository": "https://github.com/rohitg00/agentmemory",
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "hooks": "./hooks/hooks.copilot.json"
+}

--- a/plugin/hooks/hooks.copilot.json
+++ b/plugin/hooks/hooks.copilot.json
@@ -1,0 +1,97 @@
+{
+  "version": 1,
+  "hooks": {
+    "SessionStart": [
+      {
+        "type": "command",
+        "bash": "agentmemory-hook session-start",
+        "powershell": "agentmemory-hook session-start",
+        "env": {
+          "AGENTMEMORY_INJECT_CONTEXT": "true"
+        },
+        "timeoutSec": 10
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "type": "command",
+        "bash": "agentmemory-hook prompt-submit",
+        "powershell": "agentmemory-hook prompt-submit",
+        "timeoutSec": 10
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "edit|create|view|glob|grep",
+        "type": "command",
+        "bash": "agentmemory-hook pre-tool-use",
+        "powershell": "agentmemory-hook pre-tool-use",
+        "timeoutSec": 5
+      }
+    ],
+    "PostToolUse": [
+      {
+        "type": "command",
+        "bash": "agentmemory-hook post-tool-use",
+        "powershell": "agentmemory-hook post-tool-use",
+        "timeoutSec": 5
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "type": "command",
+        "bash": "agentmemory-hook post-tool-failure",
+        "powershell": "agentmemory-hook post-tool-failure",
+        "timeoutSec": 5
+      }
+    ],
+    "PreCompact": [
+      {
+        "type": "command",
+        "bash": "agentmemory-hook pre-compact",
+        "powershell": "agentmemory-hook pre-compact",
+        "timeoutSec": 5
+      }
+    ],
+    "SubagentStart": [
+      {
+        "type": "command",
+        "bash": "agentmemory-hook subagent-start",
+        "powershell": "agentmemory-hook subagent-start",
+        "timeoutSec": 5
+      }
+    ],
+    "SubagentStop": [
+      {
+        "type": "command",
+        "bash": "agentmemory-hook subagent-stop",
+        "powershell": "agentmemory-hook subagent-stop",
+        "timeoutSec": 5
+      }
+    ],
+    "Notification": [
+      {
+        "type": "command",
+        "bash": "agentmemory-hook notification",
+        "powershell": "agentmemory-hook notification",
+        "timeoutSec": 5
+      }
+    ],
+    "Stop": [
+      {
+        "type": "command",
+        "bash": "agentmemory-hook stop",
+        "powershell": "agentmemory-hook stop",
+        "timeoutSec": 10
+      }
+    ],
+    "SessionEnd": [
+      {
+        "type": "command",
+        "bash": "agentmemory-hook session-end",
+        "powershell": "agentmemory-hook session-end",
+        "timeoutSec": 10
+      }
+    ]
+  }
+}

--- a/plugin/scripts/post-tool-use.mjs
+++ b/plugin/scripts/post-tool-use.mjs
@@ -1,4 +1,14 @@
 #!/usr/bin/env node
+import { fileURLToPath } from "node:url";
+
+//#region src/hooks/post-tool-use-util.ts
+function pickRawToolOutput(data) {
+	const toolResult = data.tool_result;
+	if (toolResult && typeof toolResult === "object" && "text_result_for_llm" in toolResult) return toolResult.text_result_for_llm;
+	return data.tool_response ?? data.tool_output;
+}
+
+//#endregion
 //#region src/hooks/post-tool-use.ts
 function isSdkChildContext(payload) {
 	if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -23,7 +33,7 @@ async function main() {
 	}
 	if (isSdkChildContext(data)) return;
 	const sessionId = data.session_id || "unknown";
-	const { imageData, cleanOutput } = extractImageData(data.tool_response ?? data.tool_output);
+	const { imageData, cleanOutput } = extractImageData(pickRawToolOutput(data));
 	try {
 		await fetch(`${REST_URL}/agentmemory/observe`, {
 			method: "POST",
@@ -80,7 +90,7 @@ function truncate(value, max) {
 	}
 	return value;
 }
-main();
+if (process.argv[1] === fileURLToPath(import.meta.url)) main();
 
 //#endregion
 export {  };

--- a/plugin/scripts/session-start.mjs
+++ b/plugin/scripts/session-start.mjs
@@ -15,6 +15,13 @@ function authHeaders() {
 	if (SECRET) h["Authorization"] = `Bearer ${SECRET}`;
 	return h;
 }
+function isConnectionRefused(err) {
+	if (!(err instanceof Error)) return false;
+	return (typeof err.cause === "object" && err.cause !== null && "code" in err.cause ? String(err.cause["code"] ?? "") : "") === "ECONNREFUSED" || err.message.includes("ECONNREFUSED");
+}
+function logServerHint() {
+	process.stderr.write(`agentmemory: server not reachable at ${REST_URL}. Start it with: agentmemory\n`);
+}
 async function main() {
 	let input = "";
 	for await (const chunk of process.stdin) input += chunk;
@@ -41,7 +48,9 @@ async function main() {
 		fetch(url, {
 			...init,
 			signal: AbortSignal.timeout(REGISTER_TIMEOUT_MS)
-		}).catch(() => {});
+		}).catch((err) => {
+			if (isConnectionRefused(err)) logServerHint();
+		});
 		return;
 	}
 	try {
@@ -53,7 +62,9 @@ async function main() {
 			const result = await res.json();
 			if (result.context) process.stdout.write(result.context);
 		}
-	} catch {}
+	} catch (err) {
+		if (isConnectionRefused(err)) logServerHint();
+	}
 }
 main();
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -118,7 +118,7 @@ Commands:
   (default)          Start agentmemory worker
   init               Copy bundled .env.example to ~/.agentmemory/.env if absent
   connect [agent]    Wire agentmemory into an installed agent (claude-code, codex,
-                     cursor, gemini-cli, openclaw, hermes, pi, openhuman).
+                     copilot-cli, cursor, gemini-cli, openclaw, hermes, pi, openhuman).
                      No arg = interactive picker. --all wires every detected agent.
                      --dry-run shows what would change. --force re-installs.
   status             Show connection status, memory count, flags, and health

--- a/src/cli/connect/copilot-cli.ts
+++ b/src/cli/connect/copilot-cli.ts
@@ -1,0 +1,224 @@
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import * as p from "@clack/prompts";
+import type { ConnectAdapter, ConnectOptions, ConnectResult } from "./types.js";
+import {
+  AGENTMEMORY_MCP_BLOCK,
+  backupFile,
+  logAlreadyWired,
+  logBackup,
+  logInstalled,
+  readJsonSafe,
+  writeJsonAtomic,
+} from "./util.js";
+import { findPluginRoot } from "./codex-hooks.js";
+
+type CopilotHookCommand = {
+  type: "command";
+  matcher?: string;
+  bash: string;
+  powershell: string;
+  env?: Record<string, string>;
+  timeoutSec?: number;
+};
+
+type CopilotHooksConfig = {
+  version: 1;
+  hooks: Record<string, CopilotHookCommand[]>;
+  disableAllHooks?: boolean;
+};
+
+type CopilotMcpConfig = {
+  mcpServers?: Record<string, typeof AGENTMEMORY_MCP_BLOCK>;
+  [key: string]: unknown;
+};
+
+function copilotHome(): string {
+  return process.env["COPILOT_HOME"] || join(homedir(), ".copilot");
+}
+
+function hooksPath(): string {
+  return join(copilotHome(), "hooks", "agentmemory.json");
+}
+
+function mcpConfigPath(): string {
+  return join(copilotHome(), "mcp-config.json");
+}
+
+function entryMatches(entry: unknown): boolean {
+  if (!entry || typeof entry !== "object") return false;
+  const e = entry as Record<string, unknown>;
+  if (e["command"] !== "npx") return false;
+  const args = Array.isArray(e["args"]) ? (e["args"] as string[]) : [];
+  return args.includes("@agentmemory/mcp");
+}
+
+function loadTemplateHooks(pluginRoot: string): CopilotHooksConfig {
+  const templatePath = join(pluginRoot, "hooks", "hooks.copilot.json");
+  return JSON.parse(readFileSync(templatePath, "utf-8")) as CopilotHooksConfig;
+}
+
+function normalizeAbsoluteCommands(
+  hooks: CopilotHooksConfig,
+  pluginRoot: string,
+): CopilotHooksConfig {
+  const scriptsDir = join(pluginRoot, "scripts").replace(/\\/g, "/");
+  const next: CopilotHooksConfig = {
+    version: hooks.version,
+    hooks: {},
+    ...(hooks.disableAllHooks !== undefined
+      ? { disableAllHooks: hooks.disableAllHooks }
+      : {}),
+  };
+  for (const [event, commands] of Object.entries(hooks.hooks)) {
+    next.hooks[event] = commands.map((command) => {
+      const match = command.bash.match(/^agentmemory-hook\s+([a-z0-9-]+)$/);
+      if (!match) return command;
+      const name = match[1]!;
+      const absolute = `node "${scriptsDir}/${name}.mjs"`;
+      return { ...command, bash: absolute, powershell: absolute };
+    });
+  }
+  return next;
+}
+
+function preserveDisableAllHooks(
+  existing: CopilotHooksConfig | null,
+  next: CopilotHooksConfig,
+): CopilotHooksConfig {
+  if (existing && typeof existing.disableAllHooks === "boolean") {
+    return { ...next, disableAllHooks: existing.disableAllHooks };
+  }
+  return next;
+}
+
+export const adapter: ConnectAdapter = {
+  name: "copilot-cli",
+  displayName: "GitHub Copilot CLI",
+  docs: "https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/use-hooks",
+  protocolNote:
+    "→ Using hooks + MCP. Hook events capture observations and MCP exposes interactive memory tools.",
+
+  detect(): boolean {
+    return true;
+  },
+
+  async install(opts: ConnectOptions): Promise<ConnectResult> {
+    const targetHooksPath = hooksPath();
+    const targetMcpPath = mcpConfigPath();
+
+    if (opts.remove) {
+      return removeCopilotWiring(targetHooksPath, targetMcpPath, opts);
+    }
+
+    const pluginRoot = findPluginRoot();
+    const template = loadTemplateHooks(pluginRoot);
+    const maybeAbsolute = opts.withShimAbsolute
+      ? normalizeAbsoluteCommands(template, pluginRoot)
+      : template;
+
+    const existingHooks = readJsonSafe<CopilotHooksConfig>(targetHooksPath);
+    const desiredHooks = preserveDisableAllHooks(existingHooks, maybeAbsolute);
+    const existingMcp = readJsonSafe<CopilotMcpConfig>(targetMcpPath);
+    const alreadyHasMcp = entryMatches(existingMcp?.mcpServers?.["agentmemory"]);
+    const alreadyHasHooks =
+      JSON.stringify(existingHooks) === JSON.stringify(desiredHooks);
+
+    if (alreadyHasMcp && alreadyHasHooks && !opts.force) {
+      logAlreadyWired("GitHub Copilot CLI", targetHooksPath);
+      return { kind: "already-wired", mutatedPath: targetHooksPath };
+    }
+
+    if (opts.dryRun) {
+      p.log.info(
+        `[dry-run] Would ${alreadyHasHooks ? "refresh" : "write"} ${targetHooksPath}`,
+      );
+      p.log.info(
+        `[dry-run] Would ${alreadyHasMcp ? "refresh" : "merge"} mcpServers.agentmemory in ${targetMcpPath}`,
+      );
+      return { kind: "installed", mutatedPath: targetHooksPath };
+    }
+
+    mkdirSync(join(copilotHome(), "hooks"), { recursive: true });
+
+    if (existsSync(targetHooksPath)) {
+      const backup = backupFile(targetHooksPath, "copilot-hooks", "json");
+      logBackup(backup);
+    }
+    if (existsSync(targetMcpPath)) {
+      const backup = backupFile(targetMcpPath, "copilot-mcp", "json");
+      logBackup(backup);
+    }
+
+    writeJsonAtomic(targetHooksPath, desiredHooks);
+    const nextMcp: CopilotMcpConfig = existingMcp ? { ...existingMcp } : {};
+    const servers = {
+      ...((nextMcp.mcpServers as Record<string, typeof AGENTMEMORY_MCP_BLOCK>) ??
+        {}),
+    };
+    servers["agentmemory"] = AGENTMEMORY_MCP_BLOCK;
+    nextMcp.mcpServers = servers;
+    writeJsonAtomic(targetMcpPath, nextMcp);
+
+    const verifyHooks = readJsonSafe<CopilotHooksConfig>(targetHooksPath);
+    const verifyMcp = readJsonSafe<CopilotMcpConfig>(targetMcpPath);
+    if (!verifyHooks || !entryMatches(verifyMcp?.mcpServers?.["agentmemory"])) {
+      return { kind: "skipped", reason: "verification-failed" };
+    }
+
+    logInstalled("GitHub Copilot CLI hooks", targetHooksPath);
+    logInstalled("GitHub Copilot CLI MCP", targetMcpPath);
+    p.log.success(
+      "✅ Wired agentmemory into Copilot CLI. Restart `copilot` for hooks to take effect.",
+    );
+    return { kind: "installed", mutatedPath: targetHooksPath };
+  },
+};
+
+function removeCopilotWiring(
+  targetHooksPath: string,
+  targetMcpPath: string,
+  opts: ConnectOptions,
+): ConnectResult {
+  const hadHooks = existsSync(targetHooksPath);
+  const existingMcp = readJsonSafe<CopilotMcpConfig>(targetMcpPath);
+  const hadMcp = entryMatches(existingMcp?.mcpServers?.["agentmemory"]);
+
+  if (!hadHooks && !hadMcp) {
+    p.log.info("GitHub Copilot CLI: no existing agentmemory wiring found.");
+    return { kind: "removed", mutatedPath: targetHooksPath };
+  }
+
+  if (opts.dryRun) {
+    if (hadHooks) p.log.info(`[dry-run] Would remove ${targetHooksPath}`);
+    if (hadMcp) {
+      p.log.info(
+        `[dry-run] Would remove mcpServers.agentmemory from ${targetMcpPath}`,
+      );
+    }
+    return { kind: "removed", mutatedPath: targetHooksPath };
+  }
+
+  if (hadHooks) {
+    const backup = backupFile(targetHooksPath, "copilot-hooks", "json");
+    logBackup(backup);
+    rmSync(targetHooksPath, { force: true });
+  }
+
+  if (hadMcp && existingMcp) {
+    const backup = backupFile(targetMcpPath, "copilot-mcp", "json");
+    logBackup(backup);
+    const next = { ...existingMcp };
+    const servers = {
+      ...((next.mcpServers as Record<string, typeof AGENTMEMORY_MCP_BLOCK>) ??
+        {}),
+    };
+    delete servers["agentmemory"];
+    next.mcpServers = servers;
+    writeJsonAtomic(targetMcpPath, next);
+  }
+
+  p.log.success("Removed agentmemory wiring from GitHub Copilot CLI.");
+  return { kind: "removed", mutatedPath: targetHooksPath };
+}

--- a/src/cli/connect/index.ts
+++ b/src/cli/connect/index.ts
@@ -2,6 +2,7 @@ import { platform } from "node:os";
 import * as p from "@clack/prompts";
 import type { ConnectAdapter, ConnectOptions, ConnectResult } from "./types.js";
 import { adapter as claudeCode } from "./claude-code.js";
+import { adapter as copilotCli } from "./copilot-cli.js";
 import { adapter as codex } from "./codex.js";
 import { adapter as cursor } from "./cursor.js";
 import { adapter as geminiCli } from "./gemini-cli.js";
@@ -12,6 +13,7 @@ import { adapter as pi } from "./pi.js";
 
 export const ADAPTERS: readonly ConnectAdapter[] = [
   claudeCode,
+  copilotCli,
   codex,
   cursor,
   geminiCli,
@@ -33,23 +35,37 @@ export function knownAgents(): string[] {
 function parseFlags(args: string[]): {
   dryRun: boolean;
   force: boolean;
+  remove: boolean;
   all: boolean;
   withHooks: boolean;
+  withShimAbsolute: boolean;
   positional: string[];
 } {
   const positional: string[] = [];
   let dryRun = false;
   let force = false;
+  let remove = false;
   let all = false;
   let withHooks = false;
+  let withShimAbsolute = false;
   for (const a of args) {
     if (a === "--dry-run") dryRun = true;
     else if (a === "--force") force = true;
+    else if (a === "--remove") remove = true;
     else if (a === "--all") all = true;
     else if (a === "--with-hooks") withHooks = true;
+    else if (a === "--with-shim-absolute") withShimAbsolute = true;
     else if (!a.startsWith("-")) positional.push(a);
   }
-  return { dryRun, force, all, withHooks, positional };
+  return {
+    dryRun,
+    force,
+    remove,
+    all,
+    withHooks,
+    withShimAbsolute,
+    positional,
+  };
 }
 
 export async function runAdapter(
@@ -77,17 +93,35 @@ export async function runAdapter(
 }
 
 export async function runConnect(args: string[]): Promise<void> {
-  if (platform() === "win32") {
+  const {
+    dryRun,
+    force,
+    remove,
+    all,
+    withHooks,
+    withShimAbsolute,
+    positional,
+  } = parseFlags(args);
+  const requested = positional.map((name) => name.toLowerCase());
+  const allowWindowsCopilotOnly =
+    !all && requested.length === 1 && requested[0] === "copilot-cli";
+
+  if (platform() === "win32" && !allowWindowsCopilotOnly) {
     p.intro("agentmemory connect");
     p.log.warn(
-      "Windows: automated `connect` is not supported yet. See https://github.com/rohitg00/agentmemory#other-agents for manual install steps.",
+      "Windows: automated `connect` currently supports only `copilot-cli`. See https://github.com/rohitg00/agentmemory#other-agents for manual install steps for other agents.",
     );
     p.outro("Windows: manual install required — see docs");
     return;
   }
 
-  const { dryRun, force, all, withHooks, positional } = parseFlags(args);
-  const opts: ConnectOptions = { dryRun, force, withHooks };
+  const opts: ConnectOptions = {
+    dryRun,
+    force,
+    remove,
+    withHooks,
+    withShimAbsolute,
+  };
 
   p.intro("agentmemory connect");
 
@@ -156,6 +190,8 @@ function summarize(
     switch (result.kind) {
       case "installed":
         return `  ✓ ${name}${result.mutatedPath ? ` → ${result.mutatedPath}` : ""}`;
+      case "removed":
+        return `  ✓ ${name} (removed${result.mutatedPath ? ` → ${result.mutatedPath}` : ""})`;
       case "already-wired":
         return `  ✓ ${name} (already wired)`;
       case "stub":

--- a/src/cli/connect/types.ts
+++ b/src/cli/connect/types.ts
@@ -1,6 +1,7 @@
 export type ConnectOptions = {
   dryRun: boolean;
   force: boolean;
+  remove?: boolean;
   /**
    * When true, the Codex adapter additionally writes a global
    * `~/.codex/hooks.json` block referencing absolute paths to bundled hook
@@ -8,6 +9,12 @@ export type ConnectOptions = {
    * hooks from dispatching on Codex Desktop. No-op for other adapters.
    */
   withHooks?: boolean;
+  /**
+   * When true, adapters that install hook command manifests should write
+   * absolute `node "<path>/script.mjs"` commands instead of relying on
+   * `agentmemory-hook` being on PATH. Currently used by copilot-cli.
+   */
+  withShimAbsolute?: boolean;
 };
 
 export type ConnectAdapter = {
@@ -27,6 +34,7 @@ export type ConnectAdapter = {
 
 export type ConnectResult =
   | { kind: "installed"; mutatedPath?: string; backupPath?: string }
+  | { kind: "removed"; mutatedPath?: string }
   | { kind: "already-wired"; mutatedPath?: string }
   | { kind: "stub"; reason: string }
   | { kind: "skipped"; reason: string };

--- a/src/hook-shim.ts
+++ b/src/hook-shim.ts
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { dirname, join } from "node:path";
+
+const HOOKS = new Set([
+  "session-start",
+  "prompt-submit",
+  "pre-tool-use",
+  "post-tool-use",
+  "post-tool-failure",
+  "pre-compact",
+  "subagent-start",
+  "subagent-stop",
+  "notification",
+  "task-completed",
+  "stop",
+  "session-end",
+  "post-commit",
+]);
+
+async function main(): Promise<void> {
+  const hookName = process.argv[2];
+  if (!hookName || !HOOKS.has(hookName)) {
+    process.stderr.write(
+      `Usage: agentmemory-hook <hook-name>\nKnown hooks: ${Array.from(HOOKS).join(", ")}\n`,
+    );
+    process.exit(1);
+  }
+
+  const here = dirname(fileURLToPath(import.meta.url));
+  const hookPath = join(here, "hooks", `${hookName}.mjs`);
+  await import(pathToFileURL(hookPath).href);
+}
+
+void main();

--- a/src/hooks/post-tool-use-util.ts
+++ b/src/hooks/post-tool-use-util.ts
@@ -1,0 +1,11 @@
+export function pickRawToolOutput(data: Record<string, unknown>): unknown {
+  const toolResult = data.tool_result;
+  if (
+    toolResult &&
+    typeof toolResult === "object" &&
+    "text_result_for_llm" in toolResult
+  ) {
+    return (toolResult as { text_result_for_llm?: unknown }).text_result_for_llm;
+  }
+  return data.tool_response ?? data.tool_output;
+}

--- a/src/hooks/post-tool-use.ts
+++ b/src/hooks/post-tool-use.ts
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 
+import { fileURLToPath } from "node:url";
+import { pickRawToolOutput } from "./post-tool-use-util.js";
+
 function isSdkChildContext(payload: unknown): boolean {
   if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
   if (!payload || typeof payload !== "object") return false;
@@ -32,9 +35,7 @@ async function main() {
 
   const sessionId = (data.session_id as string) || "unknown";
 
-  const { imageData, cleanOutput } = extractImageData(
-    data.tool_response ?? data.tool_output,
-  );
+  const { imageData, cleanOutput } = extractImageData(pickRawToolOutput(data));
 
   try {
     await fetch(`${REST_URL}/agentmemory/observe`, {
@@ -57,6 +58,7 @@ async function main() {
     });
   } catch {
   }
+
 }
 
 function isBase64Image(val: unknown): val is string {
@@ -104,4 +106,6 @@ function truncate(value: unknown, max: number): unknown {
   return value;
 }
 
-main();
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  void main();
+}

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -33,6 +33,27 @@ function authHeaders(): Record<string, string> {
   return h;
 }
 
+function isConnectionRefused(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const code =
+    typeof (err as { cause?: unknown }).cause === "object" &&
+    (err as { cause?: unknown }).cause !== null &&
+    "code" in ((err as { cause?: unknown }).cause as Record<string, unknown>)
+      ? String(
+          (((err as { cause?: unknown }).cause as Record<string, unknown>)["code"] as
+            | string
+            | undefined) ?? "",
+        )
+      : "";
+  return code === "ECONNREFUSED" || err.message.includes("ECONNREFUSED");
+}
+
+function logServerHint(): void {
+  process.stderr.write(
+    `agentmemory: server not reachable at ${REST_URL}. Start it with: agentmemory\n`,
+  );
+}
+
 async function main() {
   let input = "";
   for await (const chunk of process.stdin) {
@@ -66,7 +87,9 @@ async function main() {
     fetch(url, {
       ...init,
       signal: AbortSignal.timeout(REGISTER_TIMEOUT_MS),
-    }).catch(() => {});
+    }).catch((err) => {
+      if (isConnectionRefused(err)) logServerHint();
+    });
     return;
   }
 
@@ -81,7 +104,8 @@ async function main() {
         process.stdout.write(result.context);
       }
     }
-  } catch {
+  } catch (err) {
+    if (isConnectionRefused(err)) logServerHint();
     // silently fail -- don't block Claude Code startup
   }
 }

--- a/test/cli-connect.test.ts
+++ b/test/cli-connect.test.ts
@@ -29,10 +29,11 @@ describe("agentmemory connect — dispatcher", () => {
     expect(resolveAdapter("")).toBeNull();
   });
 
-  it("ships exactly the 8 agents specified by the spec", () => {
+  it("ships exactly the 9 agents specified by the spec", () => {
     expect(knownAgents().sort()).toEqual(
       [
         "claude-code",
+        "copilot-cli",
         "codex",
         "cursor",
         "gemini-cli",
@@ -42,7 +43,7 @@ describe("agentmemory connect — dispatcher", () => {
         "pi",
       ].sort(),
     );
-    expect(ADAPTERS.length).toBe(8);
+    expect(ADAPTERS.length).toBe(9);
   });
 
   it("every adapter exposes detect() and install()", () => {
@@ -182,8 +183,89 @@ describe("agentmemory connect — claude-code adapter (mock filesystem)", () => 
     if (result.kind === "installed") {
       expect(result.backupPath).toBeDefined();
       expect(existsSync(result.backupPath!)).toBe(true);
-      expect(result.backupPath!).toContain(".agentmemory/backups");
+      expect(result.backupPath!).toMatch(/[\\\/]\.agentmemory[\\\/]backups[\\\/]/);
     }
+  });
+});
+
+describe("agentmemory connect — copilot-cli adapter (mock filesystem)", () => {
+  let tmpHome: string;
+  let originalHome: string | undefined;
+  let originalUserprofile: string | undefined;
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), "am-copilot-connect-"));
+    originalHome = process.env["HOME"];
+    originalUserprofile = process.env["USERPROFILE"];
+    process.env["HOME"] = tmpHome;
+    process.env["USERPROFILE"] = tmpHome;
+    delete process.env["COPILOT_HOME"];
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (originalHome !== undefined) process.env["HOME"] = originalHome;
+    else delete process.env["HOME"];
+    if (originalUserprofile !== undefined)
+      process.env["USERPROFILE"] = originalUserprofile;
+    else delete process.env["USERPROFILE"];
+    rmSync(tmpHome, { recursive: true, force: true });
+    vi.resetModules();
+  });
+
+  async function loadAdapter(): Promise<ConnectAdapter> {
+    const mod = await import("../src/cli/connect/copilot-cli.js?t=" + Date.now());
+    return (mod as { adapter: ConnectAdapter }).adapter;
+  }
+
+  it("install() writes both hooks and mcp config, then remove() cleans both", async () => {
+    const a = await loadAdapter();
+    const installResult = await a.install({
+      dryRun: false,
+      force: false,
+      remove: false,
+      withShimAbsolute: false,
+    });
+    expect(installResult.kind).toBe("installed");
+
+    const hooksPath = join(tmpHome, ".copilot", "hooks", "agentmemory.json");
+    const mcpPath = join(tmpHome, ".copilot", "mcp-config.json");
+    expect(existsSync(hooksPath)).toBe(true);
+    expect(existsSync(mcpPath)).toBe(true);
+
+    const hooks = JSON.parse(readFileSync(hooksPath, "utf-8"));
+    expect(hooks.version).toBe(1);
+    expect(hooks.hooks.SessionStart[0].bash).toContain("agentmemory-hook session-start");
+
+    const mcp = JSON.parse(readFileSync(mcpPath, "utf-8"));
+    expect(mcp.mcpServers.agentmemory.command).toBe("npx");
+    expect(mcp.mcpServers.agentmemory.args).toContain("@agentmemory/mcp");
+
+    const removeResult = await a.install({
+      dryRun: false,
+      force: false,
+      remove: true,
+    });
+    expect(removeResult.kind).toBe("removed");
+    expect(existsSync(hooksPath)).toBe(false);
+    const mcpAfter = JSON.parse(readFileSync(mcpPath, "utf-8"));
+    expect(mcpAfter.mcpServers.agentmemory).toBeUndefined();
+  });
+
+  it("install() with withShimAbsolute writes absolute node script commands", async () => {
+    const a = await loadAdapter();
+    const result = await a.install({
+      dryRun: false,
+      force: false,
+      withShimAbsolute: true,
+    });
+    expect(result.kind).toBe("installed");
+
+    const hooksPath = join(tmpHome, ".copilot", "hooks", "agentmemory.json");
+    const hooks = JSON.parse(readFileSync(hooksPath, "utf-8"));
+    const sessionStart = hooks.hooks.SessionStart[0];
+    expect(sessionStart.bash).toMatch(/^node ".*\/plugin\/scripts\/session-start\.mjs"$/);
+    expect(sessionStart.powershell).toBe(sessionStart.bash);
   });
 });
 

--- a/test/copilot-plugin.test.ts
+++ b/test/copilot-plugin.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const repoRoot = resolve(__dirname, "..");
+const pluginRoot = join(repoRoot, "plugin");
+
+function readJson<T = unknown>(path: string): T {
+  return JSON.parse(readFileSync(path, "utf-8")) as T;
+}
+
+describe("Copilot plugin manifest", () => {
+  it("ships .copilot-plugin/plugin.json with hooks + mcp references", () => {
+    const manifestPath = join(pluginRoot, ".copilot-plugin", "plugin.json");
+    expect(existsSync(manifestPath)).toBe(true);
+    const manifest = readJson<{
+      name: string;
+      version: string;
+      hooks: string;
+      mcpServers: string;
+      skills: string;
+    }>(manifestPath);
+    expect(manifest.name).toBe("agentmemory");
+    expect(manifest.hooks).toBe("./hooks/hooks.copilot.json");
+    expect(manifest.mcpServers).toBe("./.mcp.json");
+    expect(existsSync(join(pluginRoot, manifest.hooks))).toBe(true);
+    expect(existsSync(join(pluginRoot, manifest.mcpServers))).toBe(true);
+    expect(existsSync(join(pluginRoot, manifest.skills))).toBe(true);
+  });
+
+  it("manifest version matches package.json", () => {
+    const pkgVersion = readJson<{ version: string }>(join(repoRoot, "package.json")).version;
+    const pluginVersion = readJson<{ version: string }>(
+      join(pluginRoot, ".copilot-plugin", "plugin.json"),
+    ).version;
+    expect(pluginVersion).toBe(pkgVersion);
+  });
+});
+
+describe("Copilot hook manifest", () => {
+  it("uses versioned flat schema with command entries", () => {
+    const hooksPath = join(pluginRoot, "hooks", "hooks.copilot.json");
+    expect(existsSync(hooksPath)).toBe(true);
+    const hooks = readJson<{
+      version: number;
+      hooks: Record<
+        string,
+        Array<{
+          type: string;
+          bash: string;
+          powershell: string;
+          timeoutSec?: number;
+        }>
+      >;
+    }>(hooksPath);
+    expect(hooks.version).toBe(1);
+    expect(Object.keys(hooks.hooks)).toContain("SessionStart");
+    expect(Object.keys(hooks.hooks)).toContain("PostToolUse");
+    expect(Object.keys(hooks.hooks)).toContain("SessionEnd");
+    const all = Object.values(hooks.hooks).flat();
+    for (const hook of all) {
+      expect(hook.type).toBe("command");
+      expect(typeof hook.bash).toBe("string");
+      expect(typeof hook.powershell).toBe("string");
+      expect(hook.bash).toContain("agentmemory-hook ");
+    }
+  });
+});

--- a/test/hooks/copilot-cli.test.ts
+++ b/test/hooks/copilot-cli.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from "vitest";
+import { createServer, type IncomingMessage } from "node:http";
+import { spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+type CopilotHookManifest = {
+  hooks: Record<string, Array<{ bash: string }>>;
+};
+
+type CapturedRequest = {
+  path: string;
+  body: unknown;
+};
+
+const pluginRoot = join(import.meta.dirname, "..", "..", "plugin");
+const scriptsRoot = join(pluginRoot, "scripts");
+const hooksManifestPath = join(pluginRoot, "hooks", "hooks.copilot.json");
+
+const payloadByScript: Record<string, Record<string, unknown>> = {
+  "session-start": {
+    hook_event_name: "SessionStart",
+    session_id: "copilot-session-start",
+    cwd: "/tmp/copilot-project",
+    source: "new",
+  },
+  "prompt-submit": {
+    hook_event_name: "UserPromptSubmit",
+    session_id: "copilot-prompt-submit",
+    cwd: "/tmp/copilot-project",
+    prompt: "remember this",
+  },
+  "pre-tool-use": {
+    hook_event_name: "PreToolUse",
+    session_id: "copilot-pre-tool-use",
+    cwd: "/tmp/copilot-project",
+    tool_name: "Read",
+    tool_input: { file_path: "src/example.ts" },
+  },
+  "post-tool-use": {
+    hook_event_name: "PostToolUse",
+    session_id: "copilot-post-tool-use",
+    cwd: "/tmp/copilot-project",
+    tool_name: "Read",
+    tool_input: { file_path: "src/example.ts" },
+    tool_result: { text_result_for_llm: "copilot-tool-output" },
+  },
+  "post-tool-failure": {
+    hook_event_name: "PostToolUseFailure",
+    session_id: "copilot-post-tool-failure",
+    cwd: "/tmp/copilot-project",
+    tool_name: "Read",
+    tool_input: { file_path: "src/example.ts" },
+    error: "tool failed",
+  },
+  "pre-compact": {
+    hook_event_name: "PreCompact",
+    session_id: "copilot-pre-compact",
+    cwd: "/tmp/copilot-project",
+  },
+  "subagent-start": {
+    hook_event_name: "SubagentStart",
+    session_id: "copilot-subagent-start",
+    cwd: "/tmp/copilot-project",
+    agent_id: "a-1",
+    agent_type: "task",
+  },
+  "subagent-stop": {
+    hook_event_name: "SubagentStop",
+    session_id: "copilot-subagent-stop",
+    cwd: "/tmp/copilot-project",
+    agent_id: "a-1",
+    agent_type: "task",
+    last_assistant_message: "done",
+  },
+  notification: {
+    hook_event_name: "Notification",
+    session_id: "copilot-notification",
+    cwd: "/tmp/copilot-project",
+    notification_type: "permission_prompt",
+    title: "permission",
+    message: "allow",
+  },
+  stop: {
+    hook_event_name: "Stop",
+    session_id: "copilot-stop",
+    cwd: "/tmp/copilot-project",
+  },
+  "session-end": {
+    hook_event_name: "SessionEnd",
+    session_id: "copilot-session-end",
+    cwd: "/tmp/copilot-project",
+  },
+};
+
+const expectedPathByScript: Record<string, string> = {
+  "session-start": "/agentmemory/session/start",
+  "prompt-submit": "/agentmemory/observe",
+  "pre-tool-use": "/agentmemory/enrich",
+  "post-tool-use": "/agentmemory/observe",
+  "post-tool-failure": "/agentmemory/observe",
+  "pre-compact": "/agentmemory/context",
+  "subagent-start": "/agentmemory/observe",
+  "subagent-stop": "/agentmemory/observe",
+  notification: "/agentmemory/observe",
+  stop: "/agentmemory/summarize",
+  "session-end": "/agentmemory/session/end",
+};
+
+async function startCaptureServer(): Promise<{
+  baseUrl: string;
+  captured: CapturedRequest[];
+  close: () => Promise<void>;
+}> {
+  const captured: CapturedRequest[] = [];
+  const server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk) => chunks.push(chunk));
+    req.on("end", () => {
+      captured.push({
+        path: req.url || "",
+        body: parseJsonBody(req, Buffer.concat(chunks).toString("utf-8")),
+      });
+      const responseBody =
+        req.url === "/agentmemory/session/start" ||
+        req.url === "/agentmemory/context" ||
+        req.url === "/agentmemory/enrich"
+          ? { context: "" }
+          : { ok: true };
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(responseBody));
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("failed to start test server");
+  }
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    captured,
+    close: () => new Promise((resolve, reject) => server.close((err) => (err ? reject(err) : resolve()))),
+  };
+}
+
+function parseJsonBody(req: IncomingMessage, rawBody: string): unknown {
+  if (!rawBody) return null;
+  try {
+    return JSON.parse(rawBody) as unknown;
+  } catch {
+    throw new Error(`non-JSON body for ${req.url ?? "unknown url"}`);
+  }
+}
+
+function scriptNameFromBashCommand(command: string): string {
+  const match = command.match(/^agentmemory-hook\s+([a-z0-9-]+)$/);
+  if (!match) {
+    throw new Error(`unexpected hook command: ${command}`);
+  }
+  return match[1]!;
+}
+
+async function runHook(scriptName: string, payload: Record<string, unknown>, baseUrl: string): Promise<number | null> {
+  const scriptPath = join(scriptsRoot, `${scriptName}.mjs`);
+  return await new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [scriptPath], {
+      env: {
+        PATH: process.env["PATH"] ?? "",
+        AGENTMEMORY_URL: baseUrl,
+        AGENTMEMORY_INJECT_CONTEXT: "true",
+        CONSOLIDATION_ENABLED: "false",
+        CLAUDE_MEMORY_BRIDGE: "false",
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    child.on("error", reject);
+    child.on("close", resolve);
+    child.stdin.write(JSON.stringify(payload));
+    child.stdin.end();
+  });
+}
+
+async function waitForExpectedPath(
+  captured: CapturedRequest[],
+  path: string,
+): Promise<CapturedRequest | undefined> {
+  for (let i = 0; i < 20; i += 1) {
+    const hit = captured.find((entry) => entry.path === path);
+    if (hit) return hit;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  return undefined;
+}
+
+describe("Copilot CLI hook scripts", () => {
+  it("execute every script referenced by hooks.copilot.json and hit expected REST endpoints", async () => {
+    const manifest = JSON.parse(readFileSync(hooksManifestPath, "utf-8")) as CopilotHookManifest;
+    const scripts = Array.from(
+      new Set(
+        Object.values(manifest.hooks).flatMap((entries) =>
+          entries.map((entry) => scriptNameFromBashCommand(entry.bash)),
+        ),
+      ),
+    );
+
+    const server = await startCaptureServer();
+    try {
+      for (const script of scripts) {
+        const payload = payloadByScript[script];
+        expect(payload, `missing test payload for ${script}`).toBeDefined();
+        const beforeCount = server.captured.length;
+        const exitCode = await runHook(script, payload!, server.baseUrl);
+        expect(exitCode, `${script} should exit cleanly`).toBe(0);
+
+        const expectedPath = expectedPathByScript[script];
+        expect(expectedPath, `missing expected endpoint for ${script}`).toBeDefined();
+        const hit = await waitForExpectedPath(
+          server.captured.slice(beforeCount),
+          expectedPath!,
+        );
+        expect(hit, `${script} should call ${expectedPath}`).toBeDefined();
+      }
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("uses Copilot tool_result.text_result_for_llm in post-tool-use payload", async () => {
+    const server = await startCaptureServer();
+    try {
+      const exitCode = await runHook("post-tool-use", payloadByScript["post-tool-use"]!, server.baseUrl);
+      expect(exitCode).toBe(0);
+
+      const observeHit = await waitForExpectedPath(server.captured, "/agentmemory/observe");
+      expect(observeHit).toBeDefined();
+      const body = observeHit!.body as {
+        data?: { tool_output?: unknown };
+      };
+      expect(body.data?.tool_output).toBe("copilot-tool-output");
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/test/post-tool-use-copilot.test.ts
+++ b/test/post-tool-use-copilot.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { pickRawToolOutput } from "../src/hooks/post-tool-use-util.js";
+
+describe("post-tool-use payload compatibility", () => {
+  it("prefers Copilot's tool_result.text_result_for_llm", () => {
+    const raw = pickRawToolOutput({
+      tool_result: { text_result_for_llm: "copilot-result" },
+      tool_response: "legacy-response",
+      tool_output: "legacy-output",
+    });
+    expect(raw).toBe("copilot-result");
+  });
+
+  it("falls back to legacy tool_response/tool_output", () => {
+    expect(
+      pickRawToolOutput({
+        tool_response: "legacy-response",
+        tool_output: "legacy-output",
+      }),
+    ).toBe("legacy-response");
+
+    expect(
+      pickRawToolOutput({
+        tool_output: "legacy-output",
+      }),
+    ).toBe("legacy-output");
+  });
+});

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -48,7 +48,7 @@ export default defineConfig([
     banner: { js: "#!/usr/bin/env node" },
   },
   {
-    entry: ["src/cli.ts"],
+    entry: ["src/cli.ts", "src/hook-shim.ts"],
     outDir: "dist",
     ...shared,
     clean: false,


### PR DESCRIPTION
## Summary\n- add gentmemory connect copilot-cli adapter with install/remove and absolute shim mode\n- add Copilot hook manifest and Copilot plugin manifest\n- add gentmemory-hook shim binary and wire build entry\n- fix PostToolUse payload compatibility for Copilot 	ool_result.text_result_for_llm\n- add Copilot-focused tests for connect wiring and hook script behavior\n\n## Notes\n- includes Windows-safe test assertion for backup path separators\n- session-start now emits ECONNREFUSED server hint while still exiting successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added GitHub Copilot CLI as a new integration target
  * Added lifecycle event handlers for Copilot CLI integration
  * Improved error feedback when AgentMemory server is unreachable

* **Documentation**
  * Added GitHub Copilot CLI setup instructions

* **Tests**
  * Added test coverage for Copilot plugin integration and hook execution

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/652?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->