### PR TITLE
fix: close three v0.9.24 regressions before v0.9.25 (#778 #775 #783)

### DIFF
--- a/src/functions/replay.ts
+++ b/src/functions/replay.ts
@@ -406,7 +406,17 @@ export function registerReplayFunctions(sdk: ISdk, kv: StateKV): void {
           if (!existing.firstPrompt && firstPrompt) {
             existing.firstPrompt = firstPrompt;
           }
-          await kv.set(KV.sessions, existing.id, existing);
+          // #775: re-key on parsed.sessionId, not existing.id. Older
+          // session rows may be missing the `id` field; existing.id
+          // would then be undefined, JSON.stringify would drop the
+          // `key` from the state::set payload, and the engine would
+          // reject the call with `missing field \`key\``. Because the
+          // rejection aborts the whole import handler, a single
+          // legacy row killed the entire batch. parsed.sessionId is
+          // always populated (parseJsonlText has a three-level
+          // fallback) and is what we just used to read the row.
+          if (!existing.id) existing.id = parsed.sessionId;
+          await kv.set(KV.sessions, parsed.sessionId, existing);
         } else {
           const session: Session = {
             id: parsed.sessionId,

--- a/src/functions/summarize.ts
+++ b/src/functions/summarize.ts
@@ -184,13 +184,33 @@ async function produceSummaryXml(
   return { response, mode: "chunked", chunks: chunks.length, skipped };
 }
 
+// #783: many LLMs (DeepSeek, GPT variants, some Anthropic responses)
+// wrap structured XML in markdown code fences or add conversational
+// text before/after. Strip those wrappers before the tag regex so a
+// well-formed summary doesn't get silently dropped as parse_failed.
+function stripXmlWrappers(raw: string): string {
+  if (!raw) return "";
+  let cleaned = raw.trim();
+  // ```xml ... ``` or ``` ... ``` fences (anywhere in the payload).
+  cleaned = cleaned.replace(/```\s*xml\s*\n?/gi, "");
+  cleaned = cleaned.replace(/```/g, "");
+  cleaned = cleaned.trim();
+  // If preamble / postamble surrounds the XML root, peel it off.
+  const rootMatch = cleaned.match(
+    /(<[a-zA-Z_][a-zA-Z0-9_-]*>[\s\S]*<\/[a-zA-Z_][a-zA-Z0-9_-]*>)/,
+  );
+  if (rootMatch && rootMatch[1]) return rootMatch[1].trim();
+  return cleaned;
+}
+
 function parseSummaryXml(
   xml: string,
   sessionId: string,
   project: string,
   obsCount: number,
 ): SessionSummary | null {
-  const title = getXmlTag(xml, "title");
+  const cleaned = stripXmlWrappers(xml);
+  const title = getXmlTag(cleaned, "title");
   if (!title) return null;
 
   return {
@@ -198,10 +218,10 @@ function parseSummaryXml(
     project,
     createdAt: new Date().toISOString(),
     title,
-    narrative: getXmlTag(xml, "narrative"),
-    keyDecisions: getXmlChildren(xml, "decisions", "decision"),
-    filesModified: getXmlChildren(xml, "files", "file"),
-    concepts: getXmlChildren(xml, "concepts", "concept"),
+    narrative: getXmlTag(cleaned, "narrative"),
+    keyDecisions: getXmlChildren(cleaned, "decisions", "decision"),
+    filesModified: getXmlChildren(cleaned, "files", "file"),
+    concepts: getXmlChildren(cleaned, "concepts", "concept"),
     observationCount: obsCount,
   };
 }
@@ -253,41 +273,59 @@ export function registerSummarizeFunction(
       }
 
       try {
-        const { response, mode, chunks } = await produceSummaryXml(
-          provider,
-          compressed,
-          sessionId,
-          session.project,
-        );
+        // #783: chunk-level produceSummaryXml retries internally, but
+        // the final merge used to parse once and bail. Wrap the
+        // produce-and-parse pair in the same 2-attempt loop so a
+        // markdown-wrapped or otherwise wrapped response gets a
+        // second roll-of-the-dice instead of dropping the summary.
+        let summary: SessionSummary | null = null;
+        let response = "";
+        let mode = "single";
+        let chunks = 1;
+        for (let attempt = 1; attempt <= 2; attempt++) {
+          const produced = await produceSummaryXml(
+            provider,
+            compressed,
+            sessionId,
+            session.project,
+          );
+          response = produced.response;
+          mode = produced.mode;
+          chunks = produced.chunks;
+          if (!response || !response.trim()) {
+            logger.warn("Empty provider response on summarize", {
+              sessionId,
+              provider: provider.name,
+              mode,
+              chunks,
+              observationCount: compressed.length,
+              attempt,
+            });
+            continue;
+          }
+          summary = parseSummaryXml(
+            response,
+            sessionId,
+            session.project,
+            compressed.length,
+          );
+          if (summary) break;
+          logger.warn("Failed to parse summary XML", { sessionId, attempt });
+        }
+
         if (!response || !response.trim()) {
           const latencyMs = Date.now() - startMs;
           if (metricsStore) {
             await metricsStore.record("mem::summarize", latencyMs, false);
           }
-          logger.warn("Empty provider response on summarize", {
-            sessionId,
-            provider: provider.name,
-            mode,
-            chunks,
-            observationCount: compressed.length,
-          });
           return { success: false, error: "empty_provider_response" };
         }
-        const summary = parseSummaryXml(
-          response,
-          sessionId,
-          session.project,
-          compressed.length,
-        );
 
         if (!summary) {
           const latencyMs = Date.now() - startMs;
           if (metricsStore) {
             await metricsStore.record("mem::summarize", latencyMs, false);
           }
-          logger.warn("Failed to parse summary XML", {
-            sessionId,
-          });
           return { success: false, error: "parse_failed" };
         }
 

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -25,6 +25,35 @@ function requireEnvVar(key: string): string {
   return value;
 }
 
+// #778: fallback providers used to inherit the primary provider's
+// model name (e.g. fallback Gemini was called with `gpt-4o-mini`),
+// 404'd every call, and tripped the circuit breaker — making
+// FALLBACK_PROVIDERS actively worse than no fallback. Each provider
+// must resolve its OWN env-driven default model. Mirrors the resolution
+// in detectProvider() so primary + fallback agree on what each
+// provider's default model is.
+function defaultModelFor(providerType: ProviderConfig["provider"]): string {
+  switch (providerType) {
+    case "openai":
+      return getEnvVar("OPENAI_MODEL") || "gpt-4o-mini";
+    case "anthropic":
+      return getEnvVar("ANTHROPIC_MODEL") || "claude-sonnet-4-20250514";
+    case "gemini":
+      return getEnvVar("GEMINI_MODEL") || "gemini-2.5-flash";
+    case "openrouter":
+      return (
+        getEnvVar("OPENROUTER_MODEL") || "anthropic/claude-sonnet-4-20250514"
+      );
+    case "minimax":
+      return getEnvVar("MINIMAX_MODEL") || "MiniMax-M2.7";
+    case "agent-sdk":
+      return "claude-sonnet-4-20250514";
+    case "noop":
+    default:
+      return "noop";
+  }
+}
+
 export function createProvider(config: ProviderConfig): ResilientProvider {
   return new ResilientProvider(createBaseProvider(config));
 }
@@ -41,9 +70,14 @@ export function createFallbackProvider(
   for (const providerType of fallbackConfig.providers) {
     if (providerType === config.provider) continue;
     try {
+      // #778: resolve the fallback's OWN default model (or its env
+      // override) rather than copying config.model from the primary.
+      // Without this, FALLBACK_PROVIDERS=gemini on an OpenAI primary
+      // would call Gemini with `gpt-4o-mini`, get a 404 every time,
+      // and trip the circuit breaker.
       const fbConfig: ProviderConfig = {
         provider: providerType,
-        model: config.model,
+        model: defaultModelFor(providerType),
         maxTokens: config.maxTokens,
       };
       providers.push(createBaseProvider(fbConfig));

--- a/test/fallback-model-resolution.test.ts
+++ b/test/fallback-model-resolution.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// #778: fallback providers used to inherit the primary provider's
+// model name and 404 on every call. Each fallback must resolve its
+// own env-driven default model.
+
+const captured: Array<{ provider: string; model: string }> = [];
+
+vi.mock("../src/providers/openai.js", () => ({
+  OpenAIProvider: class {
+    name = "openai";
+    constructor(_key: string, model: string) {
+      captured.push({ provider: "openai", model });
+    }
+    async compress() {
+      return "";
+    }
+    async summarize() {
+      return "";
+    }
+  },
+}));
+
+vi.mock("../src/providers/openrouter.js", () => ({
+  OpenRouterProvider: class {
+    name = "openrouter";
+    constructor(_key: string, model: string, _max: number, url?: string) {
+      captured.push({
+        provider: url?.includes("googleapis") ? "gemini" : "openrouter",
+        model,
+      });
+    }
+    async compress() {
+      return "";
+    }
+    async summarize() {
+      return "";
+    }
+  },
+}));
+
+vi.mock("../src/providers/anthropic.js", () => ({
+  AnthropicProvider: class {
+    name = "anthropic";
+    constructor(_key: string, model: string) {
+      captured.push({ provider: "anthropic", model });
+    }
+    async compress() {
+      return "";
+    }
+    async summarize() {
+      return "";
+    }
+  },
+}));
+
+vi.mock("../src/providers/minimax.js", () => ({
+  MinimaxProvider: class {
+    name = "minimax";
+    constructor(_key: string, model: string) {
+      captured.push({ provider: "minimax", model });
+    }
+    async compress() {
+      return "";
+    }
+    async summarize() {
+      return "";
+    }
+  },
+}));
+
+import { createFallbackProvider } from "../src/providers/index.js";
+import type { ProviderConfig, FallbackConfig } from "../src/types.js";
+
+describe("Fallback provider model resolution (#778)", () => {
+  const savedEnv: Record<string, string | undefined> = {};
+  const envKeys = [
+    "OPENAI_API_KEY",
+    "OPENAI_MODEL",
+    "GEMINI_API_KEY",
+    "GEMINI_MODEL",
+    "GOOGLE_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_MODEL",
+    "OPENROUTER_API_KEY",
+    "OPENROUTER_MODEL",
+    "MINIMAX_API_KEY",
+    "MINIMAX_MODEL",
+  ];
+
+  beforeEach(() => {
+    captured.length = 0;
+    for (const k of envKeys) {
+      savedEnv[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of envKeys) {
+      if (savedEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = savedEnv[k];
+    }
+  });
+
+  it("primary OpenAI + fallback Gemini: Gemini is built with GEMINI_MODEL, NOT the primary's model", () => {
+    process.env.OPENAI_API_KEY = "sk-openai";
+    process.env.GEMINI_API_KEY = "gemini-key";
+    process.env.GEMINI_MODEL = "gemini-2.5-flash";
+
+    const primary: ProviderConfig = {
+      provider: "openai",
+      model: "gpt-4o-mini",
+      maxTokens: 4096,
+    };
+    const fallback: FallbackConfig = { providers: ["gemini"] };
+
+    createFallbackProvider(primary, fallback);
+
+    const openaiCall = captured.find((c) => c.provider === "openai");
+    const geminiCall = captured.find((c) => c.provider === "gemini");
+    expect(openaiCall?.model).toBe("gpt-4o-mini");
+    expect(geminiCall?.model).toBe("gemini-2.5-flash");
+    expect(geminiCall?.model).not.toBe("gpt-4o-mini");
+  });
+
+  it("Gemini fallback uses the documented default when GEMINI_MODEL is unset", () => {
+    process.env.OPENAI_API_KEY = "sk-openai";
+    process.env.GEMINI_API_KEY = "gemini-key";
+
+    createFallbackProvider(
+      { provider: "openai", model: "gpt-4o-mini", maxTokens: 4096 },
+      { providers: ["gemini"] },
+    );
+
+    const geminiCall = captured.find((c) => c.provider === "gemini");
+    expect(geminiCall?.model).toBe("gemini-2.5-flash");
+  });
+
+  it("primary Anthropic + fallback OpenAI + Minimax: each fallback uses its own default", () => {
+    process.env.ANTHROPIC_API_KEY = "anth-key";
+    process.env.OPENAI_API_KEY = "openai-key";
+    process.env.OPENAI_MODEL = "gpt-5";
+    process.env.MINIMAX_API_KEY = "mini-key";
+
+    createFallbackProvider(
+      {
+        provider: "anthropic",
+        model: "claude-sonnet-4-20250514",
+        maxTokens: 4096,
+      },
+      { providers: ["openai", "minimax"] },
+    );
+
+    const openai = captured.find((c) => c.provider === "openai");
+    const minimax = captured.find((c) => c.provider === "minimax");
+    expect(openai?.model).toBe("gpt-5");
+    expect(minimax?.model).toBe("MiniMax-M2.7");
+    // Neither inherits the Anthropic model name.
+    expect(openai?.model).not.toBe("claude-sonnet-4-20250514");
+    expect(minimax?.model).not.toBe("claude-sonnet-4-20250514");
+  });
+
+  it("env override on the fallback provider's MODEL var wins over the default", () => {
+    process.env.OPENAI_API_KEY = "sk";
+    process.env.GEMINI_API_KEY = "gk";
+    process.env.GEMINI_MODEL = "gemini-2.5-pro";
+
+    createFallbackProvider(
+      { provider: "openai", model: "gpt-4o-mini", maxTokens: 4096 },
+      { providers: ["gemini"] },
+    );
+
+    expect(captured.find((c) => c.provider === "gemini")?.model).toBe(
+      "gemini-2.5-pro",
+    );
+  });
+
+  it("fallback that matches the primary provider is skipped (no duplicate)", () => {
+    process.env.OPENAI_API_KEY = "sk";
+
+    createFallbackProvider(
+      { provider: "openai", model: "gpt-4o-mini", maxTokens: 4096 },
+      { providers: ["openai", "gemini"] },
+    );
+
+    const openaiCalls = captured.filter((c) => c.provider === "openai");
+    expect(openaiCalls.length).toBe(1);
+  });
+});

--- a/test/replay-import-key.test.ts
+++ b/test/replay-import-key.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+vi.mock("../src/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { registerReplayFunctions } from "../src/functions/replay.js";
+import { KV } from "../src/state/schema.js";
+
+function mockKV() {
+  const store = new Map<string, Map<string, unknown>>();
+  const setCalls: Array<{ scope: string; key: string | undefined; value: any }> = [];
+  return {
+    get: async <T>(scope: string, key: string): Promise<T | null> =>
+      (store.get(scope)?.get(key) as T) ?? null,
+    set: async <T>(scope: string, key: string, value: T): Promise<T> => {
+      setCalls.push({ scope, key, value });
+      if (!store.has(scope)) store.set(scope, new Map());
+      // Mirror the engine: a state::set with key=undefined fails. We
+      // surface this via setCalls so the test can assert key !== undefined.
+      if (key === undefined) {
+        throw new Error("missing field `key`");
+      }
+      store.get(scope)!.set(key, value);
+      return value;
+    },
+    delete: async (scope: string, key: string) => {
+      store.get(scope)?.delete(key);
+    },
+    list: async <T>(scope: string): Promise<T[]> =>
+      Array.from(store.get(scope)?.values() ?? []) as T[],
+    getSetCalls: () => setCalls,
+  };
+}
+
+function mockSdk(kv: ReturnType<typeof mockKV>) {
+  const fns = new Map<string, Function>();
+  return {
+    registerFunction: (id: string, handler: Function) => fns.set(id, handler),
+    registerTrigger: () => {},
+    trigger: async (
+      idOrInput: string | { function_id: string; payload?: unknown },
+      data?: unknown,
+    ) => {
+      const id =
+        typeof idOrInput === "string" ? idOrInput : idOrInput.function_id;
+      const payload =
+        typeof idOrInput === "string" ? data : (idOrInput as any).payload;
+      const fn = fns.get(id);
+      if (!fn) return { success: true };
+      return fn(payload);
+    },
+    _kv: kv,
+  } as any;
+}
+
+describe("import-jsonl re-key on parsed.sessionId (#775)", () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), "replay-import-key-"));
+  });
+
+  function writeFixture(sessionId: string, ts = "2026-04-17T10:00:00.000Z") {
+    const dir = join(tmpRoot, "proj");
+    rmSync(dir, { recursive: true, force: true });
+    require("node:fs").mkdirSync(dir, { recursive: true });
+    const lines = [
+      JSON.stringify({
+        type: "user",
+        uuid: "u1",
+        sessionId,
+        timestamp: ts,
+        cwd: tmpRoot,
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "hello" }],
+        },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        uuid: "a1",
+        sessionId,
+        timestamp: ts,
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "world" }],
+        },
+      }),
+    ];
+    writeFileSync(join(dir, `${sessionId}.jsonl`), lines.join("\n") + "\n");
+  }
+
+  it("re-imports a session whose stored row is missing the `id` field without aborting the batch", async () => {
+    writeFixture("sess-no-id");
+    const kv = mockKV();
+    const sdk = mockSdk(kv);
+    registerReplayFunctions(sdk, kv as never);
+
+    // Seed an existing session row that is MISSING `id` — the
+    // pre-fix code would re-key on `existing.id` (undefined) and
+    // throw `missing field \`key\``, aborting the whole import.
+    await kv.set(KV.sessions, "sess-no-id", {
+      project: "proj",
+      cwd: tmpRoot,
+      startedAt: "2026-04-17T09:00:00Z",
+      endedAt: "2026-04-17T09:30:00Z",
+      status: "completed",
+      observationCount: 2,
+      tags: [],
+    });
+
+    const result = (await sdk.trigger("mem::replay::import-jsonl", {
+      path: tmpRoot,
+    })) as { success: boolean; imported?: number; error?: string };
+
+    expect(result.success).toBe(true);
+    expect(result.imported).toBe(1);
+
+    const undefinedKeyWrites = kv
+      .getSetCalls()
+      .filter((c) => c.scope === KV.sessions && c.key === undefined);
+    expect(undefinedKeyWrites.length).toBe(0);
+
+    const sessionWrites = kv
+      .getSetCalls()
+      .filter((c) => c.scope === KV.sessions && c.key === "sess-no-id");
+    expect(sessionWrites.length).toBeGreaterThan(0);
+    // The handler also backfills the missing id field so future reads
+    // are well-formed.
+    expect((sessionWrites.at(-1)!.value as any).id).toBe("sess-no-id");
+  });
+
+  it("fresh import (no existing row) still writes session keyed by parsed.sessionId", async () => {
+    writeFixture("sess-fresh");
+    const kv = mockKV();
+    const sdk = mockSdk(kv);
+    registerReplayFunctions(sdk, kv as never);
+
+    const result = (await sdk.trigger("mem::replay::import-jsonl", {
+      path: tmpRoot,
+    })) as { success: boolean; imported?: number };
+
+    expect(result.success).toBe(true);
+    expect(result.imported).toBe(1);
+    const sessionWrites = kv
+      .getSetCalls()
+      .filter((c) => c.scope === KV.sessions && c.key === "sess-fresh");
+    expect(sessionWrites.length).toBe(1);
+  });
+});

--- a/test/summarize.test.ts
+++ b/test/summarize.test.ts
@@ -414,4 +414,69 @@ describe("mem::summarize chunking", () => {
     // Reduce is a single call so doesn't bump it.
     expect(maxInflight).toBe(2);
   });
+
+  // #783: markdown-wrapped XML used to silently fail parsing because
+  // the tag regex looked for <title> in the raw payload. stripXmlWrappers
+  // now peels ```xml ... ``` fences and conversational pre/postamble
+  // before the regex runs.
+  it("parses a summary even when the LLM wraps XML in markdown fences", async () => {
+    const wrappedXml = "Here's the summary:\n```xml\n" + summaryXml({
+      title: "wrapped",
+      narrative: "n",
+      decisions: ["d1"],
+      files: ["src/a.ts"],
+      concepts: ["c1"],
+    }) + "\n```\nLet me know if you need anything else.";
+    const provider = makeProvider([wrappedXml]);
+    const { handler, kv } = await setupHandler({
+      sessionId: "ses_md",
+      obsCount: 1,
+      provider,
+    });
+
+    const result: any = await handler({ sessionId: "ses_md" });
+
+    expect(result.success).toBe(true);
+    expect(result.summary.title).toBe("wrapped");
+    const stored = await kv.get("summaries", "ses_md");
+    expect((stored as any).title).toBe("wrapped");
+  });
+
+  it("retries the final summarize once on first-attempt parse failure", async () => {
+    // First call returns garbage (no <title>), second returns valid XML.
+    // The chunk-level retry is bypassed for a 1-obs session (no chunking),
+    // so this exercises the new final-summarize retry path.
+    const provider = makeProvider([
+      "not xml, just a sentence with no tags",
+      summaryXml({ title: "second-attempt" }),
+    ]);
+    const { handler } = await setupHandler({
+      sessionId: "ses_retry",
+      obsCount: 1,
+      provider,
+    });
+
+    const result: any = await handler({ sessionId: "ses_retry" });
+
+    expect(result.success).toBe(true);
+    expect(result.summary.title).toBe("second-attempt");
+    expect((provider as any).calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("returns parse_failed only after both attempts fail", async () => {
+    const provider = makeProvider([
+      "garbage one",
+      "garbage two",
+    ]);
+    const { handler } = await setupHandler({
+      sessionId: "ses_fail",
+      obsCount: 1,
+      provider,
+    });
+
+    const result: any = await handler({ sessionId: "ses_fail" });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("parse_failed");
+  });
 });


### PR DESCRIPTION
Three independent v0.9.24 bug fixes bundled for the v0.9.25 release.

## #778 fallback chain inherits primary's model

`createFallbackProvider` copied `config.model` from the primary into every fallback. With OpenAI primary + Gemini fallback, Gemini was called with `gpt-4o-mini` and 404'd on every call, which tripped the circuit breaker and blocked downstream LLM ops. New `defaultModelFor()` resolves each provider's env-driven default (`OPENAI_MODEL` / `GEMINI_MODEL` / `ANTHROPIC_MODEL` / `MINIMAX_MODEL` / `OPENROUTER_MODEL`).

## #775 import-jsonl aborts on legacy session row missing `id`

Existing-session branch did `kv.set(KV.sessions, existing.id, ...)` but legacy rows can lack `id`. `existing.id === undefined` → JSON.stringify drops the `key` → engine returns `missing field \`key\`` → whole handler aborts → entire import dies. One bad row killed the batch. Now re-keys on `parsed.sessionId` (always populated) + backfills `existing.id`.

## #783 parseSummaryXml fails on markdown fences

Many LLMs wrap structured XML in `\`\`\`xml ... \`\`\`` fences or add conversational text around it. The raw payload went straight to the tag regex, returning `parse_failed` silently. Added `stripXmlWrappers()` to peel fences + pre/postamble before regex. Also extended the chunk-level 2-attempt retry pattern to the final-summarize merge so one flaky wrap doesn't drop the summary.

## Tests

10 new across 3 files. Full suite: 125 files / 1379 tests pass.

Closes #778, closes #775, closes #783.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed session import to handle legacy data with missing ID fields, preventing batch failures.
  * Improved summary generation with automatic retry logic and support for markdown-wrapped XML output.
  * Fixed fallback provider model selection to prevent repeated errors and circuit-breaking issues.

* **Tests**
  * Added test coverage for session import handling, summary parsing resilience, and provider model resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->