### PR TITLE
feat: load secrets from systemd credentials ($CREDENTIALS_DIRECTORY)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import {
   isContextInjectionEnabled,
   isDropStaleIndexEnabled,
 } from "./config.js";
+import { loadSystemdCredentials } from "./load-credentials.js";
 import {
   createProvider,
   createFallbackProvider,
@@ -157,6 +158,10 @@ process.on("unhandledRejection", (reason) => {
 });
 
 async function main() {
+  // Pull any systemd-delivered secrets ($CREDENTIALS_DIRECTORY) into the
+  // environment before config/providers read keys; a value set after exec
+  // stays out of /proc/<pid>/environ. No-op when the dir is unset.
+  loadSystemdCredentials();
   const config = loadConfig();
   const embeddingConfig = loadEmbeddingConfig();
   const fallbackConfig = loadFallbackConfig();

--- a/src/load-credentials.ts
+++ b/src/load-credentials.ts
@@ -1,0 +1,49 @@
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Bridge systemd-delivered credentials into process.env at runtime.
+ *
+ * When the unit declares `LoadCredential(Encrypted)=NAME:...`, systemd
+ * decrypts the secret into a private per-service tmpfs directory (files mode
+ * 0400, owned by the service user) and exposes its path as
+ * `$CREDENTIALS_DIRECTORY`. The secret is NOT placed in the process
+ * environment, so it never appears in `/proc/<pid>/environ`. This copies each
+ * credential file into `process.env`. Assigning at runtime (setenv) does not
+ * rewrite the exec environ block, so the value becomes readable in-process
+ * while staying invisible in `/proc/<pid>/environ` (verified on the target
+ * host: a value set after exec is present in `process.env` but absent from
+ * `/proc/self/environ`).
+ *
+ * Each credential file name maps 1:1 to an env var (a credential named
+ * `ANTHROPIC_API_KEY` fills `process.env.ANTHROPIC_API_KEY`). An explicitly
+ * set, non-empty environment variable always wins - only blanks are filled -
+ * so local/dev overrides and tests keep working unchanged. No-op when
+ * `$CREDENTIALS_DIRECTORY` is unset or missing, so non-systemd launches are
+ * unaffected.
+ */
+export function loadSystemdCredentials(): void {
+  const dir = process.env["CREDENTIALS_DIRECTORY"];
+  if (!dir || !existsSync(dir)) return;
+
+  let names: string[];
+  try {
+    names = readdirSync(dir);
+  } catch {
+    return;
+  }
+
+  for (const name of names) {
+    const current = process.env[name];
+    if (current !== undefined && current !== "") continue;
+    const file = join(dir, name);
+    try {
+      if (!statSync(file).isFile()) continue;
+      const value = readFileSync(file, "utf8").replace(/\r?\n+$/, "");
+      if (value) process.env[name] = value;
+    } catch {
+      // Unreadable credential file - leave the var unset so the consumer
+      // surfaces its own clear "X is required" error instead of us masking it.
+    }
+  }
+}

--- a/test/load-credentials.test.ts
+++ b/test/load-credentials.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadSystemdCredentials } from "../src/load-credentials.js";
+
+describe("loadSystemdCredentials", () => {
+  let dir: string;
+  const savedEnv = { ...process.env };
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "agentmemory-creds-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    // Restore process.env to its pre-test shape.
+    for (const k of Object.keys(process.env)) {
+      if (!(k in savedEnv)) delete process.env[k];
+    }
+    Object.assign(process.env, savedEnv);
+    delete process.env["CREDENTIALS_DIRECTORY"];
+  });
+
+  it("populates process.env from credential files and trims a trailing newline", () => {
+    writeFileSync(join(dir, "ANTHROPIC_API_KEY"), "sk-ant-test\n");
+    writeFileSync(join(dir, "AGENTMEMORY_SECRET"), "bearer-xyz");
+    delete process.env["ANTHROPIC_API_KEY"];
+    delete process.env["AGENTMEMORY_SECRET"];
+    process.env["CREDENTIALS_DIRECTORY"] = dir;
+
+    loadSystemdCredentials();
+
+    expect(process.env["ANTHROPIC_API_KEY"]).toBe("sk-ant-test");
+    expect(process.env["AGENTMEMORY_SECRET"]).toBe("bearer-xyz");
+  });
+
+  it("never overwrites an explicitly set, non-empty environment variable", () => {
+    writeFileSync(join(dir, "ANTHROPIC_API_KEY"), "from-credential");
+    process.env["ANTHROPIC_API_KEY"] = "from-env";
+    process.env["CREDENTIALS_DIRECTORY"] = dir;
+
+    loadSystemdCredentials();
+
+    expect(process.env["ANTHROPIC_API_KEY"]).toBe("from-env");
+  });
+
+  it("fills a variable that is present but empty", () => {
+    writeFileSync(join(dir, "GEMINI_API_KEY"), "from-credential");
+    process.env["GEMINI_API_KEY"] = "";
+    process.env["CREDENTIALS_DIRECTORY"] = dir;
+
+    loadSystemdCredentials();
+
+    expect(process.env["GEMINI_API_KEY"]).toBe("from-credential");
+  });
+
+  it("is a no-op when CREDENTIALS_DIRECTORY is unset", () => {
+    delete process.env["CREDENTIALS_DIRECTORY"];
+    delete process.env["SOME_CRED_VAR"];
+
+    expect(() => loadSystemdCredentials()).not.toThrow();
+    expect(process.env["SOME_CRED_VAR"]).toBeUndefined();
+  });
+
+  it("is a no-op when CREDENTIALS_DIRECTORY points at a missing directory", () => {
+    process.env["CREDENTIALS_DIRECTORY"] = join(dir, "does-not-exist");
+
+    expect(() => loadSystemdCredentials()).not.toThrow();
+  });
+
+  it("ignores subdirectories and empty credential files", () => {
+    mkdtempSync(join(dir, "subdir-"));
+    writeFileSync(join(dir, "EMPTY_CRED"), "");
+    delete process.env["EMPTY_CRED"];
+    process.env["CREDENTIALS_DIRECTORY"] = dir;
+
+    loadSystemdCredentials();
+
+    expect(process.env["EMPTY_CRED"]).toBeUndefined();
+  });
+});

--- a/test/load-credentials.test.ts
+++ b/test/load-credentials.test.ts
@@ -19,7 +19,6 @@ describe("loadSystemdCredentials", () => {
       if (!(k in savedEnv)) delete process.env[k];
     }
     Object.assign(process.env, savedEnv);
-    delete process.env["CREDENTIALS_DIRECTORY"];
   });
 
   it("populates process.env from credential files and trims a trailing newline", () => {


### PR DESCRIPTION
## Problem

Run agentmemory as a systemd service and the only ways to pass provider keys (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `AGENTMEMORY_SECRET`, ...) are `Environment=` / `EnvironmentFile=` - both place the secrets in the process environment, readable via `/proc/<pid>/environ` and plaintext at rest.

## Change

An opt-in loader, `loadSystemdCredentials()`, called once at the start of the worker `main()`. It copies any files in `$CREDENTIALS_DIRECTORY` into `process.env` (only when unset/empty; trailing newline trimmed; file name maps 1:1 to the env var). A value assigned to `process.env` after `exec` is readable in-process but is not written back to the exec environ block, so it does not appear in `/proc/<pid>/environ` (verified on Node 22 / glibc). The providers get the keys; the environment stays clean.

## Requirements & platform support

Purely additive and **a no-op when `$CREDENTIALS_DIRECTORY` is unset**, so non-systemd hosts (macOS, Windows, Alpine/OpenRC) and existing `Environment=`/`.env` setups are entirely unaffected.

- Encrypted at rest: `LoadCredentialEncrypted=` + `systemd-creds` - **systemd >= 250** (Debian 12+, RHEL/Rocky/Alma 9+, Fedora, Arch, openSUSE, Ubuntu 24.04+).
- Out-of-environment but plaintext at rest: `LoadCredential=` - **systemd >= 247** (e.g. Ubuntu 22.04).
- systemd < 247 or no systemd: loader no-ops; use the existing env approach.

## Enabling it (operator, systemd >= 250)

```bash
systemd-creds encrypt --name=ANTHROPIC_API_KEY anthropic.key \
  /etc/credstore.encrypted/ANTHROPIC_API_KEY.cred
```

```ini
# unit / drop-in
[Service]
LoadCredentialEncrypted=ANTHROPIC_API_KEY:/etc/credstore.encrypted/ANTHROPIC_API_KEY.cred
```

systemd decrypts into a private tmpfs (`$CREDENTIALS_DIRECTORY`, mode 0400) at start; the loader reads it from there.

## Compatibility

Explicitly set env vars always win. Unit tests cover populate/trim, no-overwrite, fill-empty, unset/missing dir, and ignoring subdirs/empty files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App now automatically loads credentials delivered by systemd at startup, populating environment variables for downstream configuration while preserving existing non-empty values.

* **Tests**
  * Added comprehensive tests covering credential loading behaviors (trimming, no-ops for missing dirs, ignoring subdirectories, and preserving/restoring environment state).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->