### PR TITLE
feat(connect): print 'npx skills add' hint after successful wire

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ npm install -g @agentmemory/agentmemory          # once — bare `agentmemory` o
 # sudo npm install -g @agentmemory/agentmemory
 agentmemory                                      # start the memory server on :3111
 agentmemory demo                                 # seed sample sessions + prove recall
-agentmemory connect claude-code                  # wire your agent (also: copilot-cli, codex, cursor, gemini-cli, ...)
+agentmemory connect claude-code                  # wire MCP into your agent (also: copilot-cli, codex, cursor, gemini-cli, ...)
+npx skills add rohitg00/agentmemory -y           # install 8 native skills so your agent knows when to use the tools
 ```
 
 Or via `npx` (no install):
@@ -549,6 +550,25 @@ Full guide: [`integrations/hermes/`](integrations/hermes/)
 ### Other agents
 
 Start the memory server: `npx @agentmemory/agentmemory`
+
+#### Native skills via `npx skills add` (50+ agents)
+
+agentmemory ships 8 skills (`remember`, `recall`, `recap`, `handoff`, `forget`, `commit-context`, `commit-history`, `session-history`) in the Claude-Code-style `<dir>/SKILL.md` format. The [`skills`](https://npmjs.com/package/skills) CLI by vercel-labs auto-installs them into the calling agent's native skill directory across 50+ agents (Claude Code, Cursor, Cline, Continue, Droid, Warp, Codex, Antigravity, Kiro, OpenCode, Goose, Roo, Trae, Windsurf, and more):
+
+```bash
+npx skills add rohitg00/agentmemory -y          # auto-detects the calling agent
+npx skills add rohitg00/agentmemory -y -a warp  # explicit agent
+npx skills add rohitg00/agentmemory -y -a '*'   # install to every installed agent
+```
+
+This is **complementary** to `agentmemory connect <agent>`:
+
+- `agentmemory connect <agent>` writes the MCP server config so the tools are available.
+- `npx skills add rohitg00/agentmemory` installs the skills so the agent knows when to call them.
+
+For the few agents the skills CLI doesn't cover yet (Zed v1.3.x and below), drop the 8 SKILL.md files under the agent's native skill directory yourself — same format works everywhere.
+
+#### Standard MCP block
 
 The agentmemory entry is the **same MCP server block** across every host that uses the `mcpServers` shape (Cursor, Claude Desktop, Cline, Roo Code, Windsurf, Gemini CLI, OpenClaw):
 

--- a/src/cli/connect/index.ts
+++ b/src/cli/connect/index.ts
@@ -192,5 +192,15 @@ function summarize(
       `${stubs.length} agent(s) require manual install — see docs links above.`,
     );
   }
+
+  const wiredAny = results.some(
+    (r) => r.result.kind === "installed" || r.result.kind === "already-wired",
+  );
+  if (wiredAny) {
+    p.log.info(
+      "Next: install agentmemory's 8 skills into the same agent(s) so they know when to call the tools:\n  npx skills add rohitg00/agentmemory -y",
+    );
+  }
+
   p.outro("Restart any wired agent (or open a new session) to pick up agentmemory.");
 }


### PR DESCRIPTION
## Summary

Close the loop on the native-surface audit in #708. The [`skills`](https://npmjs.com/package/skills) CLI (vercel-labs) covers 4 of the 5 agents from #677 (warp, cline, continue, droid) plus 45+ others — wiring that path into the agentmemory UX saves ~600 LOC of would-be per-agent adapter code and tracks new agents automatically as the upstream keyword list grows.

## Changes

- `src/cli/connect/index.ts` — `summarize()` prints a one-line `npx skills add rohitg00/agentmemory -y` next-step after any successful or already-wired adapter run. No subprocess spawn — keeps `connect` offline-capable and deterministic.
- `README.md` — install snippet bumped from a one-line `connect` to the two-line flow. Adds "Native skills via `npx skills add` (50+ agents)" subsection under "Other agents" explaining the two-step pattern (`connect` writes MCP config, `skills add` installs native skills).

## Tested

```
◇  Repository cloned
◇  Found 8 skills
◇  Available Skills
    commit-context, commit-history, ... (8 total)
```

`npx skills add rohitg00/agentmemory --list` against the public repo enumerates all 8 skills correctly.

## Test plan

- [x] `npm run build` clean
- [x] `npx vitest run test/cli-connect.test.ts` — 22/22 pass
- [x] Manual: `agentmemory connect codex --dry-run` shows the new hint line after the existing "Restart any wired agent" outro.

Refs #708. Closes the documentation gap from the 5 agents in #677 (#703, #704, #705, #707 closed-as-redundant). #706 (Zed) stays open — not in the skills CLI keyword list yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced quickstart instructions with native skills installation steps.
  * Added dedicated setup section for installing native skills via CLI with usage examples.

* **New Features**
  * CLI now displays next-step guidance to install native skills after successful agent setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/709?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->