### PR TITLE
fix(plugin): per-session project detection from session.created directory

### DIFF
--- a/plugin/opencode/agentmemory-capture.ts
+++ b/plugin/opencode/agentmemory-capture.ts
@@ -168,7 +168,7 @@ function extractErrorMessage(err: unknown): string {
 }
 
 export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
-  projectPath = ctx.worktree || ctx.project?.id || process.cwd();
+  projectPath = ctx.worktree || ctx.project?.worktree || ctx.directory || process.cwd();
 
   return {
     event: async ({ event }) => {
@@ -188,13 +188,14 @@ export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
         // and another `session.created` event during the await could
         // rebind it, causing context to be cached against the wrong key.
         const sessionId = activeSessionId;
+        const sessionProject = (info?.directory as string) || projectPath;
         const startResult = await postJson("/session/start", {
           sessionId,
           title: info?.title ?? null,
           parentID: info?.parentID ?? null,
           version: info?.version ?? null,
-          project: projectPath,
-          cwd: projectPath,
+          project: sessionProject,
+          cwd: sessionProject,
         });
         // cache the context returned at session/start so the
         // chat.system.transform hook injects it without a second fetch.

--- a/plugin/opencode/agentmemory-capture.ts
+++ b/plugin/opencode/agentmemory-capture.ts
@@ -27,6 +27,7 @@ async function post(path: string, body: Record<string, unknown>, timeoutMs = 500
   }
 }
 
+/** POST JSON to the agentmemory daemon and parse the JSON response. Returns null on failure. */
 async function postJson(path: string, body: Record<string, unknown>): Promise<unknown | null> {
   try {
     const res = await fetch(`${API}/agentmemory${path}`, {
@@ -167,6 +168,14 @@ function extractErrorMessage(err: unknown): string {
   return String(err ?? "");
 }
 
+/**
+ * Agentmemory capture plugin for OpenCode.
+ *
+ * Captures session events (session.created, tool.use, etc.) and forwards them
+ * to the agentmemory daemon for persistent memory storage. The plugin determines
+ * the project path from the workspace context at init time, with per-session
+ * override from the `session.created` event's directory field.
+ */
 export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
   projectPath = ctx.worktree || ctx.project?.worktree || ctx.directory || process.cwd();
 
@@ -188,7 +197,13 @@ export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
         // and another `session.created` event during the await could
         // rebind it, causing context to be cached against the wrong key.
         const sessionId = activeSessionId;
-        const sessionProject = (info?.directory as string) || projectPath;
+        // Use session-specific directory if available and valid;
+        // fall back to the init-time projectPath otherwise.
+        // Runtime validation (typeof + length) avoids sending invalid
+        // values to the /session/start backend.
+        const sessionProject = (typeof info?.directory === 'string' && info.directory.length > 0) 
+          ? info.directory 
+          : projectPath;
         const startResult = await postJson("/session/start", {
           sessionId,
           title: info?.title ?? null,


### PR DESCRIPTION
## Problem

When OpenCode runs as a web service from a workspace root directory (e.g., `/home/user/projects/`) serving multiple sub-projects, the agentmemory-capture plugin's `projectPath` is initialized once at plugin load time. Every session receives the same project string — the workspace root — regardless of which sub-project the user is actually working in.

This causes memory cross-contamination: sessions in `project-a` and `project-b` both get tagged with `project: "/home/user/projects/"`, making project-scoped queries (`mem::search` with `project` filter) useless and mixing memories across unrelated projects.

## Solution

Two changes to `plugin/opencode/agentmemory-capture.ts`:

### 1. Better plugin-init project detection (line 171)

The OpenCode plugin context already has `ctx.project?.worktree` (full filesystem path) and `ctx.directory` — use them before falling back to `process.cwd()`:

```diff
-  projectPath = ctx.worktree || ctx.project?.id || process.cwd();
+  projectPath = ctx.worktree || ctx.project?.worktree || ctx.directory || process.cwd();
```

`ctx.project?.id` returns a short name (e.g., `my-app`) while `ctx.project?.worktree` returns the full path (e.g., `/home/user/projects/my-app`). Full paths are unique, short names are not.

### 2. Per-session project from `session.created` event (line 191, 197-198)

The OpenCode bus publishes `session.created` events that include a `directory` field with the specific project path. Extract it per-session instead of using the global init-time value:

```diff
+        const sessionProject = (info?.directory as string) || projectPath;
         const startResult = await postJson("/session/start", {
           sessionId,
           title: info?.title ?? null,
           parentID: info?.parentID ?? null,
           version: info?.version ?? null,
-          project: projectPath,
-          cwd: projectPath,
+          project: sessionProject,
+          cwd: sessionProject,
```

This is a 3-line change (1 new, 2 modified) with a clean fallback: if `info?.directory` is not available (e.g., CLI mode), it uses the init-time `projectPath`.

## Testing

Verified on OpenCode 1.15.12 running as a systemd web service with `WorkingDirectory=/home/kiffer/projects/` and multiple sub-projects. Before the fix, `agentmemory-error.log` showed all sessions with `project: "/home/kiffer/projects"`. After the fix, sessions are correctly tagged with their specific project directory (e.g., `project: "/home/kiffer/projects/kodehold"`).

## Related issues

- #656 — Memories leak across projects (closed, addressed server-side)
- #733 — Project identity uses git-toplevel basename (different scope — git remote identity)
- #515 — Codex worktrees treated as separate projects (inverse problem)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project path resolution and session initialization. Sessions now derive project and working-directory context from the workspace directory with enhanced fallbacks, ensuring accurate project tracking and correct working-directory context during agent operations and memory capture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->