### PR TITLE
fix(graph): tolerate reordered XML attrs on entity + relationship (closes #635)

### DIFF
--- a/src/functions/graph.ts
+++ b/src/functions/graph.ts
@@ -15,6 +15,22 @@ import {
 import { recordAudit } from "./audit.js";
 import { logger } from "../logger.js";
 
+// Parse all key="value" pairs from a tag's attribute string, in any
+// order. The previous parser hard-coded attribute order
+// (type before name on <entity>, type/source/target/weight on
+// <relationship>) and silently dropped nodes/edges when the upstream
+// LLM emitted attributes in a different order — Codex in particular
+// likes to lead with `name=` (#635).
+function parseAttrs(raw: string): Record<string, string> {
+  const attrs: Record<string, string> = {};
+  const attrRegex = /([A-Za-z_][\w:-]*)="([^"]*)"/g;
+  let m;
+  while ((m = attrRegex.exec(raw)) !== null) {
+    attrs[m[1]] = m[2];
+  }
+  return attrs;
+}
+
 function parseGraphXml(
   xml: string,
   observationIds: string[],
@@ -26,27 +42,25 @@ function parseGraphXml(
   const edges: GraphEdge[] = [];
   const now = new Date().toISOString();
 
-  // Lazy `[^>]*?` so the self-closing alternation gets a chance before
-  // greedy attribute matching consumes the trailing `/` and the regex
-  // falls through to the explicit-close branch, which then runs ahead to
-  // the *next* entity's `</entity>` and silently drops a node (#494
-  // follow-up: greedy `[^>]*` was eating the `/` and merging two entity
-  // declarations into one match).
-  const entityRegex =
-    /<entity\s+type="([^"]+)"\s+name="([^"]+)"[^>]*?(?:\/>|>([\s\S]*?)<\/entity>)/g;
-  let match;
-  while ((match = entityRegex.exec(xml)) !== null) {
-    const type = match[1] as GraphNode["type"];
-    const name = match[2];
-    const propsBlock = match[3] ?? "";
-    const properties: Record<string, string> = {};
+  // Two passes because <entity> can be self-closing or have a body
+  // (<property> children). The self-closing form needs `[^>]*[^/]` on
+  // the attr group so the trailing `/` isn't swallowed into the match
+  // (root cause of #494). The explicit-close form picks up the
+  // property block.
+  const entitySelfClose = /<entity\b([^>]*?)\/>/g;
+  const entityWithBody = /<entity\b([^>]*[^/])>([\s\S]*?)<\/entity>/g;
 
+  const addEntity = (rawAttrs: string, propsBlock = ""): void => {
+    const attrs = parseAttrs(rawAttrs);
+    const type = attrs["type"] as GraphNode["type"] | undefined;
+    const name = attrs["name"];
+    if (!type || !name) return;
+    const properties: Record<string, string> = {};
     const propRegex = /<property\s+key="([^"]+)">([^<]*)<\/property>/g;
     let propMatch;
     while ((propMatch = propRegex.exec(propsBlock)) !== null) {
       properties[propMatch[1]] = propMatch[2];
     }
-
     nodes.push({
       id: generateId("gn"),
       type,
@@ -55,31 +69,38 @@ function parseGraphXml(
       sourceObservationIds: observationIds,
       createdAt: now,
     });
+  };
+
+  let match;
+  while ((match = entitySelfClose.exec(xml)) !== null) {
+    addEntity(match[1]);
+  }
+  while ((match = entityWithBody.exec(xml)) !== null) {
+    addEntity(match[1], match[2]);
   }
 
-  const relRegex =
-    /<relationship\s+type="([^"]+)"\s+source="([^"]+)"\s+target="([^"]+)"\s+weight="([^"]+)"\s*\/>/g;
+  const relRegex = /<relationship\b([^>]*?)\/>/g;
   while ((match = relRegex.exec(xml)) !== null) {
-    const type = match[1] as GraphEdge["type"];
-    const sourceName = match[2];
-    const targetName = match[3];
-    const parsedWeight = parseFloat(match[4]);
-    const weight = Number.isNaN(parsedWeight) ? 0.5 : parsedWeight;
+    const attrs = parseAttrs(match[1]);
+    const type = attrs["type"] as GraphEdge["type"] | undefined;
+    const sourceName = attrs["source"];
+    const targetName = attrs["target"];
+    if (!type || !sourceName || !targetName) continue;
+    const parsedWeight = parseFloat(attrs["weight"] ?? "");
+    const weight = Number.isFinite(parsedWeight) ? parsedWeight : 0.5;
 
     const sourceNode = nodes.find((n) => n.name === sourceName);
     const targetNode = nodes.find((n) => n.name === targetName);
-
-    if (sourceNode && targetNode) {
-      edges.push({
-        id: generateId("ge"),
-        type,
-        sourceNodeId: sourceNode.id,
-        targetNodeId: targetNode.id,
-        weight: Math.max(0, Math.min(1, weight)),
-        sourceObservationIds: observationIds,
-        createdAt: now,
-      });
-    }
+    if (!sourceNode || !targetNode) continue;
+    edges.push({
+      id: generateId("ge"),
+      type,
+      sourceNodeId: sourceNode.id,
+      targetNodeId: targetNode.id,
+      weight: Math.max(0, Math.min(1, weight)),
+      sourceObservationIds: observationIds,
+      createdAt: now,
+    });
   }
 
   return { nodes, edges };

--- a/test/graph.test.ts
+++ b/test/graph.test.ts
@@ -132,6 +132,36 @@ describe("Graph Functions", () => {
     expect(edges[0].type).toBe("uses");
   });
 
+  it("graph-extract tolerates reordered attributes (#635)", async () => {
+    // Codex CLI's LLM tends to emit attribute order name→type and
+    // source→target→type rather than the hard-coded type-first /
+    // type/source/target/weight sequence the old parser required.
+    mockProvider.compress.mockResolvedValueOnce(`<entities>
+<entity name="src/index.ts" type="file"/>
+<entity name="main" type="function"><property key="lang">typescript</property></entity>
+</entities>
+<relationships>
+<relationship source="src/index.ts" target="main" type="uses" weight="0.9"/>
+</relationships>`);
+
+    const result = (await sdk.trigger("mem::graph-extract", {
+      observations: [testObs],
+    })) as { success: boolean; nodesAdded: number; edgesAdded: number };
+
+    expect(result.success).toBe(true);
+    expect(result.nodesAdded).toBe(2);
+    expect(result.edgesAdded).toBe(1);
+
+    const nodes = await kv.list<GraphNode>("mem:graph:nodes");
+    expect(nodes.find((n) => n.name === "src/index.ts")?.type).toBe("file");
+    expect(nodes.find((n) => n.name === "main")?.type).toBe("function");
+
+    const edges = await kv.list<GraphEdge>("mem:graph:edges");
+    expect(edges).toHaveLength(1);
+    expect(edges[0].type).toBe("uses");
+    expect(edges[0].weight).toBeCloseTo(0.9, 5);
+  });
+
   it("graph-query with search returns matching nodes", async () => {
     await sdk.trigger("mem::graph-extract", { observations: [testObs] });
 


### PR DESCRIPTION
Closes #635.

## Bug

`parseGraphXml` in `src/functions/graph.ts` hard-coded attribute order on both tags:
- `<entity type="..." name="...">` — type must come first
- `<relationship type="..." source="..." target="..." weight="..."/>` — strict left-to-right

Codex CLI's LLM commonly emits `name` before `type`, or `source`/`target` before `type` on relationships. Any deviation made the regex miss the tag entirely, silently dropping the node/edge. End-user symptom: a full graph-extract run completes with `nodesAdded: 0`.

## Fix

Two-pass extraction with a tiny `parseAttrs()` helper that reads any `key="value"` pair in any order:

- `entitySelfClose` (`<entity ... />`) + `entityWithBody` (`<entity ...>...</entity>`) patterns separate the two tag shapes. Preserves the #494 fix where greedy attr-matching swallowed the trailing `/` and merged adjacent entities.
- Relationship matcher reads `source` / `target` / `type` / `weight` from parsed attrs. Falls back to `0.5` when weight is missing or non-finite; requires `type` + `source` + `target` present to emit the edge (silent drop on incomplete tags, as before).

## Tests

New case in `test/graph.test.ts` feeds the Codex-style reordered shape (`<entity name=... type=...>` + `<relationship source=... target=... type=... weight=...>`) and asserts node count + edge type + weight round-trip. All 7 graph tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graph parser robustness to tolerate attribute reordering variations
  * Enhanced relationship validation with stricter node reference verification
  * Added weight normalization with intelligent defaults and clamping
  * Refined entity parsing to support multiple XML tag formats

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/685?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->