### PR TITLE
fix: slots HTTP triggers return 503 not 500 + read .env (closes #678)

### DIFF
--- a/src/functions/slots.ts
+++ b/src/functions/slots.ts
@@ -4,6 +4,7 @@ import { KV } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
 import { withKeyedLock } from "../state/keyed-mutex.js";
 import { recordAudit } from "./audit.js";
+import { getEnvVar } from "../config.js";
 import { logger } from "../logger.js";
 
 type SlotScope = "project" | "global";
@@ -95,12 +96,14 @@ export const DEFAULT_SLOTS: ReadonlyArray<
   },
 ];
 
+// Read merged env so values loaded from ~/.agentmemory/.env are
+// honoured. process.env alone misses .env-only exports (#678).
 export function isSlotsEnabled(): boolean {
-  return process.env["AGENTMEMORY_SLOTS"] === "true";
+  return getEnvVar("AGENTMEMORY_SLOTS") === "true";
 }
 
 export function isReflectEnabled(): boolean {
-  return process.env["AGENTMEMORY_REFLECT"] === "true";
+  return getEnvVar("AGENTMEMORY_REFLECT") === "true";
 }
 
 function scopeKv(scope: SlotScope): string {

--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -8,6 +8,7 @@ import type { MetricsStore } from "../eval/metrics-store.js";
 import type { ResilientProvider } from "../providers/resilient.js";
 import { VERSION } from "../version.js";
 import { timingSafeCompare } from "../auth.js";
+import { isSlotsEnabled, isReflectEnabled } from "../functions/slots.js";
 import { renderViewerDocument } from "../viewer/document.js";
 import { getBoundViewerPort, getViewerSkipped } from "../viewer/server.js";
 import { MAX_FILES_UPPER_BOUND } from "../functions/replay.js";
@@ -87,6 +88,24 @@ function consolidationDisabledResponse(): Response {
     flag: "CONSOLIDATION_ENABLED",
     enableHow: "Set CONSOLIDATION_ENABLED=true and restart. Requires an LLM provider key.",
     docsHref: "https://github.com/rohitg00/agentmemory#consolidation",
+  });
+}
+
+function slotsDisabledResponse(): Response {
+  return flagDisabledResponse({
+    error: "Memory slots not enabled",
+    flag: "AGENTMEMORY_SLOTS",
+    enableHow: "Set AGENTMEMORY_SLOTS=true (in ~/.agentmemory/.env or the shell) and restart.",
+    docsHref: "https://github.com/rohitg00/agentmemory#memory-slots",
+  });
+}
+
+function reflectDisabledResponse(): Response {
+  return flagDisabledResponse({
+    error: "Slot reflection not enabled",
+    flag: "AGENTMEMORY_REFLECT",
+    enableHow: "Set AGENTMEMORY_REFLECT=true (in ~/.agentmemory/.env or the shell) and restart. Requires AGENTMEMORY_SLOTS=true.",
+    docsHref: "https://github.com/rohitg00/agentmemory#memory-slots",
   });
 }
 
@@ -1741,6 +1760,7 @@ export function registerApiTriggers(
   sdk.registerFunction("api::slot-list", async (req: ApiRequest): Promise<Response> => {
     const authErr = checkAuth(req, secret);
     if (authErr) return authErr;
+    if (!isSlotsEnabled()) return slotsDisabledResponse();
     const result = await sdk.trigger({ function_id: "mem::slot-list", payload: {} });
     return { status_code: 200, body: result };
   });
@@ -1753,6 +1773,7 @@ export function registerApiTriggers(
   sdk.registerFunction("api::slot-get", async (req: ApiRequest): Promise<Response> => {
     const authErr = checkAuth(req, secret);
     if (authErr) return authErr;
+    if (!isSlotsEnabled()) return slotsDisabledResponse();
     const label = asNonEmptyString(req.query_params?.["label"]);
     if (!label) return { status_code: 400, body: { error: "label query param required" } };
     const result = await sdk.trigger({ function_id: "mem::slot-get", payload: { label } });
@@ -1771,6 +1792,7 @@ export function registerApiTriggers(
   sdk.registerFunction("api::slot-create", async (req: ApiRequest): Promise<Response> => {
     const authErr = checkAuth(req, secret);
     if (authErr) return authErr;
+    if (!isSlotsEnabled()) return slotsDisabledResponse();
     const body = (req.body ?? {}) as Record<string, unknown>;
     const label = asNonEmptyString(body["label"]);
     if (!label) return { status_code: 400, body: { error: "label required" } };
@@ -1820,6 +1842,7 @@ export function registerApiTriggers(
   sdk.registerFunction("api::slot-append", async (req: ApiRequest): Promise<Response> => {
     const authErr = checkAuth(req, secret);
     if (authErr) return authErr;
+    if (!isSlotsEnabled()) return slotsDisabledResponse();
     const body = (req.body ?? {}) as Record<string, unknown>;
     const label = asNonEmptyString(body["label"]);
     const text = typeof body["text"] === "string" ? body["text"] : null;
@@ -1842,6 +1865,7 @@ export function registerApiTriggers(
   sdk.registerFunction("api::slot-replace", async (req: ApiRequest): Promise<Response> => {
     const authErr = checkAuth(req, secret);
     if (authErr) return authErr;
+    if (!isSlotsEnabled()) return slotsDisabledResponse();
     const body = (req.body ?? {}) as Record<string, unknown>;
     const label = asNonEmptyString(body["label"]);
     const content = body["content"];
@@ -1866,6 +1890,7 @@ export function registerApiTriggers(
   sdk.registerFunction("api::slot-delete", async (req: ApiRequest): Promise<Response> => {
     const authErr = checkAuth(req, secret);
     if (authErr) return authErr;
+    if (!isSlotsEnabled()) return slotsDisabledResponse();
     const label = asNonEmptyString(req.query_params?.["label"]);
     if (!label) return { status_code: 400, body: { error: "label query param required" } };
     const result = await sdk.trigger({ function_id: "mem::slot-delete", payload: { label } });
@@ -1884,6 +1909,8 @@ export function registerApiTriggers(
   sdk.registerFunction("api::slot-reflect", async (req: ApiRequest): Promise<Response> => {
     const authErr = checkAuth(req, secret);
     if (authErr) return authErr;
+    if (!isSlotsEnabled()) return slotsDisabledResponse();
+    if (!isReflectEnabled()) return reflectDisabledResponse();
     const body = (req.body ?? {}) as Record<string, unknown>;
     const sessionId = asNonEmptyString(body["sessionId"]);
     if (!sessionId) return { status_code: 400, body: { error: "sessionId required" } };

--- a/test/slots-flag-gate.test.ts
+++ b/test/slots-flag-gate.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Regression tests for #678:
+//   - isSlotsEnabled / isReflectEnabled must read from ~/.agentmemory/.env
+//     (not only process.env), so users who set AGENTMEMORY_SLOTS in the
+//     dotfile see the flag take effect.
+//   - HTTP triggers must return 503 with enableHow when the flag is off,
+//     not 500.
+
+describe("isSlotsEnabled — reads merged env (#678)", () => {
+  let home: string;
+  let ORIG_HOME: string | undefined;
+  let ORIG_FLAG: string | undefined;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "am-slots-flag-"));
+    mkdirSync(join(home, ".agentmemory"), { recursive: true });
+    ORIG_HOME = process.env["HOME"];
+    ORIG_FLAG = process.env["AGENTMEMORY_SLOTS"];
+    process.env["HOME"] = home;
+    delete process.env["AGENTMEMORY_SLOTS"];
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (ORIG_HOME !== undefined) process.env["HOME"] = ORIG_HOME;
+    if (ORIG_FLAG !== undefined) process.env["AGENTMEMORY_SLOTS"] = ORIG_FLAG;
+    else delete process.env["AGENTMEMORY_SLOTS"];
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("returns false when neither process.env nor .env sets the flag", async () => {
+    const { isSlotsEnabled } = await import("../src/functions/slots.js");
+    expect(isSlotsEnabled()).toBe(false);
+  });
+
+  it("returns true when AGENTMEMORY_SLOTS=true lives only in ~/.agentmemory/.env", async () => {
+    writeFileSync(
+      join(home, ".agentmemory", ".env"),
+      "AGENTMEMORY_SLOTS=true\n",
+    );
+    const { isSlotsEnabled } = await import("../src/functions/slots.js");
+    expect(isSlotsEnabled()).toBe(true);
+  });
+
+  it("returns true when process.env wins over .env (existing behaviour preserved)", async () => {
+    writeFileSync(
+      join(home, ".agentmemory", ".env"),
+      "AGENTMEMORY_SLOTS=false\n",
+    );
+    process.env["AGENTMEMORY_SLOTS"] = "true";
+    const { isSlotsEnabled } = await import("../src/functions/slots.js");
+    expect(isSlotsEnabled()).toBe(true);
+  });
+});
+
+describe("isReflectEnabled — reads merged env (#678)", () => {
+  let home: string;
+  let ORIG_HOME: string | undefined;
+  let ORIG_FLAG: string | undefined;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "am-reflect-flag-"));
+    mkdirSync(join(home, ".agentmemory"), { recursive: true });
+    ORIG_HOME = process.env["HOME"];
+    ORIG_FLAG = process.env["AGENTMEMORY_REFLECT"];
+    process.env["HOME"] = home;
+    delete process.env["AGENTMEMORY_REFLECT"];
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (ORIG_HOME !== undefined) process.env["HOME"] = ORIG_HOME;
+    if (ORIG_FLAG !== undefined) process.env["AGENTMEMORY_REFLECT"] = ORIG_FLAG;
+    else delete process.env["AGENTMEMORY_REFLECT"];
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("returns true when AGENTMEMORY_REFLECT=true is only in ~/.agentmemory/.env", async () => {
+    writeFileSync(
+      join(home, ".agentmemory", ".env"),
+      "AGENTMEMORY_REFLECT=true\n",
+    );
+    const { isReflectEnabled } = await import("../src/functions/slots.js");
+    expect(isReflectEnabled()).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #678.

Two coupled bugs in v0.9.22:

### 1. HTTP triggers not flag-gated

`mem::slot-list` (and 6 sibling `mem::slot-*` SDK handlers) are only registered when `isSlotsEnabled()` is true. But the matching `api::slot-*` HTTP triggers at `src/triggers/api.ts` were registered unconditionally, so GET `/agentmemory/slots` with the flag off → route exists → handler tries `sdk.trigger({function_id: "mem::slot-list"})` against a non-existent function → throws → 500 with body `{error: "[object Object]"}`.

Fix: each handler now checks `isSlotsEnabled()` up front and returns 503 via a new `slotsDisabledResponse()` helper, same shape as the existing `graphDisabledResponse` / `consolidationDisabledResponse`. `slot-reflect` additionally gates on `isReflectEnabled()`.

### 2. `.env` values never reach the flag

`isSlotsEnabled()` and `isReflectEnabled()` read `process.env` directly. `loadEnvFile()` only flows into `getMergedEnv()` which the rest of `src/config.ts` uses — these two readers were the only direct `process.env` reads bypassing that path. So `AGENTMEMORY_SLOTS=true` in `~/.agentmemory/.env` had no effect.

Fix: switched both to `getEnvVar()`.

### Tests

`test/slots-flag-gate.test.ts` (4 cases) covers:
- flag stays false when neither side sets it
- `.env`-only `AGENTMEMORY_SLOTS=true` now flips it on
- process.env still wins over `.env` (existing precedence preserved)
- same for `AGENTMEMORY_REFLECT`

Full suite: 1175 pass, 1 pre-existing integration-test failure (needs running server, unrelated).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed feature flag handling to ensure memory slot and reflection API endpoints respond appropriately when features are disabled.

* **Tests**
  * Added regression test coverage for feature flag configuration behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/682?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->