### PR TITLE
fix: preserve retrieval scores on flat rerank

### DIFF
--- a/src/state/reranker.ts
+++ b/src/state/reranker.ts
@@ -53,18 +53,27 @@ export async function rerank(
   for (const pair of pairs) {
     try {
       const output = await reranker(pair.text);
-      const score = Array.isArray(output) ? output[0]?.score ?? 0 : 0;
+      const rawScore = Array.isArray(output) ? output[0]?.score : undefined;
+      const score = Number.isFinite(rawScore) ? Number(rawScore) : pair.result.combinedScore;
       scores.push({ result: pair.result, rerankScore: score });
     } catch {
       scores.push({ result: pair.result, rerankScore: pair.result.combinedScore });
     }
   }
 
+  const distinctScores = new Set(scores.map((s) => s.rerankScore));
+  if (distinctScores.size <= 1) {
+    return candidates.map((result, i) => ({
+      ...result,
+      rerankPosition: i + 1,
+    }));
+  }
+
   scores.sort((a, b) => b.rerankScore - a.rerankScore);
 
   return scores.map((s, i) => ({
     ...s.result,
-    combinedScore: s.rerankScore,
+    rerankScore: s.rerankScore,
     rerankPosition: i + 1,
   }));
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -257,6 +257,7 @@ export interface HybridSearchResult {
   vectorScore: number;
   graphScore: number;
   combinedScore: number;
+  rerankScore?: number;
   sessionId: string;
   graphContext?: string;
 }

--- a/test/reranker.test.ts
+++ b/test/reranker.test.ts
@@ -1,19 +1,25 @@
 import { describe, it, expect, vi } from "vitest";
 
 vi.mock("@xenova/transformers", () => {
-  throw new Error("not installed");
+  return {
+    pipeline: vi.fn(async () => vi.fn(async (text: string) => {
+      if (text.includes("same-score")) return [{ label: "LABEL_0", score: 1 }];
+      if (text.includes("strong-match")) return [{ label: "LABEL_0", score: 0.9 }];
+      return [{ label: "LABEL_0", score: 0.1 }];
+    })),
+  };
 });
 
 import { rerank, isRerankerAvailable } from "../src/state/reranker.js";
 
 describe("reranker", () => {
-  it("returns results unchanged when @xenova/transformers is unavailable", async () => {
+  it("keeps retrieval scores when the reranker returns constant scores", async () => {
     const results = [
       {
         observation: {
           id: "o1",
           title: "First",
-          narrative: "First result",
+          narrative: "same-score first result",
         },
         bm25Score: 0.5,
         vectorScore: 0.6,
@@ -25,7 +31,7 @@ describe("reranker", () => {
         observation: {
           id: "o2",
           title: "Second",
-          narrative: "Second result",
+          narrative: "same-score second result",
         },
         bm25Score: 0.3,
         vectorScore: 0.4,
@@ -36,11 +42,48 @@ describe("reranker", () => {
     ] as any;
 
     const reranked = await rerank("test query", results);
-    expect(reranked).toEqual(results);
+    expect(reranked.map((r) => r.observation.id)).toEqual(["o1", "o2"]);
+    expect(reranked.map((r) => r.combinedScore)).toEqual([0.8, 0.5]);
+    expect(reranked.map((r) => r.rerankPosition)).toEqual([1, 2]);
   });
 
-  it("isRerankerAvailable returns false when not loaded", () => {
-    expect(isRerankerAvailable()).toBe(false);
+  it("uses discriminative reranker scores for ordering without overwriting retrieval score", async () => {
+    const results = [
+      {
+        observation: {
+          id: "o1",
+          title: "First",
+          narrative: "weak-match first result",
+        },
+        bm25Score: 0.5,
+        vectorScore: 0.6,
+        graphScore: 0,
+        combinedScore: 0.8,
+        sessionId: "s1",
+      },
+      {
+        observation: {
+          id: "o2",
+          title: "Second",
+          narrative: "strong-match second result",
+        },
+        bm25Score: 0.3,
+        vectorScore: 0.4,
+        graphScore: 0,
+        combinedScore: 0.5,
+        sessionId: "s1",
+      },
+    ] as any;
+
+    const reranked = await rerank("test query", results);
+    expect(reranked.map((r) => r.observation.id)).toEqual(["o2", "o1"]);
+    expect(reranked[0].combinedScore).toBe(0.5);
+    expect(reranked[0].rerankScore).toBe(0.9);
+    expect(reranked[0].rerankPosition).toBe(1);
+  });
+
+  it("isRerankerAvailable reflects the loaded pipeline", () => {
+    expect(isRerankerAvailable()).toBe(true);
   });
 
   it("handles single result gracefully", async () => {

--- a/test/reranker.test.ts
+++ b/test/reranker.test.ts
@@ -82,7 +82,35 @@ describe("reranker", () => {
     expect(reranked[0].rerankPosition).toBe(1);
   });
 
-  it("isRerankerAvailable reflects the loaded pipeline", () => {
+  it("isRerankerAvailable reflects the loaded pipeline", async () => {
+    const results = [
+      {
+        observation: {
+          id: "o1",
+          title: "Availability",
+          narrative: "strong-match availability result",
+        },
+        bm25Score: 0.5,
+        vectorScore: 0.6,
+        graphScore: 0,
+        combinedScore: 0.8,
+        sessionId: "s1",
+      },
+      {
+        observation: {
+          id: "o2",
+          title: "Second",
+          narrative: "weak-match second result",
+        },
+        bm25Score: 0.3,
+        vectorScore: 0.4,
+        graphScore: 0,
+        combinedScore: 0.5,
+        sessionId: "s1",
+      },
+    ] as any;
+
+    await rerank("test query", results);
     expect(isRerankerAvailable()).toBe(true);
   });
 


### PR DESCRIPTION
## Summary
- keep retrieval ordering when the reranker returns the same score for every candidate
- preserve the original combinedScore and expose discriminative reranker output as rerankScore
- add coverage for flat and discriminative reranker behavior

## Tests
- git diff --check
- npm test -- test/reranker.test.ts
- npm run build

Closes #724

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search results now include an optional rerank score for clearer ranking insight.

* **Bug Fixes**
  * More robust extraction of reranker scores with automatic fallback to original scores.
  * Preserves original retrieval scores while adding rerank scores.
  * When all reranker scores are identical, results keep original ordering and only mark rerank positions.

* **Tests**
  * Updated tests to cover reranker availability, same-score behavior, and discriminative ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->