### PR TITLE
fix(observability): tame log defaults + user config override (closes #519)

### DIFF
--- a/iii-config.docker.yaml
+++ b/iii-config.docker.yaml
@@ -40,10 +40,11 @@ workers:
       enabled: true
       service_name: agentmemory
       exporter: memory
-      sampling_ratio: 1.0
+      # See iii-config.yaml for the rationale on 0.1 / console-off (#519).
+      sampling_ratio: 0.1
       metrics_enabled: true
       logs_enabled: true
-      logs_console_output: true
+      logs_console_output: false
   - name: iii-exec
     config:
       watch:

--- a/iii-config.yaml
+++ b/iii-config.yaml
@@ -40,10 +40,19 @@ workers:
       enabled: true
       service_name: agentmemory
       exporter: memory
-      sampling_ratio: 1.0
+      # 0.1 instead of 1.0: at full sampling under sustained load the
+      # log subscriber falls behind, the worker emits a "Log trigger
+      # subscriber lagged" WARN, and that WARN re-enters the same
+      # stream the subscriber is failing to drain — a positive
+      # feedback loop that wrote 137 GB to daemon.log.new on one user
+      # in a few days (#519).
+      sampling_ratio: 0.1
       metrics_enabled: true
       logs_enabled: true
-      logs_console_output: true
+      # Console output is off by default; the feedback path needs the
+      # console layer to amplify. Re-enable per-session via env if you
+      # need verbose tracing for debugging.
+      logs_console_output: false
   - name: iii-exec
     config:
       watch:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -302,10 +302,18 @@ async function isAgentmemoryReady(): Promise<boolean> {
 }
 
 function findIiiConfig(): string {
+  // Precedence (user-overridable wins): explicit env > project cwd >
+  // ~/.agentmemory/ > bundled. The bundled config used to win
+  // unconditionally, so users hitting the observability log-feedback
+  // loop (#519) had no way to drop a tamer config in place without
+  // editing node_modules.
+  const envPath = process.env["AGENTMEMORY_III_CONFIG"];
   const candidates = [
+    ...(envPath ? [envPath] : []),
+    join(process.cwd(), "iii-config.yaml"),
+    join(homedir(), ".agentmemory", "iii-config.yaml"),
     join(__dirname, "iii-config.yaml"),
     join(__dirname, "..", "iii-config.yaml"),
-    join(process.cwd(), "iii-config.yaml"),
   ];
   for (const c of candidates) {
     if (existsSync(c)) return c;


### PR DESCRIPTION
Closes #519.

## Bug

`iii-observability` worker emits a `tracing::warn!("Log trigger subscriber lagged, some logs were skipped")` every time the broadcast subscriber falls behind. That WARN line gets captured by the same tracing layer feeding the observability log store, so the act of warning about a lagged subscriber adds an event to the queue the subscriber is already failing to drain — positive feedback loop.

User report: `~/.agentmemory/daemon.log.new` grew to **137 GB** in a few days, filled the disk to 98%, required manual truncate + restart to recover.

## Why this side, not upstream

The actual loop lives in `engine/src/workers/observability/otel.rs` (Rust upstream in the iii binary). agentmemory can't patch the loop directly, but it can starve the trigger:

- **Lower sampling_ratio** (1.0 → 0.1): under sustained Claude Code load the subscriber stops falling behind, so the WARN never fires.
- **Turn off logs_console_output** (true → false): even if the WARN fires, the console layer that amplifies it isn't wired, breaking the feedback path.

## Config precedence fix

`findIiiConfig` used to return the **first** match in `[dist/, package_root/, cwd/]`, so the bundled config always won. Users hitting the loop had no override path that survived `npm i -g` upgrades.

New order (user-overridable wins):
```
AGENTMEMORY_III_CONFIG env > cwd/iii-config.yaml > ~/.agentmemory/iii-config.yaml > bundled
```

So an existing affected user can drop `~/.agentmemory/iii-config.yaml` with custom thresholds and survive upgrades.

## What this PR does NOT fix

The upstream loop. If a user manually flips both knobs back to `1.0` / `true`, they can still trigger the original bug. Issue stays open for tracking the upstream fix.

## Verification

`npm run build` clean. Full vitest suite passes (1228 unit tests, 17 skipped, 1 pre-existing integration-test failure).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced observability sampling and disabled console logging by default to improve system performance and reduce feedback lag during sustained operations.

* **Chores**
  * Updated configuration file resolution order to prioritize user-specified paths and local settings before checking bundled defaults, enabling better customization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/686?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->