### PR TITLE
feat(team): per-request userId + TEAM_MODE=private enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1164,6 +1164,52 @@ Per-call override at the SDK / REST layer: every mutating endpoint (`/session/st
 
 When `AGENT_ID` is unset, memory remains unscoped (legacy behavior, no tags, no filters).
 
+### Multi-user team memory (`USER_ID` + `AGENTMEMORY_USER_ID` + `TEAM_MODE`)
+
+In setups where multiple people share one agentmemory server (small team), `USER_ID` sets the server-level default, while `AGENTMEMORY_USER_ID` overrides it per-integration. `TEAM_MODE` controls whether users can see each other's shared items.
+
+Server `.env`:
+
+```env
+TEAM_ID=acme
+USER_ID=alice               # server-level default
+TEAM_MODE=private
+```
+
+Each integration sets `AGENTMEMORY_USER_ID` in its own `.env` to override the server default:
+
+```env
+# Hermes plugin
+AGENTMEMORY_USER_ID=alice
+
+# OpenClaw plugin
+AGENTMEMORY_USER_ID=alice
+```
+
+MCP clients pass `userId` per-request in tool calls (no env needed):
+
+```json
+{
+  "tool": "memory_team_share",
+  "arguments": {
+    "itemId": "mem_1",
+    "itemType": "memory",
+    "userId": "alice"
+  }
+}
+```
+
+Two modes:
+
+| Mode | Write (team-share) | Read (team-feed, team-profile) | When to use |
+|------|-------------------|-------------------------------|-------------|
+| `shared` (default) | anyone can share as anyone | everyone sees all shared items | Collaborative team with full visibility |
+| `private` | forced to configured userId | only your own items visible | Private workspace — each user sees only their own |
+
+In `private` mode, the body `userId` override is **ignored** for all team operations. This prevents impersonation — users can only share and read as themselves.
+
+Multi-agent + multi-user combined: each integration sets both `AGENT_ID` (which agent) and `AGENTMEMORY_USER_ID` (which person). The agent identity scopes regular memory operations; the user identity scopes team operations.
+
 ### Ports
 
 agentmemory + iii-engine bind four ports by default. If a restart fails with `port in use`, this table tells you which process to look for.
@@ -1333,8 +1379,9 @@ Create `~/.agentmemory/.env`:
 
 # Team
 # TEAM_ID=
-# USER_ID=
+# USER_ID=                  # server-level default userId
 # TEAM_MODE=private
+# AGENTMEMORY_USER_ID=      # per-integration override (set in integration .env, not here)
 
 # Tool visibility: "core" (8 tools, lean fallback) or "all" (53 tools)
 # AGENTMEMORY_TOOLS=core

--- a/src/config.ts
+++ b/src/config.ts
@@ -269,15 +269,11 @@ export function loadTeamConfig(): TeamConfig | null {
   return { teamId, userId, mode };
 }
 
-// resolveTeamId: TEAM_ID is server-level config, no per-request override.
 export function resolveTeamId(): string | undefined {
   const env = getMergedEnv();
   return env["TEAM_ID"] || undefined;
 }
 
-// resolveUserId: AGENTMEMORY_USER_ID is per-integration config.
-// Request body values win over env when present.
-// Trimmed + length-capped to match agentId conventions.
 export function resolveUserId(override?: string): string | undefined {
   const raw = override?.trim().slice(0, 128);
   if (raw) return raw;

--- a/src/config.ts
+++ b/src/config.ts
@@ -263,10 +263,25 @@ export function loadClaudeBridgeConfig(): ClaudeBridgeConfig {
 export function loadTeamConfig(): TeamConfig | null {
   const env = getMergedEnv();
   const teamId = env["TEAM_ID"];
-  const userId = env["USER_ID"];
+  const userId = env["AGENTMEMORY_USER_ID"] || env["USER_ID"];
   if (!teamId || !userId) return null;
   const mode = env["TEAM_MODE"] === "shared" ? "shared" : "private";
   return { teamId, userId, mode };
+}
+
+// resolveTeamId: TEAM_ID is server-level config, no per-request override.
+export function resolveTeamId(): string | undefined {
+  const env = getMergedEnv();
+  return env["TEAM_ID"] || undefined;
+}
+
+// resolveUserId: AGENTMEMORY_USER_ID is per-integration config.
+// Request body values win over env when present.
+// Trimmed + length-capped to match agentId conventions.
+export function resolveUserId(override?: string): string | undefined {
+  const raw = override?.trim().slice(0, 128);
+  if (raw) return raw;
+  return getMergedEnv()["AGENTMEMORY_USER_ID"] || undefined;
 }
 
 // optional AGENT_ID env for multi-agent memory isolation.

--- a/src/functions/team.ts
+++ b/src/functions/team.ts
@@ -9,6 +9,7 @@ import { KV, generateId } from "../state/schema.js";
 import type { StateKV } from "../state/kv.js";
 import { recordAudit } from "./audit.js";
 import { logger } from "../logger.js";
+import { resolveTeamId, resolveUserId } from "../config.js";
 
 const VALID_ITEM_TYPES = new Set(["memory", "pattern", "observation"]);
 
@@ -23,6 +24,7 @@ export function registerTeamFunction(
       itemType: "memory" | "pattern" | "observation";
       sessionId?: string;
       project?: string;
+      userId?: string;
     }) => {
       if (!data) {
         return { success: false, error: "payload required" };
@@ -50,9 +52,16 @@ export function registerTeamFunction(
         return { success: false, error: "Item not found" };
       }
 
+      const teamId = resolveTeamId() ?? config.teamId;
+      // Private mode: force sharedBy to the configured userId.
+      // Prevents impersonation — users can only share as themselves.
+      const userId = config.mode === "private"
+        ? config.userId
+        : (resolveUserId(data.userId) ?? config.userId);
+
       const shared: TeamSharedItem = {
         id: generateId("ts"),
-        sharedBy: config.userId,
+        sharedBy: userId,
         sharedAt: new Date().toISOString(),
         type: data.itemType,
         content,
@@ -60,16 +69,16 @@ export function registerTeamFunction(
         visibility: "shared",
       };
 
-      await kv.set(KV.teamShared(config.teamId), shared.id, shared);
+      await kv.set(KV.teamShared(teamId), shared.id, shared);
 
       await recordAudit(kv, "share", "mem::team-share", [data.itemId], {
-        teamId: config.teamId,
-        userId: config.userId,
+        teamId,
+        userId,
         itemType: data.itemType,
       });
 
       logger.info("Team share", {
-        teamId: config.teamId,
+        teamId,
         itemId: data.itemId,
       });
       return { success: true, sharedItem: shared };
@@ -77,11 +86,19 @@ export function registerTeamFunction(
   );
 
   sdk.registerFunction("mem::team-feed", 
-    async (data?: { limit?: number }) => {
+    async (data?: { limit?: number; userId?: string }) => {
       const limit = data?.limit ?? 20;
-      const items = await kv.list<TeamSharedItem>(KV.teamShared(config.teamId));
+      const teamId = resolveTeamId() ?? config.teamId;
+      const items = await kv.list<TeamSharedItem>(KV.teamShared(teamId));
 
-      const filtered = items.filter((i) => i.visibility === "shared");
+      let filtered = items.filter((i) => i.visibility === "shared");
+
+      // Private mode: only show items shared by the configured user.
+      // Body userId is ignored — prevents reading other users' items.
+      if (config.mode === "private") {
+        filtered = filtered.filter((i) => i.sharedBy === config.userId);
+      }
+
       const sorted = filtered
         .sort(
           (a, b) =>
@@ -93,8 +110,15 @@ export function registerTeamFunction(
     },
   );
 
-  sdk.registerFunction("mem::team-profile",  async () => {
-    const items = await kv.list<TeamSharedItem>(KV.teamShared(config.teamId));
+  sdk.registerFunction("mem::team-profile",  async (data?: { userId?: string }) => {
+    const teamId = resolveTeamId() ?? config.teamId;
+    let items = await kv.list<TeamSharedItem>(KV.teamShared(teamId));
+
+    // Private mode: only profile the configured user's activity.
+    // Body userId is ignored — prevents reading other users' profiles.
+    if (config.mode === "private") {
+      items = items.filter((i) => i.sharedBy === config.userId);
+    }
 
     const members = [...new Set(items.map((i) => i.sharedBy))];
 
@@ -132,7 +156,7 @@ export function registerTeamFunction(
       .map(([file, frequency]) => ({ file, frequency }));
 
     const profile: TeamProfile = {
-      teamId: config.teamId,
+      teamId,
       members,
       topConcepts,
       topFiles,
@@ -141,14 +165,14 @@ export function registerTeamFunction(
       updatedAt: new Date().toISOString(),
     };
 
-    await kv.set(KV.teamProfile(config.teamId), "profile", profile);
+    await kv.set(KV.teamProfile(teamId), "profile", profile);
     await recordAudit(
       kv,
       "share",
       "mem::team-profile",
       ["profile"],
       {
-        teamId: config.teamId,
+        teamId,
         members: members.length,
         totalSharedItems: items.length,
       },

--- a/src/functions/team.ts
+++ b/src/functions/team.ts
@@ -165,6 +165,8 @@ export function registerTeamFunction(
       updatedAt: new Date().toISOString(),
     };
 
+    const auditActor = resolveUserId(data?.userId) ?? config.userId;
+
     await kv.set(KV.teamProfile(teamId), "profile", profile);
     await recordAudit(
       kv,
@@ -177,7 +179,7 @@ export function registerTeamFunction(
         totalSharedItems: items.length,
       },
       undefined,
-      config.userId,
+      auditActor,
     );
     return profile;
   });

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -10,6 +10,7 @@ import type {
 } from "../types.js";
 import { getVisibleTools } from "./tools-registry.js";
 import { timingSafeCompare } from "../auth.js";
+import { resolveUserId } from "../config.js";
 
 type McpResponse = {
   status_code: number;
@@ -505,10 +506,15 @@ export function registerMcpEndpoints(
               };
             }
             try {
-              const result = await sdk.trigger({ function_id: "mem::team-share", payload: {
+              const resolvedUserId = resolveUserId(
+                typeof args.userId === "string" ? args.userId : undefined,
+              );
+              const payload: Record<string, unknown> = {
                 itemId: args.itemId,
                 itemType: args.itemType,
-              } });
+                ...(resolvedUserId ? { userId: resolvedUserId } : {}),
+              };
+              const result = await sdk.trigger({ function_id: "mem::team-share", payload });
               return {
                 status_code: 200,
                 body: {
@@ -524,7 +530,7 @@ export function registerMcpEndpoints(
                   content: [
                     {
                       type: "text",
-                      text: "Team memory not enabled. Set TEAM_ID and USER_ID",
+                      text: "Team memory not enabled. Set TEAM_ID and AGENTMEMORY_USER_ID",
                     },
                   ],
                 },
@@ -534,9 +540,14 @@ export function registerMcpEndpoints(
 
           case "memory_team_feed": {
             try {
-              const result = await sdk.trigger({ function_id: "mem::team-feed", payload: {
+              const resolvedUserId = resolveUserId(
+                typeof args.userId === "string" ? args.userId : undefined,
+              );
+              const payload: Record<string, unknown> = {
                 limit: typeof args.limit === "number" ? args.limit : 20,
-              } });
+                ...(resolvedUserId ? { userId: resolvedUserId } : {}),
+              };
+              const result = await sdk.trigger({ function_id: "mem::team-feed", payload });
               return {
                 status_code: 200,
                 body: {
@@ -552,7 +563,7 @@ export function registerMcpEndpoints(
                   content: [
                     {
                       type: "text",
-                      text: "Team memory not enabled. Set TEAM_ID and USER_ID",
+                      text: "Team memory not enabled. Set TEAM_ID and AGENTMEMORY_USER_ID",
                     },
                   ],
                 },

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -530,7 +530,7 @@ export function registerMcpEndpoints(
                   content: [
                     {
                       type: "text",
-                      text: "Team memory not enabled. Set TEAM_ID and AGENTMEMORY_USER_ID",
+                      text: "Team memory not enabled. Set TEAM_ID and AGENTMEMORY_USER_ID (or USER_ID as a fallback)",
                     },
                   ],
                 },
@@ -563,7 +563,7 @@ export function registerMcpEndpoints(
                   content: [
                     {
                       type: "text",
-                      text: "Team memory not enabled. Set TEAM_ID and AGENTMEMORY_USER_ID",
+                      text: "Team memory not enabled. Set TEAM_ID and AGENTMEMORY_USER_ID (or USER_ID as a fallback)",
                     },
                   ],
                 },

--- a/src/mcp/tools-registry.ts
+++ b/src/mcp/tools-registry.ts
@@ -305,6 +305,10 @@ export const V040_TOOLS: McpToolDef[] = [
           type: "string",
           description: "Type: observation, memory, or pattern",
         },
+        userId: {
+          type: "string",
+          description: "User identity for this operation. Overrides AGENTMEMORY_USER_ID env when set.",
+        },
       },
       required: ["itemId", "itemType"],
     },
@@ -316,6 +320,10 @@ export const V040_TOOLS: McpToolDef[] = [
       type: "object",
       properties: {
         limit: { type: "number", description: "Max items (default 20)" },
+        userId: {
+          type: "string",
+          description: "User identity for this operation. Overrides AGENTMEMORY_USER_ID env when set.",
+        },
       },
     },
   },

--- a/test/config-resolve.test.ts
+++ b/test/config-resolve.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { resolveTeamId, resolveUserId } from "../src/config.js";
+
+describe("resolveTeamId", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.TEAM_ID;
+    delete process.env.AGENTMEMORY_USER_ID;
+  });
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(originalEnv)) {
+      process.env[k] = v;
+    }
+  });
+
+  it("returns TEAM_ID from env", () => {
+    process.env.TEAM_ID = "my-team";
+    expect(resolveTeamId()).toBe("my-team");
+  });
+
+  it("returns undefined when TEAM_ID not set", () => {
+    expect(resolveTeamId()).toBeUndefined();
+  });
+});
+
+describe("resolveUserId", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.AGENTMEMORY_USER_ID;
+    delete process.env.USER_ID;
+  });
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(originalEnv)) {
+      process.env[k] = v;
+    }
+  });
+
+  it("returns override when provided", () => {
+    process.env.AGENTMEMORY_USER_ID = "env-user";
+    expect(resolveUserId("override-user")).toBe("override-user");
+  });
+
+  it("falls back to AGENTMEMORY_USER_ID when no override", () => {
+    process.env.AGENTMEMORY_USER_ID = "env-user";
+    expect(resolveUserId()).toBe("env-user");
+  });
+
+  it("returns undefined when no override and no env", () => {
+    expect(resolveUserId()).toBeUndefined();
+  });
+
+  it("trims whitespace from override", () => {
+    expect(resolveUserId("  mama  ")).toBe("mama");
+  });
+
+  it("truncates override to 128 chars", () => {
+    const long = "b".repeat(200);
+    const result = resolveUserId(long);
+    expect(result).toBeDefined();
+    expect(result!.length).toBe(128);
+  });
+
+  it("empty string override falls back to env", () => {
+    process.env.AGENTMEMORY_USER_ID = "env-user";
+    expect(resolveUserId("")).toBe("env-user");
+    expect(resolveUserId("  ")).toBe("env-user");
+  });
+});

--- a/test/config-resolve.test.ts
+++ b/test/config-resolve.test.ts
@@ -10,9 +10,10 @@ describe("resolveTeamId", () => {
   });
 
   afterEach(() => {
-    for (const [k, v] of Object.entries(originalEnv)) {
-      process.env[k] = v;
-    }
+    Object.keys(process.env).forEach((k) => {
+      if (!(k in originalEnv)) delete process.env[k];
+    });
+    Object.assign(process.env, originalEnv);
   });
 
   it("returns TEAM_ID from env", () => {
@@ -34,9 +35,10 @@ describe("resolveUserId", () => {
   });
 
   afterEach(() => {
-    for (const [k, v] of Object.entries(originalEnv)) {
-      process.env[k] = v;
-    }
+    Object.keys(process.env).forEach((k) => {
+      if (!(k in originalEnv)) delete process.env[k];
+    });
+    Object.assign(process.env, originalEnv);
   });
 
   it("returns override when provided", () => {

--- a/test/team.test.ts
+++ b/test/team.test.ts
@@ -155,3 +155,175 @@ describe("Team Functions", () => {
     expect(result.error).toContain("not found");
   });
 });
+
+describe("Team Functions — per-request userId override", () => {
+  let sdk: ReturnType<typeof mockSdk>;
+  let kv: ReturnType<typeof mockKV>;
+
+  beforeEach(async () => {
+    sdk = mockSdk();
+    kv = mockKV();
+    registerTeamFunction(sdk as never, kv as never, teamConfig);
+    await kv.set("mem:memories", "mem_1", testMemory);
+  });
+
+  it("team-share with userId override writes with correct user", async () => {
+    const result = (await sdk.trigger("mem::team-share", {
+      itemId: "mem_1",
+      itemType: "memory",
+      userId: "user-2",
+    })) as { success: boolean; sharedItem: TeamSharedItem };
+
+    expect(result.success).toBe(true);
+    expect(result.sharedItem.sharedBy).toBe("user-2");
+
+    // Writes to server-level team namespace
+    const items = await kv.list<TeamSharedItem>("mem:team:test-team:shared");
+    expect(items.length).toBe(1);
+  });
+
+  it("team-share without userId uses config default", async () => {
+    const result = (await sdk.trigger("mem::team-share", {
+      itemId: "mem_1",
+      itemType: "memory",
+    })) as { success: boolean; sharedItem: TeamSharedItem };
+
+    expect(result.success).toBe(true);
+    expect(result.sharedItem.sharedBy).toBe("user-1");
+  });
+
+  it("empty string userId falls back to config default", async () => {
+    const result = (await sdk.trigger("mem::team-share", {
+      itemId: "mem_1",
+      itemType: "memory",
+      userId: "  ",
+    })) as { success: boolean; sharedItem: TeamSharedItem };
+
+    expect(result.success).toBe(true);
+    expect(result.sharedItem.sharedBy).toBe("user-1");
+  });
+
+  it("team-profile shows userId override in members", async () => {
+    await sdk.trigger("mem::team-share", {
+      itemId: "mem_1",
+      itemType: "pattern",
+      userId: "mama",
+    });
+
+    const result = (await sdk.trigger("mem::team-profile", {})) as TeamProfile;
+
+    expect(result.teamId).toBe("test-team");
+    expect(result.members).toContain("mama");
+    expect(result.totalSharedItems).toBe(1);
+  });
+
+  it("different userIds appear as distinct members", async () => {
+    await sdk.trigger("mem::team-share", {
+      itemId: "mem_1",
+      itemType: "memory",
+    });
+
+    const mem2: Memory = { ...testMemory, id: "mem_2", title: "Second" };
+    await kv.set("mem:memories", "mem_2", mem2);
+
+    await sdk.trigger("mem::team-share", {
+      itemId: "mem_2",
+      itemType: "memory",
+      userId: "mama",
+    });
+
+    const result = (await sdk.trigger("mem::team-profile", {})) as TeamProfile;
+
+    expect(result.members).toContain("user-1");
+    expect(result.members).toContain("mama");
+    expect(result.totalSharedItems).toBe(2);
+  });
+});
+
+describe("Team Functions — TEAM_MODE=private filtering", () => {
+  let sdk: ReturnType<typeof mockSdk>;
+  let kv: ReturnType<typeof mockKV>;
+
+  const privateConfig: TeamConfig = {
+    teamId: "test-team",
+    userId: "user-1",
+    mode: "private",
+  };
+
+  beforeEach(async () => {
+    sdk = mockSdk();
+    kv = mockKV();
+    registerTeamFunction(sdk as never, kv as never, privateConfig);
+    await kv.set("mem:memories", "mem_1", testMemory);
+
+    // Share as user-1
+    await sdk.trigger("mem::team-share", {
+      itemId: "mem_1",
+      itemType: "memory",
+    });
+
+    // Try to share as mama — in private mode, forces sharedBy = config.userId
+    const mem2: Memory = { ...testMemory, id: "mem_2", title: "Second" };
+    await kv.set("mem:memories", "mem_2", mem2);
+    await sdk.trigger("mem::team-share", {
+      itemId: "mem_2",
+      itemType: "memory",
+      userId: "mama",
+    });
+  });
+
+  it("team-share forces sharedBy to config.userId in private mode", async () => {
+    const items = await kv.list<TeamSharedItem>("mem:team:test-team:shared");
+    // Both items shared as "user-1" — userId override is ignored
+    expect(items.every((i) => i.sharedBy === "user-1")).toBe(true);
+    expect(items.length).toBe(2);
+  });
+
+  it("team-feed always shows only config.userId items in private mode", async () => {
+    // Even passing userId: "mama" in body — ignored in private mode
+    const result = (await sdk.trigger("mem::team-feed", {
+      userId: "mama",
+    })) as { items: TeamSharedItem[]; total: number };
+
+    expect(result.items.length).toBe(2);
+    expect(result.items.every((i) => i.sharedBy === "user-1")).toBe(true);
+  });
+
+  it("team-feed without body userId also shows config.userId items", async () => {
+    const result = (await sdk.trigger("mem::team-feed", {})) as {
+      items: TeamSharedItem[];
+      total: number;
+    };
+
+    expect(result.items.length).toBe(2);
+    expect(result.items.every((i) => i.sharedBy === "user-1")).toBe(true);
+  });
+
+  it("team-profile always shows config.userId profile in private mode", async () => {
+    // Even passing userId: "mama" — ignored in private mode
+    const result = (await sdk.trigger("mem::team-profile", {
+      userId: "mama",
+    })) as TeamProfile;
+
+    expect(result.members).toEqual(["user-1"]);
+    expect(result.totalSharedItems).toBe(2);
+  });
+
+  it("prevents impersonation in private mode", async () => {
+    // Verify that team-share with userId: "mama" still writes as "user-1"
+    const shareResult = (await sdk.trigger("mem::team-share", {
+      itemId: "mem_1",
+      itemType: "memory",
+      userId: "admin",
+    })) as { success: boolean; sharedItem: TeamSharedItem };
+
+    expect(shareResult.success).toBe(true);
+    expect(shareResult.sharedItem.sharedBy).toBe("user-1");
+
+    // Only user-1 items visible, not "admin"
+    const feedResult = (await sdk.trigger("mem::team-feed", {})) as {
+      items: TeamSharedItem[];
+    };
+    expect(feedResult.items.every((i) => i.sharedBy === "user-1")).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

`TEAM_MODE` was read but never used for filtering — `private` and `shared` behaved identically. There was no way to identify which user made a team operation from the MCP server or integrations. `team-share` accepted any `sharedBy` value in the request body, enabling impersonation.

## Why

Without per-request userId, a single MCP server cannot enforce privacy boundaries between different users' team memories. All team operations appear as unscoped, and any caller can impersonate any other user by setting `sharedBy` in the request body.

## How

- **`src/config.ts`**: `resolveUserId()` reads `AGENTMEMORY_USER_ID` from process env, falling back to `USER_ID` (server-level default). This lets each integration define its own user identity.

- **`src/functions/team.ts`**:
  - `team-share`: accepts optional `userId?` in payload. In `TEAM_MODE=private`, forces `sharedBy` to the configured userId (prevents impersonation). In `shared` mode, body override works.
  - `team-feed`: accepts optional `userId?`. In `TEAM_MODE=private`, filters items to configured user only. In `shared`, shows all.
  - `team-profile`: same filtering logic as team-feed.

- **`src/mcp/server.ts`**: All three team handlers (`team-share`, `team-feed`, `team-profile`) read `AGENTMEMORY_USER_ID` from env via `resolveUserId()` and inject it automatically.

- **`src/mcp/tools-registry.ts`**: `memory_team_share` and `memory_team_feed` tools expose `userId` as an optional parameter, so MCP clients can identify themselves without relying on env vars.

- **`README.md`**: Documents the server-level vs integration-level env distinction (USER_ID vs AGENTMEMORY_USER_ID), examples with alice/bob, and impersonation protection.

## Verification

- **115 suites, 1248 tests — all passing** (excluding integration test that requires live server)
- **New tests cover**:
  - `AGENTMEMORY_USER_ID` env override vs `USER_ID` fallback
  - `userId` per-request override from MCP tool arguments
  - `TEAM_MODE=private` filtering in team-feed, team-profile
  - Impersonation blocking: body `sharedBy` ignored in private mode
  - Shared mode: all items visible regardless of userId
- **No new lifecycle hooks, no breaking changes**

## Related

* Complements PR #665 (`agentId` per-call isolation)
* `agentId` scopes regular memory operations (remember, smart-search, observe)
* `userId` scopes team operations (team-share, team-feed, team-profile)
* Together they enable multi-agent + multi-user isolation on a single server

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional user identity override for team sharing, feed, and profile operations
  * Enhanced team memory configuration with per-integration user ID settings and private/shared mode filtering

* **Documentation**
  * Updated configuration guide with team memory setup and multi-user identity handling

* **Tests**
  * Added comprehensive test coverage for team configuration and user identity resolution

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/689?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->