### PR TITLE
fix(sdk): replace removed triggerVoid with trigger + TriggerAction.Void

### DIFF
--- a/src/functions/disk-size-manager.ts
+++ b/src/functions/disk-size-manager.ts
@@ -1,4 +1,4 @@
-import type { ISdk } from "iii-sdk";
+import { TriggerAction, type ISdk } from "iii-sdk";
 import { KV } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
 import { getMaxBytes } from "../utils/image-store.js";
@@ -26,7 +26,11 @@ export function registerDiskSizeManager(sdk: ISdk, kv: StateKV): void {
         await kv.set<StateScope[typeof DISK_SIZE_KEY]>(KV.state, DISK_SIZE_KEY, newTotal);
 
         if (data.deltaBytes > 0 && newTotal > getMaxBytes()) {
-          sdk.triggerVoid("mem::image-quota-cleanup", {});
+          sdk.trigger({
+            function_id: "mem::image-quota-cleanup",
+            payload: {},
+            action: TriggerAction.Void(),
+          });
           logger.info("Disk quota exceeded, cleanup triggered", {
             currentBytes: newTotal,
             maxBytes: getMaxBytes(),

--- a/src/functions/image-quota-cleanup.ts
+++ b/src/functions/image-quota-cleanup.ts
@@ -1,4 +1,4 @@
-import type { ISdk } from "iii-sdk";
+import { TriggerAction, type ISdk } from "iii-sdk";
 import { KV } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
 import { readdir, stat } from "node:fs/promises";
@@ -75,7 +75,11 @@ export function registerImageQuotaCleanup(sdk: ISdk, kv: StateKV): void {
 
             const { deletedBytes } = await deleteImage(f.filePath);
             if (deletedBytes > 0) {
-              sdk.triggerVoid("mem::disk-size-delta", { deltaBytes: -deletedBytes });
+              sdk.trigger({
+                function_id: "mem::disk-size-delta",
+                payload: { deltaBytes: -deletedBytes },
+                action: TriggerAction.Void(),
+              });
               totalToFree -= deletedBytes;
               freedBytes += deletedBytes;
               evicted++;

--- a/src/functions/image-refs.ts
+++ b/src/functions/image-refs.ts
@@ -1,4 +1,4 @@
-import type { ISdk } from "iii-sdk";
+import { TriggerAction, type ISdk } from "iii-sdk";
 import { KV } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
 import { deleteImage, touchImage } from "../utils/image-store.js";
@@ -25,7 +25,11 @@ export async function decrementImageRef(kv: StateKV, sdk: ISdk, filePath: string
       await kv.delete(KV.imageRefs, filePath);
       const { deletedBytes } = await deleteImage(filePath);
       if (deletedBytes > 0) {
-        sdk.triggerVoid("mem::disk-size-delta", { deltaBytes: -deletedBytes });
+        sdk.trigger({
+          function_id: "mem::disk-size-delta",
+          payload: { deltaBytes: -deletedBytes },
+          action: TriggerAction.Void(),
+        });
       }
     } else {
       await kv.set(KV.imageRefs, filePath, current - 1);

--- a/src/functions/observe.ts
+++ b/src/functions/observe.ts
@@ -156,12 +156,20 @@ export function registerObserveFunction(
           raw.imageData = filePath;
           const { incrementImageRef } = await import("./image-refs.js");
           await incrementImageRef(kv, filePath);
-          sdk.triggerVoid("mem::disk-size-delta", { deltaBytes: bytesWritten });
+          sdk.trigger({
+            function_id: "mem::disk-size-delta",
+            payload: { deltaBytes: bytesWritten },
+            action: TriggerAction.Void(),
+          });
           if (process.env["AGENTMEMORY_IMAGE_EMBEDDINGS"] === "true") {
-            sdk.triggerVoid("mem::vision-embed", {
-              imageRef: filePath,
-              sessionId: payload.sessionId,
-              observationId: obsId,
+            sdk.trigger({
+              function_id: "mem::vision-embed",
+              payload: {
+                imageRef: filePath,
+                sessionId: payload.sessionId,
+                observationId: obsId,
+              },
+              action: TriggerAction.Void(),
             });
           }
         }
@@ -175,7 +183,11 @@ export function registerObserveFunction(
             const { deleteImage } = await import("../utils/image-store.js");
             const { deletedBytes } = await deleteImage(raw.imageData);
             if (deletedBytes > 0) {
-              sdk.triggerVoid("mem::disk-size-delta", { deltaBytes: -deletedBytes });
+              sdk.trigger({
+                function_id: "mem::disk-size-delta",
+                payload: { deltaBytes: -deletedBytes },
+                action: TriggerAction.Void(),
+              });
             }
           }
           throw error;

--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -1,4 +1,4 @@
-import type { ISdk, ApiRequest } from "iii-sdk";
+import { TriggerAction, type ISdk, type ApiRequest } from "iii-sdk";
 import type { Session, CompressedObservation, HookPayload, CommitLink } from "../types.js";
 import { withKeyedLock } from "../state/keyed-mutex.js";
 import { KV } from "../state/schema.js";
@@ -613,9 +613,13 @@ export function registerApiTriggers(
       ]);
       // Fan out session-stopped lifecycle (non-blocking).
       try {
-        sdk.triggerVoid("event::session::stopped", { sessionId });
+        sdk.trigger({
+          function_id: "event::session::stopped",
+          payload: { sessionId },
+          action: TriggerAction.Void(),
+        });
       } catch (err) {
-        logger.warn("event::session::stopped triggerVoid failed", {
+        logger.warn("event::session::stopped trigger failed", {
           sessionId,
           error: err instanceof Error ? err.message : String(err),
         });

--- a/src/triggers/events.ts
+++ b/src/triggers/events.ts
@@ -48,9 +48,13 @@ export function registerEventTriggers(sdk: ISdk, kv: StateKV): void {
     const summary = await sdk.trigger({ function_id: "mem::summarize", payload: data });
     if (isReflectEnabled()) {
       try {
-        sdk.triggerVoid("mem::slot-reflect", { sessionId: data.sessionId });
+        sdk.trigger({
+          function_id: "mem::slot-reflect",
+          payload: { sessionId: data.sessionId },
+          action: TriggerAction.Void(),
+        });
       } catch (err) {
-        logger.warn("slot-reflect triggerVoid failed", {
+        logger.warn("slot-reflect trigger failed", {
           sessionId: data.sessionId,
           error: err instanceof Error ? err.message : String(err),
         });
@@ -63,10 +67,14 @@ export function registerEventTriggers(sdk: ISdk, kv: StateKV): void {
         );
         const compressed = observations.filter((o) => o.title);
         if (compressed.length > 0) {
-          sdk.triggerVoid("mem::graph-extract", { observations: compressed });
+          sdk.trigger({
+            function_id: "mem::graph-extract",
+            payload: { observations: compressed },
+            action: TriggerAction.Void(),
+          });
         }
       } catch (err) {
-        logger.warn("graph-extract triggerVoid failed", {
+        logger.warn("graph-extract trigger failed", {
           sessionId: data.sessionId,
           error: err instanceof Error ? err.message : String(err),
         });

--- a/test/multimodal.test.ts
+++ b/test/multimodal.test.ts
@@ -18,9 +18,8 @@ vi.mock("../src/functions/search.js", () => ({
   vectorIndexAddGuarded: vi.fn().mockResolvedValue(false),
 }));
 
-const mockTriggerVoid = vi.fn();
 const mockTrigger = vi.fn().mockResolvedValue(undefined);
-const mockSdk = { triggerVoid: mockTriggerVoid, trigger: mockTrigger } as any;
+const mockSdk = { trigger: mockTrigger } as any;
 
 function mockKV() {
   const store = new Map<string, Map<string, unknown>>();
@@ -70,7 +69,7 @@ describe("End-to-End Multimodal Flow", () => {
   });
 
   beforeEach(() => {
-    mockTriggerVoid.mockClear();
+    mockTrigger.mockClear();
   });
 
   it("Step 1: Agent image should be successfully saved to hard drive", async () => {
@@ -105,11 +104,11 @@ describe("End-to-End Multimodal Flow", () => {
 
     savedImagePath = raw.imageData;
 
-    const deltaCalls = mockTriggerVoid.mock.calls.filter(
-      (c: any[]) => c[0] === "mem::disk-size-delta"
+    const deltaCalls = mockTrigger.mock.calls.filter(
+      (c: any[]) => c[0]?.function_id === "mem::disk-size-delta"
     );
     expect(deltaCalls.length).toBe(1);
-    expect(deltaCalls[0][1].deltaBytes).toBeGreaterThan(0);
+    expect(deltaCalls[0][0].payload.deltaBytes).toBeGreaterThan(0);
   });
 
   it("Step 2 & 3: mem::compress should call the vision model and store compressed observation in KV", async () => {
@@ -168,8 +167,8 @@ describe("End-to-End Multimodal Flow", () => {
 describe("Disk Size Manager", () => {
   it("should increment disk size and trigger cleanup when over quota", async () => {
     const localKv = mockKV() as any;
-    const localTriggerVoid = vi.fn();
-    const localSdk = { triggerVoid: localTriggerVoid } as any;
+    const localTrigger = vi.fn().mockResolvedValue(undefined);
+    const localSdk = { trigger: localTrigger } as any;
 
     let managerCallback: any = null;
     const sdkMocker = {
@@ -192,7 +191,7 @@ describe("Disk Size Manager", () => {
     expect(res2.success).toBe(true);
     expect(res2.currentTotal).toBe(3000);
 
-    expect(localTriggerVoid).not.toHaveBeenCalled();
+    expect(localTrigger).not.toHaveBeenCalled();
   });
 
   it("should trigger cleanup when total exceeds max bytes", async () => {
@@ -201,8 +200,8 @@ describe("Disk Size Manager", () => {
       process.env.AGENTMEMORY_IMAGE_STORE_MAX_BYTES = "5000";
 
       const localKv = mockKV() as any;
-      const localTriggerVoid = vi.fn();
-      const localSdk = { triggerVoid: localTriggerVoid } as any;
+      const localTrigger = vi.fn().mockResolvedValue(undefined);
+      const localSdk = { trigger: localTrigger } as any;
 
       let managerCallback: any = null;
       const sdkMocker = {
@@ -216,10 +215,15 @@ describe("Disk Size Manager", () => {
       registerDiskSizeManager(sdkMocker, localKv);
 
       await managerCallback({ deltaBytes: 3000 });
-      expect(localTriggerVoid).not.toHaveBeenCalled();
+      expect(localTrigger).not.toHaveBeenCalled();
 
       await managerCallback({ deltaBytes: 3000 });
-      expect(localTriggerVoid).toHaveBeenCalledWith("mem::image-quota-cleanup", {});
+      expect(localTrigger).toHaveBeenCalledWith(
+        expect.objectContaining({
+          function_id: "mem::image-quota-cleanup",
+          payload: {},
+        }),
+      );
     } finally {
       if (originalEnv === undefined) {
         delete process.env.AGENTMEMORY_IMAGE_STORE_MAX_BYTES;
@@ -231,7 +235,7 @@ describe("Disk Size Manager", () => {
 
   it("should clamp negative totals to zero", async () => {
     const localKv = mockKV() as any;
-    const localSdk = { triggerVoid: vi.fn() } as any;
+    const localSdk = { trigger: vi.fn().mockResolvedValue(undefined) } as any;
 
     let managerCallback: any = null;
     const sdkMocker = {
@@ -250,7 +254,7 @@ describe("Disk Size Manager", () => {
 
   it("should reject invalid deltaBytes", async () => {
     const localKv = mockKV() as any;
-    const localSdk = { triggerVoid: vi.fn() } as any;
+    const localSdk = { trigger: vi.fn().mockResolvedValue(undefined) } as any;
 
     let managerCallback: any = null;
     const sdkMocker = {
@@ -271,8 +275,8 @@ describe("Disk Size Manager", () => {
 describe("Image Refs", () => {
   it("should increment and decrement ref counts correctly with deletion parity", async () => {
     const localKv = mockKV() as any;
-    const localTriggerVoid = vi.fn();
-    const localSdk = { triggerVoid: localTriggerVoid } as any;
+    const localTrigger = vi.fn().mockResolvedValue(undefined);
+    const localSdk = { trigger: localTrigger } as any;
 
     const { saveImageToDisk } = await import("../src/utils/image-store.js");
     const { incrementImageRef, decrementImageRef, getImageRefCount } = await import("../src/functions/image-refs.js");
@@ -301,25 +305,25 @@ describe("Image Refs", () => {
     
     // (c) shared image with refcount >= 2 is NOT deleted when one decrements
     expect(existsSync(testFile)).toBe(true);
-    expect(localTriggerVoid).not.toHaveBeenCalled();
+    expect(localTrigger).not.toHaveBeenCalled();
 
     // (a) decrementing to zero triggers image file deletion and negative delta
     await decrementImageRef(localKv, localSdk, testFile);
     expect(await getImageRefCount(localKv, testFile)).toBe(0);
     expect(existsSync(testFile)).toBe(false);
-    
-    const deltaCalls = localTriggerVoid.mock.calls.filter(
-      (c: any[]) => c[0] === "mem::disk-size-delta"
+
+    const deltaCalls = localTrigger.mock.calls.filter(
+      (c: any[]) => c[0]?.function_id === "mem::disk-size-delta"
     );
     expect(deltaCalls.length).toBe(1);
-    expect(deltaCalls[0][1].deltaBytes).toBeLessThan(0);
+    expect(deltaCalls[0][0].payload.deltaBytes).toBeLessThan(0);
 
     // (b) decrementing an already-zero/unknown ref is a no-op
-    localTriggerVoid.mockClear();
+    localTrigger.mockClear();
     await decrementImageRef(localKv, localSdk, "/fake/unknown/path.png");
     expect(await getImageRefCount(localKv, "/fake/unknown/path.png")).toBe(0);
-    const noOpDeltaCalls = localTriggerVoid.mock.calls.filter(
-      (c: any[]) => c[0] === "mem::disk-size-delta"
+    const noOpDeltaCalls = localTrigger.mock.calls.filter(
+      (c: any[]) => c[0]?.function_id === "mem::disk-size-delta"
     );
     expect(noOpDeltaCalls.length).toBe(0);
   });

--- a/test/session-end-triggers-graph.test.ts
+++ b/test/session-end-triggers-graph.test.ts
@@ -6,20 +6,27 @@ import { readFileSync } from "node:fs";
 // fix the `event::session::stopped` handler in events.ts was a dead
 // subscriber — no code published `agentmemory.session.stopped`, so graph
 // nodes / lessons / crystals never materialized despite the handler
-// existing. Direct triggerVoid keeps the HTTP response fast (kv.update
-// runs synchronously, downstream pipeline fan-outs without blocking).
+// existing. Direct fire-and-forget trigger keeps the HTTP response fast
+// (kv.update runs synchronously, downstream pipeline fan-outs without
+// blocking).
 describe("api::session::end → event::session::stopped (#666)", () => {
   const api = readFileSync("src/triggers/api.ts", "utf-8");
 
-  it("api::session::end calls sdk.triggerVoid('event::session::stopped') after kv.update", () => {
+  it("api::session::end fires event::session::stopped after kv.update", () => {
     expect(api).toMatch(
-      /api::session::end[\s\S]*?kv\.update\(KV\.sessions[\s\S]*?triggerVoid\("event::session::stopped"/,
+      /api::session::end[\s\S]*?kv\.update\(KV\.sessions[\s\S]*?function_id:\s*"event::session::stopped"/,
     );
   });
 
-  it("triggerVoid payload includes sessionId", () => {
+  it("event::session::stopped trigger payload includes sessionId", () => {
     expect(api).toMatch(
-      /triggerVoid\("event::session::stopped",\s*\{\s*sessionId\s*\}/,
+      /function_id:\s*"event::session::stopped",\s*payload:\s*\{\s*sessionId\s*\}/,
+    );
+  });
+
+  it("event::session::stopped uses TriggerAction.Void for fire-and-forget", () => {
+    expect(api).toMatch(
+      /function_id:\s*"event::session::stopped"[\s\S]*?action:\s*TriggerAction\.Void\(\)/,
     );
   });
 });

--- a/test/sliding-window.test.ts
+++ b/test/sliding-window.test.ts
@@ -64,7 +64,6 @@ function mockSdk() {
       if (fn) return fn(payload);
       return null;
     },
-    triggerVoid: () => {},
   };
 }
 


### PR DESCRIPTION
## Problem

Reported in #758. iii-sdk 0.11.2 (the pinned version) removed `sdk.triggerVoid` in favor of `sdk.trigger({ function_id, payload, action: TriggerAction.Void() })`. Nine call sites in agentmemory still used the removed API, producing:

```
sdk.triggerVoid is not a function
```

Three sites were wrapped in try/catch and logged warnings. The other six threw `TypeError` and broke their pipelines (image write, disk-quota cleanup, vision embeddings, session-stopped fan-out).

## Sites fixed

| File | Sites |
|---|---|
| `src/triggers/api.ts` | 1 (event::session::stopped) |
| `src/triggers/events.ts` | 2 (mem::slot-reflect, mem::graph-extract) |
| `src/functions/observe.ts` | 3 (mem::disk-size-delta x2, mem::vision-embed) |
| `src/functions/image-quota-cleanup.ts` | 1 (mem::disk-size-delta) |
| `src/functions/image-refs.ts` | 1 (mem::disk-size-delta) |
| `src/functions/disk-size-manager.ts` | 1 (mem::image-quota-cleanup) |

Each `sdk.triggerVoid(name, payload)` is replaced with:

```ts
sdk.trigger({
  function_id: name,
  payload,
  action: TriggerAction.Void(),
});
```

Added `TriggerAction` to the iii-sdk import in files that didn't already use it.

## Tests

Tests that spied on `triggerVoid` updated to spy on `trigger` and filter calls by `function_id` and `TriggerAction.Void()` shape.

Full suite passes: 120 files / 1292 tests.

## Pin

iii-sdk pin stays at 0.11.2 per current engine compatibility constraints. The migration is forward-compatible with later iii-sdk releases.

Closes #758.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal trigger invocation patterns across multiple modules to use explicit action specifications, improving consistency.

* **Tests**
  * Updated test mocks and assertions to align with the new trigger API patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->