### PR TITLE
fix(openai-embeddings): honor embedding-specific API key in factory and auto-detect

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,8 +63,9 @@
 # -----------------------------------------------------------------------------
 #
 # Without an embedding key, agentmemory runs in BM25-only mode for hybrid
-# search. Detection order: EMBEDDING_PROVIDER override → GEMINI_API_KEY →
-# OPENAI_API_KEY → VOYAGE_API_KEY → COHERE_API_KEY → OPENROUTER_API_KEY →
+# search. Detection order: EMBEDDING_PROVIDER override →
+# OPENAI_EMBEDDING_API_KEY → GEMINI_API_KEY → OPENAI_API_KEY →
+# VOYAGE_API_KEY → COHERE_API_KEY → OPENROUTER_API_KEY →
 # local (Xenova/all-MiniLM-L6-v2, 384-dim).
 
 # EMBEDDING_PROVIDER=local                       # local | openai | voyage | cohere | gemini | openrouter
@@ -73,7 +74,12 @@
 
 # COHERE_API_KEY=...                             # General-purpose embeddings
 
-# Reuses OPENAI_API_KEY / OPENAI_BASE_URL above when EMBEDDING_PROVIDER=openai.
+# When EMBEDDING_PROVIDER=openai, embeddings reuse OPENAI_API_KEY /
+# OPENAI_BASE_URL above by default. Set the two vars below to point
+# embeddings at a different endpoint / key than the chat LLM — e.g. chat
+# on a self-hosted OpenAI-compatible proxy, embeddings on OpenAI proper.
+# OPENAI_EMBEDDING_API_KEY=sk-...                # Embedding-specific key; takes precedence over OPENAI_API_KEY
+# OPENAI_EMBEDDING_BASE_URL=https://api.openai.com  # Embedding-specific base URL; takes precedence over OPENAI_BASE_URL
 # OPENAI_EMBEDDING_MODEL=text-embedding-3-small  # Embedding model when EMBEDDING_PROVIDER=openai
 # OPENAI_EMBEDDING_DIMENSIONS=1536               # Required when the model is not in the known-models table
 

--- a/README.md
+++ b/README.md
@@ -1261,6 +1261,8 @@ Create `~/.agentmemory/.env`:
 # VOYAGE_API_KEY=...
 # OPENAI_API_KEY=sk-...
 # OPENAI_BASE_URL=https://api.openai.com   # Override for Azure / vLLM / LM Studio / proxies
+# OPENAI_EMBEDDING_API_KEY=sk-...          # Optional: embedding-specific key; takes precedence over OPENAI_API_KEY
+# OPENAI_EMBEDDING_BASE_URL=https://api.openai.com  # Optional: embedding-specific base URL; takes precedence over OPENAI_BASE_URL
 # OPENAI_EMBEDDING_MODEL=text-embedding-3-small
 # OPENAI_EMBEDDING_DIMENSIONS=1536        # Required when the model is not in the known-models table
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -226,6 +226,12 @@ export function detectEmbeddingProvider(
   const forced = source["EMBEDDING_PROVIDER"];
   if (forced) return forced;
 
+  // Embedding-specific key beats generic provider auto-detection: it's a
+  // stronger signal of intent than a chat-LLM key that merely shares the
+  // OpenAI wire shape. Without this, "chat on Gemini, embeddings on OpenAI"
+  // silently routes embeddings through the Gemini branch.
+  if (source["OPENAI_EMBEDDING_API_KEY"]) return "openai";
+
   if (source["GEMINI_API_KEY"]) return "gemini";
   if (source["OPENAI_API_KEY"]) return "openai";
   if (source["VOYAGE_API_KEY"]) return "voyage";

--- a/src/providers/embedding/index.ts
+++ b/src/providers/embedding/index.ts
@@ -35,7 +35,7 @@ export function createEmbeddingProvider(): EmbeddingProvider | null {
     case "gemini":
       return withDimensionGuard(new GeminiEmbeddingProvider(getEnvVar("GEMINI_API_KEY")!));
     case "openai":
-      return withDimensionGuard(new OpenAIEmbeddingProvider(getEnvVar("OPENAI_API_KEY")!));
+      return withDimensionGuard(new OpenAIEmbeddingProvider());
     case "voyage":
       return withDimensionGuard(new VoyageEmbeddingProvider(getEnvVar("VOYAGE_API_KEY")!));
     case "cohere":

--- a/src/providers/embedding/openai.ts
+++ b/src/providers/embedding/openai.ts
@@ -48,7 +48,7 @@ function resolveDimensions(model: string, override: string | undefined): number 
  * `api-key` header instead of `Authorization: Bearer`.
  *
  * Required env vars:
- *   OPENAI_API_KEY               — API key (fallback for OPENAI_EMBEDDING_API_KEY)
+ *   OPENAI_API_KEY               — Fallback API key when OPENAI_EMBEDDING_API_KEY is unset
  *
  * Optional:
  *   OPENAI_BASE_URL              — base URL without path (default: https://api.openai.com).

--- a/test/embedding-provider.test.ts
+++ b/test/embedding-provider.test.ts
@@ -18,6 +18,11 @@ describe("createEmbeddingProvider", () => {
     delete process.env["COHERE_API_KEY"];
     delete process.env["OPENROUTER_API_KEY"];
     delete process.env["EMBEDDING_PROVIDER"];
+    delete process.env["OPENAI_BASE_URL"];
+    delete process.env["OPENAI_EMBEDDING_API_KEY"];
+    delete process.env["OPENAI_EMBEDDING_BASE_URL"];
+    delete process.env["OPENAI_EMBEDDING_MODEL"];
+    delete process.env["OPENAI_EMBEDDING_DIMENSIONS"];
   });
 
   afterEach(() => {
@@ -49,6 +54,41 @@ describe("createEmbeddingProvider", () => {
     process.env["EMBEDDING_PROVIDER"] = "openai";
     const provider = createEmbeddingProvider();
     expect(provider).toBeInstanceOf(OpenAIEmbeddingProvider);
+  });
+
+  it("uses OPENAI_EMBEDDING_API_KEY in Authorization when both keys are set", async () => {
+    process.env["OPENAI_API_KEY"] = "llm-key";
+    process.env["OPENAI_EMBEDDING_API_KEY"] = "embedding-key";
+    const provider = createEmbeddingProvider();
+    expect(provider).toBeInstanceOf(OpenAIEmbeddingProvider);
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({ data: [{ embedding: new Array(1536).fill(0.1) }] }),
+        { status: 200 },
+      ),
+    );
+
+    await provider!.embed("hi");
+    const headers = (fetchSpy.mock.calls[0]![1] as RequestInit).headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer embedding-key");
+
+    fetchSpy.mockRestore();
+  });
+
+  it("detects openai when only OPENAI_EMBEDDING_API_KEY is set", () => {
+    process.env["OPENAI_EMBEDDING_API_KEY"] = "embedding-only-key";
+    const provider = createEmbeddingProvider();
+    expect(provider).toBeInstanceOf(OpenAIEmbeddingProvider);
+    expect(provider!.name).toBe("openai");
+  });
+
+  it("OPENAI_EMBEDDING_API_KEY takes precedence over GEMINI_API_KEY for embedding detection", () => {
+    process.env["GEMINI_API_KEY"] = "gemini-chat-key";
+    process.env["OPENAI_EMBEDDING_API_KEY"] = "embedding-key";
+    const provider = createEmbeddingProvider();
+    expect(provider).toBeInstanceOf(OpenAIEmbeddingProvider);
+    expect(provider!.name).toBe("openai");
   });
 });
 


### PR DESCRIPTION
Follow-up to #503.

### Repro

```
OPENAI_API_KEY=sk-deepseek-...                  # chat on a self-hosted/proxy
OPENAI_EMBEDDING_API_KEY=sk-openai-real-...
OPENAI_EMBEDDING_BASE_URL=https://api.openai.com
```

Embedding requests 401 from OpenAI because the LLM key is still sent. The bug is invisible against local endpoints (vLLM / Ollama / LM Studio) that ignore `Authorization`, which is why #503's verification didn't surface it.

### Fix

Two call sites still bypass the embedding-specific env added in #503:

| File | Change |
|---|---|
| `src/providers/embedding/index.ts:38` | Drop the explicit `OPENAI_API_KEY` argument; let the constructor resolve precedence (`apiKey arg > OPENAI_EMBEDDING_API_KEY > OPENAI_API_KEY`). |
| `src/config.ts` `detectEmbeddingProvider` | Check `OPENAI_EMBEDDING_API_KEY` ahead of generic provider keys so "chat on X, embeddings on OpenAI" auto-detects without forcing `EMBEDDING_PROVIDER=openai`. |
| `src/providers/embedding/openai.ts` JSDoc | Fix one reversed-fallback summary line (lines 65-69 are already correct). |
| `.env.example`, `README.md` | Document `OPENAI_EMBEDDING_API_KEY` and `OPENAI_EMBEDDING_BASE_URL`; update the detection-order comment. |
| `test/embedding-provider.test.ts` | 3 regression tests + expanded `beforeEach` to strip embedding-specific env. |

### Compatibility

| Existing config | Before | After |
|---|---|---|
| Only `OPENAI_API_KEY` set | factory passes it in → constructor falls through to `OPENAI_API_KEY` | factory passes nothing → constructor falls through to `OPENAI_API_KEY` — **identical** |
| Only `GEMINI_API_KEY` set | detect → `"gemini"` | detect → `"gemini"` — **identical** |
| `OPENAI_API_KEY` + `EMBEDDING_PROVIDER=openai` | constructor uses `OPENAI_API_KEY` | constructor uses `OPENAI_API_KEY` — **identical** |
| `OPENAI_API_KEY` + `OPENAI_EMBEDDING_API_KEY` | **broken** (LLM key wins) | embedding key wins — **fixed** |
| `GEMINI_API_KEY` + `OPENAI_EMBEDDING_API_KEY` (no `EMBEDDING_PROVIDER`) | **broken** (detect → `"gemini"`) | detect → `"openai"` — **fixed** |

The only behavior shifts are in the two currently-broken rows — those configurations misroute embeddings today, so changing them is the intent. No silent regression for any working config.

### Test plan

- `npm test -- embedding-provider` — 20/20 green (17 existing + 3 new regression tests).
- `npm test` — full suite green (1241/1241; integration test under `test/integration.test.ts` skipped per CONTRIBUTING.md).
- `npm run build` — `tsdown` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support for embedding-specific OpenAI API keys and base URLs that take precedence over general settings.

* **Documentation**
  * Updated configuration guides with new embedding-specific environment variables.

* **Tests**
  * Added test coverage for embedding key precedence and provider detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/692?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->