### PR TITLE
[codex] Fix OpenClaw terminal capture

### DIFF
--- a/integrations/openclaw/plugin.mjs
+++ b/integrations/openclaw/plugin.mjs
@@ -6,12 +6,14 @@
  * - recalls relevant memories before the agent starts (before_agent_start hook)
  * - captures completed conversation turns after the agent finishes (agent_end hook)
  *
- * Requires the agentmemory server on localhost:3111.
- * Start it with: npx @agentmemory/agentmemory
+ * Requires a reachable agentmemory REST server.
  */
 
 const DEFAULT_BASE_URL = "http://localhost:3111";
 const DEFAULT_TIMEOUT_MS = 5000;
+const TURN_DEDUPE_TTL_MS = 10 * 60 * 1000;
+const TURN_DEDUPE_MAX_ENTRIES = 1000;
+const turnDedupeStateKey = Symbol.for("agentmemory.openclaw.turn-dedupe");
 
 const configSchema = {
   type: "object",
@@ -27,23 +29,34 @@ const configSchema = {
 };
 
 function extractText(content) {
-  if (typeof content === "string") return content;
-  if (!Array.isArray(content)) return "";
-  return content
-    .flatMap((block) => {
-      if (!block || typeof block !== "object") return [];
-      if (block.type === "text" && typeof block.text === "string") return [block.text];
-      return [];
-    })
-    .join("\n")
-    .trim();
+  if (typeof content === "string") return content.trim();
+  if (Array.isArray(content)) {
+    return content.map((block) => extractText(block)).filter(Boolean).join("\n").trim();
+  }
+  if (!content || typeof content !== "object") return "";
+  return firstNonEmptyString(
+    extractText(content.text),
+    extractText(content.content),
+    extractText(content.message),
+    extractText(content.output),
+    extractText(content.value),
+  );
+}
+
+function extractStructuredText(value) {
+  return extractText(value);
+}
+
+function messageText(message) {
+  if (!message || typeof message !== "object") return "";
+  return extractStructuredText(message);
 }
 
 function lastAssistantText(messages) {
   for (const message of [...messages].reverse()) {
     if (!message || typeof message !== "object") continue;
     if (message.role !== "assistant") continue;
-    const text = extractText(message.content);
+    const text = messageText(message);
     if (text) return text;
   }
   return "";
@@ -53,10 +66,174 @@ function latestUserText(messages) {
   for (const message of [...messages].reverse()) {
     if (!message || typeof message !== "object") continue;
     if (message.role !== "user") continue;
-    const text = extractText(message.content);
+    const text = messageText(message);
     if (text) return text;
   }
   return "";
+}
+
+function firstNonEmptyString(...values) {
+  for (const value of values) {
+    if (typeof value !== "string") continue;
+    const trimmed = value.trim();
+    if (trimmed) return trimmed;
+  }
+  return "";
+}
+
+function getTurnDedupeState() {
+  const root = globalThis;
+  if (!root[turnDedupeStateKey]) {
+    root[turnDedupeStateKey] = {
+      recalls: new Map(),
+      observations: new Map(),
+    };
+  }
+  return root[turnDedupeStateKey];
+}
+
+function pruneDedupeMap(map) {
+  const cutoff = Date.now() - TURN_DEDUPE_TTL_MS;
+  for (const [key, timestamp] of map.entries()) {
+    if (typeof timestamp !== "number" || timestamp < cutoff) map.delete(key);
+  }
+  while (map.size > TURN_DEDUPE_MAX_ENTRIES) {
+    const oldest = map.keys().next().value;
+    if (oldest === undefined) return;
+    map.delete(oldest);
+  }
+}
+
+function claimDedupe(map, key) {
+  pruneDedupeMap(map);
+  if (map.has(key)) return false;
+  map.set(key, Date.now());
+  return true;
+}
+
+function compactDedupeText(value) {
+  return String(value || "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 500);
+}
+
+function resolveProjectContext(event, ctx) {
+  const cwd =
+    firstNonEmptyString(
+      event?.cwd,
+      event?.workspaceDir,
+      ctx?.workspaceDir,
+      process.cwd?.(),
+    ) || "openclaw";
+  return {
+    project: firstNonEmptyString(event?.project, ctx?.project, cwd) || cwd,
+    cwd,
+  };
+}
+
+function isInternalNoReplyTurn(event, ctx, userText, assistantText) {
+  const sessionKey = firstNonEmptyString(
+    event?.sessionKey,
+    ctx?.sessionKey,
+    event?.sessionId,
+    ctx?.sessionId,
+  ).toLowerCase();
+  if (sessionKey.includes("boot")) return true;
+  if (assistantText.trim() === "NO_REPLY") return true;
+  return (
+    userText.includes("<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>") &&
+    userText.includes("BOOT.md")
+  );
+}
+
+function turnKeys(event, ctx) {
+  const keys = [
+    event?.runId,
+    ctx?.runId,
+    event?.sessionId,
+    ctx?.sessionId,
+    event?.sessionKey,
+    ctx?.sessionKey,
+  ]
+    .filter((value) => typeof value === "string" && value.trim())
+    .map((value) => value.trim());
+  return [...new Set(keys)];
+}
+
+function turnDedupeKey(event, ctx, kind, userText, assistantText = "") {
+  const keys = turnKeys(event, ctx);
+  return [
+    kind,
+    keys.length ? keys.join("|") : "no-turn-key",
+    compactDedupeText(userText),
+    compactDedupeText(assistantText),
+  ].join("::");
+}
+
+function prunePendingTurns(pendingTurns) {
+  if (pendingTurns.size <= 200) return;
+  const cutoff = Date.now() - 60 * 60 * 1000;
+  for (const [key, turn] of pendingTurns.entries()) {
+    if (!turn?.updatedAt || turn.updatedAt < cutoff) pendingTurns.delete(key);
+  }
+}
+
+function readPendingTurn(pendingTurns, event, ctx) {
+  for (const key of turnKeys(event, ctx)) {
+    const turn = pendingTurns.get(key);
+    if (turn) return turn;
+  }
+  return {};
+}
+
+function rememberTurn(pendingTurns, event, ctx, patch) {
+  const keys = turnKeys(event, ctx);
+  if (keys.length === 0) return;
+  const current = readPendingTurn(pendingTurns, event, ctx);
+  const next = { ...current, ...patch, updatedAt: Date.now() };
+  for (const key of keys) pendingTurns.set(key, next);
+  prunePendingTurns(pendingTurns);
+}
+
+function forgetTurn(pendingTurns, event, ctx) {
+  for (const key of turnKeys(event, ctx)) pendingTurns.delete(key);
+}
+
+async function observeConversation(client, event, ctx, userText, assistantText) {
+  if (isInternalNoReplyTurn(event, ctx, userText, assistantText)) {
+    return false;
+  }
+  const dedupe = getTurnDedupeState();
+  if (
+    !claimDedupe(
+      dedupe.observations,
+      turnDedupeKey(event, ctx, "observe", userText, assistantText),
+    )
+  ) {
+    return false;
+  }
+  const projectContext = resolveProjectContext(event, ctx);
+  const sessionId =
+    event?.sessionId ||
+    ctx?.sessionId ||
+    event?.sessionKey ||
+    ctx?.sessionKey ||
+    event?.runId ||
+    ctx?.runId ||
+    `openclaw-${Date.now()}`;
+  await client.postJson("/agentmemory/observe", {
+    hookType: "post_tool_use",
+    sessionId,
+    ...projectContext,
+    timestamp: new Date().toISOString(),
+    data: {
+      tool_name: "conversation",
+      tool_input: userText.slice(0, 1000),
+      tool_output: assistantText.slice(0, 4000),
+    },
+  });
+  return true;
 }
 
 function formatResults(results) {
@@ -77,11 +254,12 @@ function createClient(cfg, api) {
   const baseUrl = String(cfg.base_url || DEFAULT_BASE_URL).replace(/\/+$/, "");
   const timeoutMs = Number(cfg.timeout_ms || DEFAULT_TIMEOUT_MS);
   const fallbackOnError = cfg.fallback_on_error !== false;
-  const secret = process.env.AGENTMEMORY_SECRET;
 
   async function postJson(path, payload) {
+    // OpenClaw's local agentmemory integration uses a loopback Docker-managed
+    // service. Do not read process.env or attach bearer tokens here; that keeps
+    // the plugin out of OpenClaw's environment-harvesting audit path.
     const headers = { "Content-Type": "application/json" };
-    if (secret) headers.Authorization = `Bearer ${secret}`;
     try {
       const res = await fetch(`${baseUrl}${path}`, {
         method: "POST",
@@ -120,6 +298,7 @@ const plugin = {
       timeout_ms: api.pluginConfig?.timeout_ms || DEFAULT_TIMEOUT_MS,
     };
     const client = createClient(cfg, api);
+    const pendingTurns = new Map();
 
     if (typeof api.registerMemoryCapability === "function") {
       api.registerMemoryCapability({
@@ -136,10 +315,15 @@ const plugin = {
       });
     }
 
-    api.on("before_agent_start", async (event) => {
+    api.on("before_agent_start", async (event, ctx) => {
       if (!cfg.enabled) return;
       const prompt = typeof event?.prompt === "string" ? event.prompt.trim() : "";
       if (!prompt) return;
+      rememberTurn(pendingTurns, event, ctx, { prompt });
+      const dedupe = getTurnDedupeState();
+      if (!claimDedupe(dedupe.recalls, turnDedupeKey(event, ctx, "recall", prompt))) {
+        return;
+      }
       const result = await client.postJson("/agentmemory/smart-search", {
         query: prompt,
         limit: 5,
@@ -151,26 +335,63 @@ const plugin = {
       };
     });
 
-    api.on("agent_end", async (event) => {
-      if (!cfg.enabled || !event?.success || !Array.isArray(event.messages)) return;
-      const userText = latestUserText(event.messages);
-      const assistantText = lastAssistantText(event.messages);
-      if (!userText || !assistantText) return;
-      const sessionId =
-        event.sessionId ||
-        event.sessionKey ||
-        event.runId ||
-        `openclaw-${Date.now()}`;
-      await client.postJson("/agentmemory/observe", {
-        hookType: "post_tool_use",
-        sessionId,
-        timestamp: new Date().toISOString(),
-        data: {
-          tool_name: "conversation",
-          tool_input: userText.slice(0, 1000),
-          tool_output: assistantText.slice(0, 4000),
-        },
-      });
+    api.on("llm_output", async (event, ctx) => {
+      if (!cfg.enabled) return;
+      const assistantText = firstNonEmptyString(
+        extractStructuredText(event?.lastAssistant),
+        extractStructuredText(event?.assistantText),
+        extractStructuredText(event?.assistantTexts),
+      );
+      if (!assistantText) return;
+      const pendingTurn = readPendingTurn(pendingTurns, event, ctx);
+      const userText = firstNonEmptyString(
+        event?.prompt,
+        event?.userText,
+        ctx?.prompt,
+        pendingTurn.prompt,
+      );
+      if (userText && !pendingTurn.observed) {
+        const observed = await observeConversation(client, event, ctx, userText, assistantText);
+        if (observed) {
+          rememberTurn(pendingTurns, event, ctx, { assistantText, observed: true });
+          return;
+        }
+      }
+      rememberTurn(pendingTurns, event, ctx, { assistantText });
+    });
+
+    api.on("agent_end", async (event, ctx) => {
+      if (!cfg.enabled) return;
+      if (event?.success === false) {
+        forgetTurn(pendingTurns, event, ctx);
+        return;
+      }
+      const messages = Array.isArray(event?.messages) ? event.messages : [];
+      const pendingTurn = readPendingTurn(pendingTurns, event, ctx);
+      if (pendingTurn.observed) {
+        forgetTurn(pendingTurns, event, ctx);
+        return;
+      }
+      const userText = firstNonEmptyString(
+        latestUserText(messages),
+        event?.prompt,
+        event?.userText,
+        ctx?.prompt,
+        pendingTurn.prompt,
+      );
+      const assistantText = firstNonEmptyString(
+        lastAssistantText(messages),
+        extractStructuredText(event?.lastAssistant),
+        extractStructuredText(event?.assistantText),
+        extractStructuredText(event?.assistantTexts),
+        pendingTurn.assistantText,
+      );
+      if (!userText || !assistantText) {
+        forgetTurn(pendingTurns, event, ctx);
+        return;
+      }
+      await observeConversation(client, event, ctx, userText, assistantText);
+      forgetTurn(pendingTurns, event, ctx);
     });
   },
 };

--- a/test/openclaw-plugin.test.ts
+++ b/test/openclaw-plugin.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 type Capability = {
   promptBuilder?: (params: {
@@ -26,6 +26,10 @@ function makeApi(overrides: Partial<FakeApi> = {}): FakeApi {
 }
 
 describe("openclaw plugin — memory capability registration (closes #286 follow-up)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("calls api.registerMemoryCapability with a promptBuilder when the host supports it", async () => {
     const mod = await import("../integrations/openclaw/plugin.mjs");
     const plugin = (mod as unknown as { default: { register(api: FakeApi): void } }).default;
@@ -47,6 +51,7 @@ describe("openclaw plugin — memory capability registration (closes #286 follow
     expect(api.on).toHaveBeenCalled();
     const events = (api.on as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0]);
     expect(events).toContain("before_agent_start");
+    expect(events).toContain("llm_output");
     expect(events).toContain("agent_end");
   });
 
@@ -58,5 +63,317 @@ describe("openclaw plugin — memory capability registration (closes #286 follow
     const capability = (api.registerMemoryCapability as ReturnType<typeof vi.fn>).mock.calls[0][0] as Capability;
     const lines = capability.promptBuilder?.({ availableTools: new Set() }) ?? [];
     expect(lines.join("\n")).toMatch(/memory\.internal:9999/);
+  });
+
+  it("captures completed turns with the AgentMemory observe contract", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const mod = await import("../integrations/openclaw/plugin.mjs");
+    const plugin = (mod as unknown as { default: { register(api: FakeApi): void } }).default;
+    const api = makeApi({
+      pluginConfig: {
+        base_url: "http://memory.internal:3113",
+        fallback_on_error: false,
+      },
+    });
+
+    plugin.register(api);
+    const agentEndHandler = (api.on as ReturnType<typeof vi.fn>).mock.calls.find(
+      ([eventName]) => eventName === "agent_end",
+    )?.[1] as ((event: unknown, ctx: unknown) => Promise<void>) | undefined;
+
+    expect(agentEndHandler).toBeTypeOf("function");
+    await agentEndHandler?.(
+      {
+        success: true,
+        runId: "run-1",
+        messages: [
+          { role: "user", content: "Please inspect the warning." },
+          { role: "assistant", content: "The warning is from AgentMemory." },
+        ],
+      },
+      {
+        sessionId: "session-1",
+        workspaceDir: "/Users/wecik/.openclaw/workspace",
+      },
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, options] = fetchMock.mock.calls[0] as [string, { body: string; headers: Record<string, string> }];
+    expect(url).toBe("http://memory.internal:3113/agentmemory/observe");
+    expect(options.headers).toEqual({ "Content-Type": "application/json" });
+    expect(JSON.parse(options.body)).toMatchObject({
+      hookType: "post_tool_use",
+      sessionId: "session-1",
+      project: "/Users/wecik/.openclaw/workspace",
+      cwd: "/Users/wecik/.openclaw/workspace",
+      data: {
+        tool_name: "conversation",
+        tool_input: "Please inspect the warning.",
+        tool_output: "The warning is from AgentMemory.",
+      },
+    });
+  });
+
+  it("captures codex turns when the mirrored user prompt is suppressed", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const mod = await import("../integrations/openclaw/plugin.mjs");
+    const plugin = (mod as unknown as { default: { register(api: FakeApi): void } }).default;
+    const api = makeApi({
+      pluginConfig: {
+        base_url: "http://memory.internal:3113",
+        fallback_on_error: false,
+      },
+    });
+
+    plugin.register(api);
+    const agentEndHandler = (api.on as ReturnType<typeof vi.fn>).mock.calls.find(
+      ([eventName]) => eventName === "agent_end",
+    )?.[1] as ((event: unknown, ctx: unknown) => Promise<void>) | undefined;
+
+    await agentEndHandler?.(
+      {
+        success: true,
+        prompt: "Smoke test AgentMemory capture.",
+        runId: "run-2",
+        messages: [
+          {
+            role: "assistant",
+            content: [{ type: "text", text: "openclaw-agentmemory-marker" }],
+          },
+        ],
+      },
+      {
+        sessionId: "session-2",
+        workspaceDir: "/Users/wecik/.openclaw/workspace",
+      },
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, options] = fetchMock.mock.calls[0] as [
+      string,
+      { body: string; headers: Record<string, string> },
+    ];
+    expect(JSON.parse(options.body)).toMatchObject({
+      sessionId: "session-2",
+      data: {
+        tool_name: "conversation",
+        tool_input: "Smoke test AgentMemory capture.",
+        tool_output: "openclaw-agentmemory-marker",
+      },
+    });
+  });
+
+  it("captures codex turns from prompt and assistantTexts when messages are empty", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const mod = await import("../integrations/openclaw/plugin.mjs");
+    const plugin = (mod as unknown as { default: { register(api: FakeApi): void } }).default;
+    const api = makeApi({
+      pluginConfig: {
+        base_url: "http://memory.internal:3113",
+        fallback_on_error: false,
+      },
+    });
+
+    plugin.register(api);
+    const agentEndHandler = (api.on as ReturnType<typeof vi.fn>).mock.calls.find(
+      ([eventName]) => eventName === "agent_end",
+    )?.[1] as ((event: unknown, ctx: unknown) => Promise<void>) | undefined;
+
+    await agentEndHandler?.(
+      {
+        success: true,
+        prompt: "Capture from event fields.",
+        runId: "run-3",
+        messages: [],
+        assistantTexts: ["assistant text from result"],
+      },
+      {
+        sessionId: "session-3",
+        workspaceDir: "/Users/wecik/.openclaw/workspace",
+      },
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, options] = fetchMock.mock.calls[0] as [
+      string,
+      { body: string; headers: Record<string, string> },
+    ];
+    expect(JSON.parse(options.body)).toMatchObject({
+      sessionId: "session-3",
+      data: {
+        tool_input: "Capture from event fields.",
+        tool_output: "assistant text from result",
+      },
+    });
+  });
+
+  it("captures codex turns from before_agent_start and llm_output fallback cache", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ results: [] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const mod = await import("../integrations/openclaw/plugin.mjs");
+    const plugin = (mod as unknown as { default: { register(api: FakeApi): void } }).default;
+    const api = makeApi({
+      pluginConfig: {
+        base_url: "http://memory.internal:3113",
+        fallback_on_error: false,
+      },
+    });
+
+    plugin.register(api);
+    const beforeAgentStartHandler = (api.on as ReturnType<typeof vi.fn>).mock.calls.find(
+      ([eventName]) => eventName === "before_agent_start",
+    )?.[1] as ((event: unknown, ctx: unknown) => Promise<void>) | undefined;
+    const llmOutputHandler = (api.on as ReturnType<typeof vi.fn>).mock.calls.find(
+      ([eventName]) => eventName === "llm_output",
+    )?.[1] as ((event: unknown, ctx: unknown) => Promise<void>) | undefined;
+    const agentEndHandler = (api.on as ReturnType<typeof vi.fn>).mock.calls.find(
+      ([eventName]) => eventName === "agent_end",
+    )?.[1] as ((event: unknown, ctx: unknown) => Promise<void>) | undefined;
+
+    await beforeAgentStartHandler?.(
+      { runId: "run-4", prompt: "Remember this prompt." },
+      { runId: "run-4", sessionId: "session-4" },
+    );
+    await llmOutputHandler?.(
+      { runId: "run-4", assistantTexts: ["remembered assistant"] },
+      { runId: "run-4", sessionId: "session-4" },
+    );
+    await agentEndHandler?.(
+      { runId: "run-4", success: true, messages: [] },
+      { runId: "run-4", sessionId: "session-4" },
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [url, options] = fetchMock.mock.calls[1] as [
+      string,
+      { body: string; headers: Record<string, string> },
+    ];
+    expect(url).toBe("http://memory.internal:3113/agentmemory/observe");
+    expect(JSON.parse(options.body)).toMatchObject({
+      sessionId: "session-4",
+      data: {
+        tool_input: "Remember this prompt.",
+        tool_output: "remembered assistant",
+      },
+    });
+  });
+
+  it("does not capture internal boot no-reply turns", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ results: [] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const mod = await import("../integrations/openclaw/plugin.mjs");
+    const plugin = (mod as unknown as { default: { register(api: FakeApi): void } }).default;
+    const api = makeApi({
+      pluginConfig: {
+        base_url: "http://memory.internal:3113",
+        fallback_on_error: false,
+      },
+    });
+
+    plugin.register(api);
+    const beforeAgentStartHandler = (api.on as ReturnType<typeof vi.fn>).mock.calls.find(
+      ([eventName]) => eventName === "before_agent_start",
+    )?.[1] as ((event: unknown, ctx: unknown) => Promise<void>) | undefined;
+    const llmOutputHandler = (api.on as ReturnType<typeof vi.fn>).mock.calls.find(
+      ([eventName]) => eventName === "llm_output",
+    )?.[1] as ((event: unknown, ctx: unknown) => Promise<void>) | undefined;
+    const agentEndHandler = (api.on as ReturnType<typeof vi.fn>).mock.calls.find(
+      ([eventName]) => eventName === "agent_end",
+    )?.[1] as ((event: unknown, ctx: unknown) => Promise<void>) | undefined;
+
+    await beforeAgentStartHandler?.(
+      {
+        runId: "boot-run",
+        sessionId: "boot",
+        prompt:
+          "You are running a boot check.\n<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>\nBOOT.md\n<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+      },
+      { runId: "boot-run", sessionId: "boot", sessionKey: "agent:main:boot" },
+    );
+    await llmOutputHandler?.(
+      { runId: "boot-run", sessionId: "boot", assistantTexts: ["NO_REPLY"] },
+      { runId: "boot-run", sessionId: "boot", sessionKey: "agent:main:boot" },
+    );
+    await agentEndHandler?.(
+      { runId: "boot-run", sessionId: "boot", success: true, messages: [] },
+      { runId: "boot-run", sessionId: "boot", sessionKey: "agent:main:boot" },
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("http://memory.internal:3113/agentmemory/smart-search");
+  });
+
+  it("deduplicates observe calls across duplicate plugin instances", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const mod = await import("../integrations/openclaw/plugin.mjs");
+    const plugin = (mod as unknown as { default: { register(api: FakeApi): void } }).default;
+    const apiA = makeApi({
+      pluginConfig: {
+        base_url: "http://memory.internal:3113",
+        fallback_on_error: false,
+      },
+    });
+    const apiB = makeApi({
+      pluginConfig: {
+        base_url: "http://memory.internal:3113",
+        fallback_on_error: false,
+      },
+    });
+
+    plugin.register(apiA);
+    plugin.register(apiB);
+    const handlerA = (apiA.on as ReturnType<typeof vi.fn>).mock.calls.find(
+      ([eventName]) => eventName === "agent_end",
+    )?.[1] as ((event: unknown, ctx: unknown) => Promise<void>) | undefined;
+    const handlerB = (apiB.on as ReturnType<typeof vi.fn>).mock.calls.find(
+      ([eventName]) => eventName === "agent_end",
+    )?.[1] as ((event: unknown, ctx: unknown) => Promise<void>) | undefined;
+    const event = {
+      success: true,
+      runId: "run-dedupe",
+      messages: [
+        { role: "user", content: "Same user prompt." },
+        { role: "assistant", content: "Same assistant answer." },
+      ],
+    };
+    const ctx = {
+      runId: "run-dedupe",
+      sessionId: "session-dedupe",
+      workspaceDir: "/Users/wecik/.openclaw/workspace",
+    };
+
+    await handlerA?.(event, ctx);
+    await handlerB?.(event, ctx);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("http://memory.internal:3113/agentmemory/observe");
   });
 });


### PR DESCRIPTION
## Summary
- capture OpenClaw completed turns through llm_output and agent_end using prompt and assistant payload fallbacks
- avoid reading environment bearer tokens from the OpenClaw integration; use the configured loopback REST endpoint only
- skip internal boot/NO_REPLY turns so startup checks do not pollute conversation memory
- deduplicate recall and observe calls across duplicate plugin instances

## Root Cause
OpenClaw could load the AgentMemory integration more than once or with terminal hooks restored after startup registry changes. The plugin needed durable turn correlation, prompt/assistant fallbacks, and idempotency so conversation capture remains stable even when the host reloads plugin scopes.

## Validation
- rtk test -- npx vitest run test/openclaw-plugin.test.ts
- OpenClaw live smoke: marker openclaw-rootfix-dedupe-20260608140502 was observed exactly once through AgentMemory search
