### PR TITLE
fix: import randomUUID from node crypto

### DIFF
--- a/src/state/schema.ts
+++ b/src/state/schema.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 
 export const KV = {
   sessions: "mem:sessions",
@@ -60,7 +60,7 @@ export const STREAM = {
 
 export function generateId(prefix: string): string {
   const ts = Date.now().toString(36);
-  const rand = crypto.randomUUID().replace(/-/g, "").slice(0, 12);
+  const rand = randomUUID().replace(/-/g, "").slice(0, 12);
   return `${prefix}_${ts}_${rand}`;
 }
 


### PR DESCRIPTION
## Summary
- import `randomUUID` from `node:crypto` in the shared schema module
- remove the bare global `crypto.randomUUID()` dependency from generated ids
- keep the generated id format unchanged

## Tests
- git diff --check
- npm test -- test/schema.test.ts
- npm run build
- `! rg -n "crypto\.randomUUID\(" dist`

Closes #715

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal ID generation implementation with no changes to functionality or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->