### PR TITLE
fix: make hook-project, embedding, and mesh tests hermetic

### DIFF
--- a/test/embedding-provider.test.ts
+++ b/test/embedding-provider.test.ts
@@ -1,4 +1,33 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Isolate from the on-disk ~/.agentmemory/.env file. The providers resolve
+// keys through config's getEnvVar/detectEmbeddingProvider, which call the
+// internal getMergedEnv() -> loadEnvFile() and re-read that file every call.
+// A live Voyage/OpenAI-compat key (and OPENAI_EMBEDDING_MODEL /
+// OPENAI_EMBEDDING_DIMENSIONS) would otherwise leak in and break the
+// "returns null when no API keys" and default-dimension assertions.
+// Re-implement only the two env-reading exports so they see process.env
+// alone (equivalent to loadEnvFile() returning {}); keep everything else
+// original.
+vi.mock("../src/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/config.js")>();
+  const getEnvVar = (key: string): string | undefined => process.env[key];
+  const detectEmbeddingProvider = (
+    env?: Record<string, string>,
+  ): string | null => {
+    const source = env ?? (process.env as Record<string, string>);
+    const forced = source["EMBEDDING_PROVIDER"];
+    if (forced) return forced;
+    if (source["GEMINI_API_KEY"]) return "gemini";
+    if (source["OPENAI_API_KEY"]) return "openai";
+    if (source["VOYAGE_API_KEY"]) return "voyage";
+    if (source["COHERE_API_KEY"]) return "cohere";
+    if (source["OPENROUTER_API_KEY"]) return "openrouter";
+    return null;
+  };
+  return { ...actual, getEnvVar, detectEmbeddingProvider };
+});
+
 import {
   createEmbeddingProvider,
   withDimensionGuard,

--- a/test/hook-project.test.ts
+++ b/test/hook-project.test.ts
@@ -1,11 +1,31 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
+import { execSync } from "node:child_process";
 import { resolveProject } from "../src/hooks/_project.js";
+
+// Derive the expected basename the same way the resolver does (git toplevel
+// basename) instead of hardcoding "agentmemory". The clone dir may be named
+// anything (e.g. "agentmemory-lancedb"), so a hardcoded literal is not
+// hermetic. Falls back to the cwd basename if not in a git repo.
+function expectedRepoBasename(): string {
+  try {
+    const top = execSync("git rev-parse --show-toplevel", {
+      cwd: process.cwd(),
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 500,
+    })
+      .toString()
+      .trim();
+    if (top) return basename(top);
+  } catch {}
+  return basename(process.cwd());
+}
 
 describe("resolveProject — hook project basename resolver", () => {
   const originalEnv = process.env.AGENTMEMORY_PROJECT_NAME;
+  const repoBasename = expectedRepoBasename();
 
   beforeEach(() => {
     delete process.env.AGENTMEMORY_PROJECT_NAME;
@@ -32,35 +52,34 @@ describe("resolveProject — hook project basename resolver", () => {
 
   it("ignores empty env override", () => {
     process.env.AGENTMEMORY_PROJECT_NAME = "   ";
-    const repoBasename = "agentmemory";
     expect(resolveProject(process.cwd())).toBe(repoBasename);
   });
 
   it("returns git toplevel basename when cwd is inside a repo", () => {
     const top = resolveProject(process.cwd());
-    expect(top).toBe("agentmemory");
+    expect(top).toBe(repoBasename);
   });
 
   it("returns git toplevel basename from a nested subdir", () => {
     const nested = join(process.cwd(), "src", "hooks");
-    expect(resolveProject(nested)).toBe("agentmemory");
+    expect(resolveProject(nested)).toBe(repoBasename);
   });
 
   it("falls back to basename(cwd) when not in a git repo", () => {
     const dir = mkdtempSync(join(tmpdir(), "amem-noproj-"));
     try {
-      expect(resolveProject(dir)).toBe(dir.split("/").pop());
+      expect(resolveProject(dir)).toBe(basename(dir));
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
   });
 
   it("defaults to process.cwd() when no cwd argument given", () => {
-    expect(resolveProject()).toBe("agentmemory");
+    expect(resolveProject()).toBe(repoBasename);
   });
 
   it("defaults to process.cwd() when cwd argument is empty", () => {
-    expect(resolveProject("")).toBe("agentmemory");
-    expect(resolveProject("   ")).toBe("agentmemory");
+    expect(resolveProject("")).toBe(repoBasename);
+    expect(resolveProject("   ")).toBe(repoBasename);
   });
 });

--- a/test/mesh.test.ts
+++ b/test/mesh.test.ts
@@ -4,6 +4,15 @@ vi.mock("../src/logger.js", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
+// isAllowedUrl() in src/functions/mesh.ts calls dns/promises.lookup() on any
+// non-IP hostname (e.g. the *.example.com peers used below). On DNS-restricted
+// hosts that real lookup hangs to the vitest timeout. Mock the dns layer to
+// return a fixed PUBLIC address so isAllowedUrl's own private-IP/loopback
+// logic still runs and resolves instantly without touching the network.
+vi.mock("node:dns/promises", () => ({
+  lookup: vi.fn(async () => [{ address: "93.184.216.34", family: 4 }]),
+}));
+
 import { registerMeshFunction } from "../src/functions/mesh.js";
 import type {
   MeshPeer,


### PR DESCRIPTION
Three test suites coupled to the developer's environment and failed outside a specific setup. All three fixes are **test-only**; no production code changes.

### `test/hook-project.test.ts`
Hardcoded the resolved project basename as `"agentmemory"`, so the suite fails for anyone who clones the repo into a directory with a different name (e.g. a fork checked out as `agentmemory-lancedb`). Now derives the expected basename from the git toplevel the same way `resolveProject` does. Also fixes a Windows-only assertion that used `dir.split('/')` instead of `path.basename`.

### `test/embedding-provider.test.ts`
Asserts "returns null when no API keys are set" and the default embedding dimensions, but the provider resolves keys through `getMergedEnv()`, which re-reads `~/.agentmemory/.env` on every call. A developer with a real key on disk leaks it into those assertions and the tests fail. Now mocks the config env-merge so the tests see only `process.env`.

### `test/mesh.test.ts`
Let `isAllowedUrl()` run a real `dns.lookup()` on `*.example.com` hostnames, which hangs to the vitest timeout on DNS-restricted CI hosts. Now mocks `node:dns/promises` so it resolves instantly while `isAllowedUrl`'s own logic still runs.

Verified `npm run build` clean and `npm test` green on a fresh `main` checkout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by isolating environment-dependent behavior and mocking external dependencies to prevent file system and network access during test execution, ensuring consistent test results across different environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/734?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->