### PR TITLE
docs: clarify graph extraction lifecycle on site

### DIFF
--- a/website/components/Features.tsx
+++ b/website/components/Features.tsx
@@ -55,7 +55,7 @@ export function Features({ hooks, mcpTools, restEndpoints }: Props) {
       unit: "EXTRACTION",
       title: "KNOWLEDGE GRAPH",
       text:
-        "Entities and relations extracted on compress. Query with /agentmemory/graph. Visualize in the viewer. Temporal edges supported.",
+        "Entities and relations extract after Stop / SessionEnd. /session/end fans out the stopped lifecycle, and the viewer can backfill with /agentmemory/graph/build.",
     },
     {
       k: "MESH",

--- a/website/lib/generated-meta.json
+++ b/website/lib/generated-meta.json
@@ -1,8 +1,8 @@
 {
-  "version": "0.9.20",
+  "version": "0.9.24",
   "mcpTools": 53,
   "hooks": 12,
-  "restEndpoints": 124,
-  "testsPassing": 1055,
-  "generatedAt": "2026-05-18T20:08:39.354Z"
+  "restEndpoints": 125,
+  "testsPassing": 1312,
+  "generatedAt": "2026-05-30T03:33:07.087Z"
 }


### PR DESCRIPTION
Updates the website's Knowledge Graph feature copy to match the current session-end lifecycle:\n\n- Graph extraction runs after Stop / SessionEnd, not generic compression.\n- /session/end fans out the stopped lifecycle.\n- The viewer can backfill via /agentmemory/graph/build.\n- Regenerated website metadata so the landing page reflects v0.9.24 counts.\n\nThis aligns the site with the v0.9.23+ fix for session-end graph extraction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GRAPH feature documentation to reflect entity and relation extraction behavior after session end with available backfill options.

* **Chores**
  * Version and build metadata updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/727?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->