### PR TITLE
Allow XENOVA_CACHE_HOME to redirect local embedding model path

### DIFF
--- a/src/providers/embedding/local.ts
+++ b/src/providers/embedding/local.ts
@@ -33,7 +33,10 @@ export class LocalEmbeddingProvider implements EmbeddingProvider {
   private async getExtractor() {
     if (this.extractor) return this.extractor;
 
-    let transformers: { pipeline: Pipeline };
+    let transformers: {
+      pipeline: Pipeline;
+      env: { localModelPath: string; cacheDir: string };
+    };
     try {
       // @ts-ignore - optional peer dependency
       transformers = await import("@xenova/transformers");
@@ -41,6 +44,19 @@ export class LocalEmbeddingProvider implements EmbeddingProvider {
       throw new Error(
         "Install @xenova/transformers for local embeddings: npm install @xenova/transformers",
       );
+    }
+
+    // Pre-downloaded models (offline / restricted-network setups) live in
+    // ~/.cache/Xenova/ by convention. @xenova/transformers defaults
+    // localModelPath to its own install dir — which is deep inside npm's
+    // global node_modules and rarely holds pre-downloaded files. When
+    // XENOVA_CACHE_HOME is set, redirect both the local-model lookup and
+    // the download cache so the library finds existing files without a
+    // network fetch.
+    const cacheHome = process.env["XENOVA_CACHE_HOME"];
+    if (cacheHome) {
+      transformers.env.localModelPath = cacheHome;
+      transformers.env.cacheDir = cacheHome;
     }
 
     this.extractor = await transformers.pipeline(


### PR DESCRIPTION
### Problem

`@xenova/transformers` defaults `env.localModelPath` to its own install directory — deep inside npm's global `node_modules` (e.g. `.../node_modules/@xenova/transformers/models/`). When users pre-download embedding models to `~/.cache/Xenova/` — a common pattern in offline or restricted-network environments — the library never looks there.

If HuggingFace CDN is unreachable (firewall, air-gapped network, etc.), every observation save logs:

[agentmemory] warn vector-index add: embed failed — skipping {"provider":"local","error":"fetch failed"}

This means every new observation lacks a vector embedding, and semantic search silently degrades to BM25-only.

### Fix

In `LocalEmbeddingProvider.getExtractor()`, read `XENOVA_CACHE_HOME` from the environment after importing `@xenova/transformers`. When set, override both `env.localModelPath` (the primary file lookup path) and `env.cacheDir` (the download cache destination) before calling `pipeline()`.

| `XENOVA_CACHE_HOME` | Behavior |
|---|---|
| unset | Unchanged — uses default paths inside npm `node_modules` |
| `~/.cache/Xenova` | Finds pre-downloaded models directly, no network fetch needed |

### Why `localModelPath` + `cacheDir` both

- `localModelPath` is the **primary lookup** (`hub.js:392`) — the library checks it first
- `cacheDir` is where downloads are **persisted** — redirecting it keeps the npm directory clean

The convention matches: `~/.cache/Xenova/` already uses the `{org}/{model}/` layout that `@xenova/transformers` expects, so `XENOVA_CACHE_HOME=~/.cache/Xenova` works directly with pre-downloaded models.

### Verification

- [x] `XENOVA_CACHE_HOME=~/.cache/Xenova` → embed succeeds, 384-dim vector returned
- [x] env var unset → `env.localModelPath` unchanged, existing behavior preserved
- [x] `test/embedding-provider.test.ts` unaffected (no env var set → default path)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for offline and restricted-network setups, enabling use of pre-downloaded models without network access via environment variable configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->