### PR TITLE
fix(viewer): sort Memories tab newest first (#674)

### DIFF
--- a/src/viewer/index.html
+++ b/src/viewer/index.html
@@ -2265,8 +2265,15 @@
       // corpora. Older endpoints returned the full unbounded list which
       // hit the iii invocation timeout and the UI fell through to 0.
       var result = await apiGet('memories?latest=true&limit=2000');
-      state.memories.items = (result && result.memories) || [];
-      state.memories.total = (result && typeof result.total === 'number') ? result.total : state.memories.items.length;
+      var items = (result && result.memories) || [];
+      // Newest first — server returns KV-insertion order.
+      items.sort(function(a, b) {
+        var ac = (a && a.createdAt) || (a && a.updatedAt) || '';
+        var bc = (b && b.createdAt) || (b && b.updatedAt) || '';
+        return bc.localeCompare(ac);
+      });
+      state.memories.items = items;
+      state.memories.total = (result && typeof result.total === 'number') ? result.total : items.length;
       state.memories.loaded = true;
       renderMemories();
     }

--- a/test/viewer-memories-sort.test.ts
+++ b/test/viewer-memories-sort.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+
+// Viewer Memories tab used to render in KV-insertion order, hiding new
+// entries at the bottom of long lists (#674). loadMemories() now sorts
+// the response newest-first on `createdAt` (fallback `updatedAt`) before
+// renderMemories sees it. Matches the pattern already used by Sessions
+// and Metrics tabs which sort on `startedAt` desc via localeCompare.
+describe("viewer Memories tab sorts newest first (#674)", () => {
+  const viewer = readFileSync("src/viewer/index.html", "utf-8");
+
+  it("loadMemories sorts items by createdAt desc before storing in state", () => {
+    expect(viewer).toMatch(
+      /loadMemories[\s\S]*?items\.sort\(function\(a,\s*b\)\s*\{[\s\S]*?bc\.localeCompare\(ac\)/,
+    );
+  });
+
+  it("sort falls back to updatedAt when createdAt is missing", () => {
+    expect(viewer).toMatch(
+      /\(a && a\.createdAt\) \|\| \(a && a\.updatedAt\)/,
+    );
+    expect(viewer).toMatch(
+      /\(b && b\.createdAt\) \|\| \(b && b\.updatedAt\)/,
+    );
+  });
+
+  it("Memories sort mirrors the Sessions/Metrics localeCompare descending pattern", () => {
+    expect(viewer).toMatch(
+      /sessions\.sort\(function\(a, b\) \{ return \(b\.startedAt \|\| ''\)\.localeCompare\(a\.startedAt \|\| ''\); \}\)/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

[#674](https://github.com/rohitg00/agentmemory/issues/674) — viewer Memories tab renders in KV-insertion order, so newly-saved memories appear at the bottom of long lists. Sessions and Metrics tabs already sort `startedAt` desc via `localeCompare`; Memories should match.

## Changes

- `src/viewer/index.html` — `loadMemories()` now sorts items newest-first on `createdAt` (fallback `updatedAt`) before storing in `state.memories.items`. Sort runs once on load, not per render — same pattern the Sessions / Metrics tabs use at viewer:1426 / :2407 / :2420 / :2636. No new deps, no API change.
- `test/viewer-memories-sort.test.ts` — 3 source-string assertions confirming the sort + fallback + parallel structure with sessions sort.

## Test plan

- [x] `npx vitest run test/viewer-memories-sort.test.ts` — 3/3 pass
- [x] Manual: open viewer with 500+ memories, call `memory_save`, refresh Memories tab — new entry appears at top.

Closes #674.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Memory entries in the Memories tab now display with the newest items appearing first.

* **Tests**
  * Added test coverage for memory sorting functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/701?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->