### PR TITLE
fix: configure OpenRouter embedding dimensions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,6 +78,7 @@
 # OPENAI_EMBEDDING_DIMENSIONS=1536               # Required when the model is not in the known-models table
 
 # OPENROUTER_EMBEDDING_MODEL=openai/text-embedding-3-small  # When EMBEDDING_PROVIDER=openrouter
+# OPENROUTER_EMBEDDING_DIMENSIONS=1536                     # Override for non-1536 OpenRouter embedding models
 
 # -----------------------------------------------------------------------------
 # 3. Auth & security

--- a/src/providers/embedding/openrouter.ts
+++ b/src/providers/embedding/openrouter.ts
@@ -3,10 +3,24 @@ import { getEnvVar } from "../../config.js";
 import { fetchWithTimeout } from "../_fetch.js";
 
 const API_URL = "https://openrouter.ai/api/v1/embeddings";
+const DEFAULT_DIMENSIONS = 1536;
+
+function resolveDimensions(override: string | undefined): number {
+  if (override !== undefined && override.trim().length > 0) {
+    const parsed = Number(override);
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+      throw new Error(
+        `OPENROUTER_EMBEDDING_DIMENSIONS must be a positive integer, got: ${override}`,
+      );
+    }
+    return parsed;
+  }
+  return DEFAULT_DIMENSIONS;
+}
 
 export class OpenRouterEmbeddingProvider implements EmbeddingProvider {
   readonly name = "openrouter";
-  readonly dimensions = 1536;
+  readonly dimensions: number;
   private apiKey: string;
   private model: string;
 
@@ -16,6 +30,9 @@ export class OpenRouterEmbeddingProvider implements EmbeddingProvider {
     this.model =
       getEnvVar("OPENROUTER_EMBEDDING_MODEL") ||
       "openai/text-embedding-3-small";
+    this.dimensions = resolveDimensions(
+      getEnvVar("OPENROUTER_EMBEDDING_DIMENSIONS"),
+    );
   }
 
   async embed(text: string): Promise<Float32Array> {
@@ -33,6 +50,7 @@ export class OpenRouterEmbeddingProvider implements EmbeddingProvider {
       body: JSON.stringify({
         model: this.model,
         input: texts,
+        dimensions: this.dimensions,
       }),
     });
 

--- a/test/embedding-provider.test.ts
+++ b/test/embedding-provider.test.ts
@@ -5,6 +5,7 @@ import {
 } from "../src/providers/embedding/index.js";
 import { GeminiEmbeddingProvider } from "../src/providers/embedding/gemini.js";
 import { OpenAIEmbeddingProvider } from "../src/providers/embedding/openai.js";
+import { OpenRouterEmbeddingProvider } from "../src/providers/embedding/openrouter.js";
 import type { EmbeddingProvider } from "../src/types.js";
 
 describe("createEmbeddingProvider", () => {
@@ -17,6 +18,7 @@ describe("createEmbeddingProvider", () => {
     delete process.env["VOYAGE_API_KEY"];
     delete process.env["COHERE_API_KEY"];
     delete process.env["OPENROUTER_API_KEY"];
+    delete process.env["OPENROUTER_EMBEDDING_DIMENSIONS"];
     delete process.env["EMBEDDING_PROVIDER"];
   });
 
@@ -49,6 +51,65 @@ describe("createEmbeddingProvider", () => {
     process.env["EMBEDDING_PROVIDER"] = "openai";
     const provider = createEmbeddingProvider();
     expect(provider).toBeInstanceOf(OpenAIEmbeddingProvider);
+  });
+});
+
+describe("OpenRouterEmbeddingProvider", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env["OPENROUTER_EMBEDDING_MODEL"];
+    delete process.env["OPENROUTER_EMBEDDING_DIMENSIONS"];
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.env = originalEnv;
+  });
+
+  it("defaults to 1536 dimensions", () => {
+    const provider = new OpenRouterEmbeddingProvider("test-key");
+    expect(provider.name).toBe("openrouter");
+    expect(provider.dimensions).toBe(1536);
+  });
+
+  it("OPENROUTER_EMBEDDING_DIMENSIONS overrides the default dimensions", () => {
+    process.env["OPENROUTER_EMBEDDING_DIMENSIONS"] = "1024";
+    const provider = new OpenRouterEmbeddingProvider("test-key");
+    expect(provider.dimensions).toBe(1024);
+  });
+
+  it("rejects invalid OPENROUTER_EMBEDDING_DIMENSIONS values", () => {
+    for (const value of ["not-a-number", "-5", "0", "1.5"]) {
+      process.env["OPENROUTER_EMBEDDING_DIMENSIONS"] = value;
+      expect(() => new OpenRouterEmbeddingProvider("test-key")).toThrow(
+        /OPENROUTER_EMBEDDING_DIMENSIONS must be a positive integer/,
+      );
+    }
+  });
+
+  it("sends dimensions in the OpenRouter embeddings request body", async () => {
+    process.env["OPENROUTER_EMBEDDING_MODEL"] = "perplexity/pplx-embed-v1-0.6b";
+    process.env["OPENROUTER_EMBEDDING_DIMENSIONS"] = "1024";
+    const provider = new OpenRouterEmbeddingProvider("test-key");
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ data: [{ embedding: [0.1, 0.2, 0.3] }] }), {
+        status: 200,
+      }),
+    );
+
+    await provider.embed("hello");
+
+    const body = JSON.parse(
+      (fetchSpy.mock.calls[0][1] as RequestInit).body as string,
+    );
+    expect(body).toEqual({
+      model: "perplexity/pplx-embed-v1-0.6b",
+      input: ["hello"],
+      dimensions: 1024,
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- add OPENROUTER_EMBEDDING_DIMENSIONS support with a 1536 default
- validate OpenRouter embedding dimensions as a positive integer
- send dimensions in the OpenRouter embeddings request body
- document the new env var and add provider regression tests

Fixes #809

## Testing
- npx vitest run test/embedding-provider.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable embedding dimensions for OpenRouter models. Use the `OPENROUTER_EMBEDDING_DIMENSIONS` environment variable to override the default 1536 dimensions, enabling support for custom embedding model configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->