### PR TITLE
Fix vector index Buffer serialization

### DIFF
--- a/src/state/vector-index.ts
+++ b/src/state/vector-index.ts
@@ -1,9 +1,16 @@
 function float32ToBase64(arr: Float32Array): string {
-  return Buffer.from(arr.buffer).toString("base64");
+  return Buffer.from(arr.buffer, arr.byteOffset, arr.byteLength).toString(
+    "base64",
+  );
 }
 
 function base64ToFloat32(b64: string): Float32Array {
-  return new Float32Array(Buffer.from(b64, "base64").buffer);
+  const buf = Buffer.from(b64, "base64");
+  return new Float32Array(
+    buf.buffer,
+    buf.byteOffset,
+    buf.byteLength / Float32Array.BYTES_PER_ELEMENT,
+  );
 }
 
 function cosineSimilarity(a: Float32Array, b: Float32Array): number {

--- a/test/vector-index.test.ts
+++ b/test/vector-index.test.ts
@@ -71,6 +71,42 @@ describe("VectorIndex", () => {
     expect(results[0].sessionId).toBe("ses_1");
   });
 
+  it("preserves vector dimensions when Buffer uses a pooled ArrayBuffer", () => {
+    const embedding = new Float32Array([0.1, 0.2, 0.3]);
+    const pooled = Buffer.from(
+      Buffer.from(embedding.buffer).toString("base64"),
+      "base64",
+    );
+    expect(pooled.buffer.byteLength).toBeGreaterThan(pooled.byteLength);
+
+    const restored = VectorIndex.deserialize(
+      JSON.stringify([
+        [
+          "obs_pooled",
+          {
+            embedding: pooled.toString("base64"),
+            sessionId: "ses_1",
+          },
+        ],
+      ]),
+    );
+
+    expect(restored.validateDimensions(3).mismatches).toEqual([]);
+    expect(restored.search(embedding)[0].obsId).toBe("obs_pooled");
+  });
+
+  it("serializes only the active Float32Array slice", () => {
+    const backing = new Float32Array([99, 1, 0, 0, 99]);
+    index.add("obs_slice", "ses_1", backing.subarray(1, 4));
+
+    const restored = VectorIndex.deserialize(index.serialize());
+
+    expect(restored.validateDimensions(3).mismatches).toEqual([]);
+    expect(restored.search(new Float32Array([1, 0, 0]))[0].obsId).toBe(
+      "obs_slice",
+    );
+  });
+
   it("handles zero vectors without error", () => {
     index.add("obs_zero", "ses_1", new Float32Array([0, 0, 0]));
     const results = index.search(new Float32Array([1, 0, 0]));


### PR DESCRIPTION
## Summary

Fix vector index serialization/deserialization so persisted `Float32Array` embeddings preserve their intended byte range instead of using the entire backing `ArrayBuffer`.

## Why

`Buffer.from(arr.buffer)` serializes the entire backing buffer, ignoring `Float32Array.byteOffset` and `byteLength`. Similarly, `new Float32Array(Buffer.from(b64, "base64").buffer)` can read the entire pooled Buffer backing store instead of just the decoded bytes.

In a live AgentMemory instance this caused a rebuilt 384-dimension local embedding index to be persisted, then rejected on restart as 2048-dimensional vectors:

```text
Refusing to start: persisted vector index has 6471 of 6471 vectors with the wrong dimension.
Active provider (local) declares 384; dimensions seen on disk: 2048.
```

The service then refused to start until the installed package was patched locally or the vector index was discarded.

## Changes

- Serialize only the active `Float32Array` byte range.
- Deserialize using the decoded Buffer's `byteOffset` and `byteLength`.
- Add regression tests for pooled Buffer-backed deserialization and sliced Float32Array serialization.

## Verification

```bash
npx vitest run test/vector-index.test.ts test/index-persistence.test.ts
npm run build
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed vector embedding serialization and deserialization to correctly handle array slices, ensuring data integrity when working with vector indices.

* **Tests**
  * Added test cases to verify vector embedding serialization preserves dimensions and search functionality after deserialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/653?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->