### PR TITLE
feat(viewer): add timeline sort toggle

### DIFF
--- a/src/viewer/index.html
+++ b/src/viewer/index.html
@@ -367,6 +367,10 @@
     .btn-danger:hover { background: var(--accent); color: white; box-shadow: 3px 3px 0px 0px var(--border); }
     .btn-primary { background: var(--ink); color: var(--bg); border-color: var(--ink); }
     .btn-primary:hover { background: var(--ink-secondary); box-shadow: 3px 3px 0px 0px var(--ink-muted); }
+    .sort-toggle { display: inline-flex; gap: 0; }
+    .sort-toggle .btn { padding: 7px 10px; }
+    .sort-toggle .btn.active { background: var(--ink); color: var(--bg); border-color: var(--ink); }
+    .sort-toggle .btn + .btn { border-left: none; }
 
     .graph-container {
       display: flex;
@@ -1071,7 +1075,7 @@
       dashboard: { loaded: false, health: null, sessions: [], memories: [], graphStats: null, recentAudit: [], lessons: [], crystals: [] },
       graph: { loaded: false, nodes: [], edges: [], stats: null, filters: {}, selectedNode: null },
       memories: { loaded: false, items: [], search: '', typeFilter: '' },
-      timeline: { loaded: false, observations: [], sessionId: '', minImportance: 0, page: 0, pageSize: 50 },
+      timeline: { loaded: false, observations: [], sessionId: '', minImportance: 0, page: 0, pageSize: 50, sortOrder: 'desc' },
       sessions: { loaded: false, items: [], selectedId: null },
       audit: { loaded: false, entries: [], opFilter: '' },
       activity: { loaded: false, observations: [], sessions: [], typeFilter: '' },
@@ -2427,7 +2431,11 @@
       for (var i = 1; i <= 9; i++) {
         html += '<option value="' + i + '"' + (state.timeline.minImportance === i ? ' selected' : '') + '>&ge; ' + i + '</option>';
       }
-      html += '</select></div>';
+      html += '</select>';
+      html += '<div class="sort-toggle" role="group" aria-label="Timeline sort order">';
+      html += '<button type="button" class="btn' + (timelineSortOrder() === 'desc' ? ' active' : '') + '" data-action="timeline-sort" data-sort-order="desc" aria-pressed="' + (timelineSortOrder() === 'desc' ? 'true' : 'false') + '">NEWEST FIRST</button>';
+      html += '<button type="button" class="btn' + (timelineSortOrder() === 'asc' ? ' active' : '') + '" data-action="timeline-sort" data-sort-order="asc" aria-pressed="' + (timelineSortOrder() === 'asc' ? 'true' : 'false') + '">OLDEST FIRST</button>';
+      html += '</div></div>';
       html += '<div id="tl-content"></div>';
       el.innerHTML = html;
 
@@ -2457,6 +2465,28 @@
 
     var tlTypeFilter = '';
 
+    function timelineSortOrder() {
+      return state.timeline.sortOrder === 'asc' ? 'asc' : 'desc';
+    }
+
+    function sortedTimelineObservations(items) {
+      var order = timelineSortOrder();
+      return items.slice().sort(function(a, b) {
+        var at = a && a.timestamp ? String(a.timestamp) : '';
+        var bt = b && b.timestamp ? String(b.timestamp) : '';
+        if (at === bt) return 0;
+        return order === 'asc' ? at.localeCompare(bt) : bt.localeCompare(at);
+      });
+    }
+
+    function updateTimelineSortButtons() {
+      document.querySelectorAll('[data-action="timeline-sort"]').forEach(function(button) {
+        var active = button.getAttribute('data-sort-order') === timelineSortOrder();
+        button.classList.toggle('active', active);
+        button.setAttribute('aria-pressed', active ? 'true' : 'false');
+      });
+    }
+
     function renderObservations() {
       var content = document.getElementById('tl-content');
       if (!content) return;
@@ -2479,6 +2509,7 @@
           return t === tlTypeFilter;
         });
       }
+      filtered = sortedTimelineObservations(filtered);
 
       var pageSize = state.timeline.pageSize;
       var page = state.timeline.page;
@@ -2619,6 +2650,13 @@
 
     function tlPage(p) {
       state.timeline.page = p;
+      renderObservations();
+    }
+
+    function setTimelineSortOrder(order) {
+      state.timeline.sortOrder = order === 'asc' ? 'asc' : 'desc';
+      state.timeline.page = 0;
+      updateTimelineSortButtons();
       renderObservations();
     }
 
@@ -3761,6 +3799,10 @@
       }
       if (action === 'timeline-filter') {
         setTlTypeFilter(target.getAttribute('data-type-filter') || '');
+        return;
+      }
+      if (action === 'timeline-sort') {
+        setTimelineSortOrder(target.getAttribute('data-sort-order') || 'desc');
         return;
       }
       if (action === 'timeline-page') {

--- a/test/viewer-session-id.test.ts
+++ b/test/viewer-session-id.test.ts
@@ -168,6 +168,18 @@ function loadViewerSandbox() {
   return { sandbox, getElement };
 }
 
+function expectTextOrder(html: string, labels: string[]) {
+  const positions = labels.map((label) => html.indexOf(label));
+  positions.forEach((position, index) => {
+    expect(position, `${labels[index]} should be rendered`)
+      .toBeGreaterThanOrEqual(0);
+  });
+  for (let i = 1; i < positions.length; i++) {
+    expect(positions[i - 1], `${labels[i - 1]} should render before ${labels[i]}`)
+      .toBeLessThan(positions[i]);
+  }
+}
+
 describe("viewer session rendering", () => {
   it("does not throw when dashboard sessions are missing ids", () => {
     const { sandbox, getElement } = loadViewerSandbox();
@@ -201,5 +213,74 @@ describe("viewer session rendering", () => {
     expect(tabButtons.length).toBeGreaterThan(0);
     expect(() => sandbox.switchTab("sessions")).not.toThrow();
     expect(tabButtons.some((button: any) => button.classList.contains("active"))).toBe(true);
+  });
+});
+
+describe("viewer timeline sort order", () => {
+  it("renders newest-first and oldest-first sort buttons", () => {
+    const { sandbox, getElement } = loadViewerSandbox();
+
+    sandbox.renderTimelineToolbar([
+      {
+        id: "ses_1",
+        status: "completed",
+        observationCount: 3,
+        startedAt: "2026-05-13T12:00:00Z",
+      },
+    ]);
+
+    const html = getElement("view-timeline").innerHTML;
+    expect(html).toContain('data-action="timeline-sort"');
+    expect(html).toContain("NEWEST FIRST");
+    expect(html).toContain("OLDEST FIRST");
+  });
+
+  it("orders observations by selected timeline sort direction", () => {
+    const { sandbox, getElement } = loadViewerSandbox();
+    sandbox.state.timeline.observations = [
+      {
+        id: "old",
+        sessionId: "ses_1",
+        timestamp: "2026-05-13T10:00:00Z",
+        title: "Oldest observation",
+        type: "conversation",
+        importance: 5,
+      },
+      {
+        id: "mid",
+        sessionId: "ses_1",
+        timestamp: "2026-05-13T11:00:00Z",
+        title: "Middle observation",
+        type: "conversation",
+        importance: 5,
+      },
+      {
+        id: "new",
+        sessionId: "ses_1",
+        timestamp: "2026-05-13T12:00:00Z",
+        title: "Newest observation",
+        type: "conversation",
+        importance: 5,
+      },
+    ];
+    sandbox.state.timeline.sortOrder = "desc";
+
+    sandbox.renderObservations();
+    expectTextOrder(getElement("tl-content").innerHTML, [
+      "Newest observation",
+      "Middle observation",
+      "Oldest observation",
+    ]);
+
+    sandbox.state.timeline.page = 2;
+    sandbox.setTimelineSortOrder("asc");
+
+    expect(sandbox.state.timeline.sortOrder).toBe("asc");
+    expect(sandbox.state.timeline.page).toBe(0);
+    expectTextOrder(getElement("tl-content").innerHTML, [
+      "Oldest observation",
+      "Middle observation",
+      "Newest observation",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- add NEWEST FIRST / OLDEST FIRST controls to the viewer timeline toolbar
- sort timeline observations by timestamp before pagination while preserving newest-first as the default
- cover toolbar rendering and both sort directions in viewer VM tests

## Testing
- npm test -- test/viewer-session-id.test.ts
- env HOME=/tmp/agentmemory-test-home npm test
- npm run build
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added timeline sort order controls to the viewer interface, allowing users to toggle between "Newest First" and "Oldest First" sorting options for observations in the timeline view.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/672?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->