### PR TITLE
docs(readme): refresh stats + v0.9.26 callout + corrected P@5

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@
   <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-tools.svg"><img src="assets/tags/stat-tools.svg" alt="53 MCP tools" height="38" /></picture>
   <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-hooks.svg"><img src="assets/tags/stat-hooks.svg" alt="12 auto hooks" height="38" /></picture>
   <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-deps.svg"><img src="assets/tags/stat-deps.svg" alt="0 external DBs" height="38" /></picture>
-  <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-tests.svg"><img src="assets/tags/stat-tests.svg" alt="950+ tests passing" height="38" /></picture>
+  <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-tests.svg"><img src="assets/tags/stat-tests.svg" alt="1,390+ tests passing" height="38" /></picture>
 </p>
 
 <p align="center">
@@ -226,7 +226,9 @@ You explain the same architecture every session. You re-discover the same bugs. 
 npx @agentmemory/agentmemory
 ```
 
-> **New in v0.9.22** — Three new connect adapters (Qwen Code, Antigravity, Kiro), `AGENT_ID` multi-agent isolation with opt-in `AGENTMEMORY_AGENT_SCOPE=isolated` filtering, install ERESOLVE fixed, OpenAI thinking-model output handled, OpenCode auto-context + session creation, viewer graph settles on 1000+ nodes, 22 fixes total. Full notes in [CHANGELOG.md](CHANGELOG.md).
+> **New in v0.9.26** — Hotfix: first-boot crash on missing index manifest ([#797](https://github.com/rohitg00/agentmemory/issues/797)) now self-heals instead of throwing on `manifest.v`.
+>
+> **v0.9.25** — Eleven breaking regressions closed (cross-provider fallback 404, `triggerVoid` removal in iii-sdk 0.11.2, summarize XML in markdown fences, pi `tool_input/tool_output` field mismatch, viewer graph 500 on 11k+ nodes, agent-sdk recursion guard race under `Promise.all`, obsidian-export missing-id crash, iii runtime pin auto-fallback, import-jsonl legacy session re-key). Added: sharded BM25/vector index persistence with manifest commit/rollback ([@Rokurolize](https://github.com/Rokurolize) [#762](https://github.com/rohitg00/agentmemory/issues/762)), smart-search followup-rate diagnostic ([#771](https://github.com/rohitg00/agentmemory/issues/771)). Drop-in upgrade, no breaking changes. Full notes in [CHANGELOG.md](CHANGELOG.md).
 
 ---
 
@@ -242,10 +244,10 @@ npx @agentmemory/agentmemory
 
 | Adapter | P@5 | R@5 | Top-5 hit rate | p50 latency |
 |---|---|---|---|---|
-| **agentmemory hybrid** | **0.578** | **0.967** | **15 / 15** | 14 ms |
-| grep baseline | 0.267 | 0.967 | 15 / 15 | 0 ms |
+| **agentmemory hybrid** | **0.240** | **1.000** | **15 / 15** | 14 ms |
+| grep baseline | 0.227 | 0.967 | 15 / 15 | 0 ms |
 
-100% top-5 hit rate. **2.2×** better precision than the grep baseline on identical input. Full per-type breakdown: [`docs/benchmarks/2026-05-20-coding-agent-life-v1.md`](docs/benchmarks/2026-05-20-coding-agent-life-v1.md).
+100% top-5 hit rate at the **P@5 math ceiling** for this corpus (0.240, see scorecard). Hybrid retrieves every gold session; grep misses 1 of 2 gold on the multi-session temporal query. Lift is **recall + temporal**, not aggregate precision — this benchmark is small + gold-sparse, the larger LongMemEval-S below differentiates better. Full per-type breakdown + correction note: [`docs/benchmarks/2026-05-20-coding-agent-life-v1.md`](docs/benchmarks/2026-05-20-coding-agent-life-v1.md).
 
 **LongMemEval-S** (ICLR 2025, 500 questions)
 
@@ -1139,7 +1141,7 @@ Full registry: [workers.iii.dev](https://workers.iii.dev). Every worker there co
 | Prometheus / Grafana | iii OTEL + health monitor |
 | Custom plugin systems | `iii worker add <name>` |
 
-**118 source files · ~21,800 LOC · 950+ tests · 123 functions · 34 KV scopes** — all on three primitives. No `agentmemory plugin install`. The plugin system is iii itself.
+**174 source files · ~37,800 LOC · 1,390+ tests · 258 functions · 44 KV scopes** — all on three primitives. No `agentmemory plugin install`. The plugin system is iii itself.
 
 ---
 
@@ -1463,7 +1465,7 @@ Full endpoint list: [`src/triggers/api.ts`](src/triggers/api.ts)
 ```bash
 npm run dev               # Hot reload
 npm run build             # Production build
-npm test                  # 950+ tests
+npm test                  # 1,390+ tests
 npm run test:integration  # API tests (requires running services)
 ```
 

--- a/assets/tags/light/stat-tests.svg
+++ b/assets/tags/light/stat-tests.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 48" fill="none" role="img" aria-label="TESTS PASSING: 1171+">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 48" fill="none" role="img" aria-label="TESTS PASSING: 1390+">
   <rect x="0" y="0" width="140" height="48" rx="10" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1"/>
-  <text x="70" y="24" fill="#16A34A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="18" font-weight="900" text-anchor="middle" letter-spacing="-0.3">1171+</text>
+  <text x="70" y="24" fill="#16A34A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="18" font-weight="900" text-anchor="middle" letter-spacing="-0.3">1390+</text>
   <text x="70" y="38" fill="#64748B" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="9" font-weight="600" text-anchor="middle" letter-spacing="1.5">TESTS PASSING</text>
 </svg>

--- a/assets/tags/stat-tests.svg
+++ b/assets/tags/stat-tests.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 48" fill="none" role="img" aria-label="TESTS PASSING: 1171+">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 48" fill="none" role="img" aria-label="TESTS PASSING: 1390+">
   <rect x="0" y="0" width="140" height="48" rx="10" fill="#1A1A1A" stroke="#2A2A2A" stroke-width="1"/>
-  <text x="70" y="24" fill="#00D26A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="18" font-weight="900" text-anchor="middle" letter-spacing="-0.3">1171+</text>
+  <text x="70" y="24" fill="#00D26A" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="18" font-weight="900" text-anchor="middle" letter-spacing="-0.3">1390+</text>
   <text x="70" y="38" fill="#9CA3AF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="9" font-weight="600" text-anchor="middle" letter-spacing="1.5">TESTS PASSING</text>
 </svg>

--- a/website/lib/generated-meta.json
+++ b/website/lib/generated-meta.json
@@ -1,8 +1,8 @@
 {
-  "version": "0.9.20",
+  "version": "0.9.26",
   "mcpTools": 53,
   "hooks": 12,
-  "restEndpoints": 124,
-  "testsPassing": 1055,
-  "generatedAt": "2026-05-18T20:08:39.354Z"
+  "restEndpoints": 126,
+  "testsPassing": 1394,
+  "generatedAt": "2026-06-03T10:14:01.074Z"
 }


### PR DESCRIPTION
## Summary

README + website meta were both behind v0.9.25/v0.9.26.

### README

- **\"New in\" callout**: v0.9.22 → v0.9.26 + v0.9.25 summary
- **coding-agent-life-v1 table** (line 247): P@5 0.578 / 0.267 → 0.240 / 0.227. The pre-#562 numbers were mathematically impossible under the current `hits / k` formula (math ceiling at K=5 = 0.240 on this corpus). Reframed lift as recall + temporal not aggregate precision. Same root cause as PR #805 (scorecard correction).
- **Stats line** (line 1144): 118 files / 21,800 LOC / 950+ tests / 123 functions / 34 KV scopes → 174 / 37,800 / 1,390+ / 258 / 44.
- **`npm test` comment** (line 1468): 950+ → 1,390+.
- **`stat-tests.svg` + dark variant**: 1171+ → 1390+.

### Website

- **`website/lib/generated-meta.json`**: regen via `node scripts/gen-meta.mjs`. Bumped v0.9.20 → v0.9.26, tests 1055 → 1394, REST endpoints 124 → 126.
- The live site at https://www.agent-memory.dev/ already auto-derives the right numbers at Vercel prebuild — this only refreshes the committed local-dev snapshot.

### Out of scope

- 95.2% R@5 LongMemEval still backed by `benchmark/LONGMEMEVAL.md` — unchanged.
- `stat-tools` (53), `stat-hooks` (12), `stat-deps` (0), `stat-recall`, `stat-tokens` verified against current source — unchanged.
- No code changes. Doc/asset-only.

## Test plan

- [ ] Doc-only; no source or test files touched
- [ ] Numbers verified against current `src/`, `plugin/hooks/hooks.json`, `benchmark/LONGMEMEVAL.md`
- [ ] `node website/scripts/gen-meta.mjs` writes the committed JSON
- [ ] P@5 numbers consistent with merged scorecard correction in PR #805

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated test coverage metrics to show 1,390+ passing tests.
  * Expanded release notes with v0.9.26 hotfix details and added v0.9.25 regression/feature summary.
  * Refreshed benchmark results and explanations for the coding-agent-life-v1 agent.
  * Updated public feature statistics (sources, LOC, tests, functions, KV scopes) and build metadata/version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->