### PR TITLE
fix: remove premature session/end call from stop hook

### DIFF
--- a/plugin/scripts/stop.mjs
+++ b/plugin/scripts/stop.mjs
@@ -29,12 +29,6 @@ async function main() {
 		body: JSON.stringify({ sessionId }),
 		signal: AbortSignal.timeout(12e4)
 	}).catch(() => {});
-	fetch(`${REST_URL}/agentmemory/session/end`, {
-		method: "POST",
-		headers: authHeaders(),
-		body: JSON.stringify({ sessionId }),
-		signal: AbortSignal.timeout(5e3)
-	}).catch(() => {});
 	setTimeout(() => process.exit(0), 1500).unref();
 }
 main();

--- a/src/hooks/stop.ts
+++ b/src/hooks/stop.ts
@@ -46,12 +46,17 @@ async function main() {
     signal: AbortSignal.timeout(120000),
   }).catch(() => {});
 
-  fetch(`${REST_URL}/agentmemory/session/end`, {
-    method: "POST",
-    headers: authHeaders(),
-    body: JSON.stringify({ sessionId }),
-    signal: AbortSignal.timeout(5000),
-  }).catch(() => {});
+  // TODO(codex-session-end): Codex does not fire a separate SessionEnd event,
+  // so its Stop hook was the only signal to close the session lifecycle.
+  // We removed the /session/end call here because Claude Code (and other agents)
+  // fire Stop after every assistant turn, causing premature session completion.
+  // Re-add once a reliable Codex identifier is available in the hook payload.
+  // fetch(`${REST_URL}/agentmemory/session/end`, {
+  //   method: "POST",
+  //   headers: authHeaders(),
+  //   body: JSON.stringify({ sessionId }),
+  //   signal: AbortSignal.timeout(5000),
+  // }).catch(() => {});
 
   setTimeout(() => process.exit(0), 1500).unref();
 }

--- a/test/copilot-plugin.test.ts
+++ b/test/copilot-plugin.test.ts
@@ -377,4 +377,16 @@ describe("Copilot hook scripts", () => {
       },
     });
   });
+
+  it("stop calls /summarize but not /session/end", async () => {
+    const result = await runHook("scripts/stop.mjs", {
+      sessionId: "copilot-session",
+      cwd: "C:\\repo",
+    });
+
+    expect(result.stdout).toBe("");
+    const paths = result.requests.map((r) => r.path);
+    expect(paths).toContain("/agentmemory/summarize");
+    expect(paths).not.toContain("/agentmemory/session/end");
+  });
 });


### PR DESCRIPTION
## Summary

Removes the premature `/agentmemory/session/end` call from the `stop.mjs` hook script that was causing Claude Code sessions to be marked `completed` mid-conversation.

## Problem

`src/hooks/stop.ts` fired `/agentmemory/session/end` on every `agentStop` event. In Claude Code CLI, `agentStop` fires after **every** assistant turn — not just at session exit — because Claude Code has a dedicated `sessionEnd` hook for true exit. This caused:

- Sessions marked `completed` while the user was still actively chatting.
- `session-end.mjs` lifecycle events (slot-reflect, graph-extract, consolidation) firing prematurely or against an already-completed session.
- Log noise from `event::session::stopped trigger failed`.

## Root Cause

The `/session/end` call was intentionally added in commit `35512414` (#579) as a workaround for Codex, which does **not** fire a separate `SessionEnd` event. At the time it was assumed to be "harmless idempotent" for Claude Code, but that assumption was incorrect — Claude Code fires `agentStop` after every assistant turn.

## Why not guard by agent type?

We cannot reliably detect Codex from the hook payload (no confirmed `entrypoint` value or other identifier). A black-list guard (`entrypoint !== "cli"`) would still incorrectly fire `session/end` for Hermes and other agents that also lack a dedicated `SessionEnd` hook. A white-list guard is not possible without a known Codex identifier.

## Changes

- **`src/hooks/stop.ts`**: Commented out the `session/end` fetch with a `TODO(codex-session-end)` explaining the regression.
- **`test/copilot-plugin.test.ts`**: Added a test verifying `stop.mjs` calls `/summarize` but **not** `/session/end`.
- **`plugin/scripts/stop.mjs`**: Rebuilt from source.

## Verification

```bash
npm run build
npx vitest run test/copilot-plugin.test.ts
```

All 17 tests in `copilot-plugin.test.ts` pass, including the new stop-hook behavior test.

## Regression Note

Codex sessions will no longer be auto-closed on the `Stop` hook. This is a known regression that can be reverted once a reliable Codex identifier is available in the hook payload.

## Related

Fixes #745
- Commit `35512414` — originally added `session/end` to `stop.mjs` as a Codex workaround (#579, fixes #493).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed premature session termination that interrupted agent workflows. Sessions now maintain proper continuity without unexpected interruptions from stop events.
  * Improved shutdown process with enhanced timeout handling for better reliability during graceful session closure.

* **Tests**
  * Added comprehensive test coverage for session shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->