### PR TITLE
fix(graph): wire session-end → graph extraction + repair status (#666)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,7 +117,7 @@ Hook scripts in `src/hooks/` are standalone Node.js scripts (no iii-sdk import).
 ## Current Stats (v0.9.16)
 
 - 53 MCP tools (8 visible by default, `AGENTMEMORY_TOOLS=all` for all)
-- 124 REST endpoints
+- 125 REST endpoints
 - 6 MCP resources, 3 MCP prompts
 - 12 hooks, 4 skills
 - 50+ iii functions

--- a/README.md
+++ b/README.md
@@ -1363,7 +1363,7 @@ Create `~/.agentmemory/.env`:
 
 <h2 id="api"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/section-api.svg"><img src="assets/tags/section-api.svg" alt="API" height="32" /></picture></h2>
 
-124 endpoints on port `3111`. The REST API binds to `127.0.0.1` by default. Protected endpoints require `Authorization: Bearer <secret>` when `AGENTMEMORY_SECRET` is set, and mesh sync endpoints require `AGENTMEMORY_SECRET` on both peers.
+125 endpoints on port `3111`. The REST API binds to `127.0.0.1` by default. Protected endpoints require `Authorization: Bearer <secret>` when `AGENTMEMORY_SECRET` is set, and mesh sync endpoints require `AGENTMEMORY_SECRET` on both peers.
 
 <details>
 <summary>Key endpoints</summary>

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1162,7 +1162,7 @@ async function runStatus() {
       apiFetch<any>(base, "health"),
       apiFetch<any>(base, "sessions"),
       apiFetch<any>(base, "graph/stats"),
-      apiFetch<any>(base, "export"),
+      apiFetch<any>(base, "memories"),
       apiFetch<any>(base, "config/flags"),
     ]);
 
@@ -1172,15 +1172,19 @@ async function runStatus() {
     const h = healthRes?.health;
     const status = healthRes?.status || "unknown";
     const version = healthRes?.version || "?";
-    const sessions = Array.isArray(sessionsRes?.sessions) ? sessionsRes.sessions.length : 0;
+    const sessionList = Array.isArray(sessionsRes?.sessions) ? sessionsRes.sessions : [];
+    const sessions = sessionList.length;
     const nodes = Number(graphRes?.totalNodes ?? graphRes?.nodes ?? graphRes?.nodeCount ?? 0);
     const edges = Number(graphRes?.totalEdges ?? graphRes?.edges ?? graphRes?.edgeCount ?? 0);
     const cb = healthRes?.circuitBreaker?.state || "closed";
     const heapMB = h?.memory ? Math.round(h.memory.heapUsed / 1048576) : 0;
     const uptime = h?.uptimeSeconds ? Math.round(h.uptimeSeconds) : 0;
 
-    const obsCount = memoriesRes?.observations?.length || 0;
-    const memCount = memoriesRes?.memories?.length || 0;
+    const obsCount = sessionList.reduce(
+      (sum: number, s: any) => sum + (Number(s?.observationCount) || 0),
+      0,
+    );
+    const memCount = Array.isArray(memoriesRes?.memories) ? memoriesRes.memories.length : 0;
     const estFullTokens = obsCount * 80;
     const estInjectedTokens = Math.min(obsCount, 50) * 38;
     const tokensSaved = estFullTokens - estInjectedTokens;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1162,7 +1162,7 @@ async function runStatus() {
       apiFetch<any>(base, "health"),
       apiFetch<any>(base, "sessions"),
       apiFetch<any>(base, "graph/stats"),
-      apiFetch<any>(base, "memories"),
+      apiFetch<any>(base, "memories?count=true"),
       apiFetch<any>(base, "config/flags"),
     ]);
 
@@ -1184,7 +1184,7 @@ async function runStatus() {
       (sum: number, s: any) => sum + (Number(s?.observationCount) || 0),
       0,
     );
-    const memCount = Array.isArray(memoriesRes?.memories) ? memoriesRes.memories.length : 0;
+    const memCount = Number(memoriesRes?.latestCount ?? memoriesRes?.total ?? 0) || 0;
     const estFullTokens = obsCount * 80;
     const estInjectedTokens = Math.min(obsCount, 50) * 38;
     const tokensSaved = estFullTokens - estInjectedTokens;

--- a/src/index.ts
+++ b/src/index.ts
@@ -516,7 +516,7 @@ async function main() {
     `Ready. ${embeddingProvider ? "Triple-stream (BM25+Vector+Graph)" : "BM25+Graph"} search active.`,
   );
   bootLog(
-    `REST API: 124 endpoints at http://localhost:${config.restPort}/agentmemory/*`,
+    `REST API: 125 endpoints at http://localhost:${config.restPort}/agentmemory/*`,
   );
   bootLog(
     `MCP surface (opt-in via \`npx @agentmemory/mcp\`): ${getAllTools().length} tools · 6 resources · 3 prompts`,

--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -12,6 +12,7 @@ import { isSlotsEnabled, isReflectEnabled } from "../functions/slots.js";
 import { renderViewerDocument } from "../viewer/document.js";
 import { getBoundViewerPort, getViewerSkipped } from "../viewer/server.js";
 import { MAX_FILES_UPPER_BOUND } from "../functions/replay.js";
+import { logger } from "../logger.js";
 import {
   isGraphExtractionEnabled,
   isConsolidationEnabled,
@@ -610,6 +611,11 @@ export function registerApiTriggers(
         { type: "set", path: "endedAt", value: new Date().toISOString() },
         { type: "set", path: "status", value: "completed" },
       ]);
+      // Fan out the session-stopped lifecycle (summarize → slot reflect →
+      // graph extraction) without blocking the HTTP response. The
+      // `agentmemory.session.stopped` topic has no publisher today (#666),
+      // so subscribers in events.ts never fired and graphs stayed empty.
+      sdk.triggerVoid("event::session::stopped", { sessionId });
       return { status_code: 200, body: { success: true } };
     },
   );
@@ -1386,7 +1392,72 @@ export function registerApiTriggers(
     config: { api_path: "/agentmemory/graph/extract", http_method: "POST" },
   });
 
-  sdk.registerFunction("api::consolidate-pipeline", 
+  // Backfill the knowledge graph from existing compressed observations.
+  // Viewer calls this when the graph is empty (#666). Iterates every
+  // session, collects observations that have a `title` (compressed only),
+  // and feeds them through `mem::graph-extract` in batches.
+  sdk.registerFunction("api::graph-build",
+    async (req: ApiRequest<{ batchSize?: number }>): Promise<Response> => {
+      const authErr = checkAuth(req, secret);
+      if (authErr) return authErr;
+      const batchSize = Math.max(
+        1,
+        Math.min(100, Number((req.body as { batchSize?: number })?.batchSize) || 25),
+      );
+      try {
+        const sessions = await kv.list<Session>(KV.sessions);
+        let totalNodes = 0;
+        let totalEdges = 0;
+        let batchesRun = 0;
+        for (const session of sessions) {
+          const sid = session?.id;
+          if (typeof sid !== "string" || sid.length === 0) continue;
+          const observations = await kv.list<CompressedObservation>(KV.observations(sid));
+          const compressed = observations.filter((o) => o && typeof o.title === "string" && o.title.length > 0);
+          if (compressed.length === 0) continue;
+          for (let i = 0; i < compressed.length; i += batchSize) {
+            const batch = compressed.slice(i, i + batchSize);
+            try {
+              const result = (await sdk.trigger({
+                function_id: "mem::graph-extract",
+                payload: { observations: batch },
+              })) as { success?: boolean; nodesAdded?: number; edgesAdded?: number };
+              if (result?.success) {
+                totalNodes += Number(result.nodesAdded) || 0;
+                totalEdges += Number(result.edgesAdded) || 0;
+              }
+              batchesRun++;
+            } catch (err) {
+              logger.warn("graph-build batch failed", {
+                sessionId: sid,
+                batchIndex: Math.floor(i / batchSize),
+                error: err instanceof Error ? err.message : String(err),
+              });
+            }
+          }
+        }
+        return {
+          status_code: 200,
+          body: {
+            success: true,
+            sessions: sessions.length,
+            batches: batchesRun,
+            nodes: totalNodes,
+            edges: totalEdges,
+          },
+        };
+      } catch {
+        return graphDisabledResponse();
+      }
+    },
+  );
+  sdk.registerTrigger({
+    type: "http",
+    function_id: "api::graph-build",
+    config: { api_path: "/agentmemory/graph/build", http_method: "POST" },
+  });
+
+  sdk.registerFunction("api::consolidate-pipeline",
     async (req: ApiRequest<{ tier?: string }>): Promise<Response> => {
       const authErr = checkAuth(req, secret);
       if (authErr) return authErr;

--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -611,11 +611,15 @@ export function registerApiTriggers(
         { type: "set", path: "endedAt", value: new Date().toISOString() },
         { type: "set", path: "status", value: "completed" },
       ]);
-      // Fan out the session-stopped lifecycle (summarize → slot reflect →
-      // graph extraction) without blocking the HTTP response. The
-      // `agentmemory.session.stopped` topic has no publisher today (#666),
-      // so subscribers in events.ts never fired and graphs stayed empty.
-      sdk.triggerVoid("event::session::stopped", { sessionId });
+      // Fan out session-stopped lifecycle (non-blocking).
+      try {
+        sdk.triggerVoid("event::session::stopped", { sessionId });
+      } catch (err) {
+        logger.warn("event::session::stopped triggerVoid failed", {
+          sessionId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
       return { status_code: 200, body: { success: true } };
     },
   );

--- a/test/session-end-triggers-graph.test.ts
+++ b/test/session-end-triggers-graph.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+
+// #666: api::session::end must publish the session-stopped lifecycle so
+// summarize + slot-reflect + graph extraction actually fire. Before this
+// fix the `event::session::stopped` handler in events.ts was a dead
+// subscriber — no code published `agentmemory.session.stopped`, so graph
+// nodes / lessons / crystals never materialized despite the handler
+// existing. Direct triggerVoid keeps the HTTP response fast (kv.update
+// runs synchronously, downstream pipeline fan-outs without blocking).
+describe("api::session::end → event::session::stopped (#666)", () => {
+  const api = readFileSync("src/triggers/api.ts", "utf-8");
+
+  it("api::session::end calls sdk.triggerVoid('event::session::stopped') after kv.update", () => {
+    expect(api).toMatch(
+      /api::session::end[\s\S]*?kv\.update\(KV\.sessions[\s\S]*?triggerVoid\("event::session::stopped"/,
+    );
+  });
+
+  it("triggerVoid payload includes sessionId", () => {
+    expect(api).toMatch(
+      /triggerVoid\("event::session::stopped",\s*\{\s*sessionId\s*\}/,
+    );
+  });
+});
+
+// #666: viewer's "Build Graph" button used to POST /agentmemory/graph/build
+// which returned 404 because the endpoint was never registered. Backfill
+// the knowledge graph from existing compressed observations across every
+// session in batches.
+describe("api::graph-build endpoint (#666)", () => {
+  const api = readFileSync("src/triggers/api.ts", "utf-8");
+
+  it("registers api::graph-build function", () => {
+    expect(api).toMatch(/registerFunction\("api::graph-build"/);
+  });
+
+  it("registers HTTP trigger at /agentmemory/graph/build", () => {
+    expect(api).toMatch(
+      /api_path:\s*"\/agentmemory\/graph\/build",\s*http_method:\s*"POST"/,
+    );
+  });
+
+  it("iterates sessions and calls mem::graph-extract", () => {
+    expect(api).toMatch(/kv\.list<Session>\(KV\.sessions\)/);
+    expect(api).toMatch(/kv\.list<CompressedObservation>\(KV\.observations\(sid\)\)/);
+    expect(api).toMatch(
+      /sdk\.trigger\(\{\s*function_id:\s*"mem::graph-extract"/,
+    );
+  });
+
+  it("filters observations that have a title (compressed only)", () => {
+    expect(api).toMatch(/o\.title === "string" && o\.title\.length > 0/);
+  });
+
+  it("respects batchSize override with a 100-item upper bound", () => {
+    expect(api).toMatch(/Math\.min\(100,\s*Number\(.*batchSize/);
+  });
+
+  it("response shape matches what the viewer expects (success + nodes)", () => {
+    expect(api).toMatch(/success:\s*true,\s*sessions:[\s\S]*?nodes:\s*totalNodes/);
+  });
+});
+
+// #666: `agentmemory status` showed Memories/Observations as 0 because it
+// fetched /agentmemory/export which times out on iii-engine's file-based
+// KV under concurrent kv.list() pressure. Switch to /memories for the
+// memory count and derive observation count from sessions[].observationCount.
+describe("agentmemory status no longer depends on /export (#666)", () => {
+  const cli = readFileSync("src/cli.ts", "utf-8");
+
+  it("status fetches memories instead of export", () => {
+    expect(cli).toMatch(/apiFetch<any>\(base,\s*"memories"\)/);
+    expect(cli).not.toMatch(/apiFetch<any>\(base,\s*"export"\)/);
+  });
+
+  it("status derives obsCount from sessions[].observationCount", () => {
+    expect(cli).toMatch(
+      /sessionList\.reduce\([\s\S]*?observationCount/,
+    );
+  });
+
+  it("status reads memCount from memoriesRes.memories.length", () => {
+    expect(cli).toMatch(/memoriesRes\?\.memories\) \? memoriesRes\.memories\.length : 0/);
+  });
+});

--- a/test/session-end-triggers-graph.test.ts
+++ b/test/session-end-triggers-graph.test.ts
@@ -50,7 +50,7 @@ describe("api::graph-build endpoint (#666)", () => {
   });
 
   it("filters observations that have a title (compressed only)", () => {
-    expect(api).toMatch(/o\.title === "string" && o\.title\.length > 0/);
+    expect(api).toMatch(/typeof o\.title === "string" && o\.title\.length > 0/);
   });
 
   it("respects batchSize override with a 100-item upper bound", () => {
@@ -69,8 +69,8 @@ describe("api::graph-build endpoint (#666)", () => {
 describe("agentmemory status no longer depends on /export (#666)", () => {
   const cli = readFileSync("src/cli.ts", "utf-8");
 
-  it("status fetches memories instead of export", () => {
-    expect(cli).toMatch(/apiFetch<any>\(base,\s*"memories"\)/);
+  it("status uses count-only memories endpoint instead of export", () => {
+    expect(cli).toMatch(/apiFetch<any>\(base,\s*"memories\?count=true"\)/);
     expect(cli).not.toMatch(/apiFetch<any>\(base,\s*"export"\)/);
   });
 
@@ -80,7 +80,7 @@ describe("agentmemory status no longer depends on /export (#666)", () => {
     );
   });
 
-  it("status reads memCount from memoriesRes.memories.length", () => {
-    expect(cli).toMatch(/memoriesRes\?\.memories\) \? memoriesRes\.memories\.length : 0/);
+  it("status reads memCount from memoriesRes.latestCount (count endpoint)", () => {
+    expect(cli).toMatch(/memoriesRes\?\.latestCount\s*\?\?\s*memoriesRes\?\.total/);
   });
 });


### PR DESCRIPTION
## Summary

Three concrete bugs from [#666](https://github.com/rohitg00/agentmemory/issues/666), all verified line-by-line. Reporter @LeonemFu did very clean root-cause analysis — went straight to the cause for each.

### Bug 1: Knowledge graph stays empty forever

The `event::session::stopped` handler in `src/triggers/events.ts:47-81` listens on the `agentmemory.session.stopped` topic and is responsible for firing `mem::summarize` + `mem::slot-reflect` + `mem::graph-extract` when a session ends. Nothing in the codebase **publishes** that topic. `api::session::end` just runs `kv.update(endedAt, status=completed)` and returns. So the handler is a dead subscriber and graphs / lessons / crystals never materialize.

Confirmed by 3 independent reporters in the thread:
- @LeonemFu (macOS, v0.9.21)
- @HWliao (Windows + opencode)
- @evan-choi (macOS, v0.9.22 + pi)

**Fix**: `api::session::end` now calls `sdk.triggerVoid("event::session::stopped", { sessionId })` after the KV update so the existing pipeline fires. HTTP response stays fast — `kv.update` is synchronous, downstream summarize / graph-extract fans out without blocking.

### Bug 2: `agentmemory status` shows Memories/Observations = 0

`src/cli.ts:1161-1183` does `Promise.all([health, sessions, graph/stats, export, config/flags])` then reads `obsCount = memoriesRes?.observations?.length || 0`. The problem: `/agentmemory/export` consistently times out (>5s) on iii-engine's file-based KV under concurrent `kv.list()` pressure — even on small datasets (121 observations / 26 sessions in the reporter's case). The `Promise.all` swallows the timeout and falls back to 0.

**Fix**: Switch the slow fetch to `/memories` (already paginated per #544) and derive observation count from `sessionList.reduce((sum, s) => sum + (s.observationCount || 0), 0)`. Status no longer depends on the slow path.

### Bug 3: Viewer "Build Graph" button → 404

`src/viewer/index.html:1608` and `:2000` both `apiPost('graph/build', {})` when the graph is empty or the user clicks "Rebuild". The endpoint was never registered on the server.

**Fix**: New `api::graph-build` (registered at `POST /agentmemory/graph/build`) iterates every session, lists its compressed observations (filter on `title` field — uncompressed obs aren't ready for extraction), and feeds them through `mem::graph-extract` in batches (default 25, configurable via `{ batchSize: N }`, capped at 100). Returns `{ success, sessions, batches, nodes, edges }` for the viewer's progress UI.

## Test plan

- [x] `npx vitest run test/session-end-triggers-graph.test.ts` — 11/11 pass (3 groups: triggerVoid wiring, graph-build endpoint shape, cli no longer depends on /export)
- [x] `npx vitest run` — 1278/1278 pass (integration.test.ts skipped pre-existing, consistency.test.ts now requires the bumped 125 endpoint count which is updated in src/index.ts + README.md + AGENTS.md)
- [x] `npm run build` clean
- [x] Manual: status with timing-out export now reports correct counts, viewer "Build Graph" no longer 404s

## Consistency

Per AGENTS.md consistency rules — REST endpoint count bumped 124 → 125 in `src/index.ts`, README.md, AGENTS.md.

Closes #666.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated REST endpoint count to 125 across docs and startup logs

* **New Features**
  * Session completion now emits a lifecycle event
  * Added a graph-build endpoint to backfill the knowledge graph from existing session observations with configurable batching and summary stats

* **Bug Fixes / Improvements**
  * Improved status reporting to use reliable memory and observation counts

* **Tests**
  * Added coverage for session-end triggers, graph-build behavior, and status reporting changes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/698?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->