### PR TITLE
fix(codex): declare agentmemory MCP server as stdio

### DIFF
--- a/src/cli/connect/codex.ts
+++ b/src/cli/connect/codex.ts
@@ -22,6 +22,7 @@ const CODEX_TOML = join(CODEX_DIR, "config.toml");
 const CODEX_HOOKS = join(CODEX_DIR, "hooks.json");
 
 const TOML_BLOCK = `[mcp_servers.agentmemory]
+type = "stdio"
 command = "npx"
 args = ["-y", "@agentmemory/mcp"]
 

--- a/test/codex-connect.test.ts
+++ b/test/codex-connect.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import type { ConnectAdapter } from "../src/cli/connect/types.js";
+
+describe("agentmemory connect — codex adapter (mock filesystem)", () => {
+  let tmpHome: string;
+  let originalHome: string | undefined;
+  let originalUserprofile: string | undefined;
+  let importCounter = 0;
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), "am-connect-codex-"));
+    originalHome = process.env["HOME"];
+    originalUserprofile = process.env["USERPROFILE"];
+    process.env["HOME"] = tmpHome;
+    process.env["USERPROFILE"] = tmpHome;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (originalHome !== undefined) process.env["HOME"] = originalHome;
+    else delete process.env["HOME"];
+    if (originalUserprofile !== undefined)
+      process.env["USERPROFILE"] = originalUserprofile;
+    else delete process.env["USERPROFILE"];
+    rmSync(tmpHome, { recursive: true, force: true });
+    vi.resetModules();
+  });
+
+  async function loadAdapter(): Promise<ConnectAdapter> {
+    const mod = await import(
+      "../src/cli/connect/codex.js?t=" + Date.now() + "-" + importCounter++
+    );
+    return (mod as { adapter: ConnectAdapter }).adapter;
+  }
+
+  it("detect() returns false when ~/.codex doesn't exist", async () => {
+    const a = await loadAdapter();
+    expect(a.detect()).toBe(false);
+  });
+
+  it("install() writes a stdio MCP server block for Codex", async () => {
+    const codexDir = join(tmpHome, ".codex");
+    require("node:fs").mkdirSync(codexDir, { recursive: true });
+    writeFileSync(join(codexDir, "config.toml"), "");
+
+    const a = await loadAdapter();
+    expect(a.detect()).toBe(true);
+
+    const result = await a.install({ dryRun: false, force: false });
+    expect(result.kind).toBe("installed");
+
+    const config = readFileSync(join(codexDir, "config.toml"), "utf-8");
+    expect(config).toContain("[mcp_servers.agentmemory]");
+    expect(config).toContain('type = "stdio"');
+    expect(config).toContain('command = "npx"');
+    expect(config).toContain('args = ["-y", "@agentmemory/mcp"]');
+    expect(config).toContain("[mcp_servers.agentmemory.env]");
+    expect(config).toContain('AGENTMEMORY_URL = "http://localhost:3111"');
+  });
+
+  it("install() creates a backup when rewriting an existing Codex config", async () => {
+    const codexDir = join(tmpHome, ".codex");
+    require("node:fs").mkdirSync(codexDir, { recursive: true });
+    writeFileSync(join(codexDir, "config.toml"), "[projects.\"/tmp\"]\ntrust_level = \"trusted\"\n");
+
+    const a = await loadAdapter();
+    const result = await a.install({ dryRun: false, force: false });
+    expect(result.kind).toBe("installed");
+    if (result.kind === "installed") {
+      expect(result.backupPath).toBeDefined();
+      expect(existsSync(result.backupPath!)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add `type = "stdio"` to the Codex MCP block written by `agentmemory connect codex`
- add a focused Codex adapter regression test to lock the generated block shape

## Why
In my local Codex Desktop setup, the `agentmemory` server entry was written without an explicit transport type. Other Codex MCP entries in `config.toml` use `type = "stdio"`, and adding it locally brought the config back into the expected shape for stdio-launched MCP servers.

## Validation
- reproduced that `memory_save` and `memory_lesson_save` work when the standalone MCP process is launched directly
- verified the generated fork diff only changes `src/cli/connect/codex.ts` and adds a Codex adapter test
- updated my local `~/.codex/config.toml` to include `type = "stdio"` for `mcp_servers.agentmemory` as a runtime workaround

I was not able to run the full upstream test suite in this environment because getting a clean local checkout of the full repo stalled repeatedly, so this PR focuses on the minimal config change plus regression coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Codex adapter configuration for Agentmemory MCP server setup with proper stdio server type specification.

* **Tests**
  * Added test suite for Codex adapter, verifying environment detection, configuration installation, and backup creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->