### PR TITLE
fix: use fallback provider default models

### DIFF
--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -25,6 +25,54 @@ function requireEnvVar(key: string): string {
   return value;
 }
 
+function providerDefaultConfig(
+  provider: FallbackConfig["providers"][number],
+  maxTokens: number,
+): ProviderConfig {
+  switch (provider) {
+    case "openai":
+      return {
+        provider,
+        model: getEnvVar("OPENAI_MODEL") || "gpt-4o-mini",
+        maxTokens,
+        baseURL: getEnvVar("OPENAI_BASE_URL"),
+      };
+    case "minimax":
+      return {
+        provider,
+        model: getEnvVar("MINIMAX_MODEL") || "MiniMax-M2.7",
+        maxTokens,
+      };
+    case "anthropic":
+      return {
+        provider,
+        model: getEnvVar("ANTHROPIC_MODEL") || "claude-sonnet-4-20250514",
+        maxTokens,
+        baseURL: getEnvVar("ANTHROPIC_BASE_URL"),
+      };
+    case "gemini":
+      return {
+        provider,
+        model: getEnvVar("GEMINI_MODEL") || "gemini-2.5-flash",
+        maxTokens,
+      };
+    case "openrouter":
+      return {
+        provider,
+        model:
+          getEnvVar("OPENROUTER_MODEL") ||
+          "anthropic/claude-sonnet-4-20250514",
+        maxTokens,
+      };
+    case "agent-sdk":
+      return {
+        provider,
+        model: "agent-sdk",
+        maxTokens,
+      };
+  }
+}
+
 export function createProvider(config: ProviderConfig): ResilientProvider {
   return new ResilientProvider(createBaseProvider(config));
 }
@@ -41,11 +89,7 @@ export function createFallbackProvider(
   for (const providerType of fallbackConfig.providers) {
     if (providerType === config.provider) continue;
     try {
-      const fbConfig: ProviderConfig = {
-        provider: providerType,
-        model: config.model,
-        maxTokens: config.maxTokens,
-      };
+      const fbConfig = providerDefaultConfig(providerType, config.maxTokens);
       providers.push(createBaseProvider(fbConfig));
     } catch {
       // skip unavailable fallback providers

--- a/test/provider-fallback-model.test.ts
+++ b/test/provider-fallback-model.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createFallbackProvider } from "../src/providers/index.js";
+
+describe("createFallbackProvider", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    process.env.OPENAI_API_KEY = "openai-key";
+    process.env.OPENAI_MODEL = "gpt-4o-mini";
+    process.env.GEMINI_API_KEY = "gemini-key";
+    process.env.GEMINI_MODEL = "gemini-2.5-flash";
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  it("uses each fallback provider's own model instead of the primary model", async () => {
+    const bodies: Array<Record<string, unknown>> = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+      bodies.push(JSON.parse(String(init?.body ?? "{}")));
+      if (bodies.length === 1) {
+        return new Response("primary quota exhausted", { status: 429 });
+      }
+      return Response.json({
+        choices: [{ message: { content: "fallback ok" } }],
+      });
+    });
+
+    const provider = createFallbackProvider(
+      { provider: "openai", model: "gpt-4o-mini", maxTokens: 256 },
+      { providers: ["gemini"] },
+    );
+
+    await expect(provider.compress("system", "user")).resolves.toBe("fallback ok");
+
+    expect(bodies).toHaveLength(2);
+    expect(bodies[0].model).toBe("gpt-4o-mini");
+    expect(bodies[1].model).toBe("gemini-2.5-flash");
+  });
+});


### PR DESCRIPTION
## Summary
- build fallback provider configs from each fallback provider's own model defaults/env overrides
- keep the primary provider model from leaking into cross-provider fallback requests
- add a regression covering OpenAI -> Gemini failover request bodies

Fixes #778

## Validation
- `git diff --cached --check`
- `npm test -- test/provider-fallback-model.test.ts`
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for fallback provider behavior and model configuration across multiple providers.

* **Refactor**
  * Fallback provider selection now respects per-provider environment variable defaults for model and base URL configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->