### PR TITLE
fix(mcp): forward smart_search expandIds to the proxy as an array

### DIFF
--- a/src/mcp/standalone.ts
+++ b/src/mcp/standalone.ts
@@ -103,6 +103,7 @@ interface Validated {
   limit?: number;
   format?: string;
   tokenBudget?: number;
+  expandIds?: string[];
   memoryIds?: string[];
   reason?: string;
 }
@@ -142,6 +143,15 @@ function validate(toolName: string, args: Record<string, unknown>): Validated {
       } else if (typeof budget === "string" && budget.trim()) {
         const n = Number(budget);
         if (Number.isFinite(n) && n > 0) v.tokenBudget = Math.floor(n);
+      }
+      // expandIds is smart-search-only progressive disclosure. The tool
+      // schema declares it as a comma-separated string; normalizeList also
+      // accepts a raw array so direct sdk.trigger callers work too. Gate on
+      // the tool name so memory_recall (which shares this branch) never
+      // forwards it.
+      if (toolName === "memory_smart_search") {
+        const expandIds = normalizeList(args["expandIds"]);
+        if (expandIds.length > 0) v.expandIds = expandIds;
       }
       return v;
     }
@@ -201,6 +211,10 @@ async function handleProxy(
       const body: Record<string, unknown> = { query: v.query, limit: v.limit };
       if (v.format != null) body["format"] = v.format;
       if (v.tokenBudget != null) body["token_budget"] = v.tokenBudget;
+      // Send expandIds as an ARRAY: the daemon's /agentmemory/smart-search
+      // schema is `expandIds: z.array(z.string())`. A comma-joined string
+      // fails Zod validation and surfaces as HTTP 500 (issue #440).
+      if (v.expandIds != null) body["expandIds"] = v.expandIds;
       const result = await handle.call("/agentmemory/smart-search", {
         method: "POST",
         body: JSON.stringify(body),

--- a/test/mcp-standalone-proxy.test.ts
+++ b/test/mcp-standalone-proxy.test.ts
@@ -129,6 +129,20 @@ describe("@agentmemory/mcp standalone — server proxy (issue #159)", () => {
     expect(searchBody).not.toHaveProperty("expandIds");
   });
 
+  it("never forwards expandIds on memory_recall even when supplied (#440)", async () => {
+    let recallBody: Record<string, unknown> | undefined;
+    installFetch((url, init) => {
+      if (url.endsWith("/agentmemory/livez")) return new Response("ok", { status: 200 });
+      if (url.endsWith("/agentmemory/search")) {
+        recallBody = init?.body ? JSON.parse(init.body as string) : undefined;
+        return new Response(JSON.stringify({ mode: "full", facts: [] }), { status: 200 });
+      }
+      return new Response("", { status: 404 });
+    });
+    await handleToolCall("memory_recall", { query: "x", expandIds: "obs_1, obs_2" });
+    expect(recallBody).not.toHaveProperty("expandIds");
+  });
+
   it("proxies memory_recall to POST /agentmemory/search and forwards format/token_budget (#507)", async () => {
     const calls: Array<{ url: string; body?: unknown }> = [];
     installFetch((url, init) => {

--- a/test/mcp-standalone-proxy.test.ts
+++ b/test/mcp-standalone-proxy.test.ts
@@ -75,6 +75,60 @@ describe("@agentmemory/mcp standalone — server proxy (issue #159)", () => {
     expect(body.results[0].id).toBe("m1");
   });
 
+  it("forwards expandIds to /agentmemory/smart-search as an ARRAY when given a comma string (#440)", async () => {
+    let searchBody: Record<string, unknown> | undefined;
+    installFetch((url, init) => {
+      if (url.endsWith("/agentmemory/livez")) return new Response("ok", { status: 200 });
+      if (url.endsWith("/agentmemory/smart-search")) {
+        searchBody = init?.body ? JSON.parse(init.body as string) : undefined;
+        return new Response(JSON.stringify({ mode: "expanded", results: [] }), { status: 200 });
+      }
+      return new Response("", { status: 404 });
+    });
+    await handleToolCall("memory_smart_search", {
+      query: "auth bug",
+      limit: 3,
+      expandIds: "obs_1, obs_2",
+    });
+    // The daemon schema is z.array(z.string()); a comma-joined STRING 500s (#440).
+    expect(searchBody).toEqual({
+      query: "auth bug",
+      limit: 3,
+      expandIds: ["obs_1", "obs_2"],
+    });
+  });
+
+  it("forwards expandIds unchanged when given an array (#440)", async () => {
+    let searchBody: Record<string, unknown> | undefined;
+    installFetch((url, init) => {
+      if (url.endsWith("/agentmemory/livez")) return new Response("ok", { status: 200 });
+      if (url.endsWith("/agentmemory/smart-search")) {
+        searchBody = init?.body ? JSON.parse(init.body as string) : undefined;
+        return new Response(JSON.stringify({ mode: "expanded", results: [] }), { status: 200 });
+      }
+      return new Response("", { status: 404 });
+    });
+    await handleToolCall("memory_smart_search", {
+      query: "auth bug",
+      expandIds: ["obs_1", "obs_2"],
+    });
+    expect(searchBody?.["expandIds"]).toEqual(["obs_1", "obs_2"]);
+  });
+
+  it("omits expandIds from the smart-search body when not provided", async () => {
+    let searchBody: Record<string, unknown> | undefined;
+    installFetch((url, init) => {
+      if (url.endsWith("/agentmemory/livez")) return new Response("ok", { status: 200 });
+      if (url.endsWith("/agentmemory/smart-search")) {
+        searchBody = init?.body ? JSON.parse(init.body as string) : undefined;
+        return new Response(JSON.stringify({ mode: "compact", results: [] }), { status: 200 });
+      }
+      return new Response("", { status: 404 });
+    });
+    await handleToolCall("memory_smart_search", { query: "x" });
+    expect(searchBody).not.toHaveProperty("expandIds");
+  });
+
   it("proxies memory_recall to POST /agentmemory/search and forwards format/token_budget (#507)", async () => {
     const calls: Array<{ url: string; body?: unknown }> = [];
     installFetch((url, init) => {


### PR DESCRIPTION
The standalone MCP shim accepted `memory_smart_search`'s `expandIds` argument but never forwarded it to the server: `validate()` dropped it and `handleProxy()` omitted it from the POST body, so a caller asking to expand observation IDs silently received an unexpanded compact search.

This forwards `expandIds` to `POST /agentmemory/smart-search` as an **array**. The daemon schema is `expandIds: z.array(z.string())`, so a comma-joined string fails Zod validation and surfaces as HTTP 500. `normalizeList()` already accepts both the tool schema's comma-separated string and a raw array, so `sdk.trigger` and MCP-host callers both work. `memory_recall` shares the validator branch and is gated out by the tool-name check.

### Tests
Three cases in `test/mcp-standalone-proxy.test.ts` assert the wire body is `{ query, limit, expandIds: ["a","b"] }` for a comma string, an array passthrough, and omission.

Closes #440.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smart search now supports an optional `expandIds` input (either a comma-separated string or an array). When provided, it’s normalized and forwarded with smart-search requests, and is omitted when not set.
  * `expandIds` is not forwarded for recall requests.

* **Tests**
  * Added coverage to verify request serialization/forwarding behavior for `expandIds` in proxy mode for smart-search and recall.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->