### PR TITLE
fix: defensive null guards on Memory.sessionIds

### DIFF
--- a/src/functions/export-import.ts
+++ b/src/functions/export-import.ts
@@ -375,6 +375,13 @@ export function registerExportImportFunction(sdk: ISdk, kv: StateKV): void {
             continue;
           }
         }
+        // Imported JSONL may carry malformed Memory entries with sessionIds
+        // missing entirely (older exports, hand-edited dumps). Normalise to
+        // an empty array so downstream readers can rely on the field being
+        // present.
+        if (!Array.isArray(memory.sessionIds)) {
+          memory.sessionIds = [];
+        }
         await kv.set(KV.memories, memory.id, memory);
         stats.memories++;
       }

--- a/src/functions/export-import.ts
+++ b/src/functions/export-import.ts
@@ -375,10 +375,7 @@ export function registerExportImportFunction(sdk: ISdk, kv: StateKV): void {
             continue;
           }
         }
-        // Imported JSONL may carry malformed Memory entries with sessionIds
-        // missing entirely (older exports, hand-edited dumps). Normalise to
-        // an empty array so downstream readers can rely on the field being
-        // present.
+        // Older exports + hand-edited dumps can omit this field.
         if (!Array.isArray(memory.sessionIds)) {
           memory.sessionIds = [];
         }

--- a/src/functions/remember.ts
+++ b/src/functions/remember.ts
@@ -142,7 +142,7 @@ export function registerRememberFunction(sdk: ISdk, kv: StateKV): void {
         }
         await vectorIndexAddGuarded(
           memory.id,
-          memory.sessionIds[0] ?? "memory",
+          memory.sessionIds?.[0] ?? "memory",
           memory.title + " " + memory.content,
           { kind: "memory", logId: memory.id },
         );

--- a/src/functions/search.ts
+++ b/src/functions/search.ts
@@ -261,7 +261,7 @@ export async function rebuildIndex(kv: StateKV): Promise<number> {
       idx.add(memoryToObservation(memory))
       await enqueue({
         id: memory.id,
-        sessionId: memory.sessionIds[0] ?? 'memory',
+        sessionId: memory.sessionIds?.[0] ?? 'memory',
         text: memory.title + ' ' + memory.content,
         context: { kind: "memory", logId: memory.id },
       })

--- a/src/index.ts
+++ b/src/index.ts
@@ -482,7 +482,7 @@ async function main() {
         if (bm25Index.has(memory.id)) continue;
         bm25Index.add({
           id: memory.id,
-          sessionId: memory.sessionIds[0] ?? "memory",
+          sessionId: memory.sessionIds?.[0] ?? "memory",
           timestamp: memory.createdAt,
           type: "decision",
           title: memory.title,

--- a/src/state/memory-utils.ts
+++ b/src/state/memory-utils.ts
@@ -11,7 +11,7 @@ import type { CompressedObservation, Memory } from "../types.js";
 export function memoryToObservation(memory: Memory): CompressedObservation {
   return {
     id: memory.id,
-    sessionId: memory.sessionIds[0] ?? "memory",
+    sessionId: memory.sessionIds?.[0] ?? "memory",
     timestamp: memory.createdAt,
     type: "decision",
     title: memory.title,


### PR DESCRIPTION
Bug-fix-triage pass: five callsites assumed `Memory.sessionIds` is always `string[]`, which the type says — but JSONL imports + older on-disk records can deliver `undefined`. Touching `memory.sessionIds[0]` would then throw `TypeError: Cannot read properties of undefined`.

Read-side (now `memory.sessionIds?.[0] ?? "memory"`):
- `src/index.ts:485` — BM25 rebuild loop
- `src/state/memory-utils.ts:14` — `memoryToObservation` helper
- `src/functions/remember.ts:145` — `vectorIndexAddGuarded` call
- `src/functions/search.ts:264` — rebuild loop

Import side (`src/functions/export-import.ts`): normalise to `[]` before persisting, so downstream code never has to defend against the missing-field shape.

Full suite locally: 1227 pass, 1 pre-existing integration-test failure (needs running server, unrelated).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of memory import so records with missing or malformed session info are handled safely.
  * Prevented index and search failures by defaulting missing session identifiers, ensuring memories remain indexed and retrievable.
  * Made memory-to-observation and backfill flows tolerant of absent session data to avoid runtime errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/684?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->