### PR TITLE
fix: recover fenced summary XML responses

### DIFF
--- a/src/functions/summarize.ts
+++ b/src/functions/summarize.ts
@@ -35,6 +35,14 @@ const CHUNK_CONCURRENCY_DEFAULT = 6;
 // Bail on the merged summary if more than this fraction of chunks fail
 // to parse — a half-blind narrative is worse than a clean error.
 const MAX_SKIP_RATIO = 0.5;
+const SUMMARY_BLOCK_RE = /<summary\b[^>]*>[\s\S]*?<\/summary>/i;
+
+function normalizeSummaryXml(raw: string): string {
+  const fenced = raw.match(/```(?:xml)?\s*([\s\S]*?)```/i);
+  const candidate = fenced?.[1] ?? raw;
+  const summaryBlock = candidate.match(SUMMARY_BLOCK_RE);
+  return (summaryBlock?.[0] ?? candidate).trim();
+}
 
 function getChunkSize(): number {
   const raw = process.env.SUMMARIZE_CHUNK_SIZE;
@@ -90,6 +98,41 @@ async function summarizeChunkWithRetry(
   return null;
 }
 
+async function summarizeFinalXmlWithRetry(
+  provider: MemoryProvider,
+  system: string,
+  prompt: string,
+  context: {
+    sessionId: string;
+    project: string;
+    observationCount: number;
+    mode: "single" | "chunked";
+    chunks: number;
+  },
+): Promise<string> {
+  let response = "";
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    response = await provider.summarize(system, prompt);
+    if (
+      parseSummaryXml(
+        response,
+        context.sessionId,
+        context.project,
+        context.observationCount,
+      )
+    ) {
+      return response;
+    }
+    logger.warn("Final summary parse failed", {
+      sessionId: context.sessionId,
+      attempt,
+      mode: context.mode,
+      chunks: context.chunks,
+    });
+  }
+  return response;
+}
+
 // Returns the final summary XML string. For sessions ≤ chunk size, this is
 // a single LLM call (legacy behavior). For larger sessions, observations
 // are split into chunks processed in parallel batches, each chunk retried
@@ -108,9 +151,17 @@ async function produceSummaryXml(
 }> {
   const chunkSize = getChunkSize();
   if (compressed.length <= chunkSize) {
-    const response = await provider.summarize(
+    const response = await summarizeFinalXmlWithRetry(
+      provider,
       SUMMARY_SYSTEM,
       buildSummaryPrompt(compressed),
+      {
+        sessionId,
+        project,
+        observationCount: compressed.length,
+        mode: "single",
+        chunks: 1,
+      },
     );
     return { response, mode: "single", chunks: 1 };
   }
@@ -177,9 +228,17 @@ async function produceSummaryXml(
       obsRangeEnd: Math.min((originalIdx + 1) * chunkSize, compressed.length),
     };
   });
-  const response = await provider.summarize(
+  const response = await summarizeFinalXmlWithRetry(
+    provider,
     REDUCE_SYSTEM,
     buildReducePrompt(reduceInput),
+    {
+      sessionId,
+      project,
+      observationCount: compressed.length,
+      mode: "chunked",
+      chunks: chunks.length,
+    },
   );
   return { response, mode: "chunked", chunks: chunks.length, skipped };
 }
@@ -190,6 +249,7 @@ function parseSummaryXml(
   project: string,
   obsCount: number,
 ): SessionSummary | null {
+  xml = normalizeSummaryXml(xml);
   const title = getXmlTag(xml, "title");
   if (!title) return null;
 

--- a/src/functions/summarize.ts
+++ b/src/functions/summarize.ts
@@ -112,23 +112,34 @@ async function summarizeFinalXmlWithRetry(
 ): Promise<string> {
   let response = "";
   for (let attempt = 1; attempt <= 2; attempt++) {
-    response = await provider.summarize(system, prompt);
-    if (
-      parseSummaryXml(
-        response,
-        context.sessionId,
-        context.project,
-        context.observationCount,
-      )
-    ) {
-      return response;
+    try {
+      response = await provider.summarize(system, prompt);
+      if (
+        parseSummaryXml(
+          response,
+          context.sessionId,
+          context.project,
+          context.observationCount,
+        )
+      ) {
+        return response;
+      }
+      logger.warn("Final summary parse failed", {
+        sessionId: context.sessionId,
+        attempt,
+        mode: context.mode,
+        chunks: context.chunks,
+      });
+    } catch (err) {
+      logger.warn("Final summary LLM call failed", {
+        sessionId: context.sessionId,
+        attempt,
+        mode: context.mode,
+        chunks: context.chunks,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      if (attempt === 2) throw err;
     }
-    logger.warn("Final summary parse failed", {
-      sessionId: context.sessionId,
-      attempt,
-      mode: context.mode,
-      chunks: context.chunks,
-    });
   }
   return response;
 }

--- a/test/summarize.test.ts
+++ b/test/summarize.test.ts
@@ -231,6 +231,33 @@ Done.`,
     expect(stored?.title).toBe("Retried final summary");
   });
 
+  it("retries the final summarize call when the provider throws", async () => {
+    let calls = 0;
+    const provider: MemoryProvider & { calls: any[] } = {
+      name: "test",
+      calls: [],
+      compress: async () => "",
+      summarize: async (system: string, user: string) => {
+        provider.calls.push({ system, user });
+        calls += 1;
+        if (calls === 1) throw new Error("transient provider failure");
+        return summaryXml({ title: "Recovered final summary" });
+      },
+    };
+    const { handler, kv } = await setupHandler({
+      sessionId: "ses_final_throw_retry",
+      obsCount: 10,
+      provider,
+    });
+
+    const result: any = await handler({ sessionId: "ses_final_throw_retry" });
+
+    expect(result.success).toBe(true);
+    expect(provider.calls).toHaveLength(2);
+    const stored: any = await kv.get("summaries", "ses_final_throw_retry");
+    expect(stored?.title).toBe("Recovered final summary");
+  });
+
   it("large session map-reduces: N chunk calls + 1 reduce call", async () => {
     process.env.SUMMARIZE_CHUNK_SIZE = "100";
     process.env.SUMMARIZE_CHUNK_CONCURRENCY = "1"; // serial keeps call ordering deterministic

--- a/test/summarize.test.ts
+++ b/test/summarize.test.ts
@@ -233,7 +233,9 @@ Done.`,
 
   it("retries the final summarize call when the provider throws", async () => {
     let calls = 0;
-    const provider: MemoryProvider & { calls: any[] } = {
+    const provider: MemoryProvider & {
+      calls: Array<{ system: string; user: string }>;
+    } = {
       name: "test",
       calls: [],
       compress: async () => "",

--- a/test/summarize.test.ts
+++ b/test/summarize.test.ts
@@ -182,6 +182,55 @@ describe("mem::summarize chunking", () => {
     expect(stored?.title).toBe("Small session");
   });
 
+  it("extracts the summary block from fenced output with surrounding text", async () => {
+    const provider = makeProvider([
+      `Here is the summary draft:
+<title>Ignore this stray title</title>
+
+\`\`\`xml
+${summaryXml({
+  title: "Fenced session",
+  narrative: "fenced narrative",
+  decisions: ["kept"],
+})}
+\`\`\`
+
+Done.`,
+    ]);
+    const { handler, kv } = await setupHandler({
+      sessionId: "ses_fenced",
+      obsCount: 10,
+      provider,
+    });
+
+    const result: any = await handler({ sessionId: "ses_fenced" });
+
+    expect(result.success).toBe(true);
+    const stored: any = await kv.get("summaries", "ses_fenced");
+    expect(stored?.title).toBe("Fenced session");
+    expect(stored?.narrative).toBe("fenced narrative");
+    expect(stored?.keyDecisions).toEqual(["kept"]);
+  });
+
+  it("retries the final summarize response when XML parsing fails", async () => {
+    const provider = makeProvider([
+      "<summary><narrative>missing title</narrative></summary>",
+      summaryXml({ title: "Retried final summary" }),
+    ]);
+    const { handler, kv } = await setupHandler({
+      sessionId: "ses_final_retry",
+      obsCount: 10,
+      provider,
+    });
+
+    const result: any = await handler({ sessionId: "ses_final_retry" });
+
+    expect(result.success).toBe(true);
+    expect(provider.calls).toHaveLength(2);
+    const stored: any = await kv.get("summaries", "ses_final_retry");
+    expect(stored?.title).toBe("Retried final summary");
+  });
+
   it("large session map-reduces: N chunk calls + 1 reduce call", async () => {
     process.env.SUMMARIZE_CHUNK_SIZE = "100";
     process.env.SUMMARIZE_CHUNK_CONCURRENCY = "1"; // serial keeps call ordering deterministic


### PR DESCRIPTION
Fixes #783.

Summary:
- extract the first fenced or embedded <summary>...</summary> block before parsing
- retry the final summary/reduce response once when XML parsing fails
- add regressions for fenced output and final-response retry

Validation:
- npm test -- test/summarize.test.ts
- npm run build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Correctly extract summaries even when wrapped in fenced XML or embedded in surrounding text.
  * Retry final summary generation once on parse failure or transient LLM errors; logs a warning and returns the last raw response if parsing still fails.

* **Tests**
  * Added tests covering fenced-XML extraction, retry behavior for failing/parsing responses, and persistence of parsed summary fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->