### PR TITLE
fix(cli): doctor points to correct iii install URL

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -563,7 +563,7 @@ function detectIiiConsole(): IiiConsoleState {
 }
 
 const III_CONSOLE_INSTALL_CMD =
-  "curl -fsSL https://install.iii.dev/console/main/install.sh | sh";
+  "curl -fsSL https://install.iii.dev/iii/main/install.sh | sh";
 
 async function ensureIiiConsole(): Promise<IiiConsoleState> {
   const state = detectIiiConsole();


### PR DESCRIPTION
Closes #680.

`III_CONSOLE_INSTALL_CMD` in `src/cli.ts` referenced `install.iii.dev/console/main/install.sh` which 404s. The canonical install route is `install.iii.dev/iii/main/install.sh` (the iii installer ships console alongside the engine). One-line fix.

Verified via `npm run build` and a clean grep for the broken URL across the source tree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the iii-console installation script endpoint to use the correct version when the tool is missing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/681?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->