### PR TITLE
feat(deploy): add systemd service template

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -17,6 +17,15 @@ exec'ing the agentmemory CLI.
 | [Railway](./railway/README.md) | Push from GitHub, volume in the dashboard. Easiest managed dashboard flow. | $5/month (Hobby plan flat fee) |
 | [Render](./render/README.md) | Blueprint-driven; persistent disk attaches automatically. Most "set it and forget it." | $7.25/month (Starter web + 1 GB disk) |
 | [Coolify](./coolify/README.md) | Self-hosted on your own VPS. Same Docker Compose stack, you own the host and the data. | VPS cost only (Hetzner CX22 ~€3.79/month) |
+| [systemd](./systemd/README.md) | Bare Linux host, no Docker required. A `systemd` unit supervises a global `npm` install and survives crashes + reboots. | Host cost only (runs on a box you already own) |
+
+The first four templates are Docker-based and share the guarantees below.
+**[systemd](./systemd/README.md)** is the exception: it supervises a
+global `npm install -g @agentmemory/agentmemory` directly on a Linux host
+with no container, so it follows host conventions instead (state under
+`/var/lib/agentmemory`, an operator-set `AGENTMEMORY_SECRET`, loopback
+viewer). Reach for it when you want agentmemory running on a box you
+already own without adding a Docker layer.
 
 ## What every template guarantees
 
@@ -49,8 +58,11 @@ exec'ing the agentmemory CLI.
 - Pick **Coolify** if you already run a VPS and want a self-hosted
   control plane — same Docker Compose stack, no third-party host has
   your memories.
+- Pick **systemd** if you want agentmemory on a Linux box you own with no
+  Docker at all — a global `npm` install supervised by the init system,
+  auto-restarting on crashes and reboots.
 
-All four give you the same agentmemory API at the same port (3111)
+All of them give you the same agentmemory API at the same port (3111)
 with the same auth model. Migrating between them later is a `tar` of
 `/data` and a re-import — see each platform's README for the exact
 commands.

--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -1,0 +1,225 @@
+# Run agentmemory as a systemd service
+
+Supervise agentmemory on a Linux box you own — a home server, a bare VPS,
+or a workstation — without Docker `restart:` policies or a managed host.
+This template ships a single `agentmemory.service` unit that runs the
+agentmemory server under systemd, restarts it on failure, and brings it
+back automatically after a reboot.
+
+It fills a real gap: every other template under `deploy/` leans on Docker
+or a platform supervisor to keep the process alive. On a plain Linux host
+with a global `npm install -g @agentmemory/agentmemory`, nothing keeps the
+server running across crashes and reboots. This unit does.
+
+## What you get
+
+- A boot-persistent **system service** running the bare `agentmemory`
+  CLI as a dedicated unprivileged `agentmemory` user (mirrors the
+  `gosu node:node` drop-privilege pattern the Docker templates use).
+- **Automatic restart** on failure (`Restart=always`) and on reboot
+  (`WantedBy=multi-user.target`) — the systemd equivalent of the compose
+  templates' `restart: unless-stopped`.
+- A **FHS-correct state directory** at `/var/lib/agentmemory`, created and
+  owned by systemd via `StateDirectory=`. Because the CLI's data dir is
+  hardcoded to `$HOME/.agentmemory`, the unit points `HOME` at the state
+  directory, so memories, the BM25 index, and snapshots land under
+  `/var/lib/agentmemory/.agentmemory`. The self-managed iii engine writes
+  its KV and stream stores to `/var/lib/agentmemory/data`.
+- Engine teardown on stop via `ExecStop=agentmemory stop`, which shuts
+  down the iii engine this unit started (including a docker-compose
+  engine); systemd then SIGTERMs the worker.
+- The same health endpoint as every other template:
+  `/agentmemory/livez`.
+
+## One-time setup
+
+```bash
+# 1. Install the CLI globally so `agentmemory` is on PATH.
+sudo npm install -g @agentmemory/agentmemory
+
+# 2. Create the dedicated service user (home = the state dir).
+sudo useradd --system --create-home --home-dir /var/lib/agentmemory \
+  --shell /usr/sbin/nologin agentmemory
+
+# 3. Install the unit and start it.
+sudo install -m 644 agentmemory.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now agentmemory
+```
+
+If `which agentmemory` reports a path outside `/usr/local/bin` (nvm,
+Volta, asdf, or a custom npm `--prefix`), edit the `Environment=PATH=`
+line in the unit to include that directory before reloading.
+
+Operator configuration goes in an optional environment file at
+`/etc/agentmemory/agentmemory.env` (one `KEY=value` per line, no
+`export`). The CLI reads these the same way it reads
+`~/.agentmemory/.env`:
+
+```ini
+# /etc/agentmemory/agentmemory.env
+AGENTMEMORY_SECRET=<64 hex chars — see "Set the auth secret" below>
+# Optional LLM / embedding provider keys (search works without them):
+# ANTHROPIC_API_KEY=sk-ant-...
+# OPENAI_API_KEY=sk-...
+# Override the pinned iii engine version only after migrating models:
+# AGENTMEMORY_III_VERSION=0.11.2
+```
+
+```bash
+sudo install -d -m 755 /etc/agentmemory
+sudo install -m 600 -o root -g agentmemory /dev/null /etc/agentmemory/agentmemory.env
+# then edit the file with your secret and any keys
+sudo systemctl restart agentmemory
+```
+
+### Variants
+
+**Variant A — self-managed engine (default).** The unit as shipped runs
+`agentmemory`, which starts and supervises its own iii engine (a local
+`iii` binary if present, otherwise Docker Compose). Nothing else to do.
+
+**Variant B — engine in Docker, worker under systemd.** If you already
+run the iii engine via the bundled `docker-compose.yml`
+(`restart: unless-stopped`), have this unit manage only the worker and
+connect to the running engine:
+
+```ini
+# in agentmemory.service
+ExecStart=/usr/bin/env agentmemory --no-engine
+```
+
+Then uncomment the `After=docker.service` / `Wants=docker.service` lines
+so the worker waits for Docker at boot, and add the service user to the
+`docker` group (`sudo usermod -aG docker agentmemory`). `--no-engine`
+skips spawning a second engine; the worker registers against the
+existing one (default `ws://localhost:49134`) and serves the REST API on
+`:3111`.
+
+**Variant C — per-user service (no root).** To run it under your own
+login instead of a system user, drop the file into
+`~/.config/systemd/user/agentmemory.service` and remove the `User=`,
+`Group=`, `StateDirectory=`, `WorkingDirectory=`, and
+`Environment=HOME=` lines — a user unit already runs as you, with your
+real `$HOME`, so the CLI's default `~/.agentmemory` data dir is exactly
+what you want. Then:
+
+```bash
+systemctl --user enable --now agentmemory
+sudo loginctl enable-linger "$USER"   # keep it running with no session
+```
+
+## Set the auth secret
+
+`AGENTMEMORY_SECRET` is the bearer token that authenticates REST API and
+viewer requests. Unlike the Docker `deploy/` templates — where the
+container entrypoint generates it on first boot and prints it to the logs
+— the bare CLI does **not** generate a secret. You set one yourself.
+
+It is optional for a pure-localhost personal install (the server starts
+without it), but **required** if you authenticate API calls or expose the
+viewer on a non-loopback address. Generate one and put it in the
+environment file:
+
+```bash
+openssl rand -hex 32
+# paste the value as AGENTMEMORY_SECRET=... in
+# /etc/agentmemory/agentmemory.env, then:
+sudo systemctl restart agentmemory
+```
+
+Copy the same value into your client environment (Claude Desktop config,
+the `AGENTMEMORY_SECRET` env of your MCP block). Treat the file as a
+secret: `chmod 600`, owner-readable by the service user only.
+
+## Verify the deployment
+
+```bash
+curl -s http://localhost:3111/agentmemory/livez   # {"status":"ok"}
+systemctl status agentmemory                       # active (running)
+journalctl -u agentmemory -f                        # follow the logs
+```
+
+For a richer health + memory-count summary, run the CLI as the service
+user with the same `HOME` the unit uses:
+
+```bash
+sudo -u agentmemory env HOME=/var/lib/agentmemory agentmemory status
+```
+
+For an authenticated call, send `Authorization: Bearer <secret>`.
+
+## Viewer access (port 3113 stays internal)
+
+The viewer binds to loopback by default, so it never belongs on a public
+interface. On the host itself, browse `http://localhost:3113` directly.
+From another machine, tunnel over SSH rather than exposing the port:
+
+```bash
+ssh -L 3113:127.0.0.1:3113 <user>@<host>
+# then open http://localhost:3113 on your laptop
+```
+
+If you deliberately bind the viewer to a non-loopback address with
+`AGENTMEMORY_VIEWER_HOST`, the server refuses to start unless
+`AGENTMEMORY_SECRET` is also set, so the viewer API can validate inbound
+bearer tokens.
+
+## Rotate the auth secret
+
+```bash
+openssl rand -hex 32
+# replace AGENTMEMORY_SECRET=... in /etc/agentmemory/agentmemory.env
+sudo systemctl restart agentmemory
+# update the same value in every client that talks to this server
+```
+
+## Back up `/var/lib/agentmemory`
+
+All durable state lives under the `StateDirectory`:
+`./.agentmemory` (memories, BM25 index, snapshots) and `./data` (the
+engine's KV and stream stores). Snapshot the whole directory with your
+existing host tooling (Restic, Borg, `rsync`, BTRFS/ZFS snapshots). A
+consistent copy is safest with the service stopped:
+
+```bash
+sudo systemctl stop agentmemory
+sudo tar czf agentmemory-backup-$(date +%F).tar.gz -C /var/lib agentmemory
+sudo systemctl start agentmemory
+```
+
+Restore by extracting back into `/var/lib` (preserving ownership) before
+starting the service.
+
+## Resources
+
+Self-hosted, so the only cost is the host you already run. The worker is
+a Node process and the self-managed iii engine adds a second process; a
+small always-on VM (1 vCPU, 1 GB RAM) is a comfortable starting point for
+a personal install. `StateDirectory` storage grows with your memory
+corpus. Measure your own footprint with `systemctl status agentmemory`
+(shows current memory) and `du -sh /var/lib/agentmemory` before sizing a
+constrained host.
+
+## Known caveats
+
+- **`ExecStop` uses the `stop` subcommand.** If your installed CLI
+  predates `agentmemory stop`, drop the `ExecStop=` line and let systemd
+  send `SIGTERM` to the control group on shutdown.
+- **`AGENTMEMORY_DATA_DIR` is not a CLI setting.** The data dir is
+  hardcoded to `$HOME/.agentmemory`; this unit controls it by setting
+  `HOME=/var/lib/agentmemory`. Don't expect an `AGENTMEMORY_DATA_DIR`
+  env var to move it.
+- **Hardening is tuned for Variant A.** The unit sets `NoNewPrivileges`,
+  `PrivateTmp`, `ProtectSystem=full`, `ProtectControlGroups`, and
+  `RestrictSUIDSGID`. These are safe for the self-managed-engine path. If
+  you run the engine via Docker (Variant B) and hit permission errors
+  talking to the Docker socket, relax `NoNewPrivileges` and confirm the
+  service user is in the `docker` group.
+- **PATH is environment-specific.** Node version managers install the
+  global bin outside `/usr/local/bin`; update the `Environment=PATH=`
+  line to match `which agentmemory`.
+- **The iii engine version is pinned** (currently v0.11.2) in the
+  self-managed path, same as the Docker templates. Override with
+  `AGENTMEMORY_III_VERSION=` in the environment file only after migrating
+  to a newer engine model.

--- a/deploy/systemd/agentmemory.service
+++ b/deploy/systemd/agentmemory.service
@@ -1,0 +1,85 @@
+# agentmemory — systemd system service
+#
+# Runs the agentmemory server (REST API on :3111, viewer on :3113,
+# streams on :3112) as a supervised, boot-persistent system service.
+#
+# This unit supervises the top-level `agentmemory` process. In the
+# default configuration that process also starts and supervises its own
+# iii engine (a local `iii` binary if installed, otherwise Docker
+# Compose). If you run the iii engine separately — e.g. via the bundled
+# docker-compose.yml with `restart: unless-stopped` — append
+# `--no-engine` to ExecStart so this unit only manages the worker and
+# connects to the already-running engine (see deploy/systemd/README.md,
+# "Variant B").
+#
+# Install:
+#   sudo useradd --system --create-home --home-dir /var/lib/agentmemory \
+#     --shell /usr/sbin/nologin agentmemory
+#   sudo install -m 644 agentmemory.service /etc/systemd/system/
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable --now agentmemory
+# Verify:
+#   curl -s http://localhost:3111/agentmemory/livez   # {"status":"ok"}
+#   systemctl status agentmemory
+
+[Unit]
+Description=agentmemory — persistent memory for AI coding agents
+Documentation=https://github.com/rohitg00/agentmemory
+# network-online so the worker can reach the engine / pull provider APIs.
+After=network-online.target
+Wants=network-online.target
+# If you run the engine via Docker (Variant B), also gate on Docker so
+# the worker doesn't spin on a missing engine at boot. Harmless if
+# docker.service is absent; uncomment to enable.
+#After=docker.service
+#Wants=docker.service
+
+[Service]
+Type=simple
+User=agentmemory
+Group=agentmemory
+
+# Operator config: AGENTMEMORY_SECRET (recommended — see README), plus
+# any provider keys, AGENTMEMORY_URL, AGENTMEMORY_III_VERSION, etc.
+# The leading "-" makes the file optional.
+EnvironmentFile=-/etc/agentmemory/agentmemory.env
+
+# Resolve the globally-installed `agentmemory` from a standard npm prefix.
+# Adjust PATH if `which agentmemory` reports a different location
+# (e.g. nvm, Volta, or a custom --prefix).
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+
+# FHS-correct state location. systemd creates /var/lib/agentmemory and
+# chowns it to User=/Group=. The CLI's data dir is hardcoded to
+# `$HOME/.agentmemory`, so pointing HOME at the StateDirectory lands all
+# durable state (memories, BM25 index, snapshots) under
+# /var/lib/agentmemory/.agentmemory. The self-managed iii engine writes
+# its KV + stream stores to ./data relative to WorkingDirectory, i.e.
+# /var/lib/agentmemory/data.
+StateDirectory=agentmemory
+WorkingDirectory=/var/lib/agentmemory
+Environment=HOME=/var/lib/agentmemory
+
+ExecStart=/usr/bin/env agentmemory
+# `agentmemory stop` tears down the iii engine this unit started
+# (including a docker-compose engine, via `docker compose down`); systemd
+# then SIGTERMs the worker. Harmless no-op in Variant B (--no-engine).
+ExecStop=/usr/bin/env agentmemory stop
+
+Restart=always
+RestartSec=5
+# Cold start = engine boot (~3s) + worker registration (~2s) with margin.
+TimeoutStartSec=90
+
+# Conservative hardening, tuned for the default (self-managed engine)
+# mode. If you run the engine via Docker (Variant B), the service user
+# must be in the `docker` group and you may need to relax
+# NoNewPrivileges depending on your Docker setup — see the README.
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## What

Adds a `deploy/systemd/` template so agentmemory can run as a supervised, boot-persistent service on a bare Linux host — no Docker `restart:` policy, no managed platform.

- `deploy/systemd/agentmemory.service` — a hardened **system** unit that runs the CLI as a dedicated unprivileged `agentmemory` user, with `Restart=always` and `WantedBy=multi-user.target`.
- `deploy/systemd/README.md` — one-time setup, three engine topologies, secret handling, verification, viewer SSH tunneling, and backups.
- `deploy/README.md` — a new index row plus a short note distinguishing this non-Docker option from the container-based templates.

## Why

Every existing template under `deploy/` (Fly, Railway, Render, Coolify) relies on a container supervisor to keep the process alive. On a plain Linux host with a global `npm install -g @agentmemory/agentmemory`, nothing restarts the server after a crash or reboot. This fills that gap for people self-hosting on a box they already own.

## Design notes

- **State is FHS-correct** under `/var/lib/agentmemory` via `StateDirectory=`. Because the CLI's data dir resolves from `$HOME/.agentmemory` (`src/config.ts`) and the self-managed engine writes `./data` relative to `WorkingDirectory` (`iii-config.yaml`), the unit sets `HOME` and `WorkingDirectory` accordingly so everything lands under the state dir.
- **Secret handling differs from the Docker templates on purpose.** The container `entrypoint.sh` generates `AGENTMEMORY_SECRET` on first boot; the bare CLI only *consumes* it. The README has the operator generate one (`openssl rand -hex 32`) and place it in `/etc/agentmemory/agentmemory.env`.
- **Three topologies** are documented: (A) self-managed engine, (B) Docker engine + `agentmemory --no-engine` worker, (C) rootless per-user unit with linger.

## How to verify

```bash
npm install && npm run build && npm test   # build clean, 1400 tests pass

# on a Linux host:
sudo npm install -g @agentmemory/agentmemory
sudo useradd --system --create-home --home-dir /var/lib/agentmemory \
  --shell /usr/sbin/nologin agentmemory
sudo install -m 644 deploy/systemd/agentmemory.service /etc/systemd/system/
sudo systemctl daemon-reload && sudo systemctl enable --now agentmemory
curl -s http://localhost:3111/agentmemory/livez   # {"status":"ok"}
```

Docs-and-template only — no source files changed. `CHANGELOG.md` intentionally left untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added systemd as a one-click deployment option for Linux hosts without Docker.
  * New deployment guide covers installation, setup variants, configuration, and service management.

* **Chores**
  * Included systemd service unit file for boot-persistent deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->