### PR TITLE
fix: handle undefined manifest value in loadShardedData

### DIFF
--- a/src/state/index-persistence.ts
+++ b/src/state/index-persistence.ts
@@ -358,7 +358,7 @@ export class IndexPersistence {
       "manifest",
     );
     if (!manifest.ok) return null;
-    if (manifest.value !== null) {
+    if (manifest.value != null) {
       return this.loadManifestData(manifest.value, label);
     }
 


### PR DESCRIPTION
## Problem

When upgrading from pre-v0.9.25 to v0.9.25, the sharded index loader crashes with:

```
TypeError: Cannot read properties of undefined (reading 'v')
    at IndexPersistence.loadShardedData
```

This happens because `kv.get()` returns `undefined` for keys that don't exist in the old data format, and the strict comparison `manifest.value !== null` evaluates to `true` when `value === undefined`, causing `undefined` to be passed to `loadManifestData()` which tries to access `undefined.v`.

## Root Cause

In `loadShardedData` (src/state/index-persistence.ts:361):

```typescript
if (manifest.value !== null) {  // true when value === undefined
  return this.loadManifestData(manifest.value, label);  // crashes
}
```

`kv.get()` returns `undefined` for non-existent keys (not `null`), so the strict comparison fails to catch this case.

## Fix

Change to loose comparison `!= null` which catches both `null` and `undefined`:

```typescript
if (manifest.value != null) {  // false for both null and undefined
  return this.loadManifestData(manifest.value, label);
}
```

This allows the function to fall through to the legacy data path as originally intended.

## Testing

- Reproduced the crash on v0.9.25 with pre-existing data from v0.9.24
- Applied fix, rebuilt, and verified sharded index loads without crash
- Legacy data path correctly handles old format data


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent handling of missing index data during persistence operations. The system now uniformly treats both null and undefined values as absent, ensuring more reliable data loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->