### PR TITLE
fix: prefer embedding API key for OpenAI embeddings

### DIFF
--- a/src/providers/embedding/index.ts
+++ b/src/providers/embedding/index.ts
@@ -35,7 +35,11 @@ export function createEmbeddingProvider(): EmbeddingProvider | null {
     case "gemini":
       return withDimensionGuard(new GeminiEmbeddingProvider(getEnvVar("GEMINI_API_KEY")!));
     case "openai":
-      return withDimensionGuard(new OpenAIEmbeddingProvider(getEnvVar("OPENAI_API_KEY")!));
+      return withDimensionGuard(
+        new OpenAIEmbeddingProvider(
+          getEnvVar("OPENAI_EMBEDDING_API_KEY") || getEnvVar("OPENAI_API_KEY")!,
+        ),
+      );
     case "voyage":
       return withDimensionGuard(new VoyageEmbeddingProvider(getEnvVar("VOYAGE_API_KEY")!));
     case "cohere":

--- a/test/embedding-provider.test.ts
+++ b/test/embedding-provider.test.ts
@@ -43,6 +43,23 @@ describe("createEmbeddingProvider", () => {
     expect(provider!.name).toBe("openai");
   });
 
+  it("passes OPENAI_EMBEDDING_API_KEY to OpenAIEmbeddingProvider when set", async () => {
+    process.env["OPENAI_API_KEY"] = "text-llm-key";
+    process.env["OPENAI_EMBEDDING_API_KEY"] = "embedding-key";
+    const provider = createEmbeddingProvider();
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ data: [{ embedding: new Array(1536).fill(0.1) }] }), { status: 200 }),
+    );
+
+    await provider!.embed("hello");
+    expect(fetchSpy.mock.calls[0][1]?.headers).toMatchObject({
+      Authorization: "Bearer embedding-key",
+    });
+
+    fetchSpy.mockRestore();
+  });
+
   it("EMBEDDING_PROVIDER override takes precedence", () => {
     process.env["GEMINI_API_KEY"] = "test-key-123";
     process.env["OPENAI_API_KEY"] = "test-key-456";


### PR DESCRIPTION
## Summary

Fix `createEmbeddingProvider()` so OpenAI-compatible embeddings prefer `OPENAI_EMBEDDING_API_KEY` when it is set.

`OpenAIEmbeddingProvider` already supports a dedicated embedding key internally, but the factory currently passes `OPENAI_API_KEY` directly into the constructor. That caller-provided text LLM key wins over the provider's internal fallback chain, so deployments with separate chat and embedding providers can accidentally send embedding requests with the chat key.

## Changes

- Pass `OPENAI_EMBEDDING_API_KEY || OPENAI_API_KEY` from the OpenAI embedding factory branch.
- Add a regression test that sets both keys and verifies the embedding request uses the embedding-specific key.

## Why

This matters for OpenAI-compatible deployments where chat and embeddings live on different providers/endpoints. For example, a chat proxy key in `OPENAI_API_KEY` plus DashScope/Bailian in `OPENAI_EMBEDDING_API_KEY` currently causes vector indexing to call the embedding endpoint with the chat key and fail with `401 invalid_api_key`.

## Tests

- Not run locally in this environment; change is covered by the added `embedding-provider.test.ts` regression test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenAI embedding operations now support a dedicated API key configuration for enhanced credential management and security.

* **Tests**
  * Added test coverage to verify proper API key handling for embedding requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->