### PR TITLE
fix(viewer): correct Token Savings calculation to match CLI

### DIFF
--- a/src/viewer/index.html
+++ b/src/viewer/index.html
@@ -1355,7 +1355,7 @@
       var totalObs = d.sessions.reduce(function(a, s) { return a + (s.observationCount || 0); }, 0);
       var tokenBudget = parseInt(new URLSearchParams(window.location.search).get('tokenBudget') || '2000', 10) || 2000;
       var estFull = totalObs * 80;
-      var estInjected = d.sessions.length * tokenBudget;
+      var estInjected = Math.min(totalObs, 50) * 38;
       var savings = estFull > 0 ? Math.round((1 - estInjected / Math.max(estFull, 1)) * 100) : 0;
       if (savings < 0) savings = 0;
       var tokensSaved = Math.max(0, estFull - estInjected);


### PR DESCRIPTION
## Problem

The Viewer dashboard shows **Token Savings: 0%** even when `agentmemory status` reports significant savings (e.g., 53%).

## Root Cause

The calculation formulas are inconsistent:

| Source | Formula | Result (46 obs, 26 sessions) |
|--------|---------|------------------------------|
| **CLI (correct)** | `min(totalObs, 50) * 38` | 1,748 tokens |
| **Viewer (buggy)** | `sessions.length * tokenBudget` | 52,000 tokens |

The Viewer uses `sessions.length * 2000` which vastly overestimates injected tokens, causing savings to be negative (clamped to 0%).

## Fix

Changed Viewer calculation to match CLI:

```javascript
// Before (incorrect)
var estInjected = d.sessions.length * tokenBudget;

// After (correct)
var estInjected = Math.min(totalObs, 50) * 38;
```

## Verification

After fix:
- `totalObs = 46`
- `estFull = 46 * 80 = 3,680`
- `estInjected = min(46, 50) * 38 = 1,748`
- `savings = (1 - 1748/3680) * 100 = 52.5%`

Now matches `agentmemory status` output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Token Savings calculation in the dashboard. The estimation logic has been refined for improved accuracy, which may result in different savings percentages and cost figures displayed in the Token Savings stat card.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/721?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->