### PR TITLE
fix(replay): key existing-session re-write on parsed.sessionId, not existing.id

### DIFF
--- a/src/functions/replay.ts
+++ b/src/functions/replay.ts
@@ -406,7 +406,10 @@ export function registerReplayFunctions(sdk: ISdk, kv: StateKV): void {
           if (!existing.firstPrompt && firstPrompt) {
             existing.firstPrompt = firstPrompt;
           }
-          await kv.set(KV.sessions, existing.id, existing);
+          // Re-key on parsed.sessionId (the key we fetched with), not existing.id:
+          // a stored record missing `id` makes existing.id undefined, which drops the
+          // `key` from the state::set payload and aborts the entire import.
+          await kv.set(KV.sessions, parsed.sessionId, existing);
         } else {
           const session: Session = {
             id: parsed.sessionId,


### PR DESCRIPTION
Fixes #775.

## Problem

`import-jsonl` aborts the **entire** batch with `deserialization_error: ... missing field \`key\`` when a stored session record has no `id`. The existing-session branch re-keys the write on `existing.id`, so an `undefined` id drops `key` from the `state::set` payload and the engine rejects the whole invocation — no partial progress, opaque error.

## Change

One line in `src/functions/replay.ts`: re-key on `parsed.sessionId` — the key the record was just fetched with, always defined via `parseJsonlText`'s three-level fallback — instead of `existing.id`. This mirrors the adjacent `else` branch, which already keys new sessions on `parsed.sessionId`.

## Verification

- `npm run build` compiles clean.
- On my install, this cleared the `missing field \`key\`` abort and the import proceeded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where importing JSONL files containing data for existing sessions would fail. Sessions now update successfully during the import process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->