### PR TITLE
feat: support OpenRouter embedding dimensions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,6 +78,7 @@
 # OPENAI_EMBEDDING_DIMENSIONS=1536               # Required when the model is not in the known-models table
 
 # OPENROUTER_EMBEDDING_MODEL=openai/text-embedding-3-small  # When EMBEDDING_PROVIDER=openrouter
+# OPENROUTER_EMBEDDING_DIMENSIONS=1536                      # Required when the OpenRouter embedding model is not 1536-dim
 
 # -----------------------------------------------------------------------------
 # 3. Auth & security

--- a/README.md
+++ b/README.md
@@ -1350,6 +1350,8 @@ Create `~/.agentmemory/.env`:
 # OPENAI_BASE_URL=https://api.openai.com   # Override for Azure / vLLM / LM Studio / proxies
 # OPENAI_EMBEDDING_MODEL=text-embedding-3-small
 # OPENAI_EMBEDDING_DIMENSIONS=1536        # Required when the model is not in the known-models table
+# OPENROUTER_EMBEDDING_MODEL=perplexity/pplx-embed-v1-0.6b
+# OPENROUTER_EMBEDDING_DIMENSIONS=1024    # Required when the OpenRouter embedding model is not 1536-dim
 
 # Outbound LLM / embedding timeout
 # AGENTMEMORY_LLM_TIMEOUT_MS=60000       # Default: 60 000 ms (60 s). Applies to every

--- a/src/providers/embedding/openrouter.ts
+++ b/src/providers/embedding/openrouter.ts
@@ -69,8 +69,8 @@ export class OpenRouterEmbeddingProvider implements EmbeddingProvider {
 }
 
 function resolveDimensions(raw: string | undefined): number {
-  if (!raw) return 1536;
-  const trimmed = raw.trim();
+  const trimmed = raw?.trim();
+  if (!trimmed) return 1536;
   if (!/^\d+$/.test(trimmed)) {
     throw new Error(DIMENSIONS_ERROR);
   }

--- a/src/providers/embedding/openrouter.ts
+++ b/src/providers/embedding/openrouter.ts
@@ -3,16 +3,28 @@ import { getEnvVar } from "../../config.js";
 import { fetchWithTimeout } from "../_fetch.js";
 
 const API_URL = "https://openrouter.ai/api/v1/embeddings";
+const DIMENSIONS_ERROR =
+  "OPENROUTER_EMBEDDING_DIMENSIONS must be a positive integer";
+
+type OpenRouterEmbeddingRequestBody = {
+  model: string;
+  input: string[];
+  dimensions?: number;
+};
 
 export class OpenRouterEmbeddingProvider implements EmbeddingProvider {
   readonly name = "openrouter";
-  readonly dimensions = 1536;
+  readonly dimensions: number;
   private apiKey: string;
   private model: string;
+  private sendDimensions: boolean;
 
   constructor(apiKey?: string) {
     this.apiKey = apiKey || getEnvVar("OPENROUTER_API_KEY") || "";
     if (!this.apiKey) throw new Error("OPENROUTER_API_KEY is required");
+    const configuredDimensions = getEnvVar("OPENROUTER_EMBEDDING_DIMENSIONS");
+    this.dimensions = resolveDimensions(configuredDimensions);
+    this.sendDimensions = Boolean(configuredDimensions?.trim());
     this.model =
       getEnvVar("OPENROUTER_EMBEDDING_MODEL") ||
       "openai/text-embedding-3-small";
@@ -24,16 +36,21 @@ export class OpenRouterEmbeddingProvider implements EmbeddingProvider {
   }
 
   async embedBatch(texts: string[]): Promise<Float32Array[]> {
+    const body: OpenRouterEmbeddingRequestBody = {
+      model: this.model,
+      input: texts,
+    };
+    if (this.sendDimensions) {
+      body.dimensions = this.dimensions;
+    }
+
     const response = await fetchWithTimeout(API_URL, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${this.apiKey}`,
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({
-        model: this.model,
-        input: texts,
-      }),
+      body: JSON.stringify(body),
     });
 
     if (!response.ok) {
@@ -49,4 +66,17 @@ export class OpenRouterEmbeddingProvider implements EmbeddingProvider {
 
     return data.data.map((d) => new Float32Array(d.embedding));
   }
+}
+
+function resolveDimensions(raw: string | undefined): number {
+  if (!raw) return 1536;
+  const trimmed = raw.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    throw new Error(DIMENSIONS_ERROR);
+  }
+  const parsed = Number(trimmed);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(DIMENSIONS_ERROR);
+  }
+  return parsed;
 }

--- a/test/embedding-provider.test.ts
+++ b/test/embedding-provider.test.ts
@@ -227,6 +227,25 @@ describe("OpenRouterEmbeddingProvider", () => {
     expect(body.dimensions).toBeUndefined();
   });
 
+  it("treats whitespace-only OPENROUTER_EMBEDDING_DIMENSIONS as unset", async () => {
+    process.env["OPENROUTER_EMBEDDING_DIMENSIONS"] = "   ";
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ data: [{ embedding: [0.1, 0.2] }] }), {
+        status: 200,
+      }),
+    );
+
+    const provider = new OpenRouterEmbeddingProvider("test-key");
+    expect(provider.dimensions).toBe(1536);
+    await provider.embed("hello");
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const body = JSON.parse((fetchSpy.mock.calls[0][1] as RequestInit).body as string) as {
+      dimensions?: number;
+    };
+    expect(body.dimensions).toBeUndefined();
+  });
+
   it("rejects invalid OPENROUTER_EMBEDDING_DIMENSIONS values", () => {
     for (const bad of ["not-a-number", "-5", "0"]) {
       process.env["OPENROUTER_EMBEDDING_DIMENSIONS"] = bad;

--- a/test/embedding-provider.test.ts
+++ b/test/embedding-provider.test.ts
@@ -5,6 +5,7 @@ import {
 } from "../src/providers/embedding/index.js";
 import { GeminiEmbeddingProvider } from "../src/providers/embedding/gemini.js";
 import { OpenAIEmbeddingProvider } from "../src/providers/embedding/openai.js";
+import { OpenRouterEmbeddingProvider } from "../src/providers/embedding/openrouter.js";
 import type { EmbeddingProvider } from "../src/types.js";
 
 describe("createEmbeddingProvider", () => {
@@ -154,6 +155,85 @@ describe("OpenAIEmbeddingProvider", () => {
     expect(() => new OpenAIEmbeddingProvider("test-key")).toThrow(
       /OPENAI_EMBEDDING_DIMENSIONS must be a positive integer/,
     );
+  });
+});
+
+describe("OpenRouterEmbeddingProvider", () => {
+  const envKeys = [
+    "OPENROUTER_API_KEY",
+    "OPENROUTER_EMBEDDING_MODEL",
+    "OPENROUTER_EMBEDDING_DIMENSIONS",
+  ] as const;
+  const originalEnv = new Map<string, string | undefined>();
+
+  beforeEach(() => {
+    for (const key of envKeys) {
+      originalEnv.set(key, process.env[key]);
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of envKeys) {
+      const value = originalEnv.get(key);
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    originalEnv.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("uses default dimensions when OPENROUTER_EMBEDDING_DIMENSIONS is unset", () => {
+    const provider = new OpenRouterEmbeddingProvider("test-key");
+    expect(provider.dimensions).toBe(1536);
+  });
+
+  it("uses OPENROUTER_EMBEDDING_DIMENSIONS and sends it to OpenRouter", async () => {
+    process.env["OPENROUTER_EMBEDDING_DIMENSIONS"] = "1024";
+    process.env["OPENROUTER_EMBEDDING_MODEL"] = "perplexity/pplx-embed-v1-0.6b";
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ data: [{ embedding: [0.1, 0.2] }] }), {
+        status: 200,
+      }),
+    );
+
+    const provider = new OpenRouterEmbeddingProvider("test-key");
+    expect(provider.dimensions).toBe(1024);
+    await provider.embed("hello");
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const body = JSON.parse((fetchSpy.mock.calls[0][1] as RequestInit).body as string) as {
+      model: string;
+      dimensions: number;
+    };
+    expect(body.model).toBe("perplexity/pplx-embed-v1-0.6b");
+    expect(body.dimensions).toBe(1024);
+  });
+
+  it("does not send dimensions when OPENROUTER_EMBEDDING_DIMENSIONS is unset", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ data: [{ embedding: [0.1, 0.2] }] }), {
+        status: 200,
+      }),
+    );
+
+    const provider = new OpenRouterEmbeddingProvider("test-key");
+    await provider.embed("hello");
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const body = JSON.parse((fetchSpy.mock.calls[0][1] as RequestInit).body as string) as {
+      dimensions?: number;
+    };
+    expect(body.dimensions).toBeUndefined();
+  });
+
+  it("rejects invalid OPENROUTER_EMBEDDING_DIMENSIONS values", () => {
+    for (const bad of ["not-a-number", "-5", "0"]) {
+      process.env["OPENROUTER_EMBEDDING_DIMENSIONS"] = bad;
+      expect(() => new OpenRouterEmbeddingProvider("test-key")).toThrow(
+        /OPENROUTER_EMBEDDING_DIMENSIONS must be a positive integer/,
+      );
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Allows OpenRouter embedding models to declare and request non-1536 vector dimensions.

Fixes #809.

## Changes

- Add `OPENROUTER_EMBEDDING_DIMENSIONS` support with positive-integer validation.
- Default to 1536 for backward compatibility.
- Send `dimensions` in OpenRouter embedding requests.
- Document the new env var.
- Add focused OpenRouter embedding-provider tests.

## Verification

- `HOME=$(mktemp -d) npx vitest run test/embedding-provider.test.ts`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenRouter embedding now supports configurable embedding dimensions via an environment setting.

* **Documentation**
  * README and environment docs updated with OpenRouter embedding options and guidance on when to supply dimensions.

* **Tests**
  * Added tests for default dimensions, conditional inclusion of dimensions in requests, and validation of invalid dimension values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/agentmemory/pull/811?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->