### PR TITLE
fix: LLM provider works with subscription proxies + honor SUMMARIZE_CHUNK_SIZE from .env

### DIFF
--- a/src/functions/summarize.ts
+++ b/src/functions/summarize.ts
@@ -20,6 +20,7 @@ import { scoreSummary } from "../eval/quality.js";
 import type { MetricsStore } from "../eval/metrics-store.js";
 import { safeAudit } from "./audit.js";
 import { logger } from "../logger.js";
+import { getEnvVar } from "../config.js";
 
 // Per-chunk observation budget when a session is too large to fit in one
 // LLM call. Default ≈ 50k input tokens per chunk at ~110 tok/obs — fits
@@ -37,14 +38,18 @@ const CHUNK_CONCURRENCY_DEFAULT = 6;
 const MAX_SKIP_RATIO = 0.5;
 
 function getChunkSize(): number {
-  const raw = process.env.SUMMARIZE_CHUNK_SIZE;
+  // Read via the merged env (file + process.env) so ~/.agentmemory/.env works,
+  // consistent with every other config var. process.env still wins (getMergedEnv
+  // spreads it last). Previously read process.env only, so the .env file value
+  // was silently ignored — a problem for small local-LLM context windows.
+  const raw = getEnvVar("SUMMARIZE_CHUNK_SIZE");
   if (!raw) return CHUNK_SIZE_DEFAULT;
   const n = parseInt(raw, 10);
   return Number.isFinite(n) && n > 0 ? n : CHUNK_SIZE_DEFAULT;
 }
 
 function getChunkConcurrency(): number {
-  const raw = process.env.SUMMARIZE_CHUNK_CONCURRENCY;
+  const raw = getEnvVar("SUMMARIZE_CHUNK_CONCURRENCY");
   if (!raw) return CHUNK_CONCURRENCY_DEFAULT;
   const n = parseInt(raw, 10);
   return Number.isFinite(n) && n > 0 ? n : CHUNK_CONCURRENCY_DEFAULT;

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -42,11 +42,17 @@ export class AnthropicProvider implements MemoryProvider {
   }
 
   private async call(systemPrompt: string, userPrompt: string): Promise<string> {
+    // Fold the system prompt into the user message rather than using the
+    // `system` field. Some Anthropic-compatible proxies (e.g. Claude Code
+    // subscription bridges) inject their own agent system prompt and override
+    // ours — so structured-output instructions placed in `system` are ignored
+    // and the model replies conversationally ("I'll look at the files…"),
+    // yielding no parseable output. Putting the instructions in the user
+    // message survives that and behaves identically against the real API.
     const response = await this.client.messages.create({
       model: this.model,
       max_tokens: this.maxTokens,
-      system: systemPrompt,
-      messages: [{ role: 'user', content: userPrompt }],
+      messages: [{ role: 'user', content: systemPrompt ? `${systemPrompt}\n\n${userPrompt}` : userPrompt }],
     })
 
     const textBlock = response.content.find((b) => b.type === 'text')


### PR DESCRIPTION
## Summary

Two independent robustness fixes for non-standard / local LLM endpoints, both surfaced while running agentmemory's compression + summarization through a self-hosted Claude Code subscription proxy and against local Ollama models.

### 1. `fix(providers)` — fold the Anthropic system prompt into the user message

`AnthropicProvider.call()` passes the prompt via the `system` field. Some Anthropic-compatible proxies — notably **Claude Code subscription bridges** — inject their own agent system prompt and **override the caller's `system`**. The model then ignores agentmemory's structured-output instructions and replies conversationally (e.g. *"I'll look at the auth code…"*), so `content.find(b => b.type === 'text')` returns prose with no `<summary>` → every `summarize`/`compress` call fails as `empty_provider_response` / `too_many_chunks_skipped`.

Folding the instructions into the **user** message survives the override and behaves identically against the official Anthropic API.

**Evidence:** the same bulk run that produced **0/84** parseable summaries through such a proxy produced **83/84** (quality 50–100) after this change.

### 2. `fix(summarize)` — honor `SUMMARIZE_CHUNK_SIZE` / `SUMMARIZE_CHUNK_CONCURRENCY` from `.env`

`getChunkSize()` / `getChunkConcurrency()` read `process.env` directly, so the **documented** values placed in `~/.agentmemory/.env` are silently ignored — every other setting flows through `getEnvVar()` / `getMergedEnv()`. For small-context local models (e.g. an 8k-context Ollama model) the default 400-observation chunk (~44k tokens) overflows the window and all chunks fail to parse.

Routing both through `getEnvVar()` honors the file. `process.env` still wins (`getMergedEnv` spreads it last), so existing overrides are unaffected.

## Test plan
- Existing `test/summarize.test.ts` chunk-override tests pass unchanged (they set `process.env`, which still wins).
- Manual: 83/84 imported sessions summarized through a subscription proxy after fix #1 (vs 0/84 before); local Ollama summarization honors `SUMMARIZE_CHUNK_SIZE` from `.env` after fix #2.

Both fixes are small and independent; happy to split into two PRs if preferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Summarization chunk sizing and concurrency configuration now supported via environment files with fallback defaults.
  * Updated Anthropic provider implementation to improve compatibility with certain proxy services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->