### PR TITLE
_project.ts: resolve project from canonical remote.origin.url

### DIFF
--- a/plugin/scripts/notification.mjs
+++ b/plugin/scripts/notification.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { basename } from "node:path";
 
 //#region src/hooks/_project.ts
@@ -7,19 +7,69 @@ function resolveProject(cwd) {
 	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
 	if (explicit && explicit.trim()) return explicit.trim();
 	const dir = cwd && cwd.trim() ? cwd : process.cwd();
+	const remote = readGitConfig(dir, "remote.origin.url");
+	if (remote) {
+		const canonical = canonicalizeRemoteUrl(remote);
+		if (canonical) return canonical;
+	}
+	const top = readGitToplevel(dir);
+	if (top) return basename(top);
+	return basename(dir);
+}
+function readGitConfig(cwd, key) {
 	try {
-		const top = execSync("git rev-parse --show-toplevel", {
-			cwd: dir,
+		return execFileSync("git", [
+			"config",
+			"--get",
+			key
+		], {
+			cwd,
 			stdio: [
 				"ignore",
 				"pipe",
 				"ignore"
 			],
 			timeout: 500
-		}).toString().trim();
-		if (top) return basename(top);
-	} catch {}
-	return basename(dir);
+		}).toString().trim() || void 0;
+	} catch {
+		return;
+	}
+}
+function readGitToplevel(cwd) {
+	try {
+		return execFileSync("git", ["rev-parse", "--show-toplevel"], {
+			cwd,
+			stdio: [
+				"ignore",
+				"pipe",
+				"ignore"
+			],
+			timeout: 500
+		}).toString().trim() || void 0;
+	} catch {
+		return;
+	}
+}
+function canonicalizeRemoteUrl(raw) {
+	const url = raw.trim();
+	if (!url) return void 0;
+	let host;
+	let path;
+	const scp = url.match(/^[^@\s/:]+@([^:\s/[\]]+):(.+)$/);
+	if (scp && !url.includes("://")) {
+		host = scp[1];
+		path = scp[2];
+	} else try {
+		const u = new URL(url);
+		host = u.hostname;
+		path = u.pathname;
+	} catch {
+		return;
+	}
+	if (!host || !path) return void 0;
+	path = path.replace(/^\/+/, "").replace(/\/+$/, "").replace(/\.git$/i, "");
+	if (!path) return void 0;
+	return `${host}/${path}`.toLowerCase();
 }
 
 //#endregion

--- a/plugin/scripts/post-tool-failure.mjs
+++ b/plugin/scripts/post-tool-failure.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { basename } from "node:path";
 
 //#region src/hooks/_project.ts
@@ -7,19 +7,69 @@ function resolveProject(cwd) {
 	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
 	if (explicit && explicit.trim()) return explicit.trim();
 	const dir = cwd && cwd.trim() ? cwd : process.cwd();
+	const remote = readGitConfig(dir, "remote.origin.url");
+	if (remote) {
+		const canonical = canonicalizeRemoteUrl(remote);
+		if (canonical) return canonical;
+	}
+	const top = readGitToplevel(dir);
+	if (top) return basename(top);
+	return basename(dir);
+}
+function readGitConfig(cwd, key) {
 	try {
-		const top = execSync("git rev-parse --show-toplevel", {
-			cwd: dir,
+		return execFileSync("git", [
+			"config",
+			"--get",
+			key
+		], {
+			cwd,
 			stdio: [
 				"ignore",
 				"pipe",
 				"ignore"
 			],
 			timeout: 500
-		}).toString().trim();
-		if (top) return basename(top);
-	} catch {}
-	return basename(dir);
+		}).toString().trim() || void 0;
+	} catch {
+		return;
+	}
+}
+function readGitToplevel(cwd) {
+	try {
+		return execFileSync("git", ["rev-parse", "--show-toplevel"], {
+			cwd,
+			stdio: [
+				"ignore",
+				"pipe",
+				"ignore"
+			],
+			timeout: 500
+		}).toString().trim() || void 0;
+	} catch {
+		return;
+	}
+}
+function canonicalizeRemoteUrl(raw) {
+	const url = raw.trim();
+	if (!url) return void 0;
+	let host;
+	let path;
+	const scp = url.match(/^[^@\s/:]+@([^:\s/[\]]+):(.+)$/);
+	if (scp && !url.includes("://")) {
+		host = scp[1];
+		path = scp[2];
+	} else try {
+		const u = new URL(url);
+		host = u.hostname;
+		path = u.pathname;
+	} catch {
+		return;
+	}
+	if (!host || !path) return void 0;
+	path = path.replace(/^\/+/, "").replace(/\/+$/, "").replace(/\.git$/i, "");
+	if (!path) return void 0;
+	return `${host}/${path}`.toLowerCase();
 }
 
 //#endregion

--- a/plugin/scripts/post-tool-use.mjs
+++ b/plugin/scripts/post-tool-use.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { basename } from "node:path";
 
 //#region src/hooks/_project.ts
@@ -7,19 +7,69 @@ function resolveProject(cwd) {
 	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
 	if (explicit && explicit.trim()) return explicit.trim();
 	const dir = cwd && cwd.trim() ? cwd : process.cwd();
+	const remote = readGitConfig(dir, "remote.origin.url");
+	if (remote) {
+		const canonical = canonicalizeRemoteUrl(remote);
+		if (canonical) return canonical;
+	}
+	const top = readGitToplevel(dir);
+	if (top) return basename(top);
+	return basename(dir);
+}
+function readGitConfig(cwd, key) {
 	try {
-		const top = execSync("git rev-parse --show-toplevel", {
-			cwd: dir,
+		return execFileSync("git", [
+			"config",
+			"--get",
+			key
+		], {
+			cwd,
 			stdio: [
 				"ignore",
 				"pipe",
 				"ignore"
 			],
 			timeout: 500
-		}).toString().trim();
-		if (top) return basename(top);
-	} catch {}
-	return basename(dir);
+		}).toString().trim() || void 0;
+	} catch {
+		return;
+	}
+}
+function readGitToplevel(cwd) {
+	try {
+		return execFileSync("git", ["rev-parse", "--show-toplevel"], {
+			cwd,
+			stdio: [
+				"ignore",
+				"pipe",
+				"ignore"
+			],
+			timeout: 500
+		}).toString().trim() || void 0;
+	} catch {
+		return;
+	}
+}
+function canonicalizeRemoteUrl(raw) {
+	const url = raw.trim();
+	if (!url) return void 0;
+	let host;
+	let path;
+	const scp = url.match(/^[^@\s/:]+@([^:\s/[\]]+):(.+)$/);
+	if (scp && !url.includes("://")) {
+		host = scp[1];
+		path = scp[2];
+	} else try {
+		const u = new URL(url);
+		host = u.hostname;
+		path = u.pathname;
+	} catch {
+		return;
+	}
+	if (!host || !path) return void 0;
+	path = path.replace(/^\/+/, "").replace(/\/+$/, "").replace(/\.git$/i, "");
+	if (!path) return void 0;
+	return `${host}/${path}`.toLowerCase();
 }
 
 //#endregion

--- a/plugin/scripts/pre-compact.mjs
+++ b/plugin/scripts/pre-compact.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { basename } from "node:path";
 
 //#region src/hooks/_project.ts
@@ -7,19 +7,69 @@ function resolveProject(cwd) {
 	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
 	if (explicit && explicit.trim()) return explicit.trim();
 	const dir = cwd && cwd.trim() ? cwd : process.cwd();
+	const remote = readGitConfig(dir, "remote.origin.url");
+	if (remote) {
+		const canonical = canonicalizeRemoteUrl(remote);
+		if (canonical) return canonical;
+	}
+	const top = readGitToplevel(dir);
+	if (top) return basename(top);
+	return basename(dir);
+}
+function readGitConfig(cwd, key) {
 	try {
-		const top = execSync("git rev-parse --show-toplevel", {
-			cwd: dir,
+		return execFileSync("git", [
+			"config",
+			"--get",
+			key
+		], {
+			cwd,
 			stdio: [
 				"ignore",
 				"pipe",
 				"ignore"
 			],
 			timeout: 500
-		}).toString().trim();
-		if (top) return basename(top);
-	} catch {}
-	return basename(dir);
+		}).toString().trim() || void 0;
+	} catch {
+		return;
+	}
+}
+function readGitToplevel(cwd) {
+	try {
+		return execFileSync("git", ["rev-parse", "--show-toplevel"], {
+			cwd,
+			stdio: [
+				"ignore",
+				"pipe",
+				"ignore"
+			],
+			timeout: 500
+		}).toString().trim() || void 0;
+	} catch {
+		return;
+	}
+}
+function canonicalizeRemoteUrl(raw) {
+	const url = raw.trim();
+	if (!url) return void 0;
+	let host;
+	let path;
+	const scp = url.match(/^[^@\s/:]+@([^:\s/[\]]+):(.+)$/);
+	if (scp && !url.includes("://")) {
+		host = scp[1];
+		path = scp[2];
+	} else try {
+		const u = new URL(url);
+		host = u.hostname;
+		path = u.pathname;
+	} catch {
+		return;
+	}
+	if (!host || !path) return void 0;
+	path = path.replace(/^\/+/, "").replace(/\/+$/, "").replace(/\.git$/i, "");
+	if (!path) return void 0;
+	return `${host}/${path}`.toLowerCase();
 }
 
 //#endregion

--- a/plugin/scripts/prompt-submit.mjs
+++ b/plugin/scripts/prompt-submit.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { basename } from "node:path";
 
 //#region src/hooks/_project.ts
@@ -7,19 +7,69 @@ function resolveProject(cwd) {
 	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
 	if (explicit && explicit.trim()) return explicit.trim();
 	const dir = cwd && cwd.trim() ? cwd : process.cwd();
+	const remote = readGitConfig(dir, "remote.origin.url");
+	if (remote) {
+		const canonical = canonicalizeRemoteUrl(remote);
+		if (canonical) return canonical;
+	}
+	const top = readGitToplevel(dir);
+	if (top) return basename(top);
+	return basename(dir);
+}
+function readGitConfig(cwd, key) {
 	try {
-		const top = execSync("git rev-parse --show-toplevel", {
-			cwd: dir,
+		return execFileSync("git", [
+			"config",
+			"--get",
+			key
+		], {
+			cwd,
 			stdio: [
 				"ignore",
 				"pipe",
 				"ignore"
 			],
 			timeout: 500
-		}).toString().trim();
-		if (top) return basename(top);
-	} catch {}
-	return basename(dir);
+		}).toString().trim() || void 0;
+	} catch {
+		return;
+	}
+}
+function readGitToplevel(cwd) {
+	try {
+		return execFileSync("git", ["rev-parse", "--show-toplevel"], {
+			cwd,
+			stdio: [
+				"ignore",
+				"pipe",
+				"ignore"
+			],
+			timeout: 500
+		}).toString().trim() || void 0;
+	} catch {
+		return;
+	}
+}
+function canonicalizeRemoteUrl(raw) {
+	const url = raw.trim();
+	if (!url) return void 0;
+	let host;
+	let path;
+	const scp = url.match(/^[^@\s/:]+@([^:\s/[\]]+):(.+)$/);
+	if (scp && !url.includes("://")) {
+		host = scp[1];
+		path = scp[2];
+	} else try {
+		const u = new URL(url);
+		host = u.hostname;
+		path = u.pathname;
+	} catch {
+		return;
+	}
+	if (!host || !path) return void 0;
+	path = path.replace(/^\/+/, "").replace(/\/+$/, "").replace(/\.git$/i, "");
+	if (!path) return void 0;
+	return `${host}/${path}`.toLowerCase();
 }
 
 //#endregion

--- a/plugin/scripts/session-start.mjs
+++ b/plugin/scripts/session-start.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { basename } from "node:path";
 
 //#region src/hooks/_project.ts
@@ -7,19 +7,69 @@ function resolveProject(cwd) {
 	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
 	if (explicit && explicit.trim()) return explicit.trim();
 	const dir = cwd && cwd.trim() ? cwd : process.cwd();
+	const remote = readGitConfig(dir, "remote.origin.url");
+	if (remote) {
+		const canonical = canonicalizeRemoteUrl(remote);
+		if (canonical) return canonical;
+	}
+	const top = readGitToplevel(dir);
+	if (top) return basename(top);
+	return basename(dir);
+}
+function readGitConfig(cwd, key) {
 	try {
-		const top = execSync("git rev-parse --show-toplevel", {
-			cwd: dir,
+		return execFileSync("git", [
+			"config",
+			"--get",
+			key
+		], {
+			cwd,
 			stdio: [
 				"ignore",
 				"pipe",
 				"ignore"
 			],
 			timeout: 500
-		}).toString().trim();
-		if (top) return basename(top);
-	} catch {}
-	return basename(dir);
+		}).toString().trim() || void 0;
+	} catch {
+		return;
+	}
+}
+function readGitToplevel(cwd) {
+	try {
+		return execFileSync("git", ["rev-parse", "--show-toplevel"], {
+			cwd,
+			stdio: [
+				"ignore",
+				"pipe",
+				"ignore"
+			],
+			timeout: 500
+		}).toString().trim() || void 0;
+	} catch {
+		return;
+	}
+}
+function canonicalizeRemoteUrl(raw) {
+	const url = raw.trim();
+	if (!url) return void 0;
+	let host;
+	let path;
+	const scp = url.match(/^[^@\s/:]+@([^:\s/[\]]+):(.+)$/);
+	if (scp && !url.includes("://")) {
+		host = scp[1];
+		path = scp[2];
+	} else try {
+		const u = new URL(url);
+		host = u.hostname;
+		path = u.pathname;
+	} catch {
+		return;
+	}
+	if (!host || !path) return void 0;
+	path = path.replace(/^\/+/, "").replace(/\/+$/, "").replace(/\.git$/i, "");
+	if (!path) return void 0;
+	return `${host}/${path}`.toLowerCase();
 }
 
 //#endregion

--- a/plugin/scripts/subagent-start.mjs
+++ b/plugin/scripts/subagent-start.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { basename } from "node:path";
 
 //#region src/hooks/_project.ts
@@ -7,19 +7,69 @@ function resolveProject(cwd) {
 	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
 	if (explicit && explicit.trim()) return explicit.trim();
 	const dir = cwd && cwd.trim() ? cwd : process.cwd();
+	const remote = readGitConfig(dir, "remote.origin.url");
+	if (remote) {
+		const canonical = canonicalizeRemoteUrl(remote);
+		if (canonical) return canonical;
+	}
+	const top = readGitToplevel(dir);
+	if (top) return basename(top);
+	return basename(dir);
+}
+function readGitConfig(cwd, key) {
 	try {
-		const top = execSync("git rev-parse --show-toplevel", {
-			cwd: dir,
+		return execFileSync("git", [
+			"config",
+			"--get",
+			key
+		], {
+			cwd,
 			stdio: [
 				"ignore",
 				"pipe",
 				"ignore"
 			],
 			timeout: 500
-		}).toString().trim();
-		if (top) return basename(top);
-	} catch {}
-	return basename(dir);
+		}).toString().trim() || void 0;
+	} catch {
+		return;
+	}
+}
+function readGitToplevel(cwd) {
+	try {
+		return execFileSync("git", ["rev-parse", "--show-toplevel"], {
+			cwd,
+			stdio: [
+				"ignore",
+				"pipe",
+				"ignore"
+			],
+			timeout: 500
+		}).toString().trim() || void 0;
+	} catch {
+		return;
+	}
+}
+function canonicalizeRemoteUrl(raw) {
+	const url = raw.trim();
+	if (!url) return void 0;
+	let host;
+	let path;
+	const scp = url.match(/^[^@\s/:]+@([^:\s/[\]]+):(.+)$/);
+	if (scp && !url.includes("://")) {
+		host = scp[1];
+		path = scp[2];
+	} else try {
+		const u = new URL(url);
+		host = u.hostname;
+		path = u.pathname;
+	} catch {
+		return;
+	}
+	if (!host || !path) return void 0;
+	path = path.replace(/^\/+/, "").replace(/\/+$/, "").replace(/\.git$/i, "");
+	if (!path) return void 0;
+	return `${host}/${path}`.toLowerCase();
 }
 
 //#endregion

--- a/plugin/scripts/subagent-stop.mjs
+++ b/plugin/scripts/subagent-stop.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { basename } from "node:path";
 
 //#region src/hooks/_project.ts
@@ -7,19 +7,69 @@ function resolveProject(cwd) {
 	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
 	if (explicit && explicit.trim()) return explicit.trim();
 	const dir = cwd && cwd.trim() ? cwd : process.cwd();
+	const remote = readGitConfig(dir, "remote.origin.url");
+	if (remote) {
+		const canonical = canonicalizeRemoteUrl(remote);
+		if (canonical) return canonical;
+	}
+	const top = readGitToplevel(dir);
+	if (top) return basename(top);
+	return basename(dir);
+}
+function readGitConfig(cwd, key) {
 	try {
-		const top = execSync("git rev-parse --show-toplevel", {
-			cwd: dir,
+		return execFileSync("git", [
+			"config",
+			"--get",
+			key
+		], {
+			cwd,
 			stdio: [
 				"ignore",
 				"pipe",
 				"ignore"
 			],
 			timeout: 500
-		}).toString().trim();
-		if (top) return basename(top);
-	} catch {}
-	return basename(dir);
+		}).toString().trim() || void 0;
+	} catch {
+		return;
+	}
+}
+function readGitToplevel(cwd) {
+	try {
+		return execFileSync("git", ["rev-parse", "--show-toplevel"], {
+			cwd,
+			stdio: [
+				"ignore",
+				"pipe",
+				"ignore"
+			],
+			timeout: 500
+		}).toString().trim() || void 0;
+	} catch {
+		return;
+	}
+}
+function canonicalizeRemoteUrl(raw) {
+	const url = raw.trim();
+	if (!url) return void 0;
+	let host;
+	let path;
+	const scp = url.match(/^[^@\s/:]+@([^:\s/[\]]+):(.+)$/);
+	if (scp && !url.includes("://")) {
+		host = scp[1];
+		path = scp[2];
+	} else try {
+		const u = new URL(url);
+		host = u.hostname;
+		path = u.pathname;
+	} catch {
+		return;
+	}
+	if (!host || !path) return void 0;
+	path = path.replace(/^\/+/, "").replace(/\/+$/, "").replace(/\.git$/i, "");
+	if (!path) return void 0;
+	return `${host}/${path}`.toLowerCase();
 }
 
 //#endregion

--- a/plugin/scripts/task-completed.mjs
+++ b/plugin/scripts/task-completed.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { basename } from "node:path";
 
 //#region src/hooks/_project.ts
@@ -7,19 +7,69 @@ function resolveProject(cwd) {
 	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
 	if (explicit && explicit.trim()) return explicit.trim();
 	const dir = cwd && cwd.trim() ? cwd : process.cwd();
+	const remote = readGitConfig(dir, "remote.origin.url");
+	if (remote) {
+		const canonical = canonicalizeRemoteUrl(remote);
+		if (canonical) return canonical;
+	}
+	const top = readGitToplevel(dir);
+	if (top) return basename(top);
+	return basename(dir);
+}
+function readGitConfig(cwd, key) {
 	try {
-		const top = execSync("git rev-parse --show-toplevel", {
-			cwd: dir,
+		return execFileSync("git", [
+			"config",
+			"--get",
+			key
+		], {
+			cwd,
 			stdio: [
 				"ignore",
 				"pipe",
 				"ignore"
 			],
 			timeout: 500
-		}).toString().trim();
-		if (top) return basename(top);
-	} catch {}
-	return basename(dir);
+		}).toString().trim() || void 0;
+	} catch {
+		return;
+	}
+}
+function readGitToplevel(cwd) {
+	try {
+		return execFileSync("git", ["rev-parse", "--show-toplevel"], {
+			cwd,
+			stdio: [
+				"ignore",
+				"pipe",
+				"ignore"
+			],
+			timeout: 500
+		}).toString().trim() || void 0;
+	} catch {
+		return;
+	}
+}
+function canonicalizeRemoteUrl(raw) {
+	const url = raw.trim();
+	if (!url) return void 0;
+	let host;
+	let path;
+	const scp = url.match(/^[^@\s/:]+@([^:\s/[\]]+):(.+)$/);
+	if (scp && !url.includes("://")) {
+		host = scp[1];
+		path = scp[2];
+	} else try {
+		const u = new URL(url);
+		host = u.hostname;
+		path = u.pathname;
+	} catch {
+		return;
+	}
+	if (!host || !path) return void 0;
+	path = path.replace(/^\/+/, "").replace(/\/+$/, "").replace(/\.git$/i, "");
+	if (!path) return void 0;
+	return `${host}/${path}`.toLowerCase();
 }
 
 //#endregion

--- a/src/hooks/_project.ts
+++ b/src/hooks/_project.ts
@@ -1,20 +1,88 @@
 import { execSync } from "node:child_process";
 import { basename } from "node:path";
 
-// Resolution order: AGENTMEMORY_PROJECT_NAME env → git toplevel basename → cwd basename.
+// Resolution order:
+//   AGENTMEMORY_PROJECT_NAME env
+//   → canonical remote.origin.url (host/owner/repo, normalized)
+//   → git toplevel basename
+//   → cwd basename
 export function resolveProject(cwd?: string): string {
   const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
   if (explicit && explicit.trim()) return explicit.trim();
   const dir = cwd && cwd.trim() ? cwd : process.cwd();
+
+  const remote = readGitConfig(dir, "remote.origin.url");
+  if (remote) {
+    const canonical = canonicalizeRemoteUrl(remote);
+    if (canonical) return canonical;
+  }
+
+  const top = readGitToplevel(dir);
+  if (top) return basename(top);
+
+  return basename(dir);
+}
+
+function readGitConfig(cwd: string, key: string): string | undefined {
   try {
-    const top = execSync("git rev-parse --show-toplevel", {
-      cwd: dir,
+    const out = execSync(`git config --get ${key}`, {
+      cwd,
       stdio: ["ignore", "pipe", "ignore"],
       timeout: 500,
     })
       .toString()
       .trim();
-    if (top) return basename(top);
-  } catch {}
-  return basename(dir);
+    return out || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readGitToplevel(cwd: string): string | undefined {
+  try {
+    const out = execSync("git rev-parse --show-toplevel", {
+      cwd,
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 500,
+    })
+      .toString()
+      .trim();
+    return out || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function canonicalizeRemoteUrl(raw: string): string | undefined {
+  const url = raw.trim();
+  if (!url) return undefined;
+
+  let host: string | undefined;
+  let path: string | undefined;
+
+  // SCP-style SSH: user@host:path  (no scheme)
+  const scp = url.match(/^[^@\s/:]+@([^:\s/[\]]+):(.+)$/);
+  if (scp && !url.includes("://")) {
+    host = scp[1];
+    path = scp[2];
+  } else {
+    try {
+      const u = new URL(url);
+      host = u.hostname;
+      path = u.pathname;
+    } catch {
+      return undefined;
+    }
+  }
+
+  if (!host || !path) return undefined;
+  path = path
+    .replace(/^\/+/, "")
+    .replace(/\/+$/, "")
+    .replace(/\.git$/i, "");
+  if (!path) return undefined;
+  // Host providers (GitHub, GitLab, Bitbucket) treat owner/repo as
+  // case-insensitive; lowercasing the full key prevents same-repo
+  // fragmentation when clones differ only in URL case.
+  return `${host}/${path}`.toLowerCase();
 }

--- a/src/hooks/_project.ts
+++ b/src/hooks/_project.ts
@@ -1,11 +1,6 @@
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { basename } from "node:path";
 
-// Resolution order:
-//   AGENTMEMORY_PROJECT_NAME env
-//   → canonical remote.origin.url (host/owner/repo, normalized)
-//   → git toplevel basename
-//   → cwd basename
 export function resolveProject(cwd?: string): string {
   const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
   if (explicit && explicit.trim()) return explicit.trim();
@@ -25,7 +20,7 @@ export function resolveProject(cwd?: string): string {
 
 function readGitConfig(cwd: string, key: string): string | undefined {
   try {
-    const out = execSync(`git config --get ${key}`, {
+    const out = execFileSync("git", ["config", "--get", key], {
       cwd,
       stdio: ["ignore", "pipe", "ignore"],
       timeout: 500,
@@ -40,7 +35,7 @@ function readGitConfig(cwd: string, key: string): string | undefined {
 
 function readGitToplevel(cwd: string): string | undefined {
   try {
-    const out = execSync("git rev-parse --show-toplevel", {
+    const out = execFileSync("git", ["rev-parse", "--show-toplevel"], {
       cwd,
       stdio: ["ignore", "pipe", "ignore"],
       timeout: 500,
@@ -60,7 +55,7 @@ function canonicalizeRemoteUrl(raw: string): string | undefined {
   let host: string | undefined;
   let path: string | undefined;
 
-  // SCP-style SSH: user@host:path  (no scheme)
+  // URL parser doesn't recognize SCP-style (user@host:path); match it first.
   const scp = url.match(/^[^@\s/:]+@([^:\s/[\]]+):(.+)$/);
   if (scp && !url.includes("://")) {
     host = scp[1];

--- a/test/hook-project-remote.test.ts
+++ b/test/hook-project-remote.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveProject } from "../src/hooks/_project.js";
+
+function makeRepo(dir: string, remoteUrl?: string) {
+  execSync("git init -q -b main", { cwd: dir });
+  if (remoteUrl) {
+    execSync(`git remote add origin "${remoteUrl}"`, { cwd: dir });
+  }
+}
+
+describe("resolveProject — canonical remote URL", () => {
+  const originalEnv = process.env.AGENTMEMORY_PROJECT_NAME;
+  const scratch: string[] = [];
+
+  beforeEach(() => {
+    delete process.env.AGENTMEMORY_PROJECT_NAME;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.AGENTMEMORY_PROJECT_NAME;
+    } else {
+      process.env.AGENTMEMORY_PROJECT_NAME = originalEnv;
+    }
+    while (scratch.length) {
+      const d = scratch.pop()!;
+      rmSync(d, { recursive: true, force: true });
+    }
+  });
+
+  function tmpRepo(suffix: string, remoteUrl?: string): string {
+    const dir = mkdtempSync(join(tmpdir(), `amem-${suffix}-`));
+    scratch.push(dir);
+    makeRepo(dir, remoteUrl);
+    return dir;
+  }
+
+  it("uses canonical remote.origin.url over toplevel basename", () => {
+    const dir = tmpRepo("https", "https://github.com/acme/widgets.git");
+    expect(resolveProject(dir)).toBe("github.com/acme/widgets");
+  });
+
+  it("same remote URL resolves to same key across different clone paths", () => {
+    const a = tmpRepo("clone-a", "https://github.com/acme/widgets.git");
+    const b = tmpRepo("clone-b", "https://github.com/acme/widgets.git");
+    expect(resolveProject(a)).toBe(resolveProject(b));
+  });
+
+  it("different remote URLs resolve differently even when toplevel basenames collide", () => {
+    const a = mkdtempSync(join(tmpdir(), "amem-collide-utils-"));
+    const b = mkdtempSync(join(tmpdir(), "amem-collide-utils-"));
+    scratch.push(a, b);
+    makeRepo(a, "https://github.com/acme/utils.git");
+    makeRepo(b, "https://github.com/other/utils.git");
+    expect(resolveProject(a)).not.toBe(resolveProject(b));
+  });
+
+  it("normalizes SCP-style SSH remotes (git@host:owner/repo.git)", () => {
+    const dir = tmpRepo("scp", "git@github.com:acme/widgets.git");
+    expect(resolveProject(dir)).toBe("github.com/acme/widgets");
+  });
+
+  it("normalizes ssh:// URLs with user and port", () => {
+    const dir = tmpRepo("ssh", "ssh://git@git.example.com:2222/acme/widgets.git");
+    expect(resolveProject(dir)).toBe("git.example.com/acme/widgets");
+  });
+
+  it("strips embedded credentials from https URLs", () => {
+    const dir = tmpRepo("creds", "https://user:token@github.com/acme/widgets.git");
+    expect(resolveProject(dir)).toBe("github.com/acme/widgets");
+  });
+
+  it("lowercases host and path to absorb URL case differences", () => {
+    const dir = tmpRepo("case", "https://GitHub.COM/Acme/Widgets.git");
+    expect(resolveProject(dir)).toBe("github.com/acme/widgets");
+  });
+
+  it("strips trailing .git suffix", () => {
+    const dir = tmpRepo("nogit", "https://github.com/acme/widgets");
+    expect(resolveProject(dir)).toBe("github.com/acme/widgets");
+  });
+
+  it("AGENTMEMORY_PROJECT_NAME still wins over remote URL", () => {
+    process.env.AGENTMEMORY_PROJECT_NAME = "my-override";
+    const dir = tmpRepo("envwin", "https://github.com/acme/widgets.git");
+    expect(resolveProject(dir)).toBe("my-override");
+  });
+
+  it("falls back to toplevel basename when repo has no remote", () => {
+    const dir = mkdtempSync(join(tmpdir(), "amem-noremote-myproj-"));
+    scratch.push(dir);
+    makeRepo(dir);
+    expect(resolveProject(dir)).toBe(dir.split("/").pop());
+  });
+
+  it("falls back to toplevel basename when remote URL is unparseable", () => {
+    const dir = mkdtempSync(join(tmpdir(), "amem-badremote-fallback-"));
+    scratch.push(dir);
+    makeRepo(dir, "not-a-url");
+    expect(resolveProject(dir)).toBe(dir.split("/").pop());
+  });
+
+  it("resolves remote URL from a nested subdirectory", () => {
+    const dir = tmpRepo("nested", "https://github.com/acme/widgets.git");
+    const nested = join(dir, "src", "deep");
+    mkdirSync(nested, { recursive: true });
+    expect(resolveProject(nested)).toBe("github.com/acme/widgets");
+  });
+});

--- a/test/hook-project-remote.test.ts
+++ b/test/hook-project-remote.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { execSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { resolveProject } from "../src/hooks/_project.js";
 
 function makeRepo(dir: string, remoteUrl?: string) {
@@ -94,14 +94,14 @@ describe("resolveProject — canonical remote URL", () => {
     const dir = mkdtempSync(join(tmpdir(), "amem-noremote-myproj-"));
     scratch.push(dir);
     makeRepo(dir);
-    expect(resolveProject(dir)).toBe(dir.split("/").pop());
+    expect(resolveProject(dir)).toBe(basename(dir));
   });
 
   it("falls back to toplevel basename when remote URL is unparseable", () => {
     const dir = mkdtempSync(join(tmpdir(), "amem-badremote-fallback-"));
     scratch.push(dir);
     makeRepo(dir, "not-a-url");
-    expect(resolveProject(dir)).toBe(dir.split("/").pop());
+    expect(resolveProject(dir)).toBe(basename(dir));
   });
 
   it("resolves remote URL from a nested subdirectory", () => {

--- a/test/hook-project.test.ts
+++ b/test/hook-project.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { execSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { resolveProject } from "../src/hooks/_project.js";
 
 describe("resolveProject — hook project resolver", () => {
@@ -46,25 +46,25 @@ describe("resolveProject — hook project resolver", () => {
   it("ignores empty env override", () => {
     process.env.AGENTMEMORY_PROJECT_NAME = "   ";
     const dir = tmpGitRepoNoRemote("emptyenv-projx");
-    expect(resolveProject(dir)).toBe(dir.split("/").pop());
+    expect(resolveProject(dir)).toBe(basename(dir));
   });
 
   it("returns git toplevel basename when repo has no remote", () => {
     const dir = tmpGitRepoNoRemote("noremote");
-    expect(resolveProject(dir)).toBe(dir.split("/").pop());
+    expect(resolveProject(dir)).toBe(basename(dir));
   });
 
   it("returns git toplevel basename from a nested subdir when no remote", () => {
     const dir = tmpGitRepoNoRemote("nested-noremote");
     const nested = join(dir, "src", "hooks");
     mkdirSync(nested, { recursive: true });
-    expect(resolveProject(nested)).toBe(dir.split("/").pop());
+    expect(resolveProject(nested)).toBe(basename(dir));
   });
 
   it("falls back to basename(cwd) when not in a git repo", () => {
     const dir = mkdtempSync(join(tmpdir(), "amem-noproj-"));
     scratch.push(dir);
-    expect(resolveProject(dir)).toBe(dir.split("/").pop());
+    expect(resolveProject(dir)).toBe(basename(dir));
   });
 
   it("defaults to process.cwd() when no cwd argument given", () => {

--- a/test/hook-project.test.ts
+++ b/test/hook-project.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { resolveProject } from "../src/hooks/_project.js";
 
-describe("resolveProject — hook project basename resolver", () => {
+describe("resolveProject — hook project resolver", () => {
   const originalEnv = process.env.AGENTMEMORY_PROJECT_NAME;
+  const scratch: string[] = [];
 
   beforeEach(() => {
     delete process.env.AGENTMEMORY_PROJECT_NAME;
@@ -17,7 +19,18 @@ describe("resolveProject — hook project basename resolver", () => {
     } else {
       process.env.AGENTMEMORY_PROJECT_NAME = originalEnv;
     }
+    while (scratch.length) {
+      const d = scratch.pop()!;
+      rmSync(d, { recursive: true, force: true });
+    }
   });
+
+  function tmpGitRepoNoRemote(suffix: string): string {
+    const dir = mkdtempSync(join(tmpdir(), `amem-${suffix}-`));
+    scratch.push(dir);
+    execSync("git init -q -b main", { cwd: dir });
+    return dir;
+  }
 
   it("AGENTMEMORY_PROJECT_NAME env wins over everything", () => {
     process.env.AGENTMEMORY_PROJECT_NAME = "my-override";
@@ -32,35 +45,40 @@ describe("resolveProject — hook project basename resolver", () => {
 
   it("ignores empty env override", () => {
     process.env.AGENTMEMORY_PROJECT_NAME = "   ";
-    const repoBasename = "agentmemory";
-    expect(resolveProject(process.cwd())).toBe(repoBasename);
+    const dir = tmpGitRepoNoRemote("emptyenv-projx");
+    expect(resolveProject(dir)).toBe(dir.split("/").pop());
   });
 
-  it("returns git toplevel basename when cwd is inside a repo", () => {
-    const top = resolveProject(process.cwd());
-    expect(top).toBe("agentmemory");
+  it("returns git toplevel basename when repo has no remote", () => {
+    const dir = tmpGitRepoNoRemote("noremote");
+    expect(resolveProject(dir)).toBe(dir.split("/").pop());
   });
 
-  it("returns git toplevel basename from a nested subdir", () => {
-    const nested = join(process.cwd(), "src", "hooks");
-    expect(resolveProject(nested)).toBe("agentmemory");
+  it("returns git toplevel basename from a nested subdir when no remote", () => {
+    const dir = tmpGitRepoNoRemote("nested-noremote");
+    const nested = join(dir, "src", "hooks");
+    mkdirSync(nested, { recursive: true });
+    expect(resolveProject(nested)).toBe(dir.split("/").pop());
   });
 
   it("falls back to basename(cwd) when not in a git repo", () => {
     const dir = mkdtempSync(join(tmpdir(), "amem-noproj-"));
-    try {
-      expect(resolveProject(dir)).toBe(dir.split("/").pop());
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
+    scratch.push(dir);
+    expect(resolveProject(dir)).toBe(dir.split("/").pop());
   });
 
   it("defaults to process.cwd() when no cwd argument given", () => {
-    expect(resolveProject()).toBe("agentmemory");
+    // process.cwd() is the agentmemory checkout; whether it has a remote
+    // depends on environment, but the resolved key must end in /agentmemory
+    // (canonical URL) or equal "agentmemory" (no-remote fallback).
+    const result = resolveProject();
+    expect(result === "agentmemory" || result.endsWith("/agentmemory")).toBe(true);
   });
 
   it("defaults to process.cwd() when cwd argument is empty", () => {
-    expect(resolveProject("")).toBe("agentmemory");
-    expect(resolveProject("   ")).toBe("agentmemory");
+    const a = resolveProject("");
+    const b = resolveProject("   ");
+    expect(a === "agentmemory" || a.endsWith("/agentmemory")).toBe(true);
+    expect(b).toBe(a);
   });
 });


### PR DESCRIPTION
Closes #716.

Related: #687 (shipped current basename resolver — this extends it), #515 (worktree case, mostly side-effect-fixed by #687; remaining clone-path variant covered here), #530 (broader multi-key approach, closed in favor of fuller fix on #515 — this is the smaller single-key form).

## Change

Inserts canonical-URL resolution between the env override and the toplevel-basename fallback in `src/hooks/_project.ts`:

```
AGENTMEMORY_PROJECT_NAME
→ canonical(remote.origin.url)            ← new, host/owner/repo
→ basename(git rev-parse --show-toplevel) ← unchanged
→ basename(cwd)                            ← unchanged
```

Canonicalization: normalize https/ssh/SCP variants, strip credentials and `.git`, lowercase end-to-end (host providers treat owner/repo case-insensitively). Unparseable remotes fall through.

See #716 for the rationale, non-goals (monorepos, multi-remote), and precedent (`src/hooks/post-commit.ts:65` already uses the same identity source).

## Test plan

- New `test/hook-project-remote.test.ts` (12 tests): basename collision, multi-clone same-remote, SCP `git@host:path`, `ssh://` with port, embedded credentials, case-folding, `.git` stripping, env override still wins, no-remote fallback, unparseable-remote fallback, nested cwd.
- Existing `test/hook-project.test.ts` adjusted: basename-fallback tests now scope to remote-less temp repos, so they verify the fallback branch independently of the runner's own repo state.
- Tests use `mkdirSync(..., { recursive: true })` (cross-platform).
- Full suite: 1303/1303 pass.

## Compatibility

No data migration. Deployments using `AGENTMEMORY_PROJECT_NAME` see no change. Deployments relying on the basename default see their key change *only if* the repo has a configured `origin` remote — and in that case the new key is the more canonical one. Operators who want to pin the old behavior can set `AGENTMEMORY_PROJECT_NAME` to the prior basename.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project identification is more flexible: honors an environment override, derives canonical project keys from Git remotes when available (normalizing formats), and falls back to repository or directory names for consistent project naming.

* **Tests**
  * Added and expanded tests covering remote canonicalization (HTTPS/SCP/SSH forms), env-var precedence, nested repos, basename fallbacks, and no-remote scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/717?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->