### PR TITLE
fix(agent-sdk): scope recursion guard to AsyncLocalStorage, memoize SDK import

### DIFF
--- a/src/providers/agent-sdk.ts
+++ b/src/providers/agent-sdk.ts
@@ -22,6 +22,16 @@ import type { MemoryProvider } from '../types.js'
 //     callback to /summarize. ALS does not cross process boundaries.
 const sdkChildContext = new AsyncLocalStorage<true>()
 
+// Module-level refcount for the process.env marker. A per-call snapshot
+// races across overlapping calls: A saves prev=undef, B saves prev="1",
+// A's finally restores undef while B is still mid-flight (so any child
+// process B spawns won't inherit the marker), and B's finally restores
+// "1" — leaking the marker into the global env after the last caller.
+// Reference-count instead so only the first entrant snapshots the
+// original value and only the last exit restores it.
+let sdkActiveCount = 0
+let sdkOriginalEnv: string | undefined
+
 type ClaudeAgentSdkModule = typeof import('@anthropic-ai/claude-agent-sdk')
 
 export class AgentSDKProvider implements MemoryProvider {
@@ -67,12 +77,13 @@ export class AgentSDKProvider implements MemoryProvider {
       // Mark spawned subprocesses (the SDK's underlying Claude session
       // + its hook scripts) as SDK children via process.env. Hook scripts
       // run in separate processes and read process.env to short-circuit
-      // their REST callbacks. The set/restore window is the duration of
-      // the SDK call. Concurrent in-process siblings all want the value
-      // to be "1" during their respective SDK calls anyway, so the
-      // race on the global is benign for the env-inheritance purpose.
-      const prev = process.env.AGENTMEMORY_SDK_CHILD
-      process.env.AGENTMEMORY_SDK_CHILD = '1'
+      // their REST callbacks. Reference-counted so overlapping calls
+      // don't race each other into restoring stale values.
+      if (sdkActiveCount === 0) {
+        sdkOriginalEnv = process.env.AGENTMEMORY_SDK_CHILD
+        process.env.AGENTMEMORY_SDK_CHILD = '1'
+      }
+      sdkActiveCount++
 
       try {
         const { query } = await this.loadSdk()
@@ -94,10 +105,14 @@ export class AgentSDKProvider implements MemoryProvider {
         }
         return result
       } finally {
-        if (prev === undefined) {
-          delete process.env.AGENTMEMORY_SDK_CHILD
-        } else {
-          process.env.AGENTMEMORY_SDK_CHILD = prev
+        sdkActiveCount--
+        if (sdkActiveCount === 0) {
+          if (sdkOriginalEnv === undefined) {
+            delete process.env.AGENTMEMORY_SDK_CHILD
+          } else {
+            process.env.AGENTMEMORY_SDK_CHILD = sdkOriginalEnv
+          }
+          sdkOriginalEnv = undefined
         }
       }
     })

--- a/src/providers/agent-sdk.ts
+++ b/src/providers/agent-sdk.ts
@@ -1,7 +1,43 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
 import type { MemoryProvider } from '../types.js'
+
+// #781: the recursion guard used to live on `process.env.AGENTMEMORY_SDK_CHILD`
+// (#181). #472 then introduced chunked summarize that runs chunks
+// concurrently in the same process via Promise.all. The first chunk
+// flipped the global env to "1" synchronously before its `await`, and
+// every sibling chunk in the same batch immediately bailed out as a
+// "child" — returning "" — so half-plus of the chunks failed to parse
+// and the summarize threw `too_many_chunks_skipped: N/N`.
+//
+// Split the guard so each concern uses the right primitive:
+//
+//   - **In-process** recursion guard: AsyncLocalStorage. Scoped to the
+//     async call tree of the SDK query, so concurrent siblings on the
+//     same provider instance no longer see each other's marker.
+//   - **Cross-process** recursion guard for hooks: still
+//     `process.env.AGENTMEMORY_SDK_CHILD = "1"` around the SDK call.
+//     Subprocesses spawned by `@anthropic-ai/claude-agent-sdk` inherit
+//     `process.env` at spawn time, so the hook scripts (which run as
+//     separate processes) still see the marker and skip their REST
+//     callback to /summarize. ALS does not cross process boundaries.
+const sdkChildContext = new AsyncLocalStorage<true>()
+
+type ClaudeAgentSdkModule = typeof import('@anthropic-ai/claude-agent-sdk')
 
 export class AgentSDKProvider implements MemoryProvider {
   name = 'agent-sdk'
+
+  // Memoize the dynamic import so concurrent callers share one resolution
+  // instead of racing to resolve the specifier independently. Keeps the
+  // SDK out of the cold-start path for users on other providers.
+  private sdkPromise: Promise<ClaudeAgentSdkModule> | null = null
+
+  private loadSdk(): Promise<ClaudeAgentSdkModule> {
+    if (!this.sdkPromise) {
+      this.sdkPromise = import('@anthropic-ai/claude-agent-sdk')
+    }
+    return this.sdkPromise
+  }
 
   async compress(systemPrompt: string, userPrompt: string): Promise<string> {
     return this.query(systemPrompt, userPrompt)
@@ -12,48 +48,58 @@ export class AgentSDKProvider implements MemoryProvider {
   }
 
   private async query(systemPrompt: string, userPrompt: string): Promise<string> {
-    if (process.env.AGENTMEMORY_SDK_CHILD === "1") {
-      // We are already running inside a Claude Agent SDK-spawned session.
-      // Spawning another one would let its plugin-hook-driven Stop loop
-      // re-enter /agentmemory/summarize and cause unbounded recursion
-      // (#149 follow-up). Degrade to empty string so callers short-circuit.
-      return ""
+    // In-process recursion guard. Concurrent sibling calls (chunked
+    // summarize via Promise.all) each have their own ALS frame, so they
+    // do not poison each other.
+    if (sdkChildContext.getStore()) {
+      // We are already inside a Claude Agent SDK-spawned async call
+      // tree. Spawning another one would let its plugin-hook-driven
+      // Stop loop re-enter /agentmemory/summarize and cause unbounded
+      // recursion (#149 follow-up). Degrade to empty string so callers
+      // short-circuit. The chunk retry path in src/functions/summarize.ts
+      // treats "" as a parse failure but only the in-process re-entry
+      // path can reach this branch — legitimate concurrent siblings now
+      // run with their own ALS frames.
+      return ''
     }
 
-    // Mark any child process / SDK session spawned from here as a SDK
-    // child. agentmemory hook scripts check this marker and skip their
-    // REST calls to break the recursion loop. Restore the previous value
-    // in `finally` so later calls in the same parent process are not
-    // mis-classified as SDK children (otherwise every subsequent query
-    // would short-circuit to "" above).
-    const prev = process.env.AGENTMEMORY_SDK_CHILD
-    process.env.AGENTMEMORY_SDK_CHILD = "1"
+    return sdkChildContext.run(true, async () => {
+      // Mark spawned subprocesses (the SDK's underlying Claude session
+      // + its hook scripts) as SDK children via process.env. Hook scripts
+      // run in separate processes and read process.env to short-circuit
+      // their REST callbacks. The set/restore window is the duration of
+      // the SDK call. Concurrent in-process siblings all want the value
+      // to be "1" during their respective SDK calls anyway, so the
+      // race on the global is benign for the env-inheritance purpose.
+      const prev = process.env.AGENTMEMORY_SDK_CHILD
+      process.env.AGENTMEMORY_SDK_CHILD = '1'
 
-    try {
-      const { query } = await import('@anthropic-ai/claude-agent-sdk')
+      try {
+        const { query } = await this.loadSdk()
 
-      const messages = query({
-        prompt: userPrompt,
-        options: {
-          systemPrompt,
-          maxTurns: 1,
-          allowedTools: [],
-        },
-      })
+        const messages = query({
+          prompt: userPrompt,
+          options: {
+            systemPrompt,
+            maxTurns: 1,
+            allowedTools: [],
+          },
+        })
 
-      let result = ''
-      for await (const msg of messages) {
-        if (msg.type === 'result') {
-          result = (msg as any).result ?? ''
+        let result = ''
+        for await (const msg of messages) {
+          if (msg.type === 'result') {
+            result = (msg as any).result ?? ''
+          }
+        }
+        return result
+      } finally {
+        if (prev === undefined) {
+          delete process.env.AGENTMEMORY_SDK_CHILD
+        } else {
+          process.env.AGENTMEMORY_SDK_CHILD = prev
         }
       }
-      return result
-    } finally {
-      if (prev === undefined) {
-        delete process.env.AGENTMEMORY_SDK_CHILD
-      } else {
-        process.env.AGENTMEMORY_SDK_CHILD = prev
-      }
-    }
+    })
   }
 }

--- a/test/agent-sdk-provider.test.ts
+++ b/test/agent-sdk-provider.test.ts
@@ -5,9 +5,15 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 // before the first await. With the guard scoped to AsyncLocalStorage,
 // each sibling runs in its own context and receives the real SDK result.
 
-const queryCalls: Array<{ systemPrompt: string; userPrompt: string }> = [];
-let mockResult: string | ((systemPrompt: string, userPrompt: string) => string) =
-  "<result>ok</result>";
+// vi.mock is hoisted above module-scope `const`/`let`, so the factory's
+// closure can't safely reference non-hoisted bindings. Use vi.hoisted to
+// declare the mock's mutable state alongside the mock itself.
+const state = vi.hoisted(() => ({
+  queryCalls: [] as Array<{ systemPrompt: string; userPrompt: string }>,
+  mockResult: "<result>ok</result>" as
+    | string
+    | ((systemPrompt: string, userPrompt: string) => string),
+}));
 
 vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
   query: ({
@@ -17,12 +23,12 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
     prompt: string;
     options: { systemPrompt: string };
   }) => {
-    queryCalls.push({ systemPrompt: options.systemPrompt, userPrompt: prompt });
-    const value =
-      typeof mockResult === "function"
-        ? mockResult(options.systemPrompt, prompt)
-        : mockResult;
+    state.queryCalls.push({ systemPrompt: options.systemPrompt, userPrompt: prompt });
     async function* gen() {
+      const value =
+        typeof state.mockResult === "function"
+          ? await state.mockResult(options.systemPrompt, prompt)
+          : state.mockResult;
       yield { type: "result", result: value } as { type: "result"; result: string };
     }
     return gen();
@@ -33,8 +39,8 @@ import { AgentSDKProvider } from "../src/providers/agent-sdk.js";
 
 describe("AgentSDKProvider recursion guard (#781)", () => {
   beforeEach(() => {
-    queryCalls.length = 0;
-    mockResult = "<result>ok</result>";
+    state.queryCalls.length = 0;
+    state.mockResult = "<result>ok</result>";
     delete process.env.AGENTMEMORY_SDK_CHILD;
   });
 
@@ -58,8 +64,8 @@ describe("AgentSDKProvider recursion guard (#781)", () => {
       "<result>ok</result>",
       "<result>ok</result>",
     ]);
-    expect(queryCalls.length).toBe(4);
-    expect(queryCalls.map((c) => c.userPrompt)).toEqual([
+    expect(state.queryCalls.length).toBe(4);
+    expect(state.queryCalls.map((c) => c.userPrompt)).toEqual([
       "chunk 1",
       "chunk 2",
       "chunk 3",
@@ -79,14 +85,14 @@ describe("AgentSDKProvider recursion guard (#781)", () => {
     expect(a).toBe("<result>ok</result>");
     expect(b).toBe("<result>ok</result>");
     expect(c).toBe("<result>ok</result>");
-    expect(queryCalls.length).toBe(3);
+    expect(state.queryCalls.length).toBe(3);
   });
 
   it("sets AGENTMEMORY_SDK_CHILD=1 while inside the SDK call (so spawned subprocesses inherit it)", async () => {
     const provider = new AgentSDKProvider();
     let observedEnv: string | undefined;
 
-    mockResult = (sysPrompt, _userPrompt) => {
+    state.mockResult = (sysPrompt, _userPrompt) => {
       observedEnv = process.env.AGENTMEMORY_SDK_CHILD;
       return `<result>${sysPrompt}</result>`;
     };
@@ -106,11 +112,40 @@ describe("AgentSDKProvider recursion guard (#781)", () => {
     expect(process.env.AGENTMEMORY_SDK_CHILD).toBe("prev-value");
   });
 
+  it("keeps AGENTMEMORY_SDK_CHILD=1 for the full overlap of concurrent calls", async () => {
+    const provider = new AgentSDKProvider();
+    // Allow the calls to overlap: each call records the env value it
+    // saw, then a tick later records it again. With a refcounted guard
+    // both observations on both calls should see "1"; with the old
+    // per-call snapshot one call's restore would null the env while
+    // the sibling is still mid-flight.
+    const observations: Array<{ id: string; phase: string; env: string | undefined }> = [];
+
+    state.mockResult = async (sysPrompt, _user) => {
+      observations.push({ id: sysPrompt, phase: "enter", env: process.env.AGENTMEMORY_SDK_CHILD });
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      observations.push({ id: sysPrompt, phase: "exit", env: process.env.AGENTMEMORY_SDK_CHILD });
+      return `<result>${sysPrompt}</result>`;
+    };
+
+    await Promise.all([
+      provider.summarize("a", "x"),
+      provider.summarize("b", "y"),
+      provider.summarize("c", "z"),
+    ]);
+
+    expect(observations.length).toBe(6);
+    for (const o of observations) {
+      expect(o.env).toBe("1");
+    }
+    expect(process.env.AGENTMEMORY_SDK_CHILD).toBeUndefined();
+  });
+
   it("genuine re-entry (an inner call inside the same async tree) still degrades to empty", async () => {
     const provider = new AgentSDKProvider();
     let innerResult = "not-set";
 
-    mockResult = async (_sys, _user) => {
+    state.mockResult = async (_sys, _user) => {
       // Simulate the SDK callback re-entering the provider while the
       // outer call is still active. The ALS frame is active here, so
       // the inner call must return "" to break the recursion.

--- a/test/agent-sdk-provider.test.ts
+++ b/test/agent-sdk-provider.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// #781: concurrent siblings on the agent-sdk provider used to bail out
+// empty because the recursion guard mutated process.env synchronously
+// before the first await. With the guard scoped to AsyncLocalStorage,
+// each sibling runs in its own context and receives the real SDK result.
+
+const queryCalls: Array<{ systemPrompt: string; userPrompt: string }> = [];
+let mockResult: string | ((systemPrompt: string, userPrompt: string) => string) =
+  "<result>ok</result>";
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: ({
+    prompt,
+    options,
+  }: {
+    prompt: string;
+    options: { systemPrompt: string };
+  }) => {
+    queryCalls.push({ systemPrompt: options.systemPrompt, userPrompt: prompt });
+    const value =
+      typeof mockResult === "function"
+        ? mockResult(options.systemPrompt, prompt)
+        : mockResult;
+    async function* gen() {
+      yield { type: "result", result: value } as { type: "result"; result: string };
+    }
+    return gen();
+  },
+}));
+
+import { AgentSDKProvider } from "../src/providers/agent-sdk.js";
+
+describe("AgentSDKProvider recursion guard (#781)", () => {
+  beforeEach(() => {
+    queryCalls.length = 0;
+    mockResult = "<result>ok</result>";
+    delete process.env.AGENTMEMORY_SDK_CHILD;
+  });
+
+  afterEach(() => {
+    delete process.env.AGENTMEMORY_SDK_CHILD;
+  });
+
+  it("concurrent summarize calls each return the SDK result (no empty siblings)", async () => {
+    const provider = new AgentSDKProvider();
+
+    const results = await Promise.all([
+      provider.summarize("sys", "chunk 1"),
+      provider.summarize("sys", "chunk 2"),
+      provider.summarize("sys", "chunk 3"),
+      provider.summarize("sys", "chunk 4"),
+    ]);
+
+    expect(results).toEqual([
+      "<result>ok</result>",
+      "<result>ok</result>",
+      "<result>ok</result>",
+      "<result>ok</result>",
+    ]);
+    expect(queryCalls.length).toBe(4);
+    expect(queryCalls.map((c) => c.userPrompt)).toEqual([
+      "chunk 1",
+      "chunk 2",
+      "chunk 3",
+      "chunk 4",
+    ]);
+  });
+
+  it("compress and summarize share the same guard scope without interfering", async () => {
+    const provider = new AgentSDKProvider();
+
+    const [a, b, c] = await Promise.all([
+      provider.summarize("sys", "s1"),
+      provider.compress("sys", "c1"),
+      provider.summarize("sys", "s2"),
+    ]);
+
+    expect(a).toBe("<result>ok</result>");
+    expect(b).toBe("<result>ok</result>");
+    expect(c).toBe("<result>ok</result>");
+    expect(queryCalls.length).toBe(3);
+  });
+
+  it("sets AGENTMEMORY_SDK_CHILD=1 while inside the SDK call (so spawned subprocesses inherit it)", async () => {
+    const provider = new AgentSDKProvider();
+    let observedEnv: string | undefined;
+
+    mockResult = (sysPrompt, _userPrompt) => {
+      observedEnv = process.env.AGENTMEMORY_SDK_CHILD;
+      return `<result>${sysPrompt}</result>`;
+    };
+
+    expect(process.env.AGENTMEMORY_SDK_CHILD).toBeUndefined();
+    await provider.summarize("sys", "user");
+    expect(observedEnv).toBe("1");
+    expect(process.env.AGENTMEMORY_SDK_CHILD).toBeUndefined();
+  });
+
+  it("restores AGENTMEMORY_SDK_CHILD to its prior value after the call", async () => {
+    const provider = new AgentSDKProvider();
+    process.env.AGENTMEMORY_SDK_CHILD = "prev-value";
+
+    await provider.summarize("sys", "user");
+
+    expect(process.env.AGENTMEMORY_SDK_CHILD).toBe("prev-value");
+  });
+
+  it("genuine re-entry (an inner call inside the same async tree) still degrades to empty", async () => {
+    const provider = new AgentSDKProvider();
+    let innerResult = "not-set";
+
+    mockResult = async (_sys, _user) => {
+      // Simulate the SDK callback re-entering the provider while the
+      // outer call is still active. The ALS frame is active here, so
+      // the inner call must return "" to break the recursion.
+      innerResult = await provider.summarize("sys-inner", "user-inner");
+      return "<result>outer</result>";
+    };
+
+    const outer = await provider.summarize("sys", "user");
+    expect(outer).toBe("<result>outer</result>");
+    expect(innerResult).toBe("");
+  });
+});


### PR DESCRIPTION
## Problem

Reported in #781. `mem::summarize` fails with `too_many_chunks_skipped: 4/4 chunks failed to parse after retry` whenever the agent-sdk provider is active (`AGENTMEMORY_ALLOW_AGENT_SDK=true`) and a session is large enough to split into ≥2 chunks.

The two PRs interact badly:

- **#181** (Stop-hook → /summarize → agent-sdk infinite recursion fix) added the guard:
  ```ts
  if (process.env.AGENTMEMORY_SDK_CHILD === '1') return ''
  process.env.AGENTMEMORY_SDK_CHILD = '1'
  // ...await SDK...
  // restore in finally
  ```
- **#472** (chunk large sessions to fit LLM context) added chunk concurrency:
  ```ts
  for (let i = 0; i < chunks.length; i += concurrency) {
    await Promise.all(batch.map(/* provider.summarize */));
  }
  ```

The first chunk in a batch flips the env synchronously **before its first `await`**. Sibling chunks in the same batch enter `query()`, see the flag, and return `""`. Empty string has no `<title>`, `parseSummaryXml` returns `null`, the chunk is counted as skipped, > 50% skip ratio throws.

The guard (cross-process) and the chunk concurrency (in-process) were never reconciled.

## Fix — split the guard by scope

Each concern uses the right primitive:

| Concern | Primitive | Why |
|---|---|---|
| In-process recursion (concurrent siblings) | `AsyncLocalStorage` | Scoped to the async call tree of the SDK query. Concurrent siblings have separate ALS frames, no longer see each other's marker. |
| Cross-process recursion (hook scripts) | `process.env.AGENTMEMORY_SDK_CHILD = '1'` around the SDK call | Hook scripts run as separate processes spawned by the Claude SDK; they inherit `process.env` at spawn time. ALS does not cross process boundaries. |

The check now reads `sdkChildContext.getStore()` instead of `process.env`. The env var stays set+restored around the SDK call so spawned hook subprocesses still see the marker and short-circuit their REST callbacks (the original #149/#181 fix still holds).

The race on the env between concurrent in-process siblings is benign because every sibling wants `"1"` during its own SDK call anyway.

## Bonus: memoize the dynamic import

Refactored `await import('@anthropic-ai/claude-agent-sdk')` into a per-instance memoized promise. Concurrent callers share one module resolution. Two benefits:

- Production: one resolution per provider lifetime instead of N
- Test: `vi.mock` factories apply uniformly across concurrent imports (without this, the test mock raced with real module references under `Promise.all`, see commit body)

## Tests

5 cases in `test/agent-sdk-provider.test.ts`:

- 4 concurrent summarize calls each return the real SDK result (no empty siblings) — direct #781 regression
- Mixed concurrent summarize + compress on the same provider
- `AGENTMEMORY_SDK_CHILD` is set to `"1"` during the SDK call (verified by reading the env from inside the mocked query) and restored to its prior value on exit
- Genuine re-entry inside the same async tree still degrades to `""` so the #149 / #181 recursion guard stays armed

Full suite: 122 files / 1331 tests pass.

## Recommended user action

Users on `0.9.24` can remove the `SUMMARIZE_CHUNK_CONCURRENCY=1` workaround after this lands. No env or config changes required.

Closes #781.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of concurrent memory operations to prevent re-entrancy and state leakage during overlapping calls.

* **Performance Improvements**
  * Reduced repeated SDK initialization by caching the SDK load for faster subsequent calls.

* **Tests**
  * Added coverage validating concurrency behavior and guard correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->