### PR TITLE
feat(embedding): support configurable vector dimensions for OpenRouter provider

### DIFF
--- a/src/providers/embedding/openrouter.ts
+++ b/src/providers/embedding/openrouter.ts
@@ -6,7 +6,7 @@ const API_URL = "https://openrouter.ai/api/v1/embeddings";
 
 export class OpenRouterEmbeddingProvider implements EmbeddingProvider {
   readonly name = "openrouter";
-  readonly dimensions = 1536;
+  readonly dimensions: number;
   private apiKey: string;
   private model: string;
 
@@ -16,6 +16,19 @@ export class OpenRouterEmbeddingProvider implements EmbeddingProvider {
     this.model =
       getEnvVar("OPENROUTER_EMBEDDING_MODEL") ||
       "openai/text-embedding-3-small";
+
+    const dimStr = getEnvVar("OPENROUTER_EMBEDDING_DIMENSIONS");
+    if (dimStr !== undefined && dimStr.trim().length > 0) {
+      const parsed = parseInt(dimStr, 10);
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        throw new Error(
+          `OPENROUTER_EMBEDDING_DIMENSIONS must be a positive integer, got: ${dimStr}`,
+        );
+      }
+      this.dimensions = parsed;
+    } else {
+      this.dimensions = 1536;
+    }
   }
 
   async embed(text: string): Promise<Float32Array> {
@@ -33,6 +46,7 @@ export class OpenRouterEmbeddingProvider implements EmbeddingProvider {
       body: JSON.stringify({
         model: this.model,
         input: texts,
+        dimensions: this.dimensions,
       }),
     });
 

--- a/test/embedding-provider.test.ts
+++ b/test/embedding-provider.test.ts
@@ -5,7 +5,19 @@ import {
 } from "../src/providers/embedding/index.js";
 import { GeminiEmbeddingProvider } from "../src/providers/embedding/gemini.js";
 import { OpenAIEmbeddingProvider } from "../src/providers/embedding/openai.js";
+import { OpenRouterEmbeddingProvider } from "../src/providers/embedding/openrouter.js";
 import type { EmbeddingProvider } from "../src/types.js";
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    existsSync: (path: string) => {
+      if (typeof path === "string" && path.endsWith(".env")) return false;
+      return actual.existsSync(path);
+    },
+  };
+});
 
 describe("createEmbeddingProvider", () => {
   const originalEnv = { ...process.env };
@@ -153,6 +165,43 @@ describe("OpenAIEmbeddingProvider", () => {
     process.env["OPENAI_EMBEDDING_DIMENSIONS"] = "0";
     expect(() => new OpenAIEmbeddingProvider("test-key")).toThrow(
       /OPENAI_EMBEDDING_DIMENSIONS must be a positive integer/,
+    );
+  });
+});
+
+describe("OpenRouterEmbeddingProvider", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env["OPENROUTER_EMBEDDING_MODEL"];
+    delete process.env["OPENROUTER_EMBEDDING_DIMENSIONS"];
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("uses default dimensions (1536) when env is not set", () => {
+    const provider = new OpenRouterEmbeddingProvider("test-key");
+    expect(provider.dimensions).toBe(1536);
+  });
+
+  it("respects OPENROUTER_EMBEDDING_DIMENSIONS env var", () => {
+    process.env["OPENROUTER_EMBEDDING_DIMENSIONS"] = "2048";
+    const provider = new OpenRouterEmbeddingProvider("test-key");
+    expect(provider.dimensions).toBe(2048);
+  });
+
+  it("rejects invalid OPENROUTER_EMBEDDING_DIMENSIONS values", () => {
+    process.env["OPENROUTER_EMBEDDING_DIMENSIONS"] = "not-a-number";
+    expect(() => new OpenRouterEmbeddingProvider("test-key")).toThrow(
+      /OPENROUTER_EMBEDDING_DIMENSIONS must be a positive integer/,
+    );
+
+    process.env["OPENROUTER_EMBEDDING_DIMENSIONS"] = "-10";
+    expect(() => new OpenRouterEmbeddingProvider("test-key")).toThrow(
+      /OPENROUTER_EMBEDDING_DIMENSIONS must be a positive integer/,
     );
   });
 });


### PR DESCRIPTION
### WHAT
Adds dynamic configuration support for OpenRouter embedding vector dimensions via the `OPENROUTER_EMBEDDING_DIMENSIONS` environment variable, validating that inputs are positive finite integers, and defaulting to 1536.

### WHERE
- `src/providers/embedding/openrouter.ts` (Class properties and constructor parsing/validation).
- `test/embedding-provider.test.ts` (Unit tests for default, custom, and invalid values, plus a `node:fs` mock to isolate testing).

### WHEN
When initialized via environment variables or explicitly instantiated, especially when users target custom or newer models on OpenRouter (e.g., NVIDIA's 2048-dim models) that deviate from OpenAI's standard 1536 dimensions.

### WHY
To prevent runtime dimension mismatches and crashes when developers use non-1536 dimension models through the OpenRouter embedding provider, enhancing flexibility and type-safe integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Embedding provider now supports configurable embedding dimensions via an environment setting (defaults to 1536) with validation and clearer error handling for invalid values.

* **Tests**
  * Added test coverage for default behavior, configuration overrides, and invalid-dimension validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->