### PR TITLE
feat: add AGENTMEMORY_OUTPUT_LANG to control generated-text language

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -114,6 +114,7 @@
 # AGENTMEMORY_REFLECT=true                       # Periodically auto-synthesize lessons from memories
 # AGENTMEMORY_DROP_STALE_INDEX=true              # Drop on-disk BM25 / vector index on startup if dim guard fires (#248). Recovery toggle for stuck-state debugging.
 # AGENTMEMORY_IMAGE_EMBEDDINGS=true              # Enable image embeddings when an image provider is present (experimental).
+# AGENTMEMORY_OUTPUT_LANG=match                  # Language for generated text fields (title/narrative/facts/summary). Unset = current behaviour (English). "match" = follow the user's input language. Or a code/name: zh, ja, ko, "Português", … Code/paths always kept verbatim.
 
 # -----------------------------------------------------------------------------
 # 6. CLI / runtime knobs

--- a/src/prompts/output-language.ts
+++ b/src/prompts/output-language.ts
@@ -1,0 +1,66 @@
+import { getEnvVar } from "../config.js";
+
+/**
+ * Maps common short language codes / names to a canonical language label that
+ * reads naturally inside an instruction sentence. Anything not in the table is
+ * used verbatim, so `AGENTMEMORY_OUTPUT_LANG=Português` also works.
+ */
+const LANGUAGE_LABELS: Record<string, string> = {
+  zh: "Simplified Chinese",
+  "zh-cn": "Simplified Chinese",
+  "zh-hans": "Simplified Chinese",
+  chinese: "Simplified Chinese",
+  "zh-tw": "Traditional Chinese",
+  "zh-hant": "Traditional Chinese",
+  en: "English",
+  english: "English",
+  ja: "Japanese",
+  japanese: "Japanese",
+  ko: "Korean",
+  korean: "Korean",
+  es: "Spanish",
+  fr: "French",
+  de: "German",
+  pt: "Portuguese",
+  ru: "Russian",
+};
+
+/**
+ * Returns a directive, suitable for appending to any LLM *system* prompt, that
+ * controls the natural language of generated text fields (title, narrative,
+ * facts, concepts, summary, …). Code, identifiers, and file paths are always
+ * preserved verbatim.
+ *
+ * Controlled by the `AGENTMEMORY_OUTPUT_LANG` environment variable:
+ *   - unset / empty  → returns "" (no change to current behaviour; the model
+ *                       follows whatever language the system prompt is written
+ *                       in, i.e. English)
+ *   - "match"         → follow the language of the user's input/observation
+ *   - "zh" | "ja" | … → a known code, expanded to a full language label
+ *   - any other value → used verbatim as the target language name
+ *
+ * Returning "" for the unset case keeps the default behaviour byte-for-byte, so
+ * this is a strictly opt-in feature.
+ */
+export function outputLanguageDirective(): string {
+  const raw = (getEnvVar("AGENTMEMORY_OUTPUT_LANG") ?? "").trim();
+  if (!raw) return "";
+
+  if (raw.toLowerCase() === "match") {
+    return (
+      "\n\nIMPORTANT — OUTPUT LANGUAGE: Write all natural-language text fields " +
+      "(title, subtitle, narrative, facts, concepts, summary, etc.) in the SAME " +
+      "language as the user's input/observation content. If the input mixes " +
+      "languages, use the dominant language of the user's prose. Keep code, " +
+      "identifiers, and file paths verbatim. Do NOT translate user-language " +
+      "content to another language."
+    );
+  }
+
+  const label = LANGUAGE_LABELS[raw.toLowerCase()] ?? raw;
+  return (
+    `\n\nIMPORTANT — OUTPUT LANGUAGE: Write all natural-language text fields ` +
+    `(title, subtitle, narrative, facts, concepts, summary, etc.) in ${label}. ` +
+    `Keep code, identifiers, and file paths verbatim.`
+  );
+}

--- a/src/providers/resilient.ts
+++ b/src/providers/resilient.ts
@@ -1,5 +1,6 @@
 import type { MemoryProvider, CircuitBreakerState } from "../types.js";
 import { CircuitBreaker } from "./circuit-breaker.js";
+import { outputLanguageDirective } from "../prompts/output-language.js";
 
 export class ResilientProvider implements MemoryProvider {
   private breaker = new CircuitBreaker();
@@ -24,11 +25,13 @@ export class ResilientProvider implements MemoryProvider {
   }
 
   async compress(systemPrompt: string, userPrompt: string): Promise<string> {
-    return this.call(() => this.inner.compress(systemPrompt, userPrompt));
+    const system = systemPrompt + outputLanguageDirective();
+    return this.call(() => this.inner.compress(system, userPrompt));
   }
 
   async summarize(systemPrompt: string, userPrompt: string): Promise<string> {
-    return this.call(() => this.inner.summarize(systemPrompt, userPrompt));
+    const system = systemPrompt + outputLanguageDirective();
+    return this.call(() => this.inner.summarize(system, userPrompt));
   }
 
   get circuitState(): CircuitBreakerState {


### PR DESCRIPTION
## Problem

All LLM-generated memory fields (title, narrative, facts, concepts, summary) are produced in the language the system prompts are written in — English — regardless of the user's working language. For non-English users this means:

- Memories are stored in English even when every input is in their native language, making them hard to read back.
- Native-language recall queries match these English memories poorly (cross-lingual gap on both the BM25 and dense legs), so cross-session memory becomes much less useful.

A quick A/B against a real corpus showed same-concept recall scoring ~4x worse for a non-English query than its English equivalent, largely because the stored text had been forced to English.

## Change

Add an **opt-in** `AGENTMEMORY_OUTPUT_LANG` env var. It's injected once in `ResilientProvider` — the wrapper every provider passes through — so a single change covers `compress` + `summarize` across **all** providers and **all** prompts (compression, summary, consolidation, graph-extraction, reflect, …).

| Value | Behaviour |
|-------|-----------|
| unset / empty | **unchanged** — English (strictly opt-in, default byte-for-byte identical) |
| `match` | follow the user's input/observation language |
| `zh` / `ja` / `ko` / … | known code, expanded to a full language label |
| any other string | used verbatim as the target language name (e.g. `Português`) |

Code, identifiers, and file paths are always preserved verbatim.

## Why ResilientProvider

Every provider is constructed inside a `ResilientProvider` (see `createProvider` / `createFallbackProvider`), and both `compress` and `summarize` funnel through it. Injecting the directive there keeps the diff to ~6 lines and guarantees no prompt path is missed, rather than touching each of the 10+ call sites.

## Files

- `src/prompts/output-language.ts` (new) — `outputLanguageDirective()` helper
- `src/providers/resilient.ts` — append directive in `compress` / `summarize`
- `.env.example` — document the flag

## Notes

- Returning `""` for the unset case keeps current behaviour exactly, so existing users see no change.
- Verified the directive logic for all input shapes (unset, `match`, known codes case-insensitively, verbatim names).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable output language feature for generated text fields (title, narrative, facts, summary). Users can set the language to English (default), match their input language, or specify any target language via the `AGENTMEMORY_OUTPUT_LANG` environment variable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/711?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->