### PR TITLE
fix(pi): send tool_input/tool_output instead of input/output

### DIFF
--- a/integrations/pi/index.ts
+++ b/integrations/pi/index.ts
@@ -266,8 +266,8 @@ export default function agentmemoryExtension(pi: ExtensionAPI) {
         timestamp: new Date().toISOString(),
         data: {
           tool_name: "conversation",
-          input: lastPrompt.slice(0, 500),
-          output: assistantText.slice(0, 4000),
+          tool_input: lastPrompt.slice(0, 500),
+          tool_output: assistantText.slice(0, 4000),
         },
       },
     });


### PR DESCRIPTION
## Problem

Reported in #759. pi integration users see every conversation observation rendered as `No content provided` / `No actual conversation content was captured in this observation` in the viewer timeline.

## Root cause

`integrations/pi/index.ts` agent_end handler emits `post_tool_use` observations with field names `input` / `output`. `src/functions/observe.ts` reads `tool_input` / `tool_output`. The field-name mismatch leaves `raw.toolInput` / `raw.toolOutput` undefined, so `src/functions/compress.ts` finds no content to summarize and falls back to the empty-content text.

Other integrations (`openclaw`, `hermes`, `filesystem-watcher`) already use the correct names — pi was the only one affected.

## Fix

Rename `input` → `tool_input`, `output` → `tool_output` in the pi `agent_end` observation payload.

## Closes

Closes #759.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved the internal data structure used for recording agent conversations by updating property naming conventions to better organize tool-specific interaction data while maintaining existing message handling behavior for agent memory logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->