### PR TITLE
docs: stop calling HOOKS/RECALL/CONSOLIDATE 'primitives'

### DIFF
--- a/README.md
+++ b/README.md
@@ -997,7 +997,7 @@ The viewer at `:3113` shows what your agent **remembered**. The [iii console](ht
 
 Watch a `memory_smart_search` fire and see the BM25 scan → embedding lookup → RRF fusion → reranker as a waterfall. Edit a stuck consolidation timer in the KV browser. Replay a `PostToolUse` hook with a tweaked payload. Pin the WebSocket stream and watch observations land live.
 
-agentmemory ships this for free because every function, trigger, state scope, and stream is an iii primitive — nothing custom, nothing to instrument.
+agentmemory ships this for free because every function call and trigger fires through iii — nothing custom, nothing to instrument.
 
 <p align="center">
   <img src="assets/iii-console/workers.png" alt="iii console Workers page — connected workers including agentmemory instances with live function counts and runtime metadata" width="720" />
@@ -1059,7 +1059,7 @@ If you want to export to Jaeger/Honeycomb/Grafana Tempo instead, change `exporte
 
 <h2 id="powered-by-iii"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/section-architecture.svg"><img src="assets/tags/section-architecture.svg" alt="Powered by iii" height="32" /></picture></h2>
 
-agentmemory is **already a running [iii](https://iii.dev) instance**. Functions, triggers, KV state, streams, OTEL traces — all of it is iii primitives. You didn't install Postgres, Redis, Express, pm2, or Prometheus, because iii replaces them.
+agentmemory is **already a running [iii](https://iii.dev) instance**. Three primitives — worker, function, trigger — compose the runtime; KV state, streams, and OTEL traces come from iii-state, iii-stream, and iii-observability workers that ship with iii. You didn't install Postgres, Redis, Express, pm2, or Prometheus, because iii replaces them.
 
 That means one more command extends agentmemory with an entire new capability.
 

--- a/website/components/Nav.tsx
+++ b/website/components/Nav.tsx
@@ -5,7 +5,7 @@ import { MobileNavToggle } from "./MobileNavToggle";
 import styles from "./Nav.module.css";
 
 const SECTIONS = [
-  { href: "#primitives", label: "STACK" },
+  { href: "#stack", label: "STACK" },
   { href: "#features", label: "FEATURES" },
   { href: "#command-center", label: "CONTROL" },
   { href: "#live", label: "DEMO" },

--- a/website/components/Primitives.tsx
+++ b/website/components/Primitives.tsx
@@ -60,11 +60,11 @@ export function Primitives() {
   }, []);
 
   return (
-    <section className={styles.wrap} id="primitives" aria-labelledby="prim-title">
+    <section className={styles.wrap} id="stack" aria-labelledby="prim-title">
       <header className="section-head">
         <span className="section-eyebrow">THE STACK</span>
         <h2 id="prim-title" className="section-title">
-          THREE PRIMITIVES.
+          THREE LAYERS.
           <br />
           NO FRAMEWORK TAX.
         </h2>


### PR DESCRIPTION
## Summary

The three iii primitives are **worker, function, trigger**. `HOOKS / RECALL / CONSOLIDATE` (the three cards on the agentmemory landing) are pipeline layers — not primitives. Same misuse appeared twice in the root README. Fixing the framing.

## Changes

- `website/components/Primitives.tsx`: `THREE PRIMITIVES.` → `THREE LAYERS.` in the H2; section `id="primitives"` → `id="stack"` so the URL hash matches the nav label.
- `website/components/Nav.tsx`: STACK nav href bumped to the new `#stack` anchor.
- `README.md` line 1000: dropped "every function, trigger, state scope, and stream is an iii primitive" — state scopes and streams are worker-provided features, not primitives.
- `README.md` line 1062: rewrote to "Three primitives — worker, function, trigger — compose the runtime; KV state, streams, and OTEL traces come from iii-state, iii-stream, and iii-observability workers that ship with iii."

## Skipped (for follow-up)

`READMEs/README.{de,fr,es,pt,ru,tr,ja,ko,hi,zh-CN,zh-TW}.md` carry the same misuse on the equivalent lines. Translation pass is its own scope — opening a follow-up issue so the 11 locales get synced together.

## Test plan

- [x] `grep -rn -i 'primitive' website/` — only internal component/file/CSS names remain (Primitives.tsx, Primitives.module.css, import statements); no user-facing misuse
- [x] `grep -n -i 'primitive' README.md` — remaining hits accurately refer to worker/function/trigger
- [x] Visual: Nav STACK link → `#stack` anchor → "THREE LAYERS." section


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to clarify how the platform leverages runtime primitives and available services without requiring additional external dependencies.
  * Renamed primary section heading from "Three Primitives" to "Three Layers."

* **UI/Navigation**
  * Updated navigation link for the Stack section to point to the correct anchor.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/690?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->