### PR TITLE
fix(consolidation): dedup against live memories within a run (#747)

### DIFF
--- a/src/functions/consolidate.ts
+++ b/src/functions/consolidate.ts
@@ -62,6 +62,25 @@ function parseMemoryXml(
   };
 }
 
+/**
+ * Mirrors a freshly written memory into the in-run snapshot so later concept
+ * groups dedup against it. A superseded predecessor is replaced in place rather
+ * than appended: the dedup match keys on title alone, so a lingering superseded
+ * row would be re-matched by a later same-title group and spawn a second latest
+ * memory (#747).
+ */
+function reflectMemoryInSnapshot(
+  snapshot: Memory[],
+  memory: Memory,
+  supersededMemory?: Memory,
+): void {
+  const supersededIdx = supersededMemory
+    ? snapshot.indexOf(supersededMemory)
+    : -1;
+  if (supersededIdx >= 0) snapshot[supersededIdx] = memory;
+  else snapshot.push(memory);
+}
+
 export function registerConsolidateFunction(
   sdk: ISdk,
   kv: StateKV,
@@ -199,15 +218,7 @@ export function registerConsolidateFunction(
               newId: evolved.id,
               concept,
             });
-            // Keep the in-memory snapshot live so later concept groups in this
-            // same run see the evolved memory. Replace the matched predecessor
-            // in place rather than appending: the title match above does not
-            // filter on isLatest, so leaving the now-superseded row in the array
-            // would let a later same-title group re-match it and create a second
-            // latest memory (the duplicate/orphan bug, #747).
-            const matchIdx = existingMemories.indexOf(existingMatch);
-            if (matchIdx >= 0) existingMemories[matchIdx] = evolved;
-            else existingMemories.push(evolved);
+            reflectMemoryInSnapshot(existingMemories, evolved, existingMatch);
             consolidated++;
           } else {
             const memory: Memory = {
@@ -225,10 +236,7 @@ export function registerConsolidateFunction(
               action: "create_memory",
               concept,
             });
-            // Keep the in-memory snapshot live so a later concept group in this
-            // same run that synthesizes the same title evolves this memory
-            // instead of creating a duplicate (#747).
-            existingMemories.push(memory);
+            reflectMemoryInSnapshot(existingMemories, memory);
             consolidated++;
           }
         } catch (err) {

--- a/src/functions/consolidate.ts
+++ b/src/functions/consolidate.ts
@@ -112,9 +112,6 @@ export function registerConsolidateFunction(
 
       let consolidated = 0;
       const existingMemories = await kv.list<Memory>(KV.memories);
-      const existingTitles = new Set(
-        existingMemories.map((m) => m.title.toLowerCase()),
-      );
 
       const MAX_LLM_CALLS = 10;
       let llmCallCount = 0;
@@ -202,7 +199,15 @@ export function registerConsolidateFunction(
               newId: evolved.id,
               concept,
             });
-            existingTitles.add(evolved.title.toLowerCase());
+            // Keep the in-memory snapshot live so later concept groups in this
+            // same run see the evolved memory. Replace the matched predecessor
+            // in place rather than appending: the title match above does not
+            // filter on isLatest, so leaving the now-superseded row in the array
+            // would let a later same-title group re-match it and create a second
+            // latest memory (the duplicate/orphan bug, #747).
+            const matchIdx = existingMemories.indexOf(existingMatch);
+            if (matchIdx >= 0) existingMemories[matchIdx] = evolved;
+            else existingMemories.push(evolved);
             consolidated++;
           } else {
             const memory: Memory = {
@@ -220,7 +225,10 @@ export function registerConsolidateFunction(
               action: "create_memory",
               concept,
             });
-            existingTitles.add(memory.title.toLowerCase());
+            // Keep the in-memory snapshot live so a later concept group in this
+            // same run that synthesizes the same title evolves this memory
+            // instead of creating a duplicate (#747).
+            existingMemories.push(memory);
             consolidated++;
           }
         } catch (err) {

--- a/test/consolidate-project-scope.test.ts
+++ b/test/consolidate-project-scope.test.ts
@@ -268,3 +268,102 @@ describe("mem::consolidate — cross-project existingMatch guard", () => {
     expect(memories[0].project).toBeUndefined();
   });
 });
+
+describe("mem::consolidate — within-run same-title dedup (issue #747)", () => {
+  async function seedGroup(
+    kv: ReturnType<typeof makeMockKV>,
+    sessionId: string,
+    concept: string,
+    count = 3,
+  ) {
+    for (let i = 0; i < count; i++) {
+      const o = makeObs(`${concept}_${i}`, sessionId, concept);
+      await kv.set(KV.observations(sessionId), o.id, o);
+    }
+  }
+
+  it("two concept groups resolving to the same title in one run yield one active memory with an intact parent chain", async () => {
+    const sdk = makeMockSdk();
+    const kv = makeMockKV();
+    // The provider returns the SAME title regardless of concept, so both
+    // concept groups synthesize a colliding title within a single run.
+    const provider = makeProvider("Shared Title");
+
+    const session = makeSession("s1", "api");
+    await kv.set(KV.sessions, session.id, session);
+    await seedGroup(kv, "s1", "auth");
+    await seedGroup(kv, "s1", "login");
+
+    registerConsolidateFunction(sdk as never, kv as never, provider as never);
+    await sdk.trigger("mem::consolidate", { project: "api", minObservations: 1 });
+
+    const memories = await kv.list<Memory>(KV.memories);
+
+    // Exactly one active memory for the colliding title (pre-fix: 2).
+    const active = memories.filter(
+      (m) => m.isLatest && m.title.toLowerCase() === "shared title",
+    );
+    expect(active).toHaveLength(1);
+
+    // Exactly one parentless root for the title (pre-fix: 2 orphaned roots).
+    const roots = memories.filter(
+      (m) => m.title.toLowerCase() === "shared title" && !m.parentId,
+    );
+    expect(roots).toHaveLength(1);
+
+    // The second group evolved the first rather than duplicating it.
+    expect(memories).toHaveLength(2);
+    const superseded = memories.find((m) => !m.isLatest);
+    expect(superseded).toBeDefined();
+    expect(active[0].parentId).toBe(superseded!.id);
+    expect(active[0].supersedes).toContain(superseded!.id);
+    expect(active[0].version).toBe(2);
+
+    // No orphans: every non-latest memory has exactly one successor.
+    const nonLatest = memories.filter((m) => !m.isLatest);
+    for (const old of nonLatest) {
+      const successors = memories.filter((m) => m.parentId === old.id);
+      expect(successors).toHaveLength(1);
+    }
+  });
+
+  it("three concept groups resolving to the same title in one run still yield exactly one active memory in a linear chain", async () => {
+    const sdk = makeMockSdk();
+    const kv = makeMockKV();
+    const provider = makeProvider("Shared Title");
+
+    const session = makeSession("s1", "api");
+    await kv.set(KV.sessions, session.id, session);
+    await seedGroup(kv, "s1", "auth");
+    await seedGroup(kv, "s1", "login");
+    await seedGroup(kv, "s1", "session");
+
+    registerConsolidateFunction(sdk as never, kv as never, provider as never);
+    await sdk.trigger("mem::consolidate", { project: "api", minObservations: 1 });
+
+    const memories = await kv.list<Memory>(KV.memories);
+
+    // Still exactly one active memory; guards the in-place-replace subtlety
+    // (a naive append would let the 3rd group re-match a superseded row).
+    const active = memories.filter(
+      (m) => m.isLatest && m.title.toLowerCase() === "shared title",
+    );
+    expect(active).toHaveLength(1);
+
+    const roots = memories.filter(
+      (m) => m.title.toLowerCase() === "shared title" && !m.parentId,
+    );
+    expect(roots).toHaveLength(1);
+
+    // Linear chain of three versions: one root, two superseded each with
+    // exactly one successor.
+    expect(memories).toHaveLength(3);
+    expect(active[0].version).toBe(3);
+    const nonLatest = memories.filter((m) => !m.isLatest);
+    expect(nonLatest).toHaveLength(2);
+    for (const old of nonLatest) {
+      const successors = memories.filter((m) => m.parentId === old.id);
+      expect(successors).toHaveLength(1);
+    }
+  });
+});


### PR DESCRIPTION
## What

Fixes the within-run duplication and orphaning in `mem::consolidate` reported in #747.

The handler snapshots existing memories into `existingMemories` once before the concept-group loop and never refreshes it. A parallel `existingTitles` Set was populated on every create/evolve but never read - dead code. The dedup check (`existingMemories.find(...)`) therefore only ever saw the stale snapshot, so when two concept groups in the same run synthesized the same title, the second group did not find the memory the first had just created. It took the create branch and wrote a second `isLatest` memory with no `parentId` - a duplicate active memory plus an orphaned predecessor and a broken version chain.

## Why it happens

Each concept group is its own `provider.compress` call, and distinct concepts frequently compress to the same synthesized title. The snapshot is read once; new memories are persisted via `kv.set` but never added back to the in-memory array the dedup scans.

## The fix

Keep the snapshot live instead of carrying an unused index:

- Remove the dead `existingTitles` Set.
- Push each newly created memory into `existingMemories`.
- On evolve, replace the matched predecessor **in place**. The title match does not filter on `isLatest`, so a plain append would leave the now-superseded row matchable and let a third same-title group evolve it, recreating a second latest. In-place replacement keeps exactly one matchable row per title and a linear `A -> B -> C` chain.

The cross-project guard in the match predicate is untouched, so a scoped run still refuses to evolve another project's identically titled memory (the existing `consolidate-project-scope` tests pass unchanged).

## How to verify

```
npm install --legacy-peer-deps
npm run build
npm test -- test/consolidate-project-scope.test.ts
```

Two regression tests were added to `test/consolidate-project-scope.test.ts`:

- two concept groups -> same title in one run: asserts exactly one active memory, one parentless root, intact `parentId`/`supersedes` chain, no orphan.
- three concept groups -> same title: asserts still exactly one active memory in a linear three-version chain (guards the in-place-replace subtlety).

Both are red on `main` (the 2-group case yields 2 active memories / 2 parentless roots, the 3-group case yields 3) and green with this change.

Fixes #747


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the consolidation process could generate duplicate "latest" memories when multiple concept groups in the same run resolved to the same synthesized title; consolidation now preserves a single active memory and correct parent/supersedes relationships.

* **Tests**
  * Added a test suite validating same-title deduplication within a run, ensuring one active root and a correct linear evolution across multiple concept groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->