### PR TITLE
fix: skip malformed obsidian export records

### DIFF
--- a/src/functions/obsidian-export.ts
+++ b/src/functions/obsidian-export.ts
@@ -30,6 +30,16 @@ function sanitize(name: string): string {
   return name.replace(/[<>:"/\\|?*\x00-\x1f]/g, "_").slice(0, 100);
 }
 
+function hasExportId<T extends { id?: unknown }>(item: T | null | undefined): item is T & { id: string } {
+  return typeof item?.id === "string" && item.id.length > 0;
+}
+
+function timestamp(value: unknown): number {
+  if (typeof value !== "string") return 0;
+  const time = new Date(value).getTime();
+  return Number.isFinite(time) ? time : 0;
+}
+
 function toFrontmatter(obj: Record<string, unknown>): string {
   const lines = ["---"];
   for (const [key, value] of Object.entries(obj)) {
@@ -250,58 +260,59 @@ export function registerObsidianExportFunction(
         exportTypes.has("sessions") ? kv.list<Session>(KV.sessions) : Promise.resolve([] as Session[]),
       ]);
 
-      for (const m of memories.filter((m) => m.isLatest)) {
-        const filename = `${sanitize(m.id)}.md`;
-        const filepath = join(dirs.memories, filename);
+      for (const m of memories.filter((m) => m.isLatest && hasExportId(m))) {
         try {
+          const filename = `${sanitize(m.id)}.md`;
+          const filepath = join(dirs.memories, filename);
           await writeFile(filepath, memoryToMd(m));
           stats.memories++;
           memoryMoc.push(`- [[memories/${sanitize(m.id)}|${m.title}]] (${m.type}, strength: ${m.strength})`);
         } catch (err) {
-          errors.push({ id: m.id, path: filepath, error: err instanceof Error ? err.message : String(err) });
+          errors.push({ id: m.id, path: join(dirs.memories, `${sanitize(m.id)}.md`), error: err instanceof Error ? err.message : String(err) });
         }
       }
 
-      for (const l of lessons.filter((l) => !l.deleted)) {
-        const filename = `${sanitize(l.id)}.md`;
-        const filepath = join(dirs.lessons, filename);
+      for (const l of lessons.filter((l) => !l.deleted && hasExportId(l))) {
         try {
+          const filename = `${sanitize(l.id)}.md`;
+          const filepath = join(dirs.lessons, filename);
           await writeFile(filepath, lessonToMd(l));
           stats.lessons++;
           lessonMoc.push(`- [[lessons/${sanitize(l.id)}|${l.content.slice(0, 60)}]] (confidence: ${l.confidence})`);
         } catch (err) {
-          errors.push({ id: l.id, path: filepath, error: err instanceof Error ? err.message : String(err) });
+          errors.push({ id: l.id, path: join(dirs.lessons, `${sanitize(l.id)}.md`), error: err instanceof Error ? err.message : String(err) });
         }
       }
 
-      for (const c of crystals) {
-        const filename = `${sanitize(c.id)}.md`;
-        const filepath = join(dirs.crystals, filename);
+      for (const c of crystals.filter(hasExportId)) {
         try {
+          const filename = `${sanitize(c.id)}.md`;
+          const filepath = join(dirs.crystals, filename);
           await writeFile(filepath, crystalToMd(c));
           stats.crystals++;
           crystalMoc.push(`- [[crystals/${sanitize(c.id)}|${c.narrative.slice(0, 60)}]]`);
         } catch (err) {
-          errors.push({ id: c.id, path: filepath, error: err instanceof Error ? err.message : String(err) });
+          errors.push({ id: c.id, path: join(dirs.crystals, `${sanitize(c.id)}.md`), error: err instanceof Error ? err.message : String(err) });
         }
       }
 
       const recent = sessions
+        .filter(hasExportId)
         .sort(
           (a, b) =>
-            new Date(b.startedAt).getTime() -
-            new Date(a.startedAt).getTime(),
+            timestamp(b.startedAt) -
+            timestamp(a.startedAt),
         )
         .slice(0, 50);
       for (const s of recent) {
-        const filename = `${sanitize(s.id)}.md`;
-        const filepath = join(dirs.sessions, filename);
         try {
+          const filename = `${sanitize(s.id)}.md`;
+          const filepath = join(dirs.sessions, filename);
           await writeFile(filepath, sessionToMd(s));
           stats.sessions++;
           sessionMoc.push(`- [[sessions/${sanitize(s.id)}|${s.project} (${s.status})]]`);
         } catch (err) {
-          errors.push({ id: s.id, path: filepath, error: err instanceof Error ? err.message : String(err) });
+          errors.push({ id: s.id, path: join(dirs.sessions, `${sanitize(s.id)}.md`), error: err instanceof Error ? err.message : String(err) });
         }
       }
 

--- a/test/obsidian-export.test.ts
+++ b/test/obsidian-export.test.ts
@@ -297,4 +297,27 @@ describe("Obsidian Export", () => {
     expect(result.success).toBe(true);
     expect(result.errors).toBeUndefined();
   });
+
+  it("skips malformed records without ids instead of failing the export", async () => {
+    await kv.set("mem:memories", "orphan-memory", { ...makeMemory("mem_missing"), id: undefined } as any);
+    await kv.set("mem:lessons", "orphan-lesson", { ...makeLesson("lsn_missing"), id: undefined } as any);
+    await kv.set("mem:crystals", "orphan-crystal", { ...makeCrystal("crys_missing"), id: undefined } as any);
+    await kv.set("mem:sessions", "orphan-session", { ...makeSession("ses_missing"), id: undefined } as any);
+    await kv.set("mem:sessions", "valid-session", makeSession("ses_valid"));
+
+    const result = (await sdk.trigger("mem::obsidian-export", {})) as {
+      success: boolean;
+      exported: Record<string, number>;
+      errors?: unknown[];
+    };
+
+    expect(result.success).toBe(true);
+    expect(result.exported.memories).toBe(0);
+    expect(result.exported.lessons).toBe(0);
+    expect(result.exported.crystals).toBe(0);
+    expect(result.exported.sessions).toBe(1);
+    expect(result.errors).toBeUndefined();
+    expect([...writtenFiles.keys()].some((path) => path.includes("undefined.md"))).toBe(false);
+    expect([...writtenFiles.keys()].some((path) => path.includes("sessions/ses_valid.md"))).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- skip memories, lessons, crystals, and sessions that are missing export ids before writing Obsidian files
- keep export error handling focused on write failures instead of letting malformed records crash before the try/catch
- sort recent sessions with a safe timestamp helper so malformed dates do not poison the export ordering

Closes #729

## Tests
- `npm test -- test/obsidian-export.test.ts`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The Obsidian export feature now handles malformed or incomplete data records gracefully, preventing export failures when identifiers are missing or invalid

* **Improvements**
  * Enhanced validation filtering ensures only valid records are exported
  * Session exports are now limited to the 50 most recent items

<!-- end of auto-generated comment: release notes by coderabbit.ai -->