### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,7 +41,7 @@
 # OPENROUTER_MODEL=anthropic/claude-sonnet-4-20250514
 
 # MINIMAX_API_KEY=...
-# MINIMAX_MODEL=MiniMax-M2.7
+# MINIMAX_MODEL=MiniMax-M3
 
 # MAX_TOKENS=4096                                # Cap LLM completion tokens for compression / summarise calls
 

--- a/src/cli/onboarding.ts
+++ b/src/cli/onboarding.ts
@@ -64,7 +64,7 @@ const PROVIDERS: { value: string; label: string; envKey: string | null }[] = [
   { value: "openai", label: "OpenAI — gpt", envKey: "OPENAI_API_KEY" },
   { value: "gemini", label: "Google — gemini", envKey: "GEMINI_API_KEY" },
   { value: "openrouter", label: "OpenRouter — multi-model", envKey: "OPENROUTER_API_KEY" },
-  { value: "minimax", label: "MiniMax — minimax-m1", envKey: "MINIMAX_API_KEY" },
+  { value: "minimax", label: "MiniMax — MiniMax-M3", envKey: "MINIMAX_API_KEY" },
   { value: "skip", label: "Skip — BM25-only mode (no LLM key)", envKey: null },
 ];
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -66,7 +66,7 @@ function detectProvider(env: Record<string, string>): ProviderConfig {
   if (hasRealValue(env["MINIMAX_API_KEY"])) {
     return {
       provider: "minimax",
-      model: env["MINIMAX_MODEL"] || "MiniMax-M2.7",
+      model: env["MINIMAX_MODEL"] || "MiniMax-M3",
       maxTokens,
     };
   }

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -45,7 +45,7 @@ function defaultModelFor(providerType: ProviderConfig["provider"]): string {
         getEnvVar("OPENROUTER_MODEL") || "anthropic/claude-sonnet-4-20250514"
       );
     case "minimax":
-      return getEnvVar("MINIMAX_MODEL") || "MiniMax-M2.7";
+      return getEnvVar("MINIMAX_MODEL") || "MiniMax-M3";
     case "agent-sdk":
       return "claude-sonnet-4-20250514";
     case "noop":

--- a/src/providers/minimax.ts
+++ b/src/providers/minimax.ts
@@ -10,8 +10,8 @@ import { fetchWithTimeout } from './_fetch.js'
  *
  * Required env vars (loaded from ~/.agentmemory/.env or process.env):
  *   MINIMAX_API_KEY  — your MiniMax API key
- *   MINIMAX_MODEL    — model name (default: MiniMax-M2.7)
- *   MAX_TOKENS       — max output tokens (default: 800; MiniMax-M2.7 needs ≤800)
+ *   MINIMAX_MODEL    — model name (default: MiniMax-M3; MiniMax-M2.7 / MiniMax-M2.7-highspeed also supported)
+ *   MAX_TOKENS       — max output tokens (default: 800; MiniMax-M2.7 needs ≤800, MiniMax-M3 supports up to 128K)
  *
  * Optional:
  *   MINIMAX_BASE_URL — base URL without path (default: https://api.minimax.io/anthropic)

--- a/test/fallback-model-resolution.test.ts
+++ b/test/fallback-model-resolution.test.ts
@@ -155,7 +155,7 @@ describe("Fallback provider model resolution (#778)", () => {
     const openai = captured.find((c) => c.provider === "openai");
     const minimax = captured.find((c) => c.provider === "minimax");
     expect(openai?.model).toBe("gpt-5");
-    expect(minimax?.model).toBe("MiniMax-M2.7");
+    expect(minimax?.model).toBe("MiniMax-M3");
     // Neither inherits the Anthropic model name.
     expect(openai?.model).not.toBe("claude-sonnet-4-20250514");
     expect(minimax?.model).not.toBe("claude-sonnet-4-20250514");

--- a/test/fetch-timeout.test.ts
+++ b/test/fetch-timeout.test.ts
@@ -91,7 +91,7 @@ describe("Provider hang regression — MinimaxProvider", () => {
   });
 
   it("compress() aborts after timeout when upstream hangs", async () => {
-    const provider = new MinimaxProvider("test-key", "MiniMax-M2.7", 800);
+    const provider = new MinimaxProvider("test-key", "MiniMax-M3", 800);
     await expect(provider.compress("system", "user")).rejects.toThrow();
   });
 });

--- a/test/minimax-provider.test.ts
+++ b/test/minimax-provider.test.ts
@@ -14,7 +14,7 @@ describe("MinimaxProvider — base URL resolution (#285)", () => {
 
   it("defaults to https://api.minimax.io/anthropic (not the legacy minimaxi.com host)", () => {
     delete process.env["MINIMAX_BASE_URL"];
-    const provider = new MinimaxProvider("test-key", "MiniMax-M2.7", 800);
+    const provider = new MinimaxProvider("test-key", "MiniMax-M3", 800);
     expect((provider as unknown as { baseUrl: string }).baseUrl).toBe(
       "https://api.minimax.io/anthropic",
     );
@@ -22,7 +22,7 @@ describe("MinimaxProvider — base URL resolution (#285)", () => {
 
   it("honors MINIMAX_BASE_URL via getEnvVar (merged ~/.agentmemory/.env + process.env)", () => {
     process.env["MINIMAX_BASE_URL"] = "https://custom.example.com/anthropic";
-    const provider = new MinimaxProvider("test-key", "MiniMax-M2.7", 800);
+    const provider = new MinimaxProvider("test-key", "MiniMax-M3", 800);
     expect((provider as unknown as { baseUrl: string }).baseUrl).toBe(
       "https://custom.example.com/anthropic",
     );


### PR DESCRIPTION
## Summary

Upgrade the default MiniMax model from `MiniMax-M2.7` to `MiniMax-M3` so agentmemory benefits from the latest MiniMax release out of the box. `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` remain fully supported via `MINIMAX_MODEL`.

`MiniMax-M3` features:
- 512K context window
- Up to 128K max output tokens
- Image input support (Anthropic-compatible side as well)

## Changes

- `src/config.ts` — default model fallback in `detectProvider()` is now `MiniMax-M3`
- `src/providers/index.ts` — `defaultModelFor("minimax")` returns `MiniMax-M3`
- `src/providers/minimax.ts` — docstring updated; explicit mention that M2.7 / M2.7-highspeed remain supported alternatives
- `src/cli/onboarding.ts` — provider picker label updated to `MiniMax — MiniMax-M3`
- `.env.example` — sample `MINIMAX_MODEL` value bumped to `MiniMax-M3`
- `test/minimax-provider.test.ts`, `test/fetch-timeout.test.ts`, `test/fallback-model-resolution.test.ts` — model strings updated and assertion for minimax default model bumped to `MiniMax-M3`

## Backwards compatibility

- Existing users who explicitly set `MINIMAX_MODEL=MiniMax-M2.7` (or `MiniMax-M2.7-highspeed`) are unaffected — only the default changes.
- No env vars, function signatures, or public APIs are modified.

## Testing

```
npm test -- --run test/minimax-provider.test.ts test/fetch-timeout.test.ts test/fallback-model-resolution.test.ts
# Test Files  3 passed (3)
#      Tests  26 passed (26)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default MiniMax LLM model from M2.7 to M3 across configuration and provider defaults.

* **Documentation**
  * Enhanced MiniMax provider documentation with updated model version details.

* **Tests**
  * Updated test cases to reflect new default model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->