### PR TITLE
fix(smart-search): findObservation returns empty for bare expand obsIds

### DIFF
--- a/src/functions/smart-search.ts
+++ b/src/functions/smart-search.ts
@@ -5,8 +5,10 @@ import type {
   CompressedObservation,
   HybridSearchResult,
   Lesson,
+  Memory,
 } from "../types.js";
 import { KV } from "../state/schema.js";
+import { memoryToObservation } from "../state/memory-utils.js";
 import { StateKV } from "../state/kv.js";
 import { withKeyedLock } from "../state/keyed-mutex.js";
 import { recordAccessBatch } from "./access-tracker.js";
@@ -371,6 +373,12 @@ async function findObservation(
     if (obs) return obs;
   }
 
+  // Saved memories (mem::remember) live in KV.memories under a synthetic
+  // session, not KV.observations(*); resolve them before the scan so a bare
+  // obsId for a saved memory resolves and skips the O(sessions) scan.
+  const mem = (await kv.get<Memory>(KV.memories, obsId).catch(() => null)) ?? null;
+  if (mem) return memoryToObservation(mem);
+
   const sessions = await kv.list<{ id: string }>(KV.sessions);
   for (let i = 0; i < sessions.length; i += 5) {
     const batch = sessions.slice(i, i + 5);
@@ -379,7 +387,7 @@ async function findObservation(
         kv.get<CompressedObservation>(KV.observations(s.id), obsId).catch(() => null),
       ),
     );
-    const found = results.find((r) => r !== null);
+    const found = results.find((r) => r != null);
     if (found) return found;
   }
   return null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import {
 } from "./providers/index.js";
 import { StateKV } from "./state/kv.js";
 import { KV } from "./state/schema.js";
+import { memoryToObservation } from "./state/memory-utils.js";
 import { VectorIndex } from "./state/vector-index.js";
 import { HybridSearch } from "./state/hybrid-search.js";
 import { IndexPersistence } from "./state/index-persistence.js";
@@ -482,18 +483,7 @@ async function main() {
         if (memory.isLatest === false) continue;
         if (!memory.title || !memory.content) continue;
         if (bm25Index.has(memory.id)) continue;
-        bm25Index.add({
-          id: memory.id,
-          sessionId: memory.sessionIds?.[0] ?? "memory",
-          timestamp: memory.createdAt,
-          type: "decision",
-          title: memory.title,
-          facts: [memory.content],
-          narrative: memory.content,
-          concepts: memory.concepts,
-          files: memory.files,
-          importance: memory.strength,
-        });
+        bm25Index.add(memoryToObservation(memory));
         backfilled++;
       }
       if (backfilled > 0) {

--- a/src/state/memory-utils.ts
+++ b/src/state/memory-utils.ts
@@ -20,5 +20,8 @@ export function memoryToObservation(memory: Memory): CompressedObservation {
     concepts: memory.concepts,
     files: memory.files,
     importance: memory.strength,
+    ...(memory.agentId ? { agentId: memory.agentId } : {}),
+    ...(memory.imageRef ? { imageRef: memory.imageRef } : {}),
+    ...(memory.imageData ? { imageData: memory.imageData } : {}),
   };
 }

--- a/test/findobservation-undefined-miss.test.ts
+++ b/test/findobservation-undefined-miss.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../src/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { registerSmartSearchFunction } from "../src/functions/smart-search.js";
+import type { CompressedObservation, Memory, Session } from "../src/types.js";
+
+function mockSdk() {
+  const fns = new Map<string, (p: unknown) => Promise<unknown>>();
+  return {
+    registerFunction: (
+      idOrOpts: string | { id: string },
+      handler: (p: unknown) => Promise<unknown>,
+    ) => {
+      fns.set(typeof idOrOpts === "string" ? idOrOpts : idOrOpts.id, handler);
+    },
+    registerTrigger: () => {},
+    trigger: async (
+      idOrInput: string | { function_id: string; payload: unknown },
+      data?: unknown,
+    ) => {
+      const id = typeof idOrInput === "string" ? idOrInput : idOrInput.function_id;
+      const payload = typeof idOrInput === "string" ? data : idOrInput.payload;
+      const fn = fns.get(id);
+      if (!fn) throw new Error("No function: " + id);
+      return fn(payload);
+    },
+  };
+}
+
+// KV mock whose get() returns the RAW Map value -- `undefined` on a miss, NOT
+// `?? null`. This mirrors the engine (state::get) and is what exposes the bug;
+// mocks that coalesce misses to null hide it.
+function rawMissKV() {
+  const store = new Map<string, Map<string, unknown>>();
+  return {
+    get: async <T>(scope: string, key: string): Promise<T | null> =>
+      store.get(scope)?.get(key) as T,
+    set: async <T>(scope: string, key: string, data: T): Promise<T> => {
+      if (!store.has(scope)) store.set(scope, new Map());
+      store.get(scope)!.set(key, data);
+      return data;
+    },
+    delete: async (scope: string, key: string): Promise<void> => {
+      store.get(scope)?.delete(key);
+    },
+    list: async <T>(scope: string): Promise<T[]> => {
+      const entries = store.get(scope);
+      return entries ? (Array.from(entries.values()) as T[]) : [];
+    },
+  };
+}
+
+function makeObs(over: Partial<CompressedObservation>): CompressedObservation {
+  return {
+    id: "obs_x", sessionId: "ses_real", timestamp: "2026-02-01T00:00:00Z",
+    type: "command_run", title: "real observation", facts: ["f"], narrative: "n",
+    concepts: [], files: [], importance: 5, ...over,
+  };
+}
+
+describe("findObservation undefined-on-miss regression", () => {
+  it("bare obsId resolves when a partial/id-less session precedes the real one in the same batch", async () => {
+    const sdk = mockSdk();
+    const kv = rawMissKV();
+    // Partial (id-less) record first, real session second -- both in the first
+    // 5-item scan batch. The partial yields kv.get("mem:obs:undefined", id) ===
+    // undefined; `.find(r => r !== null)` selects that undefined and stops.
+    await kv.set("mem:sessions", "partial", { status: "completed" } as never);
+    const realSession: Session = {
+      id: "ses_real", project: "p", cwd: "/tmp",
+      startedAt: "2026-02-01T00:00:00Z", status: "active", observationCount: 1,
+    };
+    await kv.set("mem:sessions", "ses_real", realSession);
+    await kv.set("mem:obs:ses_real", "obs_x", makeObs({ id: "obs_x", sessionId: "ses_real" }));
+    registerSmartSearchFunction(sdk as never, kv as never, async () => []);
+    const result = (await sdk.trigger("mem::smart-search", {
+      expandIds: ["obs_x"],
+    })) as { mode: string; results: Array<{ observation: CompressedObservation }> };
+    expect(result.mode).toBe("expanded");
+    expect(result.results.length).toBe(1); // fails against `!== null`
+    expect(result.results[0].observation.id).toBe("obs_x");
+  });
+
+  it("bare obsId for a saved memory resolves via KV.memories with agentId preserved", async () => {
+    const sdk = mockSdk();
+    const kv = rawMissKV();
+    const memory: Memory = {
+      id: "mem_x", createdAt: "2026-02-01T00:00:00Z", updatedAt: "2026-02-01T00:00:00Z",
+      type: "architecture", title: "saved memory", content: "body", concepts: ["c"],
+      files: [], sessionIds: ["memory"], strength: 7, version: 1, isLatest: true,
+      agentId: "agent-a",
+    };
+    await kv.set("mem:memories", "mem_x", memory);
+    registerSmartSearchFunction(sdk as never, kv as never, async () => []);
+    const result = (await sdk.trigger("mem::smart-search", {
+      expandIds: ["mem_x"],
+    })) as { mode: string; results: Array<{ observation: CompressedObservation }> };
+    expect(result.mode).toBe("expanded");
+    expect(result.results.length).toBe(1);
+    expect(result.results[0].observation.title).toBe("saved memory");
+    expect(result.results[0].observation.agentId).toBe("agent-a");
+  });
+});


### PR DESCRIPTION
## Problem
`memory_smart_search` with `expandIds` returns an empty `results` array for a
bare obsId, even when the observation exists and a session-hinted lookup
resolves it.

## Root cause
`findObservation` scans sessions in batches and selects the hit with
`.find((r) => r !== null)`. But `StateKV.get` returns the raw `state::get`
value, which is `undefined` for a missing key (not `null`); the surrounding
`.catch(() => null)` only normalizes rejections. Most sessions don't hold a
given obsId (and some session records are partial, without an `id`), so each
batch contains `undefined` before the real observation. Since
`undefined !== null` is `true`, `.find` returns the first `undefined`, and
`if (found)` discards it as falsy — so the real observation later in the batch
is never returned. The hint path and the hybrid-search enrich path are
unaffected because they use a truthy `if (obs)` check.

Separately, `findObservation` only consults `KV.observations(sessionId)` and
never `KV.memories`, so observations saved via `mem::remember` (stored in
`KV.memories` under a synthetic session) cannot be resolved by a bare obsId.

## Fix
- Use `.find((r) => r != null)` so `undefined` misses are skipped.
- Resolve saved memories from `KV.memories` (via `memoryToObservation`) before
  the session scan. Preserve `agentId`/`imageRef`/`imageData` in
  `memoryToObservation` so agent-scope filtering stays correct, and route the
  existing BM25 backfill through `memoryToObservation` for consistency.
- Add a regression test whose KV mock returns `undefined` on a miss (mocks that
  coalesce misses to `null` mask the bug), with a partial session ordered
  before the real one in the same scan batch.

Complements #837, which forwards `expandIds` from the MCP proxy to the daemon.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Smart search can now resolve observations backed by saved memories.
  * Improves reliability when cache misses return undefined during session scanning.

* **Improvements**
  * Observation expansion preserves additional memory metadata (such as agent ID and image-related fields) more consistently.

* **Tests**
  * Added regression coverage for undefined-on-miss behavior and memory-based observation resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->