### PR TITLE
fix: replace non-existent sdk.triggerVoid with sdk.trigger + action: { type: 'void' }

### DIFF
--- a/src/functions/disk-size-manager.ts
+++ b/src/functions/disk-size-manager.ts
@@ -1,4 +1,4 @@
-import type { ISdk } from "iii-sdk";
+import { TriggerAction, type ISdk } from "iii-sdk";
 import { KV } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
 import { getMaxBytes } from "../utils/image-store.js";
@@ -29,7 +29,11 @@ export function registerDiskSizeManager(sdk: ISdk, kv: StateKV): void {
           sdk.trigger({
             function_id: "mem::image-quota-cleanup",
             payload: {},
-            action: { type: "void" },
+            action: TriggerAction.Void(),
+          }).catch((err) => {
+            logger.error("Failed to trigger image-quota-cleanup", {
+              error: err instanceof Error ? err.message : String(err),
+            });
           });
           logger.info("Disk quota exceeded, cleanup triggered", {
             currentBytes: newTotal,

--- a/src/functions/disk-size-manager.ts
+++ b/src/functions/disk-size-manager.ts
@@ -26,7 +26,11 @@ export function registerDiskSizeManager(sdk: ISdk, kv: StateKV): void {
         await kv.set<StateScope[typeof DISK_SIZE_KEY]>(KV.state, DISK_SIZE_KEY, newTotal);
 
         if (data.deltaBytes > 0 && newTotal > getMaxBytes()) {
-          sdk.triggerVoid("mem::image-quota-cleanup", {});
+          sdk.trigger({
+            function_id: "mem::image-quota-cleanup",
+            payload: {},
+            action: { type: "void" },
+          });
           logger.info("Disk quota exceeded, cleanup triggered", {
             currentBytes: newTotal,
             maxBytes: getMaxBytes(),

--- a/src/functions/image-quota-cleanup.ts
+++ b/src/functions/image-quota-cleanup.ts
@@ -75,7 +75,11 @@ export function registerImageQuotaCleanup(sdk: ISdk, kv: StateKV): void {
 
             const { deletedBytes } = await deleteImage(f.filePath);
             if (deletedBytes > 0) {
-              sdk.triggerVoid("mem::disk-size-delta", { deltaBytes: -deletedBytes });
+              sdk.trigger({
+                function_id: "mem::disk-size-delta",
+                payload: { deltaBytes: -deletedBytes },
+                action: { type: "void" },
+              });
               totalToFree -= deletedBytes;
               freedBytes += deletedBytes;
               evicted++;

--- a/src/functions/image-quota-cleanup.ts
+++ b/src/functions/image-quota-cleanup.ts
@@ -1,4 +1,4 @@
-import type { ISdk } from "iii-sdk";
+import { TriggerAction, type ISdk } from "iii-sdk";
 import { KV } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
 import { readdir, stat } from "node:fs/promises";
@@ -78,7 +78,7 @@ export function registerImageQuotaCleanup(sdk: ISdk, kv: StateKV): void {
               sdk.trigger({
                 function_id: "mem::disk-size-delta",
                 payload: { deltaBytes: -deletedBytes },
-                action: { type: "void" },
+                action: TriggerAction.Void(),
               });
               totalToFree -= deletedBytes;
               freedBytes += deletedBytes;

--- a/src/functions/image-refs.ts
+++ b/src/functions/image-refs.ts
@@ -25,7 +25,11 @@ export async function decrementImageRef(kv: StateKV, sdk: ISdk, filePath: string
       await kv.delete(KV.imageRefs, filePath);
       const { deletedBytes } = await deleteImage(filePath);
       if (deletedBytes > 0) {
-        sdk.triggerVoid("mem::disk-size-delta", { deltaBytes: -deletedBytes });
+        sdk.trigger({
+          function_id: "mem::disk-size-delta",
+          payload: { deltaBytes: -deletedBytes },
+          action: { type: "void" },
+        });
       }
     } else {
       await kv.set(KV.imageRefs, filePath, current - 1);

--- a/src/functions/image-refs.ts
+++ b/src/functions/image-refs.ts
@@ -1,4 +1,4 @@
-import type { ISdk } from "iii-sdk";
+import { TriggerAction, type ISdk } from "iii-sdk";
 import { KV } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
 import { deleteImage, touchImage } from "../utils/image-store.js";
@@ -28,7 +28,7 @@ export async function decrementImageRef(kv: StateKV, sdk: ISdk, filePath: string
         sdk.trigger({
           function_id: "mem::disk-size-delta",
           payload: { deltaBytes: -deletedBytes },
-          action: { type: "void" },
+          action: TriggerAction.Void(),
         });
       }
     } else {

--- a/src/functions/observe.ts
+++ b/src/functions/observe.ts
@@ -156,12 +156,20 @@ export function registerObserveFunction(
           raw.imageData = filePath;
           const { incrementImageRef } = await import("./image-refs.js");
           await incrementImageRef(kv, filePath);
-          sdk.triggerVoid("mem::disk-size-delta", { deltaBytes: bytesWritten });
+          sdk.trigger({
+            function_id: "mem::disk-size-delta",
+            payload: { deltaBytes: bytesWritten },
+            action: { type: "void" },
+          });
           if (process.env["AGENTMEMORY_IMAGE_EMBEDDINGS"] === "true") {
-            sdk.triggerVoid("mem::vision-embed", {
-              imageRef: filePath,
-              sessionId: payload.sessionId,
-              observationId: obsId,
+            sdk.trigger({
+              function_id: "mem::vision-embed",
+              payload: {
+                imageRef: filePath,
+                sessionId: payload.sessionId,
+                observationId: obsId,
+              },
+              action: { type: "void" },
             });
           }
         }
@@ -175,7 +183,11 @@ export function registerObserveFunction(
             const { deleteImage } = await import("../utils/image-store.js");
             const { deletedBytes } = await deleteImage(raw.imageData);
             if (deletedBytes > 0) {
-              sdk.triggerVoid("mem::disk-size-delta", { deltaBytes: -deletedBytes });
+              sdk.trigger({
+                function_id: "mem::disk-size-delta",
+                payload: { deltaBytes: -deletedBytes },
+                action: { type: "void" },
+              });
             }
           }
           throw error;

--- a/src/functions/observe.ts
+++ b/src/functions/observe.ts
@@ -159,7 +159,7 @@ export function registerObserveFunction(
           sdk.trigger({
             function_id: "mem::disk-size-delta",
             payload: { deltaBytes: bytesWritten },
-            action: { type: "void" },
+            action: TriggerAction.Void(),
           });
           if (process.env["AGENTMEMORY_IMAGE_EMBEDDINGS"] === "true") {
             sdk.trigger({
@@ -169,7 +169,7 @@ export function registerObserveFunction(
                 sessionId: payload.sessionId,
                 observationId: obsId,
               },
-              action: { type: "void" },
+              action: TriggerAction.Void(),
             });
           }
         }
@@ -186,7 +186,7 @@ export function registerObserveFunction(
               sdk.trigger({
                 function_id: "mem::disk-size-delta",
                 payload: { deltaBytes: -deletedBytes },
-                action: { type: "void" },
+                action: TriggerAction.Void(),
               });
             }
           }

--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -1,4 +1,4 @@
-import type { ISdk, ApiRequest } from "iii-sdk";
+import { TriggerAction, type ISdk, type ApiRequest } from "iii-sdk";
 import type { Session, CompressedObservation, HookPayload, CommitLink } from "../types.js";
 import { withKeyedLock } from "../state/keyed-mutex.js";
 import { KV } from "../state/schema.js";
@@ -616,7 +616,7 @@ export function registerApiTriggers(
         sdk.trigger({
           function_id: "event::session::stopped",
           payload: { sessionId },
-          action: { type: "void" },
+          action: TriggerAction.Void(),
         });
       } catch (err) {
         logger.warn("event::session::stopped trigger failed", {

--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -613,9 +613,13 @@ export function registerApiTriggers(
       ]);
       // Fan out session-stopped lifecycle (non-blocking).
       try {
-        sdk.triggerVoid("event::session::stopped", { sessionId });
+        sdk.trigger({
+          function_id: "event::session::stopped",
+          payload: { sessionId },
+          action: { type: "void" },
+        });
       } catch (err) {
-        logger.warn("event::session::stopped triggerVoid failed", {
+        logger.warn("event::session::stopped trigger failed", {
           sessionId,
           error: err instanceof Error ? err.message : String(err),
         });

--- a/src/triggers/events.ts
+++ b/src/triggers/events.ts
@@ -48,9 +48,13 @@ export function registerEventTriggers(sdk: ISdk, kv: StateKV): void {
     const summary = await sdk.trigger({ function_id: "mem::summarize", payload: data });
     if (isReflectEnabled()) {
       try {
-        sdk.triggerVoid("mem::slot-reflect", { sessionId: data.sessionId });
+        sdk.trigger({
+          function_id: "mem::slot-reflect",
+          payload: { sessionId: data.sessionId },
+          action: { type: "void" },
+        });
       } catch (err) {
-        logger.warn("slot-reflect triggerVoid failed", {
+        logger.warn("slot-reflect trigger failed", {
           sessionId: data.sessionId,
           error: err instanceof Error ? err.message : String(err),
         });
@@ -63,10 +67,14 @@ export function registerEventTriggers(sdk: ISdk, kv: StateKV): void {
         );
         const compressed = observations.filter((o) => o.title);
         if (compressed.length > 0) {
-          sdk.triggerVoid("mem::graph-extract", { observations: compressed });
+          sdk.trigger({
+            function_id: "mem::graph-extract",
+            payload: { observations: compressed },
+            action: { type: "void" },
+          });
         }
       } catch (err) {
-        logger.warn("graph-extract triggerVoid failed", {
+        logger.warn("graph-extract trigger failed", {
           sessionId: data.sessionId,
           error: err instanceof Error ? err.message : String(err),
         });

--- a/src/triggers/events.ts
+++ b/src/triggers/events.ts
@@ -51,7 +51,7 @@ export function registerEventTriggers(sdk: ISdk, kv: StateKV): void {
         sdk.trigger({
           function_id: "mem::slot-reflect",
           payload: { sessionId: data.sessionId },
-          action: { type: "void" },
+          action: TriggerAction.Void(),
         });
       } catch (err) {
         logger.warn("slot-reflect trigger failed", {
@@ -70,7 +70,7 @@ export function registerEventTriggers(sdk: ISdk, kv: StateKV): void {
           sdk.trigger({
             function_id: "mem::graph-extract",
             payload: { observations: compressed },
-            action: { type: "void" },
+            action: TriggerAction.Void(),
           });
         }
       } catch (err) {

--- a/test/multimodal.test.ts
+++ b/test/multimodal.test.ts
@@ -167,8 +167,8 @@ describe("End-to-End Multimodal Flow", () => {
 describe("Disk Size Manager", () => {
   it("should increment disk size and trigger cleanup when over quota", async () => {
     const localKv = mockKV() as any;
-    const localTriggerVoid = vi.fn();
-    const localSdk = { triggerVoid: localTriggerVoid } as any;
+    const localTrigger = vi.fn();
+    const localSdk = { trigger: localTrigger } as any;
 
     let managerCallback: any = null;
     const sdkMocker = {
@@ -191,7 +191,7 @@ describe("Disk Size Manager", () => {
     expect(res2.success).toBe(true);
     expect(res2.currentTotal).toBe(3000);
 
-    expect(localTriggerVoid).not.toHaveBeenCalled();
+    expect(localTrigger).not.toHaveBeenCalled();
   });
 
   it("should trigger cleanup when total exceeds max bytes", async () => {

--- a/test/multimodal.test.ts
+++ b/test/multimodal.test.ts
@@ -18,9 +18,8 @@ vi.mock("../src/functions/search.js", () => ({
   vectorIndexAddGuarded: vi.fn().mockResolvedValue(false),
 }));
 
-const mockTriggerVoid = vi.fn();
 const mockTrigger = vi.fn().mockResolvedValue(undefined);
-const mockSdk = { triggerVoid: mockTriggerVoid, trigger: mockTrigger } as any;
+const mockSdk = { trigger: mockTrigger } as any;
 
 function mockKV() {
   const store = new Map<string, Map<string, unknown>>();
@@ -70,7 +69,7 @@ describe("End-to-End Multimodal Flow", () => {
   });
 
   beforeEach(() => {
-    mockTriggerVoid.mockClear();
+    mockTrigger.mockClear();
   });
 
   it("Step 1: Agent image should be successfully saved to hard drive", async () => {
@@ -105,11 +104,11 @@ describe("End-to-End Multimodal Flow", () => {
 
     savedImagePath = raw.imageData;
 
-    const deltaCalls = mockTriggerVoid.mock.calls.filter(
-      (c: any[]) => c[0] === "mem::disk-size-delta"
+    const deltaCalls = mockTrigger.mock.calls.filter(
+      (c: any[]) => c[0].function_id === "mem::disk-size-delta"
     );
     expect(deltaCalls.length).toBe(1);
-    expect(deltaCalls[0][1].deltaBytes).toBeGreaterThan(0);
+    expect(deltaCalls[0][0].payload.deltaBytes).toBeGreaterThan(0);
   });
 
   it("Step 2 & 3: mem::compress should call the vision model and store compressed observation in KV", async () => {
@@ -201,8 +200,8 @@ describe("Disk Size Manager", () => {
       process.env.AGENTMEMORY_IMAGE_STORE_MAX_BYTES = "5000";
 
       const localKv = mockKV() as any;
-      const localTriggerVoid = vi.fn();
-      const localSdk = { triggerVoid: localTriggerVoid } as any;
+      const localTrigger = vi.fn();
+      const localSdk = { trigger: localTrigger } as any;
 
       let managerCallback: any = null;
       const sdkMocker = {
@@ -216,10 +215,14 @@ describe("Disk Size Manager", () => {
       registerDiskSizeManager(sdkMocker, localKv);
 
       await managerCallback({ deltaBytes: 3000 });
-      expect(localTriggerVoid).not.toHaveBeenCalled();
+      expect(localTrigger).not.toHaveBeenCalled();
 
       await managerCallback({ deltaBytes: 3000 });
-      expect(localTriggerVoid).toHaveBeenCalledWith("mem::image-quota-cleanup", {});
+      expect(localTrigger).toHaveBeenCalledWith({
+        function_id: "mem::image-quota-cleanup",
+        payload: {},
+        action: { type: "void" },
+      });
     } finally {
       if (originalEnv === undefined) {
         delete process.env.AGENTMEMORY_IMAGE_STORE_MAX_BYTES;
@@ -231,7 +234,7 @@ describe("Disk Size Manager", () => {
 
   it("should clamp negative totals to zero", async () => {
     const localKv = mockKV() as any;
-    const localSdk = { triggerVoid: vi.fn() } as any;
+    const localSdk = { trigger: vi.fn() } as any;
 
     let managerCallback: any = null;
     const sdkMocker = {
@@ -250,7 +253,7 @@ describe("Disk Size Manager", () => {
 
   it("should reject invalid deltaBytes", async () => {
     const localKv = mockKV() as any;
-    const localSdk = { triggerVoid: vi.fn() } as any;
+    const localSdk = { trigger: vi.fn() } as any;
 
     let managerCallback: any = null;
     const sdkMocker = {
@@ -271,8 +274,8 @@ describe("Disk Size Manager", () => {
 describe("Image Refs", () => {
   it("should increment and decrement ref counts correctly with deletion parity", async () => {
     const localKv = mockKV() as any;
-    const localTriggerVoid = vi.fn();
-    const localSdk = { triggerVoid: localTriggerVoid } as any;
+    const localTrigger = vi.fn();
+    const localSdk = { trigger: localTrigger } as any;
 
     const { saveImageToDisk } = await import("../src/utils/image-store.js");
     const { incrementImageRef, decrementImageRef, getImageRefCount } = await import("../src/functions/image-refs.js");
@@ -301,25 +304,25 @@ describe("Image Refs", () => {
     
     // (c) shared image with refcount >= 2 is NOT deleted when one decrements
     expect(existsSync(testFile)).toBe(true);
-    expect(localTriggerVoid).not.toHaveBeenCalled();
+    expect(localTrigger).not.toHaveBeenCalled();
 
     // (a) decrementing to zero triggers image file deletion and negative delta
     await decrementImageRef(localKv, localSdk, testFile);
     expect(await getImageRefCount(localKv, testFile)).toBe(0);
     expect(existsSync(testFile)).toBe(false);
     
-    const deltaCalls = localTriggerVoid.mock.calls.filter(
-      (c: any[]) => c[0] === "mem::disk-size-delta"
+    const deltaCalls = localTrigger.mock.calls.filter(
+      (c: any[]) => c[0].function_id === "mem::disk-size-delta"
     );
     expect(deltaCalls.length).toBe(1);
-    expect(deltaCalls[0][1].deltaBytes).toBeLessThan(0);
+    expect(deltaCalls[0][0].payload.deltaBytes).toBeLessThan(0);
 
     // (b) decrementing an already-zero/unknown ref is a no-op
-    localTriggerVoid.mockClear();
+    localTrigger.mockClear();
     await decrementImageRef(localKv, localSdk, "/fake/unknown/path.png");
     expect(await getImageRefCount(localKv, "/fake/unknown/path.png")).toBe(0);
-    const noOpDeltaCalls = localTriggerVoid.mock.calls.filter(
-      (c: any[]) => c[0] === "mem::disk-size-delta"
+    const noOpDeltaCalls = localTrigger.mock.calls.filter(
+      (c: any[]) => c[0].function_id === "mem::disk-size-delta"
     );
     expect(noOpDeltaCalls.length).toBe(0);
   });

--- a/test/session-end-triggers-graph.test.ts
+++ b/test/session-end-triggers-graph.test.ts
@@ -6,7 +6,7 @@ import { readFileSync } from "node:fs";
 // fix the `event::session::stopped` handler in events.ts was a dead
 // subscriber — no code published `agentmemory.session.stopped`, so graph
 // nodes / lessons / crystals never materialized despite the handler
-// existing. Direct triggerVoid keeps the HTTP response fast (kv.update
+// existing. Direct trigger with void action keeps the HTTP response fast (kv.update
 // runs synchronously, downstream pipeline fan-outs without blocking).
 describe("api::session::end → event::session::stopped (#666)", () => {
   const api = readFileSync("src/triggers/api.ts", "utf-8");

--- a/test/session-end-triggers-graph.test.ts
+++ b/test/session-end-triggers-graph.test.ts
@@ -11,15 +11,15 @@ import { readFileSync } from "node:fs";
 describe("api::session::end → event::session::stopped (#666)", () => {
   const api = readFileSync("src/triggers/api.ts", "utf-8");
 
-  it("api::session::end calls sdk.triggerVoid('event::session::stopped') after kv.update", () => {
+  it("api::session::end calls sdk.trigger('event::session::stopped') after kv.update", () => {
     expect(api).toMatch(
-      /api::session::end[\s\S]*?kv\.update\(KV\.sessions[\s\S]*?triggerVoid\("event::session::stopped"/,
+      /api::session::end[\s\S]*?kv\.update\(KV\.sessions[\s\S]*?sdk\.trigger\(\s*\{\s*function_id:\s*"event::session::stopped"/,
     );
   });
 
-  it("triggerVoid payload includes sessionId", () => {
+  it("trigger payload includes sessionId", () => {
     expect(api).toMatch(
-      /triggerVoid\("event::session::stopped",\s*\{\s*sessionId\s*\}/,
+      /function_id:\s*"event::session::stopped"[\s\S]*?payload:\s*\{\s*sessionId\s*\}/,
     );
   });
 });

--- a/test/sliding-window.test.ts
+++ b/test/sliding-window.test.ts
@@ -64,7 +64,6 @@ function mockSdk() {
       if (fn) return fn(payload);
       return null;
     },
-    triggerVoid: () => {},
   };
 }
 


### PR DESCRIPTION
## Problem
   `iii-sdk` (the underlying engine SDK) has never exposed a `triggerVoid` method. Every
 call site was silently throwing:

 ```

 TypeError: sdk.triggerVoid is not a function

 ```

   The errors were caught by local `try/catch`, so the process didn't crash, but the
 intended background tasks were **never executed**.

   Affected fire-and-forget paths:
   - `mem::disk-size-delta`
   - `mem::vision-embed`
   - `mem::image-quota-cleanup`
   - `mem::slot-reflect`
   - `mem::graph-extract`
   - `event::session::stopped`

   ## Fix

   Replace every `sdk.triggerVoid("id", payload)` with the canonical `iii-sdk` API:

   ```ts
   sdk.trigger({
     function_id: "id",
     payload: { ... },
     action: { type: "void" }
   });
 ```

 Also updates log messages (triggerVoid failed → trigger failed) and corresponding test
 mocks.

 Verification

 • npm run build — TypeScript compiles clean
 • npm test — 1285 tests pass (6 pre-existing failures in embedding-provider.test.ts
 unrelated to this change)
 • grep -r "triggerVoid" dist/ — no occurrences in built output

 Fixes #726

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal trigger invocation mechanism across disk management, image handling, and session tracking functions for improved consistency.
  * Updated corresponding tests to reflect trigger handling changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->