### PR TITLE
Fix OpenAI embedding provider key selection

### DIFF
--- a/src/providers/embedding/index.ts
+++ b/src/providers/embedding/index.ts
@@ -35,7 +35,11 @@ export function createEmbeddingProvider(): EmbeddingProvider | null {
     case "gemini":
       return withDimensionGuard(new GeminiEmbeddingProvider(getEnvVar("GEMINI_API_KEY")!));
     case "openai":
-      return withDimensionGuard(new OpenAIEmbeddingProvider(getEnvVar("OPENAI_API_KEY")!));
+      return withDimensionGuard(
+        new OpenAIEmbeddingProvider(
+          getEnvVar("OPENAI_EMBEDDING_API_KEY") || getEnvVar("OPENAI_API_KEY")!,
+        ),
+      );
     case "voyage":
       return withDimensionGuard(new VoyageEmbeddingProvider(getEnvVar("VOYAGE_API_KEY")!));
     case "cohere":

--- a/test/embedding-provider.test.ts
+++ b/test/embedding-provider.test.ts
@@ -43,6 +43,16 @@ describe("createEmbeddingProvider", () => {
     expect(provider!.name).toBe("openai");
   });
 
+  it("prefers OPENAI_EMBEDDING_API_KEY over OPENAI_API_KEY for openai embeddings", () => {
+    process.env["OPENAI_API_KEY"] = "llm-key-123";
+    process.env["OPENAI_EMBEDDING_API_KEY"] = "embedding-key-456";
+    const provider = createEmbeddingProvider() as OpenAIEmbeddingProvider & {
+      apiKey: string;
+    };
+    expect(provider).toBeInstanceOf(OpenAIEmbeddingProvider);
+    expect(provider.apiKey).toBe("embedding-key-456");
+  });
+
   it("EMBEDDING_PROVIDER override takes precedence", () => {
     process.env["GEMINI_API_KEY"] = "test-key-123";
     process.env["OPENAI_API_KEY"] = "test-key-456";


### PR DESCRIPTION
## Summary
- prefer `OPENAI_EMBEDDING_API_KEY` when creating the OpenAI-compatible embedding provider
- keep `OPENAI_API_KEY` as the fallback for existing setups
- add a regression test covering split LLM key and embedding key setups

## Why
When `agentmemory` is configured with different OpenAI-compatible providers for chat and embeddings, `createEmbeddingProvider()` was still passing `OPENAI_API_KEY` into `OpenAIEmbeddingProvider`. In practice this breaks setups like `LLM=DeepSeek` and `embeddings=DashScope`, because the DeepSeek key gets sent to the embedding endpoint.

## Verification
- `env -i HOME=/tmp/agentmemory-test-home PATH="$PATH" TERM="$TERM" npm test -- --run test/embedding-provider.test.ts`
- `env -i HOME=/tmp/agentmemory-test-home PATH="$PATH" TERM="$TERM" npm run build`
- local runtime verification against a real split-provider setup: `LLM=DeepSeek`, `embeddings=DashScope text-embedding-v4`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for dedicated OpenAI embedding API key configuration, taking precedence over the general OpenAI API key when both are set.

* **Tests**
  * Added test coverage for embedding provider API key precedence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->