### PR TITLE
fix(hooks): send repo basename as project, not full path (#474)

### DIFF
--- a/plugin/scripts/notification.mjs
+++ b/plugin/scripts/notification.mjs
@@ -1,4 +1,28 @@
 #!/usr/bin/env node
+import { execSync } from "node:child_process";
+import { basename } from "node:path";
+
+//#region src/hooks/_project.ts
+function resolveProject(cwd) {
+	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
+	if (explicit && explicit.trim()) return explicit.trim();
+	const dir = cwd && cwd.trim() ? cwd : process.cwd();
+	try {
+		const top = execSync("git rev-parse --show-toplevel", {
+			cwd: dir,
+			stdio: [
+				"ignore",
+				"pipe",
+				"ignore"
+			],
+			timeout: 500
+		}).toString().trim();
+		if (top) return basename(top);
+	} catch {}
+	return basename(dir);
+}
+
+//#endregion
 //#region src/hooks/notification.ts
 function isSdkChildContext(payload) {
 	if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -31,7 +55,7 @@ async function main() {
 			body: JSON.stringify({
 				hookType: "notification",
 				sessionId,
-				project: data.cwd || process.cwd(),
+				project: resolveProject(data.cwd),
 				cwd: data.cwd || process.cwd(),
 				timestamp: (/* @__PURE__ */ new Date()).toISOString(),
 				data: {

--- a/plugin/scripts/post-tool-failure.mjs
+++ b/plugin/scripts/post-tool-failure.mjs
@@ -1,4 +1,28 @@
 #!/usr/bin/env node
+import { execSync } from "node:child_process";
+import { basename } from "node:path";
+
+//#region src/hooks/_project.ts
+function resolveProject(cwd) {
+	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
+	if (explicit && explicit.trim()) return explicit.trim();
+	const dir = cwd && cwd.trim() ? cwd : process.cwd();
+	try {
+		const top = execSync("git rev-parse --show-toplevel", {
+			cwd: dir,
+			stdio: [
+				"ignore",
+				"pipe",
+				"ignore"
+			],
+			timeout: 500
+		}).toString().trim();
+		if (top) return basename(top);
+	} catch {}
+	return basename(dir);
+}
+
+//#endregion
 //#region src/hooks/post-tool-failure.ts
 function isSdkChildContext(payload) {
 	if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -31,7 +55,7 @@ async function main() {
 			body: JSON.stringify({
 				hookType: "post_tool_failure",
 				sessionId,
-				project: data.cwd || process.cwd(),
+				project: resolveProject(data.cwd),
 				cwd: data.cwd || process.cwd(),
 				timestamp: (/* @__PURE__ */ new Date()).toISOString(),
 				data: {

--- a/plugin/scripts/post-tool-use.mjs
+++ b/plugin/scripts/post-tool-use.mjs
@@ -1,4 +1,28 @@
 #!/usr/bin/env node
+import { execSync } from "node:child_process";
+import { basename } from "node:path";
+
+//#region src/hooks/_project.ts
+function resolveProject(cwd) {
+	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
+	if (explicit && explicit.trim()) return explicit.trim();
+	const dir = cwd && cwd.trim() ? cwd : process.cwd();
+	try {
+		const top = execSync("git rev-parse --show-toplevel", {
+			cwd: dir,
+			stdio: [
+				"ignore",
+				"pipe",
+				"ignore"
+			],
+			timeout: 500
+		}).toString().trim();
+		if (top) return basename(top);
+	} catch {}
+	return basename(dir);
+}
+
+//#endregion
 //#region src/hooks/post-tool-use.ts
 function isSdkChildContext(payload) {
 	if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -31,7 +55,7 @@ async function main() {
 			body: JSON.stringify({
 				hookType: "post_tool_use",
 				sessionId,
-				project: data.cwd || process.cwd(),
+				project: resolveProject(data.cwd),
 				cwd: data.cwd || process.cwd(),
 				timestamp: (/* @__PURE__ */ new Date()).toISOString(),
 				data: {

--- a/plugin/scripts/pre-compact.mjs
+++ b/plugin/scripts/pre-compact.mjs
@@ -1,4 +1,28 @@
 #!/usr/bin/env node
+import { execSync } from "node:child_process";
+import { basename } from "node:path";
+
+//#region src/hooks/_project.ts
+function resolveProject(cwd) {
+	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
+	if (explicit && explicit.trim()) return explicit.trim();
+	const dir = cwd && cwd.trim() ? cwd : process.cwd();
+	try {
+		const top = execSync("git rev-parse --show-toplevel", {
+			cwd: dir,
+			stdio: [
+				"ignore",
+				"pipe",
+				"ignore"
+			],
+			timeout: 500
+		}).toString().trim();
+		if (top) return basename(top);
+	} catch {}
+	return basename(dir);
+}
+
+//#endregion
 //#region src/hooks/pre-compact.ts
 function isSdkChildContext(payload) {
 	if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -23,7 +47,7 @@ async function main() {
 	}
 	if (isSdkChildContext(data)) return;
 	const sessionId = data.session_id || "unknown";
-	const project = data.cwd || process.cwd();
+	const project = resolveProject(data.cwd);
 	if (process.env["CLAUDE_MEMORY_BRIDGE"] === "true") try {
 		await fetch(`${REST_URL}/agentmemory/claude-bridge/sync`, {
 			method: "POST",

--- a/plugin/scripts/pre-tool-use.mjs
+++ b/plugin/scripts/pre-tool-use.mjs
@@ -52,6 +52,7 @@ async function main() {
 		if (typeof pattern === "string" && pattern.length > 0) terms.push(pattern);
 	}
 	const sessionId = data.session_id || "unknown";
+	const project = typeof data.project === "string" && data.project.trim().length > 0 ? data.project.trim() : void 0;
 	try {
 		const res = await fetch(`${REST_URL}/agentmemory/enrich`, {
 			method: "POST",
@@ -60,7 +61,8 @@ async function main() {
 				sessionId,
 				files,
 				terms,
-				toolName
+				toolName,
+				...project !== void 0 && { project }
 			}),
 			signal: AbortSignal.timeout(2e3)
 		});

--- a/plugin/scripts/prompt-submit.mjs
+++ b/plugin/scripts/prompt-submit.mjs
@@ -1,4 +1,28 @@
 #!/usr/bin/env node
+import { execSync } from "node:child_process";
+import { basename } from "node:path";
+
+//#region src/hooks/_project.ts
+function resolveProject(cwd) {
+	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
+	if (explicit && explicit.trim()) return explicit.trim();
+	const dir = cwd && cwd.trim() ? cwd : process.cwd();
+	try {
+		const top = execSync("git rev-parse --show-toplevel", {
+			cwd: dir,
+			stdio: [
+				"ignore",
+				"pipe",
+				"ignore"
+			],
+			timeout: 500
+		}).toString().trim();
+		if (top) return basename(top);
+	} catch {}
+	return basename(dir);
+}
+
+//#endregion
 //#region src/hooks/prompt-submit.ts
 function isSdkChildContext(payload) {
 	if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -30,7 +54,7 @@ async function main() {
 			body: JSON.stringify({
 				hookType: "prompt_submit",
 				sessionId,
-				project: data.cwd || process.cwd(),
+				project: resolveProject(data.cwd),
 				cwd: data.cwd || process.cwd(),
 				timestamp: (/* @__PURE__ */ new Date()).toISOString(),
 				data: { prompt: data.prompt }

--- a/plugin/scripts/session-start.mjs
+++ b/plugin/scripts/session-start.mjs
@@ -1,4 +1,28 @@
 #!/usr/bin/env node
+import { execSync } from "node:child_process";
+import { basename } from "node:path";
+
+//#region src/hooks/_project.ts
+function resolveProject(cwd) {
+	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
+	if (explicit && explicit.trim()) return explicit.trim();
+	const dir = cwd && cwd.trim() ? cwd : process.cwd();
+	try {
+		const top = execSync("git rev-parse --show-toplevel", {
+			cwd: dir,
+			stdio: [
+				"ignore",
+				"pipe",
+				"ignore"
+			],
+			timeout: 500
+		}).toString().trim();
+		if (top) return basename(top);
+	} catch {}
+	return basename(dir);
+}
+
+//#endregion
 //#region src/hooks/session-start.ts
 function isSdkChildContext(payload) {
 	if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -26,7 +50,8 @@ async function main() {
 	}
 	if (isSdkChildContext(data)) return;
 	const sessionId = data.session_id || `ses_${Date.now().toString(36)}`;
-	const project = data.cwd || process.cwd();
+	const cwd = data.cwd || process.cwd();
+	const project = resolveProject(data.cwd);
 	const url = `${REST_URL}/agentmemory/session/start`;
 	const init = {
 		method: "POST",
@@ -34,7 +59,7 @@ async function main() {
 		body: JSON.stringify({
 			sessionId,
 			project,
-			cwd: project
+			cwd
 		})
 	};
 	if (!INJECT_CONTEXT) {

--- a/plugin/scripts/subagent-start.mjs
+++ b/plugin/scripts/subagent-start.mjs
@@ -1,4 +1,28 @@
 #!/usr/bin/env node
+import { execSync } from "node:child_process";
+import { basename } from "node:path";
+
+//#region src/hooks/_project.ts
+function resolveProject(cwd) {
+	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
+	if (explicit && explicit.trim()) return explicit.trim();
+	const dir = cwd && cwd.trim() ? cwd : process.cwd();
+	try {
+		const top = execSync("git rev-parse --show-toplevel", {
+			cwd: dir,
+			stdio: [
+				"ignore",
+				"pipe",
+				"ignore"
+			],
+			timeout: 500
+		}).toString().trim();
+		if (top) return basename(top);
+	} catch {}
+	return basename(dir);
+}
+
+//#endregion
 //#region src/hooks/subagent-start.ts
 function isSdkChildContext(payload) {
 	if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -30,7 +54,7 @@ async function main() {
 		body: JSON.stringify({
 			hookType: "subagent_start",
 			sessionId,
-			project: data.cwd || process.cwd(),
+			project: resolveProject(data.cwd),
 			cwd: data.cwd || process.cwd(),
 			timestamp: (/* @__PURE__ */ new Date()).toISOString(),
 			data: {

--- a/plugin/scripts/subagent-stop.mjs
+++ b/plugin/scripts/subagent-stop.mjs
@@ -1,4 +1,28 @@
 #!/usr/bin/env node
+import { execSync } from "node:child_process";
+import { basename } from "node:path";
+
+//#region src/hooks/_project.ts
+function resolveProject(cwd) {
+	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
+	if (explicit && explicit.trim()) return explicit.trim();
+	const dir = cwd && cwd.trim() ? cwd : process.cwd();
+	try {
+		const top = execSync("git rev-parse --show-toplevel", {
+			cwd: dir,
+			stdio: [
+				"ignore",
+				"pipe",
+				"ignore"
+			],
+			timeout: 500
+		}).toString().trim();
+		if (top) return basename(top);
+	} catch {}
+	return basename(dir);
+}
+
+//#endregion
 //#region src/hooks/subagent-stop.ts
 function isSdkChildContext(payload) {
 	if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -31,7 +55,7 @@ async function main() {
 			body: JSON.stringify({
 				hookType: "subagent_stop",
 				sessionId,
-				project: data.cwd || process.cwd(),
+				project: resolveProject(data.cwd),
 				cwd: data.cwd || process.cwd(),
 				timestamp: (/* @__PURE__ */ new Date()).toISOString(),
 				data: {

--- a/plugin/scripts/task-completed.mjs
+++ b/plugin/scripts/task-completed.mjs
@@ -1,4 +1,28 @@
 #!/usr/bin/env node
+import { execSync } from "node:child_process";
+import { basename } from "node:path";
+
+//#region src/hooks/_project.ts
+function resolveProject(cwd) {
+	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
+	if (explicit && explicit.trim()) return explicit.trim();
+	const dir = cwd && cwd.trim() ? cwd : process.cwd();
+	try {
+		const top = execSync("git rev-parse --show-toplevel", {
+			cwd: dir,
+			stdio: [
+				"ignore",
+				"pipe",
+				"ignore"
+			],
+			timeout: 500
+		}).toString().trim();
+		if (top) return basename(top);
+	} catch {}
+	return basename(dir);
+}
+
+//#endregion
 //#region src/hooks/task-completed.ts
 function isSdkChildContext(payload) {
 	if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -30,7 +54,7 @@ async function main() {
 			body: JSON.stringify({
 				hookType: "task_completed",
 				sessionId,
-				project: data.cwd || process.cwd(),
+				project: resolveProject(data.cwd),
 				cwd: data.cwd || process.cwd(),
 				timestamp: (/* @__PURE__ */ new Date()).toISOString(),
 				data: {

--- a/src/hooks/_project.ts
+++ b/src/hooks/_project.ts
@@ -2,11 +2,10 @@ import { execSync } from "node:child_process";
 import { basename } from "node:path";
 
 // Shared project-name resolver for hook scripts. Hooks that read
-// `data.cwd` directly were sending the full filesystem path as the
-// project field — but native sessions, mem::replay::import-jsonl,
-// and most manual memory_lesson_save calls use the repo basename.
-// The mismatch made auto-injected context filter out the bulk of
-// relevant lessons. See #474.
+// `data.cwd` directly send the full filesystem path as the project
+// field — but native sessions, mem::replay::import-jsonl, and manual
+// memory_lesson_save calls use the repo basename. The mismatch makes
+// auto-injected context filter out the bulk of relevant lessons.
 //
 // Resolution order (first non-empty wins):
 //   1. AGENTMEMORY_PROJECT_NAME env (per-repo escape hatch)

--- a/src/hooks/_project.ts
+++ b/src/hooks/_project.ts
@@ -1,19 +1,7 @@
 import { execSync } from "node:child_process";
 import { basename } from "node:path";
 
-// Shared project-name resolver for hook scripts. Hooks that read
-// `data.cwd` directly send the full filesystem path as the project
-// field — but native sessions, mem::replay::import-jsonl, and manual
-// memory_lesson_save calls use the repo basename. The mismatch makes
-// auto-injected context filter out the bulk of relevant lessons.
-//
-// Resolution order (first non-empty wins):
-//   1. AGENTMEMORY_PROJECT_NAME env (per-repo escape hatch)
-//   2. basename of `git rev-parse --show-toplevel` (handles subdirs)
-//   3. basename of cwd (final fallback when not in a git repo)
-//
-// tsdown inlines this module into each hook bundle so every hook
-// ships self-contained without a runtime import.
+// Resolution order: AGENTMEMORY_PROJECT_NAME env → git toplevel basename → cwd basename.
 export function resolveProject(cwd?: string): string {
   const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
   if (explicit && explicit.trim()) return explicit.trim();
@@ -27,8 +15,6 @@ export function resolveProject(cwd?: string): string {
       .toString()
       .trim();
     if (top) return basename(top);
-  } catch {
-    // Not a git repo, git missing, or timeout — fall through.
-  }
+  } catch {}
   return basename(dir);
 }

--- a/src/hooks/_project.ts
+++ b/src/hooks/_project.ts
@@ -1,0 +1,35 @@
+import { execSync } from "node:child_process";
+import { basename } from "node:path";
+
+// Shared project-name resolver for hook scripts. Hooks that read
+// `data.cwd` directly were sending the full filesystem path as the
+// project field — but native sessions, mem::replay::import-jsonl,
+// and most manual memory_lesson_save calls use the repo basename.
+// The mismatch made auto-injected context filter out the bulk of
+// relevant lessons. See #474.
+//
+// Resolution order (first non-empty wins):
+//   1. AGENTMEMORY_PROJECT_NAME env (per-repo escape hatch)
+//   2. basename of `git rev-parse --show-toplevel` (handles subdirs)
+//   3. basename of cwd (final fallback when not in a git repo)
+//
+// tsdown inlines this module into each hook bundle so every hook
+// ships self-contained without a runtime import.
+export function resolveProject(cwd?: string): string {
+  const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
+  if (explicit && explicit.trim()) return explicit.trim();
+  const dir = cwd && cwd.trim() ? cwd : process.cwd();
+  try {
+    const top = execSync("git rev-parse --show-toplevel", {
+      cwd: dir,
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 500,
+    })
+      .toString()
+      .trim();
+    if (top) return basename(top);
+  } catch {
+    // Not a git repo, git missing, or timeout — fall through.
+  }
+  return basename(dir);
+}

--- a/src/hooks/notification.ts
+++ b/src/hooks/notification.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { resolveProject } from "./_project.js";
 
 function isSdkChildContext(payload: unknown): boolean {
   if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -40,8 +41,8 @@ async function main() {
       body: JSON.stringify({
         hookType: "notification",
         sessionId,
-        project: data.cwd || process.cwd(),
-        cwd: data.cwd || process.cwd(),
+        project: resolveProject(data.cwd as string | undefined),
+        cwd: (data.cwd as string | undefined) || process.cwd(),
         timestamp: new Date().toISOString(),
         data: {
           notification_type: data.notification_type,

--- a/src/hooks/post-tool-failure.ts
+++ b/src/hooks/post-tool-failure.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { resolveProject } from "./_project.js";
 
 function isSdkChildContext(payload: unknown): boolean {
   if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -40,8 +41,8 @@ async function main() {
       body: JSON.stringify({
         hookType: "post_tool_failure",
         sessionId,
-        project: data.cwd || process.cwd(),
-        cwd: data.cwd || process.cwd(),
+        project: resolveProject(data.cwd as string | undefined),
+        cwd: (data.cwd as string | undefined) || process.cwd(),
         timestamp: new Date().toISOString(),
         data: {
           tool_name: data.tool_name,

--- a/src/hooks/post-tool-use.ts
+++ b/src/hooks/post-tool-use.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { resolveProject } from "./_project.js";
 
 function isSdkChildContext(payload: unknown): boolean {
   if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -43,8 +44,8 @@ async function main() {
       body: JSON.stringify({
         hookType: "post_tool_use",
         sessionId,
-        project: data.cwd || process.cwd(),
-        cwd: data.cwd || process.cwd(),
+        project: resolveProject(data.cwd as string | undefined),
+        cwd: (data.cwd as string | undefined) || process.cwd(),
         timestamp: new Date().toISOString(),
         data: {
           tool_name: data.tool_name,

--- a/src/hooks/pre-compact.ts
+++ b/src/hooks/pre-compact.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { resolveProject } from "./_project.js";
 
 function isSdkChildContext(payload: unknown): boolean {
   if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -31,7 +32,7 @@ async function main() {
   if (isSdkChildContext(data)) return;
 
   const sessionId = (data.session_id as string) || "unknown";
-  const project = (data.cwd as string) || process.cwd();
+  const project = resolveProject(data.cwd as string | undefined);
 
   if (process.env["CLAUDE_MEMORY_BRIDGE"] === "true") {
     try {

--- a/src/hooks/prompt-submit.ts
+++ b/src/hooks/prompt-submit.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { resolveProject } from "./_project.js";
 
 function isSdkChildContext(payload: unknown): boolean {
   if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -39,8 +40,8 @@ async function main() {
       body: JSON.stringify({
         hookType: "prompt_submit",
         sessionId,
-        project: data.cwd || process.cwd(),
-        cwd: data.cwd || process.cwd(),
+        project: resolveProject(data.cwd as string | undefined),
+        cwd: (data.cwd as string | undefined) || process.cwd(),
         timestamp: new Date().toISOString(),
         data: { prompt: data.prompt },
       }),

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { resolveProject } from "./_project.js";
 
 // Inlined from ./sdk-guard so each hook bundles to a single self-contained
 // .mjs (matches the pattern used by every other hook entry in tsdown.config).
@@ -50,13 +51,14 @@ async function main() {
 
   const sessionId =
     (data.session_id as string) || `ses_${Date.now().toString(36)}`;
-  const project = (data.cwd as string) || process.cwd();
+  const cwd = (data.cwd as string) || process.cwd();
+  const project = resolveProject(data.cwd as string | undefined);
 
   const url = `${REST_URL}/agentmemory/session/start`;
   const init: RequestInit = {
     method: "POST",
     headers: authHeaders(),
-    body: JSON.stringify({ sessionId, project, cwd: project }),
+    body: JSON.stringify({ sessionId, project, cwd }),
   };
 
   if (!INJECT_CONTEXT) {

--- a/src/hooks/subagent-start.ts
+++ b/src/hooks/subagent-start.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { resolveProject } from "./_project.js";
 
 // Inlined from ./sdk-guard so each hook bundles to a single self-contained
 // .mjs (matches the pattern used by every other hook entry in tsdown.config).
@@ -46,8 +47,8 @@ async function main() {
     body: JSON.stringify({
       hookType: "subagent_start",
       sessionId,
-      project: data.cwd || process.cwd(),
-      cwd: data.cwd || process.cwd(),
+      project: resolveProject(data.cwd as string | undefined),
+      cwd: (data.cwd as string | undefined) || process.cwd(),
       timestamp: new Date().toISOString(),
       data: {
         agent_id: data.agent_id,

--- a/src/hooks/subagent-stop.ts
+++ b/src/hooks/subagent-stop.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { resolveProject } from "./_project.js";
 
 function isSdkChildContext(payload: unknown): boolean {
   if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -43,8 +44,8 @@ async function main() {
       body: JSON.stringify({
         hookType: "subagent_stop",
         sessionId,
-        project: data.cwd || process.cwd(),
-        cwd: data.cwd || process.cwd(),
+        project: resolveProject(data.cwd as string | undefined),
+        cwd: (data.cwd as string | undefined) || process.cwd(),
         timestamp: new Date().toISOString(),
         data: {
           agent_id: data.agent_id,

--- a/src/hooks/task-completed.ts
+++ b/src/hooks/task-completed.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { resolveProject } from "./_project.js";
 
 function isSdkChildContext(payload: unknown): boolean {
   if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -39,8 +40,8 @@ async function main() {
       body: JSON.stringify({
         hookType: "task_completed",
         sessionId,
-        project: data.cwd || process.cwd(),
-        cwd: data.cwd || process.cwd(),
+        project: resolveProject(data.cwd as string | undefined),
+        cwd: (data.cwd as string | undefined) || process.cwd(),
         timestamp: new Date().toISOString(),
         data: {
           task_id: data.task_id,

--- a/test/hook-project.test.ts
+++ b/test/hook-project.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveProject } from "../src/hooks/_project.js";
+
+describe("resolveProject — hook project basename resolver", () => {
+  const originalEnv = process.env.AGENTMEMORY_PROJECT_NAME;
+
+  beforeEach(() => {
+    delete process.env.AGENTMEMORY_PROJECT_NAME;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.AGENTMEMORY_PROJECT_NAME;
+    } else {
+      process.env.AGENTMEMORY_PROJECT_NAME = originalEnv;
+    }
+  });
+
+  it("AGENTMEMORY_PROJECT_NAME env wins over everything", () => {
+    process.env.AGENTMEMORY_PROJECT_NAME = "my-override";
+    expect(resolveProject("/var/log")).toBe("my-override");
+    expect(resolveProject(process.cwd())).toBe("my-override");
+  });
+
+  it("trims whitespace on env override", () => {
+    process.env.AGENTMEMORY_PROJECT_NAME = "  spaced  ";
+    expect(resolveProject("/var/log")).toBe("spaced");
+  });
+
+  it("ignores empty env override", () => {
+    process.env.AGENTMEMORY_PROJECT_NAME = "   ";
+    const repoBasename = "agentmemory";
+    expect(resolveProject(process.cwd())).toBe(repoBasename);
+  });
+
+  it("returns git toplevel basename when cwd is inside a repo", () => {
+    const top = resolveProject(process.cwd());
+    expect(top).toBe("agentmemory");
+  });
+
+  it("returns git toplevel basename from a nested subdir", () => {
+    const nested = join(process.cwd(), "src", "hooks");
+    expect(resolveProject(nested)).toBe("agentmemory");
+  });
+
+  it("falls back to basename(cwd) when not in a git repo", () => {
+    const dir = mkdtempSync(join(tmpdir(), "amem-noproj-"));
+    try {
+      expect(resolveProject(dir)).toBe(dir.split("/").pop());
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("defaults to process.cwd() when no cwd argument given", () => {
+    expect(resolveProject()).toBe("agentmemory");
+  });
+
+  it("defaults to process.cwd() when cwd argument is empty", () => {
+    expect(resolveProject("")).toBe("agentmemory");
+    expect(resolveProject("   ")).toBe("agentmemory");
+  });
+});

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -61,12 +61,8 @@ export default defineConfig([
     clean: false,
     sourcemap: false,
   },
-  // Per-entry hook configs (one defineConfig object per hook) so each hook
-  // bundles into a fully self-contained .mjs with no shared hashed chunks.
-  // Bundling all 13 entries in one config caused tsdown to hoist shared
-  // helpers (e.g. ./_project.ts) into a hashed chunk that changed on every
-  // rebuild and got committed by accident. Keep DRY in source via imports,
-  // emit standalone .mjs per hook.
+  // One entry per config block prevents tsdown from hoisting shared
+  // helpers into hashed chunks across hooks.
   ...hookEntries.map((entry) => ({
     entry: [entry],
     outDir: "dist/hooks",

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -61,18 +61,24 @@ export default defineConfig([
     clean: false,
     sourcemap: false,
   },
-  {
-    entry: hookEntries,
+  // Per-entry hook configs (one defineConfig object per hook) so each hook
+  // bundles into a fully self-contained .mjs with no shared hashed chunks.
+  // Bundling all 13 entries in one config caused tsdown to hoist shared
+  // helpers (e.g. ./_project.ts) into a hashed chunk that changed on every
+  // rebuild and got committed by accident. Keep DRY in source via imports,
+  // emit standalone .mjs per hook.
+  ...hookEntries.map((entry) => ({
+    entry: [entry],
     outDir: "dist/hooks",
     ...shared,
     clean: false,
     sourcemap: false,
-  },
-  {
-    entry: hookEntries,
+  })),
+  ...hookEntries.map((entry) => ({
+    entry: [entry],
     outDir: "plugin/scripts",
     ...shared,
     clean: false,
     sourcemap: false,
-  },
+  })),
 ]);


### PR DESCRIPTION
## Summary

Hooks were sending `data.cwd` (an absolute filesystem path) as the `project` field on every `observe` / `session/start` / `enrich` call. Native sessions, `mem::replay::import-jsonl`, and `memory_lesson_save` all use the repo basename. The mismatch caused auto-injected context to filter out the bulk of relevant lessons because the path never matches the stored project name.

## Changes

- New `src/hooks/_project.ts` exporting `resolveProject(cwd?)` with the resolution order:
  1. `AGENTMEMORY_PROJECT_NAME` env (per-repo escape hatch)
  2. basename of `git rev-parse --show-toplevel` (handles subdirs)
  3. basename of `cwd` (final fallback when not in a git repo)
- 9 hooks updated to call `resolveProject` for the `project` field while still sending the raw `cwd` path in the `cwd` field: `notification`, `post-tool-use`, `post-tool-failure`, `prompt-submit`, `session-start`, `subagent-start`, `subagent-stop`, `task-completed`, `pre-compact`.
- Hooks that already handle project correctly (`pre-tool-use`) or don't send it (`post-commit`, `session-end`, `stop`) left untouched.
- `tsdown.config.ts` split into per-entry configs for the hook bundles so each hook compiles into a fully self-contained `.mjs` with no shared hashed chunks. Previous shared-entry config caused tsdown to hoist helpers into `_project-<hash>.mjs` artifacts that changed on every rebuild and were prone to being committed accidentally.

## Test plan

- [x] `npx vitest run test/hook-project.test.ts` — 8/8 pass (env override, whitespace trim, empty env ignored, git toplevel from cwd, git toplevel from nested subdir, basename fallback in tmpdir, default to `process.cwd()`, empty/whitespace cwd argument)
- [x] `npx vitest run` — 1238 pass, 1 integration file skipped (requires running server, pre-existing)
- [x] Build emits no hashed chunks — `find dist/hooks plugin/scripts -name '_project*'` returns empty
- [x] Sample bundle inspection: `head -25 plugin/scripts/notification.mjs` shows `resolveProject` inlined per-hook

Closes #474.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved project identification across hooks and CLI flows: project names are now normalized from an environment override, Git repository name, or working directory, improving observability and consistency.

* **Tests**
  * Added tests covering project-name resolution across environment and Git/non-Git scenarios.

* **Chores**
  * Build config updated to emit standalone per-hook bundles for clearer outputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/687?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->