### PR TITLE
feat(mcp): add AGENTMEMORY_DISABLE_LOCAL_FALLBACK to fail loud on outage

### DIFF
--- a/src/mcp/rest-proxy.ts
+++ b/src/mcp/rest-proxy.ts
@@ -15,6 +15,18 @@ function forceProxy(): boolean {
   return raw === "1" || raw === "true";
 }
 
+/**
+ * When AGENTMEMORY_DISABLE_LOCAL_FALLBACK is set, the shim throws instead of
+ * silently switching to the local InMemoryKV / ~/.agentmemory/standalone.json
+ * store on a server outage. Clients that treat a remote agentmemory server as
+ * the single source of truth use this so an outage surfaces as an error rather
+ * than being masked by a divergent local store.
+ */
+export function disableLocalFallback(): boolean {
+  const raw = process.env["AGENTMEMORY_DISABLE_LOCAL_FALLBACK"];
+  return raw === "1" || raw === "true";
+}
+
 export interface ProxyHandle {
   mode: "proxy";
   baseUrl: string;
@@ -158,6 +170,11 @@ export async function resolveHandle(): Promise<Handle> {
       cached = handle;
       cachedAt = Date.now();
       return handle;
+    }
+    if (disableLocalFallback()) {
+      throw new Error(
+        `agentmemory server unavailable at ${url}; local fallback disabled by AGENTMEMORY_DISABLE_LOCAL_FALLBACK`,
+      );
     }
     const local: LocalHandle = { mode: "local" };
     cached = local;

--- a/src/mcp/rest-proxy.ts
+++ b/src/mcp/rest-proxy.ts
@@ -103,17 +103,23 @@ export function setLivezProbe(fn?: LivezProbe): void {
 
 async function probe(url: string): Promise<boolean> {
   const timeout = probeTimeoutMs();
+  // When local fallback is disabled a failed probe surfaces as a thrown error,
+  // not a silent switch to InMemoryKV, so the message must not promise a
+  // fallback that will never happen.
+  const onProbeFail = disableLocalFallback()
+    ? "local fallback disabled (request will fail)"
+    : "falling back to local InMemoryKV";
   try {
     const res = await livezProbe(url, timeout, authHeader());
     if (!res.ok) {
       process.stderr.write(
-        `[@agentmemory/mcp] livez probe ${url}/agentmemory/livez -> ${res.status ?? "?"} ${res.statusText ?? ""}; falling back to local InMemoryKV (set AGENTMEMORY_FORCE_PROXY=1 to skip the probe)\n`,
+        `[@agentmemory/mcp] livez probe ${url}/agentmemory/livez -> ${res.status ?? "?"} ${res.statusText ?? ""}; ${onProbeFail} (set AGENTMEMORY_FORCE_PROXY=1 to skip the probe)\n`,
       );
     }
     return res.ok;
   } catch (err) {
     process.stderr.write(
-      `[@agentmemory/mcp] livez probe ${url}/agentmemory/livez failed in ${timeout}ms: ${err instanceof Error ? err.message : String(err)}; falling back to local InMemoryKV (set AGENTMEMORY_FORCE_PROXY=1 to skip the probe, or raise AGENTMEMORY_PROBE_TIMEOUT_MS)\n`,
+      `[@agentmemory/mcp] livez probe ${url}/agentmemory/livez failed in ${timeout}ms: ${err instanceof Error ? err.message : String(err)}; ${onProbeFail} (set AGENTMEMORY_FORCE_PROXY=1 to skip the probe, or raise AGENTMEMORY_PROBE_TIMEOUT_MS)\n`,
     );
     return false;
   }

--- a/src/mcp/standalone.ts
+++ b/src/mcp/standalone.ts
@@ -9,6 +9,7 @@ import { generateId } from "../state/schema.js";
 import {
   resolveHandle,
   invalidateHandle,
+  disableLocalFallback,
   type Handle,
   type ProxyHandle,
 } from "./rest-proxy.js";
@@ -386,10 +387,18 @@ export async function handleToolCall(
       return await handleProxy(validated, handle);
     } catch (err) {
       process.stderr.write(
-        `[@agentmemory/mcp] proxy call failed for ${toolName}: ${err instanceof Error ? err.message : String(err)}; invalidating handle and falling back to local KV\n`,
+        `[@agentmemory/mcp] proxy call failed for ${toolName}: ${err instanceof Error ? err.message : String(err)}; invalidating handle\n`,
       );
       invalidateHandle();
+      // With local fallback disabled, surface the proxy error instead of
+      // silently serving a divergent local result.
+      if (disableLocalFallback()) throw err;
     }
+  }
+  if (disableLocalFallback()) {
+    throw new Error(
+      `agentmemory local fallback disabled by AGENTMEMORY_DISABLE_LOCAL_FALLBACK; refusing local handling for ${toolName}`,
+    );
   }
   return handleLocal(validated, kvInstance);
 }
@@ -426,15 +435,26 @@ export async function handleToolsList(): Promise<{ tools: unknown[] }> {
         }
         return { tools: remote.tools };
       }
+      if (disableLocalFallback()) {
+        throw new Error(
+          "agentmemory tools/list returned unexpected remote shape and local fallback is disabled",
+        );
+      }
       process.stderr.write(
         `[@agentmemory/mcp] tools/list: server returned unexpected shape (no .tools array); falling back to local IMPLEMENTED_TOOLS list. Set AGENTMEMORY_DEBUG=1 to inspect response.\n`,
       );
     } catch (err) {
       process.stderr.write(
-        `[@agentmemory/mcp] tools/list proxy failed: ${err instanceof Error ? err.message : String(err)}; falling back to local list\n`,
+        `[@agentmemory/mcp] tools/list proxy failed: ${err instanceof Error ? err.message : String(err)}\n`,
       );
       invalidateHandle();
+      if (disableLocalFallback()) throw err;
     }
+  }
+  if (disableLocalFallback()) {
+    throw new Error(
+      "agentmemory tools/list local fallback disabled by AGENTMEMORY_DISABLE_LOCAL_FALLBACK",
+    );
   }
   const fallback = getAllTools().filter((t) => IMPLEMENTED_TOOLS.has(t.name));
   if (debug) {

--- a/test/mcp-standalone-proxy.test.ts
+++ b/test/mcp-standalone-proxy.test.ts
@@ -383,4 +383,70 @@ describe("@agentmemory/mcp standalone — server proxy (issue #159)", () => {
       delete process.env["AGENTMEMORY_PROBE_TIMEOUT_MS"];
     }
   });
+
+  it("AGENTMEMORY_DISABLE_LOCAL_FALLBACK=1 throws on proxy-call failure instead of writing locally", async () => {
+    process.env["AGENTMEMORY_DISABLE_LOCAL_FALLBACK"] = "1";
+    installFetch((url) => {
+      if (url.endsWith("/agentmemory/livez")) return new Response("ok", { status: 200 });
+      // The actual tool call fails after a healthy probe.
+      return new Response("boom", { status: 500, statusText: "Internal Server Error" });
+    });
+    const localKv = new InMemoryKV(undefined);
+    try {
+      await expect(
+        handleToolCall("memory_save", { content: "must not be stored locally" }, localKv),
+      ).rejects.toThrow();
+      // The error must NOT have been masked by a silent local write.
+      expect(await localKv.list("mem:memories")).toHaveLength(0);
+    } finally {
+      delete process.env["AGENTMEMORY_DISABLE_LOCAL_FALLBACK"];
+    }
+  });
+
+  it("AGENTMEMORY_DISABLE_LOCAL_FALLBACK=1 throws when the server is unreachable (probe path)", async () => {
+    process.env["AGENTMEMORY_DISABLE_LOCAL_FALLBACK"] = "1";
+    installFetch(() => {
+      throw new Error("ECONNREFUSED");
+    });
+    const localKv = new InMemoryKV(undefined);
+    try {
+      await expect(
+        handleToolCall("memory_save", { content: "x" }, localKv),
+      ).rejects.toThrow(/AGENTMEMORY_DISABLE_LOCAL_FALLBACK/);
+      expect(await localKv.list("mem:memories")).toHaveLength(0);
+    } finally {
+      delete process.env["AGENTMEMORY_DISABLE_LOCAL_FALLBACK"];
+    }
+  });
+
+  it("still falls back to local KV when AGENTMEMORY_DISABLE_LOCAL_FALLBACK is unset (no regression)", async () => {
+    delete process.env["AGENTMEMORY_DISABLE_LOCAL_FALLBACK"];
+    installFetch(() => {
+      throw new Error("ECONNREFUSED");
+    });
+    const localKv = new InMemoryKV(undefined);
+    await handleToolCall("memory_save", { content: "local ok" }, localKv);
+    const recall = await handleToolCall("memory_recall", { query: "local" }, localKv);
+    const out = JSON.parse(recall.content[0].text);
+    expect(out.results).toHaveLength(1);
+    expect(out.results[0].content).toBe("local ok");
+  });
+
+  it("tools/list throws on unexpected remote shape when fallback is disabled", async () => {
+    process.env["AGENTMEMORY_DISABLE_LOCAL_FALLBACK"] = "1";
+    process.env["AGENTMEMORY_FORCE_PROXY"] = "1";
+    const { handleToolsList } = await import("../src/mcp/standalone.js");
+    installFetch((url) => {
+      if (url.endsWith("/agentmemory/mcp/tools")) {
+        return new Response(JSON.stringify({ notTools: true }), { status: 200 });
+      }
+      return new Response("ok", { status: 200 });
+    });
+    try {
+      await expect(handleToolsList()).rejects.toThrow(/unexpected remote shape/);
+    } finally {
+      delete process.env["AGENTMEMORY_DISABLE_LOCAL_FALLBACK"];
+      delete process.env["AGENTMEMORY_FORCE_PROXY"];
+    }
+  });
 });


### PR DESCRIPTION
By default the standalone shim silently switches to the local InMemoryKV / `~/.agentmemory/standalone.json` store when the configured server is unreachable or a proxy call fails. For deployments that treat a remote agentmemory server as the single source of truth, that masks an outage and lets writes diverge into a local store the operator never sees.

This adds an opt-in `AGENTMEMORY_DISABLE_LOCAL_FALLBACK` flag (off by default — existing behaviour is unchanged). When set, every silent-fallback path throws instead:
- probe-failure handle resolution (`resolveHandle`)
- the proxy-call-failure catch in `handleToolCall`
- the `tools/list` unexpected-shape and proxy-failure paths

`AGENTMEMORY_FORCE_PROXY` only skips the startup probe; a mid-session proxy failure still fell back. This closes that gap for callers that opt in.

### Tests
Four cases in `test/mcp-standalone-proxy.test.ts`: proxy-failure throw (asserting no local write), the probe-failure throw, `tools/list` throw on unexpected remote shape, and a regression guard that the unset flag still falls back.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an environment option to disable automatic local fallback when the remote agent memory server is unavailable.

* **Behavior Changes / Bug Fixes**
  * When local fallback is disabled, previously silent fallbacks now return errors instead of using local storage; tool-call and tool-list fallback behavior is refused.
  * Health/probe failure messaging now reflects whether local fallback is enabled.

* **Tests**
  * Added coverage for the new configuration, including unreachable server behavior, rejecting proxied tool-call failures, and handling unexpected remote tool-list responses (including forced-proxy scenarios).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->