### PR TITLE
fix: preserve graph layout on viewer refresh

### DIFF
--- a/src/viewer/index.html
+++ b/src/viewer/index.html
@@ -1824,6 +1824,10 @@
       var previousPanX = graphSim.panX;
       var previousPanY = graphSim.panY;
       var previousZoom = graphSim.zoom;
+      if (graphSim.raf) {
+        cancelAnimationFrame(graphSim.raf);
+        graphSim.raf = null;
+      }
       if (graphSim.resizeHandler) {
         window.removeEventListener('resize', graphSim.resizeHandler);
       }

--- a/src/viewer/index.html
+++ b/src/viewer/index.html
@@ -1660,7 +1660,7 @@
       }, 30000);
     }
 
-    var graphSim = { nodes: [], edges: [], running: false, canvas: null, ctx: null, raf: null, panX: 0, panY: 0, zoom: 1, dragNode: null, mouseX: 0, mouseY: 0, tickCount: 0, quietTicks: 0 };
+    var graphSim = { nodes: [], edges: [], running: false, canvas: null, ctx: null, raf: null, panX: 0, panY: 0, zoom: 1, dragNode: null, mouseX: 0, mouseY: 0, tickCount: 0, quietTicks: 0, resizeHandler: null };
     function wakeGraphSim() {
       graphSim.quietTicks = 0;
       if (graphSim.running && !graphSim.raf) {
@@ -1818,6 +1818,15 @@
     function initGraph() {
       var canvas = document.getElementById('graph-canvas');
       if (!canvas) return;
+      var previousLayout = {};
+      graphSim.nodes.forEach(function(n) { previousLayout[n.id] = n; });
+      var hadLayout = Object.keys(previousLayout).length > 0;
+      var previousPanX = graphSim.panX;
+      var previousPanY = graphSim.panY;
+      var previousZoom = graphSim.zoom;
+      if (graphSim.resizeHandler) {
+        window.removeEventListener('resize', graphSim.resizeHandler);
+      }
       graphSim.canvas = canvas;
       graphSim.ctx = canvas.getContext('2d');
 
@@ -1830,12 +1839,19 @@
         graphSim.ctx.setTransform(window.devicePixelRatio, 0, 0, window.devicePixelRatio, 0, 0);
       }
       resize();
-      window.addEventListener('resize', resize);
+      graphSim.resizeHandler = resize;
+      window.addEventListener('resize', graphSim.resizeHandler);
 
       var cw = canvas.width / window.devicePixelRatio;
       var ch = canvas.height / window.devicePixelRatio;
-      graphSim.panX = cw / 2;
-      graphSim.panY = ch / 2;
+      if (hadLayout) {
+        graphSim.panX = previousPanX;
+        graphSim.panY = previousPanY;
+        graphSim.zoom = previousZoom;
+      } else {
+        graphSim.panX = cw / 2;
+        graphSim.panY = ch / 2;
+      }
 
       var edgeMap = {};
       state.graph.edges.forEach(function(e) {
@@ -1847,11 +1863,12 @@
         var angle = (2 * Math.PI * i) / Math.max(state.graph.nodes.length, 1);
         var radius = Math.min(cw, ch) * 0.3;
         var deg = edgeMap[n.id] || 0;
+        var previous = previousLayout[n.id];
         return {
           id: n.id, type: n.type, name: n.name, properties: n.properties,
-          x: Math.cos(angle) * radius + (Math.random() - 0.5) * 50,
-          y: Math.sin(angle) * radius + (Math.random() - 0.5) * 50,
-          vx: 0, vy: 0,
+          x: previous ? previous.x : Math.cos(angle) * radius + (Math.random() - 0.5) * 50,
+          y: previous ? previous.y : Math.sin(angle) * radius + (Math.random() - 0.5) * 50,
+          vx: previous ? previous.vx : 0, vy: previous ? previous.vy : 0,
           r: Math.max(8, Math.min(22, 8 + deg * 2.5))
         };
       });

--- a/test/viewer-graph-cooldown.test.ts
+++ b/test/viewer-graph-cooldown.test.ts
@@ -48,4 +48,10 @@ describe("viewer graph cool-down", () => {
     expect(viewer).toMatch(/graphSim\.panX\s*=\s*previousPanX/);
     expect(viewer).toMatch(/graphSim\.zoom\s*=\s*previousZoom/);
   });
+
+  it("cancels any in-flight animation frame before restarting the graph loop", () => {
+    expect(viewer).toMatch(/if\s*\(graphSim\.raf\)/);
+    expect(viewer).toMatch(/cancelAnimationFrame\(graphSim\.raf\)/);
+    expect(viewer).toMatch(/graphSim\.raf\s*=\s*null/);
+  });
 });

--- a/test/viewer-graph-cooldown.test.ts
+++ b/test/viewer-graph-cooldown.test.ts
@@ -35,4 +35,17 @@ describe("viewer graph cool-down", () => {
     expect(viewer).toMatch(/graphSim\.quietTicks\s*=\s*0/);
     expect(viewer).toMatch(/if\s*\(graphSim\.running\s*&&\s*!graphSim\.raf\)/);
   });
+
+  it("preserves graph node positions across graph reloads", () => {
+    expect(viewer).toMatch(/previousLayout\[n\.id\]\s*=\s*n/);
+    expect(viewer).toMatch(/var previous = previousLayout\[n\.id\]/);
+    expect(viewer).toMatch(/x:\s*previous\s*\?\s*previous\.x\s*:/);
+    expect(viewer).toMatch(/y:\s*previous\s*\?\s*previous\.y\s*:/);
+  });
+
+  it("keeps the current graph viewport when graph data refreshes", () => {
+    expect(viewer).toMatch(/var previousPanX = graphSim\.panX/);
+    expect(viewer).toMatch(/graphSim\.panX\s*=\s*previousPanX/);
+    expect(viewer).toMatch(/graphSim\.zoom\s*=\s*previousZoom/);
+  });
 });


### PR DESCRIPTION
## Summary
- preserve existing graph node positions when the viewer graph reloads
- keep the current graph pan and zoom across refreshes instead of recentering every time
- avoid stacking stale resize listeners during repeated graph initialization
- add regression coverage for graph layout and viewport preservation

## Tests
- git diff --check
- npm test -- test/viewer-graph-cooldown.test.ts
- npm run build

Closes #691


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Graph viewer now preserves node positions and viewport zoom/pan across refreshes and window resizes; avoids duplicate resize handlers and restores prior view or recenters as needed.
  * Prevents overlapping animations by canceling any in-flight animation loop before restarting.

* **Tests**
  * Added tests verifying layout and viewport preservation and that animation frames are properly canceled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->