### PR TITLE
feat(memory): concept_edges derivation + boot backfill (#345 Phase 1)

### DIFF
--- a/src/functions/compress.ts
+++ b/src/functions/compress.ts
@@ -192,6 +192,24 @@ export function registerCompressFunction(
           { kind: "observation", logId: compressed.id },
         );
 
+        // #345 Phase 1: derive concept co-occurrence edges from the
+        // freshly extracted concepts[]. Fire-and-forget — edge upkeep
+        // must never block or fail the compression itself.
+        if (compressed.concepts.length >= 2) {
+          try {
+            await sdk.trigger({
+              function_id: "mem::concept-edges-derive",
+              payload: { concepts: compressed.concepts },
+              action: TriggerAction.Void(),
+            });
+          } catch (err) {
+            logger.warn("Non-fatal concept-edge derivation failure", {
+              obsId: compressed.id,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }
+
         const streamResults = await Promise.allSettled([
           sdk.trigger({
             function_id: "stream::set",

--- a/src/functions/concept-edges.ts
+++ b/src/functions/concept-edges.ts
@@ -1,0 +1,140 @@
+import type { ISdk } from "iii-sdk";
+import type { StateKV } from "../state/kv.js";
+import { KV } from "../state/schema.js";
+import type { ConceptEdge, Memory, StateScope, StateScopeKey } from "../types.js";
+import { withKeyedLock } from "../state/keyed-mutex.js";
+import { logger } from "../logger.js";
+
+const MIGRATION_KEY = "migrations:concept-edges-backfill" satisfies StateScopeKey;
+
+/**
+ * Same saturation curve as reinforceLesson (lessons.ts) so the
+ * strength lifecycle profile stays consistent across surfaces:
+ * asymptotic approach to 1.0, +10% of the remaining headroom per
+ * co-occurrence.
+ */
+function reinforceConceptEdge(edge: ConceptEdge): void {
+  edge.reinforcements++;
+  edge.strength = Math.min(1.0, edge.strength + 0.1 * (1 - edge.strength));
+  edge.lastSeenAt = new Date().toISOString();
+}
+
+/**
+ * Concepts come from LLM compression output and from user-supplied
+ * memory_save payloads, so casing and whitespace vary for the same
+ * term. Normalize before pairing so "JWT" and "jwt" reinforce one
+ * edge instead of fragmenting the graph.
+ */
+function normalizeConcepts(concepts: string[]): string[] {
+  const seen = new Set<string>();
+  for (const raw of concepts) {
+    if (typeof raw !== "string") continue;
+    const concept = raw.trim().toLowerCase();
+    if (concept.length === 0) continue;
+    seen.add(concept);
+  }
+  return [...seen];
+}
+
+/** Canonical key for an unordered pair: lexicographic order, "|" separator. */
+export function conceptEdgeKey(a: string, b: string): string {
+  return a < b ? `${a}|${b}` : `${b}|${a}`;
+}
+
+/**
+ * Walk a memory's concepts[] and upsert one edge per unordered pair.
+ * Existing edges reinforce; new edges start at strength 0.5 with the
+ * same decayRate lessons use (0.05). Runs under a keyed lock because
+ * the upsert is read-modify-write and derivation can fire from
+ * mem::compress and mem::remember concurrently.
+ */
+export async function deriveConceptEdges(
+  kv: StateKV,
+  concepts: string[],
+): Promise<number> {
+  const normalized = normalizeConcepts(concepts);
+  if (normalized.length < 2) return 0;
+  normalized.sort();
+
+  return withKeyedLock("mem:concept-edges", async () => {
+    let touched = 0;
+    for (let i = 0; i < normalized.length; i++) {
+      for (let j = i + 1; j < normalized.length; j++) {
+        // normalized is sorted, so [i] < [j] is already canonical order
+        const from = normalized[i];
+        const to = normalized[j];
+        const key = conceptEdgeKey(from, to);
+        const existing = await kv.get<ConceptEdge>(KV.conceptEdges, key);
+        if (existing) {
+          reinforceConceptEdge(existing);
+          await kv.set(KV.conceptEdges, key, existing);
+        } else {
+          const now = new Date().toISOString();
+          const edge: ConceptEdge = {
+            from,
+            to,
+            strength: 0.5,
+            lastSeenAt: now,
+            reinforcements: 0,
+            createdAt: now,
+            decayRate: 0.05,
+          };
+          await kv.set(KV.conceptEdges, key, edge);
+        }
+        touched++;
+      }
+    }
+    return touched;
+  });
+}
+
+export function registerConceptEdgesFunction(sdk: ISdk, kv: StateKV): void {
+  sdk.registerFunction("mem::concept-edges-derive",
+    async (data: { concepts?: string[] }) => {
+      if (!Array.isArray(data.concepts)) {
+        return { success: false, error: "concepts must be an array" };
+      }
+      const edgesTouched = await deriveConceptEdges(kv, data.concepts);
+      return { success: true, edgesTouched };
+    },
+  );
+
+  sdk.registerFunction("mem::concept-edges-backfill",
+    async () => {
+      const migrated = await kv.get<StateScope[typeof MIGRATION_KEY]>(
+        KV.state,
+        MIGRATION_KEY,
+      );
+      if (migrated === true) {
+        return { success: true, skipped: "already-migrated" };
+      }
+
+      // A non-empty scope means edges are already being derived live
+      // (or a previous backfill ran before the flag existed) — re-running
+      // would double-reinforce every pre-existing pair.
+      const existingEdges = await kv.list<ConceptEdge>(KV.conceptEdges);
+      if (existingEdges.length > 0) {
+        await kv.set(KV.state, MIGRATION_KEY, true);
+        return { success: true, skipped: "edges-already-present" };
+      }
+
+      const memories = await kv.list<Memory>(KV.memories);
+      let memoriesWalked = 0;
+      let edgesTouched = 0;
+      for (const memory of memories) {
+        if (!Array.isArray(memory.concepts) || memory.concepts.length < 2) {
+          continue;
+        }
+        edgesTouched += await deriveConceptEdges(kv, memory.concepts);
+        memoriesWalked++;
+      }
+
+      await kv.set(KV.state, MIGRATION_KEY, true);
+      logger.info("Concept edges backfilled from existing memories", {
+        memoriesWalked,
+        edgesTouched,
+      });
+      return { success: true, memoriesWalked, edgesTouched };
+    },
+  );
+}

--- a/src/functions/disk-size-manager.ts
+++ b/src/functions/disk-size-manager.ts
@@ -6,7 +6,9 @@ import { withKeyedLock } from "../state/keyed-mutex.js";
 import { logger } from "../logger.js";
 import type { StateScope, StateScopeKey } from "../types.js";
 
-const DISK_SIZE_KEY: StateScopeKey = "system:currentDiskSize";
+// `satisfies` keeps the literal type so StateScope[typeof DISK_SIZE_KEY]
+// stays `number` even now that StateScope has more than one key.
+const DISK_SIZE_KEY = "system:currentDiskSize" satisfies StateScopeKey;
 
 export function registerDiskSizeManager(sdk: ISdk, kv: StateKV): void {
   sdk.registerFunction(

--- a/src/functions/remember.ts
+++ b/src/functions/remember.ts
@@ -157,6 +157,24 @@ export function registerRememberFunction(sdk: ISdk, kv: StateKV): void {
           });
         }
 
+        // #345 Phase 1: concept_edges populate as memories are
+        // remembered. Fire-and-forget — same non-blocking contract as
+        // cascade-update above.
+        if (memory.concepts.length >= 2) {
+          try {
+            await sdk.trigger({
+              function_id: "mem::concept-edges-derive",
+              payload: { concepts: memory.concepts },
+              action: TriggerAction.Void(),
+            });
+          } catch (err) {
+            logger.warn("Non-fatal concept-edge derivation failure", {
+              memId: memory.id,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }
+
         logger.info("Memory saved", {
           memId: memory.id,
           type: memory.type,

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ import { registerFileIndexFunction } from "./functions/file-index.js";
 import { registerConsolidateFunction } from "./functions/consolidate.js";
 import { registerPatternsFunction } from "./functions/patterns.js";
 import { registerRememberFunction } from "./functions/remember.js";
+import { registerConceptEdgesFunction } from "./functions/concept-edges.js";
 import { registerEvictFunction } from "./functions/evict.js";
 import { registerRelationsFunction } from "./functions/relations.js";
 import { registerTimelineFunction } from "./functions/timeline.js";
@@ -249,6 +250,7 @@ async function main() {
   registerConsolidateFunction(sdk, kv, provider);
   registerPatternsFunction(sdk, kv);
   registerRememberFunction(sdk, kv);
+  registerConceptEdgesFunction(sdk, kv);
   registerEvictFunction(sdk, kv);
 
   registerRelationsFunction(sdk, kv);
@@ -508,6 +510,30 @@ async function main() {
         err,
       );
     }
+  }
+
+  // #345 Phase 1: one-shot backfill of concept_edges from existing
+  // memories' concepts[]. Guarded by a migrations flag in KV.state so
+  // it runs once per deployment; the function itself also
+  // short-circuits when edges already exist, so a crash between
+  // backfill and flag write cannot double-reinforce on the next boot.
+  try {
+    const migrated = await kv.get<
+      import("./types.js").StateScope["migrations:concept-edges-backfill"]
+    >(KV.state, "migrations:concept-edges-backfill");
+    if (migrated !== true) {
+      const result = (await sdk.trigger({
+        function_id: "mem::concept-edges-backfill",
+        payload: {},
+      })) as { memoriesWalked?: number; edgesTouched?: number };
+      if (result?.memoriesWalked) {
+        bootLog(
+          `Concept edges backfilled: ${result.edgesTouched} pairs from ${result.memoriesWalked} memories (#345 Phase 1)`,
+        );
+      }
+    }
+  } catch (err) {
+    console.warn(`[agentmemory] Concept-edges backfill failed:`, err);
   }
 
   // Ready / Endpoints lines are emitted via `bootLog` so they're

--- a/src/state/schema.ts
+++ b/src/state/schema.ts
@@ -57,6 +57,10 @@ export const KV = {
   sentinels: "mem:sentinels",
   crystals: "mem:crystals",
   lessons: "mem:lessons",
+  // #345 Phase 1: concept co-occurrence edges. Key is the canonical
+  // unordered pair `${a}|${b}` (lexicographic), one row per pair —
+  // the Phase 2 traversal adapter treats the graph as undirected.
+  conceptEdges: "mem:concept-edges",
   insights: "mem:insights",
   graphEdgeHistory: "mem:graph:edge-history",
   enrichedChunks: (sessionId: string) => `mem:enriched:${sessionId}`,

--- a/src/types.ts
+++ b/src/types.ts
@@ -810,6 +810,23 @@ export interface Lesson {
   deleted?: boolean;
 }
 
+/**
+ * #345 Phase 1 — concept co-occurrence edge. One row per unordered
+ * concept pair, derived whenever a memory (or compressed observation)
+ * carries 2+ concepts. Strength reinforces on repeated co-occurrence
+ * via the same saturation curve lessons use, so the lifecycle profile
+ * stays consistent across surfaces. Traversal lands in Phase 2.
+ */
+export interface ConceptEdge {
+  from: string;
+  to: string;
+  strength: number;
+  lastSeenAt: string;
+  reinforcements: number;
+  createdAt: string;
+  decayRate: number;
+}
+
 export interface Insight {
   id: string;
   title: string;
@@ -939,6 +956,7 @@ export interface DecayConfig {
  */
 export interface StateScope {
   "system:currentDiskSize": number;
+  "migrations:concept-edges-backfill": boolean;
 }
 
 export type StateScopeKey = keyof StateScope;

--- a/test/concept-edges.test.ts
+++ b/test/concept-edges.test.ts
@@ -1,0 +1,331 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+vi.mock("../src/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("../src/state/keyed-mutex.js", () => ({
+  withKeyedLock: <T>(_key: string, fn: () => Promise<T>) => fn(),
+}));
+
+vi.mock("iii-sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("iii-sdk")>();
+  return {
+    ...actual,
+    TriggerAction: {
+      ...actual.TriggerAction,
+      Void: vi.fn(() => ({ type: "void" })),
+    },
+  };
+});
+
+import { vi } from "vitest";
+import {
+  registerConceptEdgesFunction,
+  conceptEdgeKey,
+} from "../src/functions/concept-edges.js";
+import { registerRememberFunction } from "../src/functions/remember.js";
+import { getSearchIndex, setIndexPersistence } from "../src/functions/search.js";
+import { KV } from "../src/state/schema.js";
+import type { ConceptEdge } from "../src/types.js";
+
+const EDGES = "mem:concept-edges";
+const MIGRATION_KEY = "migrations:concept-edges-backfill";
+
+function mockKV() {
+  const store = new Map<string, Map<string, unknown>>();
+  return {
+    get: async <T>(scope: string, key: string): Promise<T | null> =>
+      (store.get(scope)?.get(key) as T) ?? null,
+    set: async <T>(scope: string, key: string, data: T): Promise<T> => {
+      if (!store.has(scope)) store.set(scope, new Map());
+      store.get(scope)!.set(key, data);
+      return data;
+    },
+    delete: async (scope: string, key: string): Promise<void> => {
+      store.get(scope)?.delete(key);
+    },
+    list: async <T>(scope: string): Promise<T[]> => {
+      const entries = store.get(scope);
+      return entries ? (Array.from(entries.values()) as T[]) : [];
+    },
+  };
+}
+
+function mockSdk() {
+  const functions = new Map<string, Function>();
+  return {
+    registerFunction: (id: string, handler: Function) => {
+      functions.set(id, handler);
+    },
+    registerTrigger: () => {},
+    trigger: async (input: { function_id: string; payload: unknown; action?: unknown }) => {
+      const fn = functions.get(input.function_id);
+      if (!fn) return {};
+      return fn(input.payload);
+    },
+  };
+}
+
+describe("conceptEdgeKey", () => {
+  it("is canonical for unordered pairs", () => {
+    expect(conceptEdgeKey("jwt", "auth")).toBe("auth|jwt");
+    expect(conceptEdgeKey("auth", "jwt")).toBe("auth|jwt");
+  });
+});
+
+describe("mem::concept-edges-derive", () => {
+  let sdk: ReturnType<typeof mockSdk>;
+  let kv: ReturnType<typeof mockKV>;
+
+  beforeEach(() => {
+    sdk = mockSdk();
+    kv = mockKV();
+    registerConceptEdgesFunction(sdk as never, kv as never);
+  });
+
+  it("creates one edge per unordered concept pair", async () => {
+    const result = await sdk.trigger({
+      function_id: "mem::concept-edges-derive",
+      payload: { concepts: ["auth", "jwt", "session-token"] },
+    });
+
+    expect(result).toMatchObject({ success: true, edgesTouched: 3 });
+    const edges = await kv.list<ConceptEdge>(EDGES);
+    expect(edges).toHaveLength(3);
+
+    const edge = await kv.get<ConceptEdge>(EDGES, "auth|jwt");
+    expect(edge).toMatchObject({
+      from: "auth",
+      to: "jwt",
+      strength: 0.5,
+      reinforcements: 0,
+      decayRate: 0.05,
+    });
+    expect(edge!.createdAt).toBeTruthy();
+    expect(edge!.lastSeenAt).toBeTruthy();
+  });
+
+  it("reinforces existing edges on repeated co-occurrence", async () => {
+    await sdk.trigger({
+      function_id: "mem::concept-edges-derive",
+      payload: { concepts: ["auth", "jwt"] },
+    });
+    await sdk.trigger({
+      function_id: "mem::concept-edges-derive",
+      payload: { concepts: ["auth", "jwt"] },
+    });
+
+    const edge = await kv.get<ConceptEdge>(EDGES, "auth|jwt");
+    // same curve as reinforceLesson: 0.5 + 0.1 * (1 - 0.5) = 0.55
+    expect(edge!.strength).toBeCloseTo(0.55, 10);
+    expect(edge!.reinforcements).toBe(1);
+    const edges = await kv.list<ConceptEdge>(EDGES);
+    expect(edges).toHaveLength(1);
+  });
+
+  it("strength saturates below 1.0", async () => {
+    for (let i = 0; i < 100; i++) {
+      await sdk.trigger({
+        function_id: "mem::concept-edges-derive",
+        payload: { concepts: ["auth", "jwt"] },
+      });
+    }
+    const edge = await kv.get<ConceptEdge>(EDGES, "auth|jwt");
+    expect(edge!.strength).toBeLessThanOrEqual(1.0);
+    expect(edge!.strength).toBeGreaterThan(0.99);
+    expect(edge!.reinforcements).toBe(99);
+  });
+
+  it("normalizes casing and whitespace before pairing", async () => {
+    const result = await sdk.trigger({
+      function_id: "mem::concept-edges-derive",
+      payload: { concepts: ["JWT", " jwt ", "Auth", "auth"] },
+    });
+
+    // collapses to {jwt, auth} -> single edge
+    expect(result).toMatchObject({ success: true, edgesTouched: 1 });
+    const edge = await kv.get<ConceptEdge>(EDGES, "auth|jwt");
+    expect(edge).not.toBeNull();
+  });
+
+  it("ignores empty and non-string entries", async () => {
+    const result = await sdk.trigger({
+      function_id: "mem::concept-edges-derive",
+      payload: { concepts: ["auth", "", "   ", 42 as never, null as never] },
+    });
+
+    expect(result).toMatchObject({ success: true, edgesTouched: 0 });
+    expect(await kv.list(EDGES)).toHaveLength(0);
+  });
+
+  it("derives nothing for fewer than two concepts", async () => {
+    const result = await sdk.trigger({
+      function_id: "mem::concept-edges-derive",
+      payload: { concepts: ["auth"] },
+    });
+    expect(result).toMatchObject({ success: true, edgesTouched: 0 });
+  });
+
+  it("rejects a missing concepts array", async () => {
+    const result = await sdk.trigger({
+      function_id: "mem::concept-edges-derive",
+      payload: {},
+    });
+    expect(result).toMatchObject({
+      success: false,
+      error: "concepts must be an array",
+    });
+  });
+});
+
+describe("mem::concept-edges-backfill", () => {
+  let sdk: ReturnType<typeof mockSdk>;
+  let kv: ReturnType<typeof mockKV>;
+
+  beforeEach(() => {
+    sdk = mockSdk();
+    kv = mockKV();
+    registerConceptEdgesFunction(sdk as never, kv as never);
+  });
+
+  it("backfills edges from existing memories and sets the migration flag", async () => {
+    await kv.set(KV.memories, "mem_1", {
+      id: "mem_1",
+      concepts: ["auth", "jwt"],
+    });
+    await kv.set(KV.memories, "mem_2", {
+      id: "mem_2",
+      concepts: ["jwt", "session-token"],
+    });
+    await kv.set(KV.memories, "mem_3", {
+      id: "mem_3",
+      concepts: ["solo-concept"],
+    });
+
+    const result = await sdk.trigger({
+      function_id: "mem::concept-edges-backfill",
+      payload: {},
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      memoriesWalked: 2,
+      edgesTouched: 2,
+    });
+    expect(await kv.get<ConceptEdge>(EDGES, "auth|jwt")).not.toBeNull();
+    expect(
+      await kv.get<ConceptEdge>(EDGES, "jwt|session-token"),
+    ).not.toBeNull();
+    expect(await kv.get<boolean>(KV.state, MIGRATION_KEY)).toBe(true);
+  });
+
+  it("is a no-op once the migration flag is set", async () => {
+    await kv.set(KV.state, MIGRATION_KEY, true);
+    await kv.set(KV.memories, "mem_1", {
+      id: "mem_1",
+      concepts: ["auth", "jwt"],
+    });
+
+    const result = await sdk.trigger({
+      function_id: "mem::concept-edges-backfill",
+      payload: {},
+    });
+
+    expect(result).toMatchObject({ success: true, skipped: "already-migrated" });
+    expect(await kv.list(EDGES)).toHaveLength(0);
+  });
+
+  it("skips when edges already exist and marks migration complete", async () => {
+    await kv.set(EDGES, "auth|jwt", {
+      from: "auth",
+      to: "jwt",
+      strength: 0.5,
+      reinforcements: 0,
+      lastSeenAt: "2026-01-01T00:00:00.000Z",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      decayRate: 0.05,
+    });
+    await kv.set(KV.memories, "mem_1", {
+      id: "mem_1",
+      concepts: ["auth", "jwt"],
+    });
+
+    const result = await sdk.trigger({
+      function_id: "mem::concept-edges-backfill",
+      payload: {},
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      skipped: "edges-already-present",
+    });
+    const edge = await kv.get<ConceptEdge>(EDGES, "auth|jwt");
+    expect(edge!.reinforcements).toBe(0); // untouched, no double-reinforce
+    expect(await kv.get<boolean>(KV.state, MIGRATION_KEY)).toBe(true);
+  });
+
+  it("handles memories without a concepts field", async () => {
+    await kv.set(KV.memories, "mem_legacy", { id: "mem_legacy" });
+
+    const result = await sdk.trigger({
+      function_id: "mem::concept-edges-backfill",
+      payload: {},
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      memoriesWalked: 0,
+      edgesTouched: 0,
+    });
+  });
+});
+
+describe("mem::remember — concept edge derivation hook", () => {
+  beforeEach(() => {
+    getSearchIndex().clear();
+    setIndexPersistence(null);
+  });
+
+  afterEach(() => {
+    setIndexPersistence(null);
+  });
+
+  it("derives concept edges when a memory with 2+ concepts is saved", async () => {
+    const sdk = mockSdk();
+    const kv = mockKV();
+    registerRememberFunction(sdk as never, kv as never);
+    registerConceptEdgesFunction(sdk as never, kv as never);
+
+    const result = await sdk.trigger({
+      function_id: "mem::remember",
+      payload: {
+        content: "express-jwt requires trimmed Bearer token",
+        type: "bug",
+        concepts: ["auth", "jwt", "express"],
+      },
+    });
+
+    expect(result).toMatchObject({ success: true });
+    const edges = await kv.list<ConceptEdge>(EDGES);
+    expect(edges).toHaveLength(3);
+    expect(await kv.get<ConceptEdge>(EDGES, "auth|jwt")).not.toBeNull();
+  });
+
+  it("does not derive edges for a single-concept memory", async () => {
+    const sdk = mockSdk();
+    const kv = mockKV();
+    registerRememberFunction(sdk as never, kv as never);
+    registerConceptEdgesFunction(sdk as never, kv as never);
+
+    await sdk.trigger({
+      function_id: "mem::remember",
+      payload: {
+        content: "standalone fact",
+        concepts: ["solo"],
+      },
+    });
+
+    expect(await kv.list(EDGES)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Motivation

Phase 1 of #345, following the phased plan you laid out there: the `concept_edges` table + derivation, nothing user-facing yet. Phases 2 (`mode: "graph"` on smart-search via the #463 `GraphRetrieval` traversal) and 3 (MCP tool + viewer) stay separate per the plan.

## What this changes

- **`KV.conceptEdges` scope** (`mem:concept-edges`) with the `ConceptEdge` row shape from the plan (`from`, `to`, `strength`, `lastSeenAt`, `reinforcements`, `createdAt`, `decayRate`). One row per unordered pair — key is the canonical `${a}|${b}` (lexicographic), so the Phase 2 adapter can treat the graph as undirected without dedup at read time.
- **Derivation** (`mem::concept-edges-derive`): walks `concepts[]`, emits every unordered pair, upserts under a keyed lock (the upsert is read-modify-write and can fire from compress and remember concurrently). Existing edges reinforce via the same saturation curve `reinforceLesson` uses — `strength += 0.1 * (1 - strength)` — and new edges start at 0.5 with `decayRate: 0.05`, mirroring the lessons lifecycle so the strength profile stays consistent across surfaces. Concepts are normalized (trim + lowercase) before pairing so `"JWT"` and `"jwt"` reinforce one edge instead of fragmenting the graph.
- **Hooks**: fire-and-forget (`TriggerAction.Void`) from `mem::compress` after the compressed observation is persisted, and from `mem::remember` after the memory row is saved — edge upkeep never blocks or fails the write itself. Both gated on `concepts.length >= 2`.
- **Boot migration** (`mem::concept-edges-backfill`): one-shot pass at startup — if `KV.conceptEdges` is empty and `KV.memories` has rows with 2+ concepts, backfill edges from existing memories. Completion is marked via `migrations:concept-edges-backfill` in `KV.state`; the function also short-circuits when edges already exist, so a crash between backfill and flag write can't double-reinforce on the next boot.

One small ripple: adding a second key to `StateScope` widened `StateScopeKey`, which broke `disk-size-manager`'s `const KEY: StateScopeKey = ...` pattern (the lookup type became `number | boolean`). Switched both call sites to `satisfies StateScopeKey` so the literal type — and the per-key value type — is preserved.

## Why this approach

Kept as close to the Phase 1 spec in #345 as possible: exact `ConceptEdge` shape, the lessons reinforce curve rather than a new one, and the `migrations:*` flag pattern in `KV.state`. No traversal code here — `GraphRetrieval`/`WeightedGraphTraversal` plumbing belongs to Phase 2 and this PR doesn't touch it.

## Testing

- `test/concept-edges.test.ts`: 14 cases — canonical pair keys, derivation, reinforcement (0.5 → 0.55 on second co-occurrence, saturation < 1.0 after 100 rounds), normalization/dedup, <2-concept no-ops, payload validation, backfill (flag set, idempotent re-run, edges-already-present short-circuit, legacy memories without `concepts`), and the `mem::remember` hook end to end.
- Full suite: 1414 passed (the only failure is `test/integration.test.ts`, which needs a running server and is excluded from `npm test`).
- `npm run build` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic concept relationship tracking: The system now derives and maintains relationships between concepts within memories, strengthening the knowledge graph for enhanced semantic connections.

* **Tests**
  * Added comprehensive test coverage for concept relationship features, including backfill and integration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->