### PR TITLE
feat(mcp): expose memory_forget tool so observations and sessions can actually be deleted

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,7 @@ Hook scripts in `src/hooks/` are standalone Node.js scripts (no iii-sdk import).
 
 ## Current Stats (v0.9.16)
 
-- 53 MCP tools (8 visible by default, `AGENTMEMORY_TOOLS=all` for all)
+- 54 MCP tools (8 visible by default, `AGENTMEMORY_TOOLS=all` for all)
 - 128 REST endpoints
 - 6 MCP resources, 3 MCP prompts
 - 12 hooks, 4 skills

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@
 <p align="center">
   <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-recall.svg"><img src="assets/tags/stat-recall.svg" alt="95.2% retrieval R@5" height="38" /></picture>
   <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-tokens.svg"><img src="assets/tags/stat-tokens.svg" alt="92% fewer tokens" height="38" /></picture>
-  <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-tools.svg"><img src="assets/tags/stat-tools.svg" alt="53 MCP tools" height="38" /></picture>
+  <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-tools.svg"><img src="assets/tags/stat-tools.svg" alt="54 MCP tools" height="38" /></picture>
   <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-hooks.svg"><img src="assets/tags/stat-hooks.svg" alt="12 auto hooks" height="38" /></picture>
   <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-deps.svg"><img src="assets/tags/stat-deps.svg" alt="0 external DBs" height="38" /></picture>
   <picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/stat-tests.svg"><img src="assets/tags/stat-tests.svg" alt="1,390+ tests passing" height="38" /></picture>
@@ -444,7 +444,7 @@ Implementation details live in `src/cli.ts` (see `runUpgrade` around the `src/cl
 ### Claude Code (one block, paste it)
 
 ```text
-Install agentmemory: run `npx @agentmemory/agentmemory` in a separate terminal to start the memory server. Then run `/plugin marketplace add rohitg00/agentmemory` and `/plugin install agentmemory` — the plugin registers all 12 hooks, 8 skills, AND auto-wires the `@agentmemory/mcp` stdio server via its `.mcp.json`, so you get 53 MCP tools (memory_smart_search, memory_save, memory_sessions, memory_governance_delete, etc.) without any extra config step. Verify with `curl http://localhost:3111/agentmemory/health`. The real-time viewer is at http://localhost:3113.
+Install agentmemory: run `npx @agentmemory/agentmemory` in a separate terminal to start the memory server. Then run `/plugin marketplace add rohitg00/agentmemory` and `/plugin install agentmemory` — the plugin registers all 12 hooks, 8 skills, AND auto-wires the `@agentmemory/mcp` stdio server via its `.mcp.json`, so you get 54 MCP tools (memory_smart_search, memory_save, memory_sessions, memory_governance_delete, etc.) without any extra config step. Verify with `curl http://localhost:3111/agentmemory/health`. The real-time viewer is at http://localhost:3113.
 ```
 
 #### Claude Code without the plugin install (MCP-standalone path)
@@ -473,7 +473,7 @@ codex plugin add agentmemory@agentmemory
 
 The Codex plugin ships from the same `plugin/` directory as the Claude Code plugin. It registers:
 
-- `@agentmemory/mcp` as an MCP server (proxies all 53 tools when `AGENTMEMORY_URL` points at a running agentmemory server; falls back to 7 tools locally when no server is reachable)
+- `@agentmemory/mcp` as an MCP server (proxies all 54 tools when `AGENTMEMORY_URL` points at a running agentmemory server; falls back to 7 tools locally when no server is reachable)
 - 6 lifecycle hooks: `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `PreCompact`, `Stop`
 - 8 skills: `/recall`, `/remember`, `/session-history`, `/forget`, `/recap`, `/handoff`, `/commit-context`, `/commit-history`
 
@@ -507,7 +507,7 @@ copilot plugin install rohitg00/agentmemory:plugin
 <summary><b>OpenClaw (paste this prompt)</b></summary>
 
 ```text
-Install agentmemory for OpenClaw. Run `npx @agentmemory/agentmemory` in a separate terminal to start the memory server on localhost:3111. Then add this to my OpenClaw MCP config so agentmemory is available with all 53 memory tools:
+Install agentmemory for OpenClaw. Run `npx @agentmemory/agentmemory` in a separate terminal to start the memory server on localhost:3111. Then add this to my OpenClaw MCP config so agentmemory is available with all 54 memory tools:
 
 {
   "mcpServers": {
@@ -532,7 +532,7 @@ Full guide: [`integrations/openclaw/`](integrations/openclaw/)
 <summary><b>Hermes Agent (paste this prompt)</b></summary>
 
 ```text
-Install agentmemory for Hermes. Run `npx @agentmemory/agentmemory` in a separate terminal to start the memory server on localhost:3111. Then add this to ~/.hermes/config.yaml so Hermes can use agentmemory as an MCP server with all 53 memory tools:
+Install agentmemory for Hermes. Run `npx @agentmemory/agentmemory` in a separate terminal to start the memory server on localhost:3111. Then add this to ~/.hermes/config.yaml so Hermes can use agentmemory as an MCP server with all 54 memory tools:
 
 mcp_servers:
   agentmemory:
@@ -889,9 +889,9 @@ npm install @xenova/transformers
 
 <h2 id="mcp-server"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/section-mcp.svg"><img src="assets/tags/section-mcp.svg" alt="MCP Server" height="32" /></picture></h2>
 
-53 tools, 6 resources, 3 prompts, and 8 skills — the most comprehensive MCP memory toolkit for any agent.
+54 tools, 6 resources, 3 prompts, and 8 skills — the most comprehensive MCP memory toolkit for any agent.
 
-> **MCP shim vs full server:** the published `@agentmemory/mcp` package is a thin shim. It exposes the full 53-tool surface **only when it can reach a running agentmemory server** via `AGENTMEMORY_URL` (proxy mode). With no server reachable, the shim falls back to a 7-tool local set (`memory_save`, `memory_recall`, `memory_smart_search`, `memory_sessions`, `memory_export`, `memory_audit`, `memory_governance_delete`). The `AGENTMEMORY_TOOLS=core|all` env var is a *server-side* flag — setting it in the shim's `env` block has no effect. If you see only 7 tools in Cursor / OpenCode / Gemini CLI, start `npx @agentmemory/agentmemory` (or the Docker stack) and set `AGENTMEMORY_URL=http://localhost:3111`.
+> **MCP shim vs full server:** the published `@agentmemory/mcp` package is a thin shim. It exposes the full 54-tool surface **only when it can reach a running agentmemory server** via `AGENTMEMORY_URL` (proxy mode). With no server reachable, the shim falls back to a 7-tool local set (`memory_save`, `memory_recall`, `memory_smart_search`, `memory_sessions`, `memory_export`, `memory_audit`, `memory_governance_delete`). The `AGENTMEMORY_TOOLS=core|all` env var is a *server-side* flag — setting it in the shim's `env` block has no effect. If you see only 7 tools in Cursor / OpenCode / Gemini CLI, start `npx @agentmemory/agentmemory` (or the Docker stack) and set `AGENTMEMORY_URL=http://localhost:3111`.
 
 ### 53 Tools
 
@@ -1423,7 +1423,7 @@ Create `~/.agentmemory/.env`:
 # USER_ID=
 # TEAM_MODE=private
 
-# Tool visibility: "core" (8 tools, lean fallback) or "all" (53 tools)
+# Tool visibility: "core" (8 tools, lean fallback) or "all" (54 tools)
 # AGENTMEMORY_TOOLS=core
 ```
 

--- a/assets/tags/light/stat-tools.svg
+++ b/assets/tags/light/stat-tools.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 48" fill="none" role="img" aria-label="MCP TOOLS: 53">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 48" fill="none" role="img" aria-label="MCP TOOLS: 54">
   <rect x="0" y="0" width="140" height="48" rx="10" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1"/>
-  <text x="70" y="24" fill="#EA580C" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="18" font-weight="900" text-anchor="middle" letter-spacing="-0.3">53</text>
+  <text x="70" y="24" fill="#EA580C" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="18" font-weight="900" text-anchor="middle" letter-spacing="-0.3">54</text>
   <text x="70" y="38" fill="#64748B" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="9" font-weight="600" text-anchor="middle" letter-spacing="1.5">MCP TOOLS</text>
 </svg>

--- a/assets/tags/stat-tools.svg
+++ b/assets/tags/stat-tools.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 48" fill="none" role="img" aria-label="MCP TOOLS: 53">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 48" fill="none" role="img" aria-label="MCP TOOLS: 54">
   <rect x="0" y="0" width="140" height="48" rx="10" fill="#1A1A1A" stroke="#2A2A2A" stroke-width="1"/>
-  <text x="70" y="24" fill="#FF6B35" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="18" font-weight="900" text-anchor="middle" letter-spacing="-0.3">53</text>
+  <text x="70" y="24" fill="#FF6B35" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="18" font-weight="900" text-anchor="middle" letter-spacing="-0.3">54</text>
   <text x="70" y="38" fill="#9CA3AF" font-family='ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif' font-size="9" font-weight="600" text-anchor="middle" letter-spacing="1.5">MCP TOOLS</text>
 </svg>

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agentmemory",
   "version": "0.9.27",
-  "description": "Persistent memory for AI coding agents -- captures tool usage, compresses via LLM, injects context into future sessions. 12 hooks, 53 MCP tools, 8 skills, real-time viewer.",
+  "description": "Persistent memory for AI coding agents -- captures tool usage, compresses via LLM, injects context into future sessions. 12 hooks, 54 MCP tools, 8 skills, real-time viewer.",
   "author": {
     "name": "Rohit Ghumare",
     "url": "https://github.com/rohitg00"

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agentmemory",
   "version": "0.9.27",
-  "description": "Persistent memory for AI coding agents -- captures tool usage, compresses via LLM, injects context into future sessions. 6 hooks, 53 MCP tools, 8 skills, real-time viewer.",
+  "description": "Persistent memory for AI coding agents -- captures tool usage, compresses via LLM, injects context into future sessions. 6 hooks, 54 MCP tools, 8 skills, real-time viewer.",
   "author": {
     "name": "Rohit Ghumare",
     "url": "https://github.com/rohitg00"

--- a/plugin/opencode/README.md
+++ b/plugin/opencode/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/MCP-53_tools-1f6feb?style=flat-square" alt="53 MCP tools" />
+  <img src="https://img.shields.io/badge/MCP-54_tools-1f6feb?style=flat-square" alt="54 MCP tools" />
   <img src="https://img.shields.io/badge/Plugin-22_hooks-1f6feb?style=flat-square" alt="22 hooks" />
   <img src="https://img.shields.io/badge/Commands-2_slash-1f6feb?style=flat-square" alt="2 slash commands" />
   <img src="https://img.shields.io/badge/R@5-95.2%25-00875f?style=flat-square" alt="95.2% R@5" />

--- a/plugin/opencode/agentmemory-capture.ts
+++ b/plugin/opencode/agentmemory-capture.ts
@@ -129,8 +129,11 @@ memory_lesson_save — Save a lesson learned (what worked, what to avoid).
 memory_lesson_recall — Search lessons by query. Returns lessons sorted by confidence.
   Use when: before making a decision, check if past lessons apply.
 
-memory_governance_delete — Delete specific memories. Requires explicit user confirmation.
-  Use when: user says "forget this", "delete that memory".
+memory_governance_delete — Delete specific saved memories (mem_* IDs). Requires explicit user confirmation.
+  Use when: user says "forget this", "delete that memory" about saved memories.
+
+memory_forget — Delete observations (obs_* IDs), an entire session, or a single memory. Requires explicit user confirmation.
+  Use when: user wants to remove session observations or a whole session; governance_delete cannot delete those.
 
 memory_patterns — Detect recurring patterns across sessions.
   Use when: you want to understand project-level trends over time.

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agentmemory",
   "version": "0.9.27",
-  "description": "Persistent memory for AI coding agents -- captures tool usage, compresses via LLM, injects context into future sessions. 12 hooks, 53 MCP tools, 8 skills, real-time viewer.",
+  "description": "Persistent memory for AI coding agents -- captures tool usage, compresses via LLM, injects context into future sessions. 12 hooks, 54 MCP tools, 8 skills, real-time viewer.",
   "author": {
     "name": "Rohit Ghumare",
     "url": "https://github.com/rohitg00"

--- a/plugin/skills/forget/SKILL.md
+++ b/plugin/skills/forget/SKILL.md
@@ -11,14 +11,18 @@ The user wants to remove data from agentmemory: $ARGUMENTS
 
 Steps:
 
-1. First search for matching observations with the `memory_smart_search` MCP tool (provided by the agentmemory server this plugin wires up via `.mcp.json`). Use the user's input as the `query` with `limit: 20`.
+1. First search for matching data with the `memory_smart_search` MCP tool (provided by the agentmemory server this plugin wires up via `.mcp.json`). Use the user's input as the `query` with `limit: 20`.
 2. Show the user what was found — session IDs, observation IDs, titles — and ask for explicit confirmation before deleting.
-3. Once confirmed, call `memory_governance_delete` with:
-   - `memoryIds: [<id>, ...]` — an array (or comma-separated string) of the memory IDs returned by the search in step 1
-   - `reason: "<short reason>"` — optional, defaults to `"plugin skill request"`
+3. Once confirmed, pick the tool that matches what is being deleted:
+   - **Observations or sessions** (`obs_*` IDs, `ses_*` IDs) → call `memory_forget` with:
+     - `sessionId: "<ses_*>"` — the session the observations belong to
+     - `observationIds: "<obs_1>,<obs_2>"` — optional; omit it to delete ALL of the session's observations plus the session record and its summary
+   - **Saved memories** (`mem_*` IDs) → call `memory_governance_delete` with:
+     - `memoryIds: [<id>, ...]` — an array (or comma-separated string) of memory IDs
+     - `reason: "<short reason>"` — optional, defaults to `"plugin skill request"`
 
-   If the user wants to drop an entire session's observations, collect every memory ID in that session from the search results and pass them all via `memoryIds`. The standalone MCP doesn't accept a bare `sessionId` argument — it deletes by memory ID only.
-4. Confirm the deletion count back to the user.
+   Do NOT pass observation IDs to `memory_governance_delete` — it only targets the saved-memories store and will report them back in `notFound` without deleting anything.
+4. Confirm the deletion count back to the user from the tool result (`deleted`, `observationsDeleted`, `sessionDeleted`, or `notFound`). If `notFound` is non-empty or `success` is `false`, tell the user which IDs were not deleted instead of reporting success.
 
 **Never delete without explicit user confirmation.** If the MCP tools aren't available, the stdio MCP shim didn't start — tell the user to:
 1. Run `/plugin list` in Claude Code and confirm `agentmemory` shows as enabled.

--- a/src/functions/governance.ts
+++ b/src/functions/governance.ts
@@ -19,6 +19,7 @@ export function registerGovernanceFunction(sdk: ISdk, kv: StateKV): void {
       }
 
       let deleted = 0;
+      const notFound: string[] = [];
       for (const id of data.memoryIds) {
         const mem = await kv.get<Memory>(KV.memories, id);
         if (mem) {
@@ -27,6 +28,8 @@ export function registerGovernanceFunction(sdk: ISdk, kv: StateKV): void {
           getSearchIndex().remove(id);
           vectorIndexRemove(id);
           deleted++;
+        } else {
+          notFound.push(id);
         }
       }
 
@@ -40,14 +43,24 @@ export function registerGovernanceFunction(sdk: ISdk, kv: StateKV): void {
         {
           reason: data.reason || "manual deletion",
           deleted,
+          ...(notFound.length > 0 ? { notFound } : {}),
         },
       );
 
       logger.info("Governance delete", {
         requested: data.memoryIds.length,
         deleted,
+        notFound: notFound.length,
       });
-      return { success: true, deleted, total: data.memoryIds.length };
+      // success only when every requested ID was actually removed —
+      // a no-op delete reporting success hid real data-retention bugs
+      // (observation IDs passed here never match the memories store).
+      return {
+        success: notFound.length === 0,
+        deleted,
+        total: data.memoryIds.length,
+        ...(notFound.length > 0 ? { notFound } : {}),
+      };
     },
   );
 

--- a/src/functions/remember.ts
+++ b/src/functions/remember.ts
@@ -258,7 +258,13 @@ export function registerRememberFunction(sdk: ISdk, kv: StateKV): void {
       }
 
       logger.info("Memory forgotten", { deleted });
-      return { success: true, deleted };
+      return {
+        success: true,
+        deleted,
+        memoriesDeleted: deletedMemoryIds.length,
+        observationsDeleted: deletedObservationIds.length,
+        sessionDeleted: deletedSession,
+      };
     },
   );
 }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -620,6 +620,47 @@ export function registerMcpEndpoints(
             }
           }
 
+          case "memory_forget": {
+            const sessionId = asNonEmptyString(args.sessionId);
+            const memoryId = asNonEmptyString(args.memoryId);
+            const observationIds = parseCsvList(args.observationIds);
+            if (observationIds.length > 0 && !sessionId) {
+              return {
+                status_code: 400,
+                body: { error: "observationIds requires sessionId" },
+              };
+            }
+            if (!sessionId && !memoryId) {
+              return {
+                status_code: 400,
+                body: { error: "sessionId or memoryId is required" },
+              };
+            }
+            try {
+              const result = await sdk.trigger({ function_id: "mem::forget", payload: {
+                ...(sessionId ? { sessionId } : {}),
+                ...(observationIds.length > 0 ? { observationIds } : {}),
+                ...(memoryId ? { memoryId } : {}),
+              } });
+              return {
+                status_code: 200,
+                body: {
+                  content: [
+                    { type: "text", text: JSON.stringify(result, null, 2) },
+                  ],
+                },
+              };
+            } catch {
+              return {
+                status_code: 200,
+                body: {
+                  content: [{ type: "text", text: "Forget failed" }],
+                  isError: true,
+                },
+              };
+            }
+          }
+
           case "memory_snapshot_create": {
             try {
               const result = await sdk.trigger({ function_id: "mem::snapshot-create", payload: {

--- a/src/mcp/tools-registry.ts
+++ b/src/mcp/tools-registry.ts
@@ -346,6 +346,34 @@ export const V040_TOOLS: McpToolDef[] = [
     },
   },
   {
+    name: "memory_forget",
+    description:
+      "Delete observations, a whole session, or a single memory with audit trail. " +
+      "Use this for observation (obs_*) and session cleanup — " +
+      "memory_governance_delete only handles saved memories (mem_*).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        sessionId: {
+          type: "string",
+          description:
+            "Session to delete from. Without observationIds, removes ALL of the " +
+            "session's observations plus the session record and its summary.",
+        },
+        observationIds: {
+          type: "string",
+          description:
+            "Comma-separated observation IDs to delete within sessionId. " +
+            "Requires sessionId.",
+        },
+        memoryId: {
+          type: "string",
+          description: "Single saved memory ID to delete",
+        },
+      },
+    },
+  },
+  {
     name: "memory_snapshot_create",
     description: "Create a git-versioned snapshot of current memory state.",
     inputSchema: {

--- a/test/governance.test.ts
+++ b/test/governance.test.ts
@@ -96,17 +96,56 @@ describe("Governance Functions", () => {
     expect(remaining.length).toBe(2);
   });
 
-  it("governance-delete handles non-existent IDs gracefully", async () => {
+  it("governance-delete reports non-existent IDs instead of claiming success (#833)", async () => {
     const result = (await sdk.trigger("mem::governance-delete", {
       memoryIds: ["nonexistent_1", "nonexistent_2"],
-    })) as { success: boolean; deleted: number; total: number };
+    })) as {
+      success: boolean;
+      deleted: number;
+      total: number;
+      notFound?: string[];
+    };
 
-    expect(result.success).toBe(true);
+    expect(result.success).toBe(false);
     expect(result.deleted).toBe(0);
     expect(result.total).toBe(2);
+    expect(result.notFound).toEqual(["nonexistent_1", "nonexistent_2"]);
 
     const remaining = await kv.list("mem:memories");
     expect(remaining.length).toBe(3);
+  });
+
+  it("governance-delete flags partial deletes with the missing IDs (#833)", async () => {
+    const result = (await sdk.trigger("mem::governance-delete", {
+      memoryIds: ["mem_1", "obs_unknown"],
+    })) as {
+      success: boolean;
+      deleted: number;
+      total: number;
+      notFound?: string[];
+    };
+
+    expect(result.success).toBe(false);
+    expect(result.deleted).toBe(1);
+    expect(result.total).toBe(2);
+    expect(result.notFound).toEqual(["obs_unknown"]);
+
+    const remaining = await kv.list("mem:memories");
+    expect(remaining.length).toBe(2);
+  });
+
+  it("governance-delete omits notFound when every ID was deleted", async () => {
+    const result = (await sdk.trigger("mem::governance-delete", {
+      memoryIds: ["mem_1", "mem_2"],
+    })) as {
+      success: boolean;
+      deleted: number;
+      notFound?: string[];
+    };
+
+    expect(result.success).toBe(true);
+    expect(result.deleted).toBe(2);
+    expect(result.notFound).toBeUndefined();
   });
 
   it("governance-bulk deletes by type filter", async () => {

--- a/test/mcp-forget-tool.test.ts
+++ b/test/mcp-forget-tool.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../src/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { registerMcpEndpoints } from "../src/mcp/server.js";
+
+function mockKV() {
+  const store = new Map<string, Map<string, unknown>>();
+  return {
+    get: async <T>(scope: string, key: string): Promise<T | null> => {
+      return (store.get(scope)?.get(key) as T) ?? null;
+    },
+    set: async <T>(scope: string, key: string, data: T): Promise<T> => {
+      if (!store.has(scope)) store.set(scope, new Map());
+      store.get(scope)!.set(key, data);
+      return data;
+    },
+    delete: async (scope: string, key: string): Promise<void> => {
+      store.get(scope)?.delete(key);
+    },
+    list: async <T>(scope: string): Promise<T[]> => {
+      const entries = store.get(scope);
+      return entries ? (Array.from(entries.values()) as T[]) : [];
+    },
+  };
+}
+
+function mockSdk() {
+  const functions = new Map<string, Function>();
+  const triggerOverrides = new Map<string, Function>();
+  return {
+    registerFunction: (idOrOpts: string | { id: string }, handler: Function) => {
+      const id = typeof idOrOpts === "string" ? idOrOpts : idOrOpts.id;
+      functions.set(id, handler);
+    },
+    registerTrigger: () => {},
+    trigger: async (
+      idOrInput: string | { function_id: string; payload: unknown },
+      data?: unknown,
+    ) => {
+      const id = typeof idOrInput === "string" ? idOrInput : idOrInput.function_id;
+      const payload = typeof idOrInput === "string" ? data : idOrInput.payload;
+      if (triggerOverrides.has(id)) {
+        return triggerOverrides.get(id)!(payload);
+      }
+      const fn = functions.get(id);
+      if (!fn) throw new Error(`No function: ${id}`);
+      return fn(payload);
+    },
+    overrideTrigger: (id: string, handler: Function) => {
+      triggerOverrides.set(id, handler);
+    },
+    getFunction: (id: string) => functions.get(id),
+  };
+}
+
+function makeReq(body?: unknown, headers?: Record<string, string>) {
+  return {
+    body,
+    headers: headers || {},
+    query_params: {},
+  };
+}
+
+type McpResponse = {
+  status_code: number;
+  body: {
+    error?: string;
+    content?: Array<{ type: string; text: string }>;
+    isError?: boolean;
+    tools?: Array<{ name: string }>;
+  };
+};
+
+describe("memory_forget MCP tool (issue #833)", () => {
+  let sdk: ReturnType<typeof mockSdk>;
+  let kv: ReturnType<typeof mockKV>;
+  let forgetPayloads: unknown[];
+
+  beforeEach(() => {
+    sdk = mockSdk();
+    kv = mockKV();
+    registerMcpEndpoints(sdk as never, kv as never);
+    forgetPayloads = [];
+    sdk.overrideTrigger("mem::forget", (payload: unknown) => {
+      forgetPayloads.push(payload);
+      return {
+        success: true,
+        deleted: 3,
+        memoriesDeleted: 0,
+        observationsDeleted: 1,
+        sessionDeleted: true,
+      };
+    });
+  });
+
+  async function callTool(
+    args: Record<string, unknown>,
+  ): Promise<McpResponse> {
+    const handler = sdk.getFunction("mcp::tools::call")!;
+    return handler(
+      makeReq({ name: "memory_forget", arguments: args }),
+    ) as Promise<McpResponse>;
+  }
+
+  it("is listed in the MCP tool registry", async () => {
+    const handler = sdk.getFunction("mcp::tools::list")!;
+    const res = (await handler(makeReq())) as McpResponse;
+    expect(res.status_code).toBe(200);
+    const names = (res.body.tools ?? []).map((t) => t.name);
+    expect(names).toContain("memory_forget");
+  });
+
+  it("rejects calls without sessionId or memoryId", async () => {
+    const res = await callTool({});
+    expect(res.status_code).toBe(400);
+    expect(res.body.error).toBe("sessionId or memoryId is required");
+    expect(forgetPayloads.length).toBe(0);
+  });
+
+  it("rejects observationIds without sessionId", async () => {
+    const res = await callTool({ observationIds: "obs_1,obs_2" });
+    expect(res.status_code).toBe(400);
+    expect(res.body.error).toBe("observationIds requires sessionId");
+    expect(forgetPayloads.length).toBe(0);
+  });
+
+  it("forwards sessionId-only deletes to mem::forget", async () => {
+    const res = await callTool({ sessionId: "ses_1" });
+    expect(res.status_code).toBe(200);
+    expect(forgetPayloads).toEqual([{ sessionId: "ses_1" }]);
+    const text = res.body.content?.[0]?.text ?? "";
+    expect(JSON.parse(text)).toMatchObject({
+      success: true,
+      deleted: 3,
+      sessionDeleted: true,
+    });
+  });
+
+  it("parses comma-separated observationIds", async () => {
+    const res = await callTool({
+      sessionId: "ses_1",
+      observationIds: "obs_1, obs_2 ,obs_3",
+    });
+    expect(res.status_code).toBe(200);
+    expect(forgetPayloads).toEqual([
+      { sessionId: "ses_1", observationIds: ["obs_1", "obs_2", "obs_3"] },
+    ]);
+  });
+
+  it("accepts observationIds as an array", async () => {
+    const res = await callTool({
+      sessionId: "ses_1",
+      observationIds: ["obs_1", "obs_2"],
+    });
+    expect(res.status_code).toBe(200);
+    expect(forgetPayloads).toEqual([
+      { sessionId: "ses_1", observationIds: ["obs_1", "obs_2"] },
+    ]);
+  });
+
+  it("forwards memoryId deletes to mem::forget", async () => {
+    const res = await callTool({ memoryId: "mem_1" });
+    expect(res.status_code).toBe(200);
+    expect(forgetPayloads).toEqual([{ memoryId: "mem_1" }]);
+  });
+
+  it("returns an isError content block when mem::forget throws", async () => {
+    sdk.overrideTrigger("mem::forget", () => {
+      throw new Error("boom");
+    });
+    const res = await callTool({ sessionId: "ses_1" });
+    expect(res.status_code).toBe(200);
+    expect(res.body.isError).toBe(true);
+    expect(res.body.content?.[0]?.text).toBe("Forget failed");
+  });
+});

--- a/test/mcp-standalone.test.ts
+++ b/test/mcp-standalone.test.ts
@@ -72,8 +72,8 @@ describe("Tools Registry", () => {
     expect(CORE_TOOLS.length).toBe(14);
   });
 
-  it("V040_TOOLS has 8 items", () => {
-    expect(V040_TOOLS.length).toBe(8);
+  it("V040_TOOLS has 9 items", () => {
+    expect(V040_TOOLS.length).toBe(9);
   });
 
   it("all tools have required name, description, inputSchema fields", () => {


### PR DESCRIPTION
Fixes #833

## Problem

The `forget` skill (and any MCP-only client) has no way to delete observations or sessions:

- `memory_governance_delete` only reads/writes the `KV.memories` store. Observation IDs (`obs_*`) never exist there, so the skill's documented happy path is a guaranteed no-op.
- Worse, the tool returned `{ "deleted": 0, "success": true }` for that no-op, so users were told their data was removed while the `.bin` files under `mem:obs:<sessionId>` stayed fully intact.
- The engine already has the correct function — `mem::forget` handles memories, per-session observation lists, and whole-session deletion (record + summary) while keeping the BM25/vector indexes and audit log consistent — but it was only reachable over REST (`POST /agentmemory/forget`), not via MCP.

## Solution

1. **New `memory_forget` MCP tool** mapping to `mem::forget` (registry + `mcp::tools::call` case). Accepts `memoryId`, or `sessionId` with optional comma-separated/array `observationIds`; bare `sessionId` deletes all of the session's observations plus the session record and summary, matching the REST behavior. Validation mirrors the REST route (`sessionId or memoryId is required`) plus a specific error for `observationIds` without `sessionId`.
2. **`mem::forget` now returns its breakdown** (`memoriesDeleted`, `observationsDeleted`, `sessionDeleted`) — it already tracked these for the audit row; returning them lets callers confirm to the user what was actually removed.
3. **`mem::governance-delete` stops reporting no-ops as success**: IDs that don't exist in the memories store are returned in a `notFound` array and `success` is only `true` when every requested ID was deleted. The audit row records `notFound` too.
4. **`forget` skill + OpenCode instructions rewritten** to route observation/session deletion through `memory_forget` and keep `memory_governance_delete` for saved memories (`mem_*`), removing the incorrect "deletes by memory ID only" workaround that never worked.

Tool count badges/docs/manifests bumped 53 → 54 to keep `test/consistency.test.ts` green.

## Testing

- New `test/mcp-forget-tool.test.ts`: registry listing, validation errors, payload forwarding for all three deletion shapes (CSV + array `observationIds`), and the error path.
- `test/governance.test.ts`: non-existent IDs now expect `success: false` + `notFound`; added partial-delete and all-deleted cases.
- Full suite: 127 files, 1410 tests pass; `npm run build` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added memory forget functionality for deleting observations, sessions, or individual saved memories with explicit user confirmation.

* **Documentation**
  * Updated MCP tools count from 53 to 54 across all documentation and plugin manifests.
  * Clarified memory deletion workflows distinguishing between deleting saved memories versus observations/sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->