### PR TITLE
fix(consolidation): default ON when LLM provider is configured (#612)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1229,11 +1229,11 @@ AGENTMEMORY_ALLOW_AGENT_SDK=true
 AGENTMEMORY_AUTO_COMPRESS=true
 ```
 
-Turn on graph or consolidation features in the same file if you want them:
+Consolidation (graph nodes, lessons, crystals) is on by default whenever an LLM provider is configured. Explicitly opt out with `CONSOLIDATION_ENABLED=false` if you want LLM-free operation. Graph extraction is a separate flag:
 
 ```env
 GRAPH_EXTRACTION_ENABLED=true
-CONSOLIDATION_ENABLED=true
+# CONSOLIDATION_ENABLED=false   # opt out of auto-consolidation
 ```
 
 ### Environment Variables
@@ -1343,7 +1343,7 @@ Create `~/.agentmemory/.env`:
                                    # Observations are still captured via
                                    # PostToolUse regardless of this flag.
 # GRAPH_EXTRACTION_ENABLED=false
-# CONSOLIDATION_ENABLED=true
+# CONSOLIDATION_ENABLED=false   # on by default when an LLM provider is configured
 # LESSON_DECAY_ENABLED=true
 # OBSIDIAN_AUTO_EXPORT=false
 # AGENTMEMORY_EXPORT_ROOT=~/.agentmemory

--- a/src/config.ts
+++ b/src/config.ts
@@ -323,7 +323,26 @@ export function getGraphBatchSize(): number {
 }
 
 export function isConsolidationEnabled(): boolean {
-  return getMergedEnv()["CONSOLIDATION_ENABLED"] === "true";
+  const env = getMergedEnv();
+  const explicit = env["CONSOLIDATION_ENABLED"];
+  if (explicit === "false" || explicit === "0") return false;
+  if (explicit === "true" || explicit === "1") return true;
+  return hasLLMProviderConfigured(env);
+}
+
+function hasLLMProviderConfigured(env: Record<string, string | undefined>): boolean {
+  const provider = (env["AGENTMEMORY_PROVIDER"] || "").toLowerCase();
+  if (provider === "noop") return false;
+  return Boolean(
+    env["ANTHROPIC_API_KEY"] ||
+      env["OPENAI_API_KEY"] ||
+      env["OPENROUTER_API_KEY"] ||
+      env["GEMINI_API_KEY"] ||
+      env["GOOGLE_API_KEY"] ||
+      env["MINIMAX_API_KEY"] ||
+      env["OPENAI_BASE_URL"] ||
+      provider === "agent-sdk",
+  );
 }
 
 // Per-observation LLM compression is OFF by default as of 0.8.8 (see #138).

--- a/src/config.ts
+++ b/src/config.ts
@@ -333,9 +333,12 @@ export function isConsolidationEnabled(): boolean {
 function hasLLMProviderConfigured(env: Record<string, string | undefined>): boolean {
   const provider = (env["AGENTMEMORY_PROVIDER"] || "").toLowerCase();
   if (provider === "noop") return false;
+  const openaiKeyForLlm =
+    env["OPENAI_API_KEY"] &&
+    (env["OPENAI_API_KEY_FOR_LLM"] || "").toLowerCase() !== "false";
   return Boolean(
     env["ANTHROPIC_API_KEY"] ||
-      env["OPENAI_API_KEY"] ||
+      openaiKeyForLlm ||
       env["OPENROUTER_API_KEY"] ||
       env["GEMINI_API_KEY"] ||
       env["GOOGLE_API_KEY"] ||

--- a/src/functions/consolidation-pipeline.ts
+++ b/src/functions/consolidation-pipeline.ts
@@ -50,7 +50,7 @@ export function registerConsolidationPipelineFunction(
   sdk.registerFunction("mem::consolidate-pipeline", 
     async (data?: { tier?: string; force?: boolean; project?: string }) => {
       if (!data?.force && !isConsolidationEnabled()) {
-        return { success: false, skipped: true, reason: "CONSOLIDATION_ENABLED is not set to true" };
+        return { success: false, skipped: true, reason: "Consolidation disabled: set CONSOLIDATION_ENABLED=true or configure an LLM provider (ANTHROPIC_API_KEY / OPENAI_API_KEY / OPENROUTER_API_KEY / GEMINI_API_KEY / MINIMAX_API_KEY)" };
       }
       const tier = data?.tier || "all";
       const decayDays = getConsolidationDecayDays();

--- a/src/functions/consolidation-pipeline.ts
+++ b/src/functions/consolidation-pipeline.ts
@@ -50,7 +50,7 @@ export function registerConsolidationPipelineFunction(
   sdk.registerFunction("mem::consolidate-pipeline", 
     async (data?: { tier?: string; force?: boolean; project?: string }) => {
       if (!data?.force && !isConsolidationEnabled()) {
-        return { success: false, skipped: true, reason: "Consolidation disabled: set CONSOLIDATION_ENABLED=true or configure an LLM provider (ANTHROPIC_API_KEY / OPENAI_API_KEY / OPENROUTER_API_KEY / GEMINI_API_KEY / MINIMAX_API_KEY)" };
+        return { success: false, skipped: true, reason: "Consolidation disabled: set CONSOLIDATION_ENABLED=true or configure an LLM provider (ANTHROPIC_API_KEY / OPENAI_API_KEY / OPENROUTER_API_KEY / GEMINI_API_KEY / GOOGLE_API_KEY / MINIMAX_API_KEY / OPENAI_BASE_URL / AGENTMEMORY_PROVIDER=agent-sdk)" };
       }
       const tier = data?.tier || "all";
       const decayDays = getConsolidationDecayDays();

--- a/test/consolidation-default.test.ts
+++ b/test/consolidation-default.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const ENV_KEYS = [
+  "CONSOLIDATION_ENABLED",
+  "AGENTMEMORY_PROVIDER",
+  "ANTHROPIC_API_KEY",
+  "OPENAI_API_KEY",
+  "OPENROUTER_API_KEY",
+  "GEMINI_API_KEY",
+  "GOOGLE_API_KEY",
+  "MINIMAX_API_KEY",
+  "OPENAI_BASE_URL",
+];
+
+const ORIGINAL_HOME = process.env["HOME"];
+const ORIGINAL_USERPROFILE = process.env["USERPROFILE"];
+const ORIGINAL: Record<string, string | undefined> = {};
+
+let sandboxHome: string;
+
+async function freshConfig() {
+  vi.resetModules();
+  return await import("../src/config.js");
+}
+
+function writeEnv(contents: string) {
+  const dir = join(sandboxHome, ".agentmemory");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, ".env"), contents);
+}
+
+describe("isConsolidationEnabled default behavior", () => {
+  beforeEach(() => {
+    sandboxHome = mkdtempSync(join(tmpdir(), "agentmemory-consolidation-"));
+    process.env["HOME"] = sandboxHome;
+    process.env["USERPROFILE"] = sandboxHome;
+    for (const k of ENV_KEYS) {
+      ORIGINAL[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_HOME === undefined) delete process.env["HOME"];
+    else process.env["HOME"] = ORIGINAL_HOME;
+    if (ORIGINAL_USERPROFILE === undefined) delete process.env["USERPROFILE"];
+    else process.env["USERPROFILE"] = ORIGINAL_USERPROFILE;
+    for (const k of ENV_KEYS) {
+      if (ORIGINAL[k] === undefined) delete process.env[k];
+      else process.env[k] = ORIGINAL[k];
+    }
+    rmSync(sandboxHome, { recursive: true, force: true });
+  });
+
+  it("returns false when no LLM provider configured (default BM25-only mode)", async () => {
+    writeEnv("");
+    const cfg = await freshConfig();
+    expect(cfg.isConsolidationEnabled()).toBe(false);
+  });
+
+  it("returns true by default when ANTHROPIC_API_KEY is set", async () => {
+    writeEnv("ANTHROPIC_API_KEY=sk-test-123");
+    const cfg = await freshConfig();
+    expect(cfg.isConsolidationEnabled()).toBe(true);
+  });
+
+  it("returns true by default when OPENAI_API_KEY is set", async () => {
+    writeEnv("OPENAI_API_KEY=sk-test-123");
+    const cfg = await freshConfig();
+    expect(cfg.isConsolidationEnabled()).toBe(true);
+  });
+
+  it("returns true by default when OPENAI_BASE_URL is set (local OpenAI-compatible)", async () => {
+    writeEnv("OPENAI_BASE_URL=http://localhost:1234/v1");
+    const cfg = await freshConfig();
+    expect(cfg.isConsolidationEnabled()).toBe(true);
+  });
+
+  it("returns true by default when AGENTMEMORY_PROVIDER=agent-sdk", async () => {
+    writeEnv("AGENTMEMORY_PROVIDER=agent-sdk");
+    const cfg = await freshConfig();
+    expect(cfg.isConsolidationEnabled()).toBe(true);
+  });
+
+  it("explicit CONSOLIDATION_ENABLED=false overrides provider-based default", async () => {
+    writeEnv("ANTHROPIC_API_KEY=sk-test-123\nCONSOLIDATION_ENABLED=false");
+    const cfg = await freshConfig();
+    expect(cfg.isConsolidationEnabled()).toBe(false);
+  });
+
+  it("explicit CONSOLIDATION_ENABLED=true overrides absence of provider", async () => {
+    writeEnv("CONSOLIDATION_ENABLED=true");
+    const cfg = await freshConfig();
+    expect(cfg.isConsolidationEnabled()).toBe(true);
+  });
+
+  it("AGENTMEMORY_PROVIDER=noop returns false even with API key set", async () => {
+    writeEnv("AGENTMEMORY_PROVIDER=noop\nANTHROPIC_API_KEY=sk-test-123");
+    const cfg = await freshConfig();
+    expect(cfg.isConsolidationEnabled()).toBe(false);
+  });
+});

--- a/test/consolidation-default.test.ts
+++ b/test/consolidation-default.test.ts
@@ -8,6 +8,7 @@ const ENV_KEYS = [
   "AGENTMEMORY_PROVIDER",
   "ANTHROPIC_API_KEY",
   "OPENAI_API_KEY",
+  "OPENAI_API_KEY_FOR_LLM",
   "OPENROUTER_API_KEY",
   "GEMINI_API_KEY",
   "GOOGLE_API_KEY",
@@ -99,6 +100,12 @@ describe("isConsolidationEnabled default behavior", () => {
 
   it("AGENTMEMORY_PROVIDER=noop returns false even with API key set", async () => {
     writeEnv("AGENTMEMORY_PROVIDER=noop\nANTHROPIC_API_KEY=sk-test-123");
+    const cfg = await freshConfig();
+    expect(cfg.isConsolidationEnabled()).toBe(false);
+  });
+
+  it("OPENAI_API_KEY_FOR_LLM=false scopes the key to embeddings only", async () => {
+    writeEnv("OPENAI_API_KEY=sk-test-123\nOPENAI_API_KEY_FOR_LLM=false");
     const cfg = await freshConfig();
     expect(cfg.isConsolidationEnabled()).toBe(false);
   });


### PR DESCRIPTION
## Summary

Users with an LLM provider configured (Anthropic / OpenAI / OpenAI-compatible local endpoint via `OPENAI_BASE_URL` / OpenRouter / Gemini / Minimax / agent-sdk) were silently getting zero graph nodes, lessons, and crystals because `CONSOLIDATION_ENABLED` defaulted to `false`. The auto-consolidate pipeline only fires when the flag is `true`, so 100+ session corpora sat unprocessed unless the user knew to flip the flag manually.

Reported in [discussion #612](https://github.com/rohitg00/agentmemory/discussions/612):

> I am running this local, have over 100 sessions but still no graph nodes, lessons, crystals. I thought today's update might resolve issues so I did a fresh install - still broken. […] I got an openai compatible URL from Open WebUI and connected my local model. Served through vllm and it handles all compression / summarization perfectly fine.

Compression worked (it's wired via `PostToolUse` and only needs the provider). Consolidation didn't fire (gated behind the flag). Classic DX landmine pattern flagged in the [feature-flag-visibility](#) lesson — disabled-by-default LLM features that produce empty tabs.

## Changes

- `src/config.ts` — `isConsolidationEnabled()` now treats unset as "on when a non-noop LLM provider is detectable from env". Detection: any of `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `OPENROUTER_API_KEY` / `GEMINI_API_KEY` / `GOOGLE_API_KEY` / `MINIMAX_API_KEY` / `OPENAI_BASE_URL` is set, or `AGENTMEMORY_PROVIDER=agent-sdk`. Explicit `=false` / `=0` / `AGENTMEMORY_PROVIDER=noop` still wins.
- `src/functions/consolidation-pipeline.ts` — skip-reason text updated from generic "CONSOLIDATION_ENABLED is not set to true" to point users at the env vars they should set.
- `README.md` — updated both occurrences of `CONSOLIDATION_ENABLED=true` so docs reflect the new default.
- `test/consolidation-default.test.ts` — 8 new tests covering: no-provider default-off, each supported provider default-on, explicit `=false` override, explicit `=true` override, `AGENTMEMORY_PROVIDER=noop` wins over API-key presence.

## Behavior matrix

| Env | Old default | New default |
|---|---|---|
| nothing set | off | off (BM25-only) |
| `ANTHROPIC_API_KEY=…` (or any provider key) | off | **on** |
| `OPENAI_BASE_URL=…` (local OpenAI-compatible) | off | **on** |
| `AGENTMEMORY_PROVIDER=agent-sdk` | off | **on** |
| `AGENTMEMORY_PROVIDER=noop` | off | off |
| `CONSOLIDATION_ENABLED=false` | off | off |
| `CONSOLIDATION_ENABLED=true` | on | on |

## Test plan

- [x] `npx vitest run test/consolidation-default.test.ts` — 8/8 pass
- [x] `npx vitest run test/env-loader.test.ts test/consolidation-pipeline.test.ts` — both green (existing assertions still hold)
- [x] `npx vitest run` — 1276/1276 pass (integration.test.ts skipped, needs running server, pre-existing)
- [x] `npm run build` clean

Closes #612.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified configuration: consolidation is enabled by default when an LLM provider is configured, can be explicitly toggled with CONSOLIDATION_ENABLED (true/false or 1/0), and graph extraction is controlled separately via GRAPH_EXTRACTION_ENABLED.
* **Tests**
  * Added comprehensive tests covering consolidation defaults and explicit overrides across various environment configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/696?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->