### PR TITLE
Add oracleagentmemory to the comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ Latest release notes: [CHANGELOG.md](CHANGELOG.md).
 <th>Khoj (35K ⭐)</th>
 <th>supermemory (26K ⭐)</th>
 <th>MemPalace (54K ⭐)</th>
+<th>oracleagentmemory</th>
 <th>Hippo</th>
 <th>Built-in (CLAUDE.md)</th>
 </tr>
@@ -307,6 +308,7 @@ Latest release notes: [CHANGELOG.md](CHANGELOG.md).
 <td>Personal AI</td>
 <td>Memory API + app</td>
 <td>Vector memory (OSS)</td>
+<td>Memory engine (Oracle DB)</td>
 <td>Memory system</td>
 <td>Static file</td>
 </tr>
@@ -318,6 +320,7 @@ Latest release notes: [CHANGELOG.md](CHANGELOG.md).
 <td>N/A</td>
 <td>Self-reported</td>
 <td>~96.6% (self-reported)</td>
+<td>94.4% (self-reported)</td>
 <td>N/A</td>
 <td>N/A (grep)</td>
 </tr>
@@ -329,6 +332,7 @@ Latest release notes: [CHANGELOG.md](CHANGELOG.md).
 <td>Manual</td>
 <td>API-side extraction</td>
 <td>Manual</td>
+<td>API extraction</td>
 <td>Manual</td>
 <td>Manual editing</td>
 </tr>
@@ -340,6 +344,7 @@ Latest release notes: [CHANGELOG.md](CHANGELOG.md).
 <td>Semantic</td>
 <td>Vector + RAG</td>
 <td>Vector-only</td>
+<td>Vector + semantic</td>
 <td>Decay-weighted</td>
 <td>Loads everything into context</td>
 </tr>
@@ -351,6 +356,7 @@ Latest release notes: [CHANGELOG.md](CHANGELOG.md).
 <td>No</td>
 <td>No</td>
 <td>No</td>
+<td>Scoped only</td>
 <td>Multi-agent shared</td>
 <td>Per-agent files</td>
 </tr>
@@ -362,6 +368,7 @@ Latest release notes: [CHANGELOG.md](CHANGELOG.md).
 <td>Standalone</td>
 <td>None</td>
 <td>None</td>
+<td>Oracle Database</td>
 <td>None</td>
 <td>Per-agent format</td>
 </tr>
@@ -373,6 +380,7 @@ Latest release notes: [CHANGELOG.md](CHANGELOG.md).
 <td>Multiple</td>
 <td>Managed cloud</td>
 <td>Vector store</td>
+<td>Oracle AI Database</td>
 <td>None</td>
 <td>None</td>
 </tr>
@@ -384,6 +392,7 @@ Latest release notes: [CHANGELOG.md](CHANGELOG.md).
 <td>Manual</td>
 <td>Auto-forget</td>
 <td>None</td>
+<td>Not stated</td>
 <td>Decay + consolidation</td>
 <td>Manual pruning</td>
 </tr>
@@ -395,6 +404,7 @@ Latest release notes: [CHANGELOG.md](CHANGELOG.md).
 <td>Varies</td>
 <td>Cloud pricing</td>
 <td>No token budget</td>
+<td>LLM-backed (varies)</td>
 <td>Varies</td>
 <td>22K+ tokens at 240 obs</td>
 </tr>
@@ -408,6 +418,7 @@ Latest release notes: [CHANGELOG.md](CHANGELOG.md).
 <td>No</td>
 <td>No</td>
 <td>No</td>
+<td>No</td>
 </tr>
 <tr>
 <td><strong>Self-hosted</strong></td>
@@ -417,12 +428,13 @@ Latest release notes: [CHANGELOG.md](CHANGELOG.md).
 <td>Yes</td>
 <td>No (cloud-only)</td>
 <td>Yes</td>
+<td>Yes (Oracle DB)</td>
 <td>Yes</td>
 <td>Yes</td>
 </tr>
 </table>
 
-<sub>Benchmark note: only agentmemory's R@5 is our own measured result (LongMemEval-S, reproducible from <a href="benchmark/COMPARISON.md"><code>benchmark/COMPARISON.md</code></a>). The mem0 and Letta figures are their published LoCoMo numbers (a different dataset); the MemPalace and supermemory figures are vendor self-reported claims we have not independently reproduced. Shown side by side for ballpark only, not a head-to-head on identical data. Star counts are approximate and drift over time.</sub>
+<sub>Benchmark note: only agentmemory's R@5 is our own measured result (LongMemEval-S, reproducible from <a href="benchmark/COMPARISON.md"><code>benchmark/COMPARISON.md</code></a>). The mem0 and Letta figures are their published LoCoMo numbers (a different dataset); the MemPalace, supermemory, and oracleagentmemory figures are vendor self-reported claims we have not independently reproduced (oracleagentmemory's run used GPT-5.5 against an Oracle AI Database). Shown side by side for ballpark only, not a head-to-head on identical data. Star counts are approximate and drift over time.</sub>
 
 ---
 

--- a/benchmark/COMPARISON.md
+++ b/benchmark/COMPARISON.md
@@ -15,10 +15,11 @@ All numbers here come from published benchmarks or public repositories. We link 
 | **agentmemory** (BM25 + Vector) | LongMemEval-S | **95.2%** | `all-MiniLM-L6-v2` embeddings, no API key |
 | agentmemory (BM25-only) | LongMemEval-S | 86.2% | Fallback when no embedding provider available |
 | MemPalace | LongMemEval-S | ~96.6% (self-reported) | Vendor-published number we have not independently reproduced. Vector-only with a larger embedding model and no agent-integration surface (no hooks, no MCP, no multi-agent) |
+| oracleagentmemory | LongMemEval | 94.4% (self-reported) | Vendor-published, scored with GPT-5.5 at "xhigh reasoning" and requires an Oracle AI Database. We have not reproduced it. agentmemory's 95.2% uses free local embeddings and no API key |
 | Letta / MemGPT | LoCoMo | 83.2% | Different benchmark (LoCoMo, not LongMemEval) |
 | Mem0 | LoCoMo | 68.5% | Different benchmark (LoCoMo, not LongMemEval) |
 
-**⚠️ Apples vs oranges caveat:** only agentmemory's 95.2% is our own measured result, reproducible from the methodology below. Every other number here is the vendor's published claim, on a different benchmark or harness, that we have not independently reproduced: MemPalace reports LongMemEval-S, while Letta and Mem0 publish on [LoCoMo](https://snap-stanford.github.io/LoCoMo/). Treat them as ballpark vendor claims, not a head-to-head on identical data. We'd love to run every system on the same dataset; if any maintainer wants to collaborate, open an issue.
+**⚠️ Apples vs oranges caveat:** only agentmemory's 95.2% is our own measured result, reproducible from the methodology below. Every other number here is the vendor's published claim, on a different benchmark or harness, that we have not independently reproduced: MemPalace and oracleagentmemory report LongMemEval (oracleagentmemory's run used GPT-5.5 at "xhigh reasoning" against an Oracle AI Database), while Letta and Mem0 publish on [LoCoMo](https://snap-stanford.github.io/LoCoMo/). Treat them as ballpark vendor claims, not a head-to-head on identical data. We'd love to run every system on the same dataset; if any maintainer wants to collaborate, open an issue.
 
 Full agentmemory methodology: [`LONGMEMEVAL.md`](LONGMEMEVAL.md)
 
@@ -26,26 +27,26 @@ Full agentmemory methodology: [`LONGMEMEVAL.md`](LONGMEMEVAL.md)
 
 ## Feature Matrix
 
-| Feature | agentmemory | mem0 | Letta/MemGPT | Khoj | supermemory | MemPalace | Hippo |
-|---|---|---|---|---|---|---|---|
-| **GitHub stars** | Growing | 58K+ | 23K+ | 35K+ | 26K+ | 54K+ | Trending |
-| **Type** | Memory engine + MCP server | Memory layer API | Full agent runtime | Personal AI | Memory API + app | Benchmark-focused OSS | Memory system |
-| **Auto-capture via hooks** | ✅ 12 lifecycle hooks | ❌ Manual `add()` | ❌ Agent self-edits | ❌ Manual | ❌ API-side extraction | ❌ Manual | ❌ Manual |
-| **Search strategy** | BM25 + Vector + Graph | Vector + Graph | Vector (archival) | Semantic | Vector + RAG | Vector-only (large model) | Decay-weighted |
-| **Multi-agent coordination** | ✅ Leases + signals + mesh | ❌ | Runtime-internal only | ❌ | ❌ | ❌ | Multi-agent shared |
-| **Framework lock-in** | None | None | High | Standalone | None (drop-in wrappers) | None | None |
-| **External deps** | None | Qdrant/pgvector | Postgres + vector | Multiple | Managed cloud | Vector store | None |
-| **Self-hostable** | ✅ default | Optional | Optional | ✅ | ❌ Cloud-only | ✅ | ✅ |
-| **Knowledge graph** | ✅ Entity extraction + BFS | ✅ Mem0g variant | ❌ | Doc links | ❌ | ❌ | ❌ |
-| **Memory decay** | ✅ Ebbinghaus + tiered | ❌ | ❌ | ❌ | ✅ Auto-forget | ❌ | ✅ Half-lives |
-| **4-tier consolidation** | ✅ Working → episodic → semantic → procedural | ❌ | OS-inspired tiers | ❌ | ❌ | ❌ | Episodic + semantic |
-| **Version / supersession** | ✅ Jaccard-based | Passive | ❌ | ❌ | ✅ Auto-resolve | ❌ | ❌ |
-| **Real-time viewer** | ✅ Port 3113 | Cloud dashboard | Cloud dashboard | Web UI | Cloud dashboard | ❌ | ❌ |
-| **Privacy filtering** | ✅ Strips secrets pre-store | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **Obsidian export** | ✅ Built-in | ❌ | ❌ | Native format | ❌ | ❌ | ❌ |
-| **Cross-agent** | ✅ MCP + REST | API calls | Within runtime | Standalone | MCP + API | Standalone | Multi-agent shared |
-| **Audit trail** | ✅ All mutations logged | ❌ | Limited | ❌ | ❌ | ❌ | ❌ |
-| **Language SDKs** | Any (REST + MCP) | Python + TS | Python only | API | Python + TS | Python | Node |
+| Feature | agentmemory | mem0 | Letta/MemGPT | Khoj | supermemory | MemPalace | oracleagentmemory | Hippo |
+|---|---|---|---|---|---|---|---|---|
+| **GitHub stars** | Growing | 58K+ | 23K+ | 35K+ | 26K+ | 54K+ | PyPI (Oracle) | Trending |
+| **Type** | Memory engine + MCP server | Memory layer API | Full agent runtime | Personal AI | Memory API + app | Benchmark-focused OSS | Memory engine (Oracle DB) | Memory system |
+| **Auto-capture via hooks** | ✅ 12 lifecycle hooks | ❌ Manual `add()` | ❌ Agent self-edits | ❌ Manual | ❌ API-side extraction | ❌ Manual | ❌ API extraction | ❌ Manual |
+| **Search strategy** | BM25 + Vector + Graph | Vector + Graph | Vector (archival) | Semantic | Vector + RAG | Vector-only (large model) | Vector + semantic | Decay-weighted |
+| **Multi-agent coordination** | ✅ Leases + signals + mesh | ❌ | Runtime-internal only | ❌ | ❌ | ❌ | Scoped only (user/agent/thread) | Multi-agent shared |
+| **Framework lock-in** | None | None | High | Standalone | None (drop-in wrappers) | None | Oracle Database | None |
+| **External deps** | None | Qdrant/pgvector | Postgres + vector | Multiple | Managed cloud | Vector store | Oracle AI Database | None |
+| **Self-hostable** | ✅ default | Optional | Optional | ✅ | ❌ Cloud-only | ✅ | ✅ (needs Oracle DB) | ✅ |
+| **Knowledge graph** | ✅ Entity extraction + BFS | ✅ Mem0g variant | ❌ | Doc links | ❌ | ❌ | ❌ | ❌ |
+| **Memory decay** | ✅ Ebbinghaus + tiered | ❌ | ❌ | ❌ | ✅ Auto-forget | ❌ | ❌ | ✅ Half-lives |
+| **4-tier consolidation** | ✅ Working → episodic → semantic → procedural | ❌ | OS-inspired tiers | ❌ | ❌ | ❌ | ❌ | Episodic + semantic |
+| **Version / supersession** | ✅ Jaccard-based | Passive | ❌ | ❌ | ✅ Auto-resolve | ❌ | ❌ | ❌ |
+| **Real-time viewer** | ✅ Port 3113 | Cloud dashboard | Cloud dashboard | Web UI | Cloud dashboard | ❌ | ❌ | ❌ |
+| **Privacy filtering** | ✅ Strips secrets pre-store | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| **Obsidian export** | ✅ Built-in | ❌ | ❌ | Native format | ❌ | ❌ | ❌ | ❌ |
+| **Cross-agent** | ✅ MCP + REST | API calls | Within runtime | Standalone | MCP + API | Standalone | Python API | Multi-agent shared |
+| **Audit trail** | ✅ All mutations logged | ❌ | Limited | ❌ | ❌ | ❌ | ❌ | ❌ |
+| **Language SDKs** | Any (REST + MCP) | Python + TS | Python only | API | Python + TS | Python | Python only | Node |
 
 ---
 
@@ -108,6 +109,12 @@ This isn't a "agentmemory wins everything" page. Different tools solve different
 - To chase its self-reported retrieval benchmark (we have not reproduced it)
 - Pure retrieval over agent workflow features
 - Note: no auto-capture, no MCP, no multi-agent coordination, so you wire all integration yourself
+
+**Choose oracleagentmemory if you want:**
+- You already run on Oracle AI Database and want memory inside it
+- Enterprise Oracle stack with vector search in the same database
+- LLM-backed extraction and are fine paying for a frontier model (their benchmark used GPT-5.5)
+- Note: Python-only, Oracle Database required, no MCP, no real-time viewer
 
 **Choose Hippo if you want:**
 - Biologically-inspired memory model (decay, consolidation, sleep)


### PR DESCRIPTION
## What

Adds oracleagentmemory (PyPI, v26.4.0) to the README comparison table and benchmark/COMPARISON.md, following the same honesty rules as the rest of the matrix.

- Memory engine that runs inside an Oracle AI Database (required dependency), Python-only, vector + semantic search, no MCP, no real-time viewer.
- Its 94.4% LongMemEval is labeled vendor self-reported: scored with GPT-5.5 at xhigh reasoning against an Oracle Database, and we have not reproduced it. agentmemory's 95.2% is our own measured result using free local embeddings with no API key.
- Added to the LongMemEval table, the feature matrix, the self-reported caveat, and a Choose section.

Only agentmemory's number remains presented as reproducible; every competitor figure is flagged as a vendor claim.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated comparison tables to include oracleagentmemory as a new system option, with details on features, retrieval accuracy benchmarks, and use-case guidance.
  * Clarified benchmark footnotes regarding vendor-published results and independent reproducibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->