### PR TITLE
fix(hermes): archive-on-delete sync strategy for on_memory_write

### DIFF
--- a/integrations/hermes/__init__.py
+++ b/integrations/hermes/__init__.py
@@ -374,9 +374,13 @@ class AgentMemoryProvider(MemoryProvider):
             })
 
     def on_memory_write(self, action: str, target: str, content: str, **kwargs: Any) -> None:
-        if action in ("add", "update") and content:
+        # Archive-on-delete: skip add/update (local-only — Hermes MEMORY.md
+        # is the active rulebook, not historical knowledge), sync only remove
+        # (preserve deleted entries as historical knowledge in agentmemory).
+        # See https://github.com/rohitg00/agentmemory/issues/834
+        if action == "remove" and content:
             _api_bg(self._base, "remember", {
-                "content": content,
+                "content": f"[Archived from local memory] {content}",
                 "type": "fact",
             })
 


### PR DESCRIPTION
## Problem

When agentmemory is installed as a Hermes memory provider plugin, the `on_memory_write` hook syncs **every** local memory write (add/update) to agentmemory. This creates noise — Hermes MEMORY.md is the active rulebook with capacity limits (~3600 chars total), and every add/update pollutes the agentmemory knowledge base. Additionally, `remove` is ignored entirely, causing the two stores to drift apart.

## Solution

Invert the sync logic — **archive-on-delete**:

- **add / update** → skip (local-only, no agentmemory noise)
- **remove** → archive to agentmemory with `[Archived from local memory]` prefix

The rationale: local MEMORY.md is for high-frequency, always-present rules. When an entry is removed (capacity pressure, outdated, or no longer needed every turn), the removal itself signals "this might still be useful historically" — and agentmemory is the right place for it.

Closes #834

## Change

`integrations/hermes/__init__.py` — `AgentMemoryProvider.on_memory_write()` method

## Testing

- Existing Hermes plugin tests pass: `npx vitest run test/hermes-plugin.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deleted memory items are now automatically archived, ensuring content is preserved rather than permanently lost.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->