### PR TITLE
fix: explain empty consolidation viewer states

### DIFF
--- a/src/viewer/index.html
+++ b/src/viewer/index.html
@@ -1419,6 +1419,7 @@
       var title = {
         semantic: 'Semantic facts are waiting for enough summaries',
         procedural: 'Procedures are waiting for repeated patterns',
+        insights: 'Insights are waiting for enough signals',
         lessons: 'Lessons require an explicit save',
         crystals: 'Crystals come from crystallize actions'
       }[kind] || 'Nothing to show yet';

--- a/src/viewer/index.html
+++ b/src/viewer/index.html
@@ -646,6 +646,24 @@
       color: var(--ink); text-align: left; font-style: normal; white-space: pre;
     }
     .empty-state .empty-link { color: var(--accent); text-decoration: underline; font-size: 13px; font-style: normal; }
+    .empty-state .empty-gates {
+      display: inline-block;
+      min-width: min(520px, 100%);
+      margin: 12px auto;
+      padding: 10px 14px;
+      background: var(--bg-alt);
+      border: 1px solid var(--border-light);
+      border-radius: 4px;
+      text-align: left;
+      color: var(--ink-muted);
+      font-family: var(--font-ui);
+      font-size: 12px;
+      font-style: normal;
+      line-height: 1.45;
+    }
+    .empty-state .empty-gates .gate-row { display: flex; justify-content: space-between; gap: 16px; padding: 3px 0; }
+    .empty-state .empty-gates .gate-label { color: var(--ink-muted); }
+    .empty-state .empty-gates .gate-value { color: var(--ink); font-family: var(--font-mono); font-weight: 600; text-align: right; }
 
     /* Feature flag banner system — compact collapsed by default */
     .flag-banners {
@@ -1388,6 +1406,30 @@
       }
     }
 
+    function gateRows(rows) {
+      var html = '<div class="empty-gates">';
+      rows.forEach(function(row) {
+        html += '<div class="gate-row"><span class="gate-label">' + esc(row.label) + '</span><span class="gate-value">' + esc(row.value) + '</span></div>';
+      });
+      html += '</div>';
+      return html;
+    }
+
+    function consolidationEmptyState(kind, current, rows, actionHtml) {
+      var title = {
+        semantic: 'Semantic facts are waiting for enough summaries',
+        procedural: 'Procedures are waiting for repeated patterns',
+        lessons: 'Lessons require an explicit save',
+        crystals: 'Crystals come from crystallize actions'
+      }[kind] || 'Nothing to show yet';
+      return '<div class="empty-state" style="padding:28px 14px;">' +
+        '<div class="empty-title">' + esc(title) + '</div>' +
+        '<div class="empty-lead">Current count: ' + current + '. This is an input gate, not a broken tab.</div>' +
+        gateRows(rows) +
+        (actionHtml || '') +
+        '</div>';
+    }
+
     function renderDashboard() {
       var el = document.getElementById('view-dashboard');
       var d = state.dashboard;
@@ -1583,7 +1625,11 @@
 
       html += '<div class="card"><div class="card-title">Semantic Memory</div>';
       if (semFacts.length === 0) {
-        html += '<div style="font-size:13px;color:var(--ink-faint);font-style:italic;">No semantic facts yet. Observations will be consolidated into semantic memories over time.</div>';
+        html += consolidationEmptyState('semantic', 0, [
+          { label: 'Gate', value: '>= 5 summaries' },
+          { label: 'Current sessions', value: String((d.sessions || []).length) },
+          { label: 'Where to check', value: 'Sessions tab' }
+        ]);
       } else {
           semFacts.slice(0, 5).forEach(function(f) {
             var conf = typeof f.confidence === 'number' ? Math.round(f.confidence * 100) : null;
@@ -1601,7 +1647,12 @@
 
         html += '<div class="card"><div class="card-title">Procedural Memory</div>';
       if (procItems.length === 0) {
-        html += '<div style="font-size:13px;color:var(--ink-faint);font-style:italic;">No procedures yet. Repeated patterns will be extracted as procedures.</div>';
+        var patternCount = (d.memories || []).filter(function(m) { return m.type === 'pattern'; }).length;
+        html += consolidationEmptyState('procedural', 0, [
+          { label: 'Gate', value: '>= 2 pattern memories' },
+          { label: 'Current patterns', value: String(patternCount) },
+          { label: 'Also needs', value: 'patterns seen in 2+ sessions' }
+        ]);
       } else {
           procItems.slice(0, 5).forEach(function(p) {
             html += '<div class="procedure-item">';
@@ -3092,13 +3143,13 @@
       html += '</div>';
 
       if (items.length === 0) {
-        html += '<div class="empty-state">' +
-          '<div class="empty-icon">&#128161;</div>' +
-          '<div class="empty-title">No lessons yet</div>' +
-          '<div class="empty-lead">Lessons are confidence-scored pattern observations &mdash; things you corrected once that the agent should never do again. They persist across projects.</div>' +
+        html += consolidationEmptyState('lessons', 0, [
+          { label: 'Source', value: 'mem::lesson-save' },
+          { label: 'MCP tool', value: 'memory_lesson_save' },
+          { label: 'Automatic path', value: 'Replay JSONL import' }
+        ],
           '<pre class="empty-cmd"># Save a lesson explicitly\nmemory_lesson_save { rule, reason, confidence }\n\n# Or: Replay tab &rarr; Import JSONL auto-extracts lessons\n# from your past Claude Code sessions</pre>' +
-          '<div><a class="empty-link" href="https://github.com/rohitg00/agentmemory#lessons" target="_blank" rel="noopener">Lesson decay &amp; scoring &rarr;</a></div>' +
-          '</div>';
+          '<div><a class="empty-link" href="https://github.com/rohitg00/agentmemory#lessons" target="_blank" rel="noopener">Lesson decay &amp; scoring &rarr;</a></div>');
       } else {
         html += '<table><thead><tr><th>Lesson</th><th>Confidence</th><th>Reinforcements</th><th>Source</th><th>Project</th><th>Updated</th></tr></thead><tbody>';
         items.forEach(function(l) {
@@ -3248,13 +3299,13 @@
       html += '</div>';
 
       if (items.length === 0) {
-        html += '<div class="empty-state">' +
-          '<div class="empty-icon">&#128142;</div>' +
-          '<div class="empty-title">No crystals yet</div>' +
-          '<div class="empty-lead">Crystals are compressed action digests &mdash; the 3-line summary of what happened in a session. Generated from long conversations to give the next session fast context without re-reading everything.</div>' +
+        html += consolidationEmptyState('crystals', 0, [
+          { label: 'Source', value: 'mem::crystallize' },
+          { label: 'Auto source', value: 'mem::auto-crystallize' },
+          { label: 'Input stream', value: 'completed actions' }
+        ],
           '<pre class="empty-cmd"># Auto: import a JSONL transcript\n#   Replay tab &rarr; Import JSONL\n\n# Manual: crystallize a specific session\nmemory_crystallize { sessionId }</pre>' +
-          '<div><a class="empty-link" href="https://github.com/rohitg00/agentmemory#crystals" target="_blank" rel="noopener">Crystal pipeline &rarr;</a></div>' +
-          '</div>';
+          '<div><a class="empty-link" href="https://github.com/rohitg00/agentmemory#crystals" target="_blank" rel="noopener">Crystal pipeline &rarr;</a></div>');
       } else {
         items.forEach(function(c) {
           html += '<div class="card" style="margin-bottom:12px;border-left:3px solid var(--accent);">';

--- a/test/viewer-consolidation-empty-state.test.ts
+++ b/test/viewer-consolidation-empty-state.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { renderViewerDocument } from "../src/viewer/document.js";
+
+describe("viewer consolidation empty states", () => {
+  it("explains input gates and sources for empty consolidation tiers", () => {
+    const rendered = renderViewerDocument();
+    expect(rendered.found).toBe(true);
+    if (!rendered.found) return;
+
+    const { html } = rendered;
+
+    expect(html).toContain("Semantic facts are waiting for enough summaries");
+    expect(html).toContain(">= 5 summaries");
+    expect(html).toContain("Current sessions");
+
+    expect(html).toContain("Procedures are waiting for repeated patterns");
+    expect(html).toContain("patterns seen in 2+ sessions");
+
+    expect(html).toContain("Lessons require an explicit save");
+    expect(html).toContain("mem::lesson-save");
+
+    expect(html).toContain("Crystals come from crystallize actions");
+    expect(html).toContain("mem::auto-crystallize");
+
+    expect(html).toContain("This is an input gate, not a broken tab");
+  });
+});

--- a/test/viewer-consolidation-empty-state.test.ts
+++ b/test/viewer-consolidation-empty-state.test.ts
@@ -16,6 +16,8 @@ describe("viewer consolidation empty states", () => {
     expect(html).toContain("Procedures are waiting for repeated patterns");
     expect(html).toContain("patterns seen in 2+ sessions");
 
+    expect(html).toContain("Insights are waiting for enough signals");
+
     expect(html).toContain("Lessons require an explicit save");
     expect(html).toContain("mem::lesson-save");
 


### PR DESCRIPTION
## Summary
- show gate/source details when semantic and procedural dashboard sections are empty
- add lessons and crystals empty states that explain where those tiers come from
- add a viewer regression test for consolidation empty-state guidance

## Tests
- git diff --check
- npm test -- test/viewer-consolidation-empty-state.test.ts
- npm run build

Closes #754

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consolidated, gate-based empty-state UI across Dashboard, Lessons, and Crystals
  * Semantic Memory shows gate requirements, current sessions, and guidance
  * Procedural Memory shows pattern counts with gate requirements
  * Lessons and Crystals include structured source/origin rows and inline command examples

* **Tests**
  * Added tests verifying empty-state instructional content and gate messaging
<!-- end of auto-generated comment: release notes by coderabbit.ai -->