### PR TITLE
fix: make CALL_TIMEOUT_MS env-overridable and raise HTTP worker default_timeout to 600 s

### DIFF
--- a/iii-config.docker.yaml
+++ b/iii-config.docker.yaml
@@ -3,7 +3,7 @@ workers:
     config:
       port: 3111
       host: 0.0.0.0
-      default_timeout: 180000
+      default_timeout: 600000
       cors:
         allowed_origins: ["http://localhost:3111", "http://localhost:3113", "http://127.0.0.1:3111", "http://127.0.0.1:3113"]
         allowed_methods: [GET, POST, PUT, DELETE, OPTIONS]

--- a/iii-config.yaml
+++ b/iii-config.yaml
@@ -3,7 +3,7 @@ workers:
     config:
       port: 3111
       host: 127.0.0.1
-      default_timeout: 180000
+      default_timeout: 600000
       cors:
         allowed_origins: ["http://localhost:3111", "http://localhost:3113", "http://127.0.0.1:3111", "http://127.0.0.1:3113"]
         allowed_methods: [GET, POST, PUT, DELETE, OPTIONS]

--- a/src/mcp/rest-proxy.ts
+++ b/src/mcp/rest-proxy.ts
@@ -10,11 +10,17 @@ function probeTimeoutMs(): number {
   return Number.isFinite(n) && n > 0 ? Math.floor(n) : DEFAULT_HEALTH_PROBE_TIMEOUT_MS;
 }
 
+// Node.js timer internals use a signed 32-bit integer; values above this
+// wrap to negative and fire immediately. Cap env overrides to stay safe.
+const MAX_TIMER_MS = 2_147_483_647;
+
 export function callTimeoutMs(): number {
   const raw = process.env["AGENTMEMORY_CALL_TIMEOUT_MS"];
   if (!raw) return DEFAULT_CALL_TIMEOUT_MS;
   const n = Number(raw);
-  return Number.isFinite(n) && n > 0 ? Math.floor(n) : DEFAULT_CALL_TIMEOUT_MS;
+  return Number.isFinite(n) && n > 0
+    ? Math.min(Math.floor(n), MAX_TIMER_MS)
+    : DEFAULT_CALL_TIMEOUT_MS;
 }
 
 function forceProxy(): boolean {

--- a/src/mcp/rest-proxy.ts
+++ b/src/mcp/rest-proxy.ts
@@ -1,6 +1,6 @@
 const DEFAULT_URL = "http://localhost:3111";
 const DEFAULT_HEALTH_PROBE_TIMEOUT_MS = 2_000;
-const CALL_TIMEOUT_MS = 15_000;
+const DEFAULT_CALL_TIMEOUT_MS = 600_000;
 const LOCAL_MODE_TTL_MS = 30_000;
 
 function probeTimeoutMs(): number {
@@ -8,6 +8,13 @@ function probeTimeoutMs(): number {
   if (!raw) return DEFAULT_HEALTH_PROBE_TIMEOUT_MS;
   const n = Number(raw);
   return Number.isFinite(n) && n > 0 ? Math.floor(n) : DEFAULT_HEALTH_PROBE_TIMEOUT_MS;
+}
+
+export function callTimeoutMs(): number {
+  const raw = process.env["AGENTMEMORY_CALL_TIMEOUT_MS"];
+  if (!raw) return DEFAULT_CALL_TIMEOUT_MS;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : DEFAULT_CALL_TIMEOUT_MS;
 }
 
 function forceProxy(): boolean {
@@ -144,7 +151,7 @@ export async function resolveHandle(): Promise<Handle> {
               ...authHeader(),
               ...(init?.headers as Record<string, string> | undefined),
             },
-            signal: AbortSignal.timeout(CALL_TIMEOUT_MS),
+            signal: AbortSignal.timeout(callTimeoutMs()),
           });
           if (!res.ok) {
             throw new Error(

--- a/test/mcp-call-timeout.test.ts
+++ b/test/mcp-call-timeout.test.ts
@@ -54,6 +54,16 @@ describe("callTimeoutMs — AGENTMEMORY_CALL_TIMEOUT_MS env var", () => {
       expect(callTimeoutMs()).toBe(600_000);
     }
   });
+
+  it("clamps values above the Node.js 32-bit timer ceiling to 2 147 483 647", () => {
+    process.env["AGENTMEMORY_CALL_TIMEOUT_MS"] = "9999999999";
+    expect(callTimeoutMs()).toBe(2_147_483_647);
+  });
+
+  it("returns the exact ceiling value when set to 2 147 483 647", () => {
+    process.env["AGENTMEMORY_CALL_TIMEOUT_MS"] = "2147483647";
+    expect(callTimeoutMs()).toBe(2_147_483_647);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────

--- a/test/mcp-call-timeout.test.ts
+++ b/test/mcp-call-timeout.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  callTimeoutMs,
+  resolveHandle,
+  resetHandleForTests,
+} from "../src/mcp/rest-proxy.js";
+
+// ─────────────────────────────────────────────────────────────
+// callTimeoutMs() unit tests
+// Mirrors the AGENTMEMORY_LLM_TIMEOUT_MS suite in fetch-timeout.test.ts
+// and the resolveEnvOrEmpty suite in mcp-env-placeholder.test.ts.
+// ─────────────────────────────────────────────────────────────
+describe("callTimeoutMs — AGENTMEMORY_CALL_TIMEOUT_MS env var", () => {
+  beforeEach(() => {
+    delete process.env["AGENTMEMORY_CALL_TIMEOUT_MS"];
+  });
+
+  afterEach(() => {
+    delete process.env["AGENTMEMORY_CALL_TIMEOUT_MS"];
+  });
+
+  it("returns 600 000 when env var is not set", () => {
+    expect(callTimeoutMs()).toBe(600_000);
+  });
+
+  it("returns 600 000 when env var is empty string", () => {
+    process.env["AGENTMEMORY_CALL_TIMEOUT_MS"] = "";
+    expect(callTimeoutMs()).toBe(600_000);
+  });
+
+  it("reads a valid numeric value from AGENTMEMORY_CALL_TIMEOUT_MS", () => {
+    process.env["AGENTMEMORY_CALL_TIMEOUT_MS"] = "30000";
+    expect(callTimeoutMs()).toBe(30_000);
+  });
+
+  it("floors a float value", () => {
+    process.env["AGENTMEMORY_CALL_TIMEOUT_MS"] = "1500.9";
+    expect(callTimeoutMs()).toBe(1_500);
+  });
+
+  it("falls back to 600 000 for a zero value", () => {
+    process.env["AGENTMEMORY_CALL_TIMEOUT_MS"] = "0";
+    expect(callTimeoutMs()).toBe(600_000);
+  });
+
+  it("falls back to 600 000 for a negative value", () => {
+    process.env["AGENTMEMORY_CALL_TIMEOUT_MS"] = "-1";
+    expect(callTimeoutMs()).toBe(600_000);
+  });
+
+  it("falls back to 600 000 for malformed values (CodeRabbit parity with fetch-timeout tests)", () => {
+    for (const bad of ["30ms", "1_000", "60s", "30abc", "Infinity", "NaN"]) {
+      process.env["AGENTMEMORY_CALL_TIMEOUT_MS"] = bad;
+      expect(callTimeoutMs()).toBe(600_000);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// Proxy call respects AGENTMEMORY_CALL_TIMEOUT_MS override
+// Sets a tiny timeout (50 ms), installs a hanging fetch that
+// honours AbortSignal, and asserts the proxy call aborts instead
+// of running forever.
+// ─────────────────────────────────────────────────────────────
+describe("proxy call — AGENTMEMORY_CALL_TIMEOUT_MS aborts hung requests", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    resetHandleForTests();
+    process.env["AGENTMEMORY_URL"] = "http://localhost:3111";
+    process.env["AGENTMEMORY_FORCE_PROXY"] = "1";
+    process.env["AGENTMEMORY_CALL_TIMEOUT_MS"] = "50";
+
+    // Fetch that never resolves but respects AbortSignal.
+    globalThis.fetch = vi.fn(
+      async (_url: string | URL, init?: RequestInit): Promise<Response> => {
+        return new Promise<Response>((_resolve, reject) => {
+          const sig = init?.signal;
+          if (!sig) return;
+          if (sig.aborted) {
+            reject(new DOMException("AbortError", "AbortError"));
+            return;
+          }
+          sig.addEventListener("abort", () =>
+            reject(new DOMException("AbortError", "AbortError")),
+          );
+        });
+      },
+    ) as typeof fetch;
+  });
+
+  afterEach(() => {
+    resetHandleForTests();
+    globalThis.fetch = originalFetch;
+    delete process.env["AGENTMEMORY_URL"];
+    delete process.env["AGENTMEMORY_FORCE_PROXY"];
+    delete process.env["AGENTMEMORY_CALL_TIMEOUT_MS"];
+  });
+
+  it("aborts a proxy call that hangs beyond the configured timeout", async () => {
+    const handle = await resolveHandle();
+    expect(handle.mode).toBe("proxy");
+    if (handle.mode !== "proxy") return;
+
+    await expect(
+      handle.call("/agentmemory/smart-search", {
+        method: "POST",
+        body: JSON.stringify({ query: "test" }),
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("does NOT abort when the server responds before the deadline", async () => {
+    // Replace the hanging mock with one that resolves immediately.
+    globalThis.fetch = vi.fn(
+      async (): Promise<Response> =>
+        new Response(JSON.stringify({ results: [] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    ) as typeof fetch;
+
+    resetHandleForTests();
+    const handle = await resolveHandle();
+    expect(handle.mode).toBe("proxy");
+    if (handle.mode !== "proxy") return;
+
+    const result = await handle.call("/agentmemory/smart-search", {
+      method: "POST",
+      body: JSON.stringify({ query: "test" }),
+    });
+    expect(result).toEqual({ results: [] });
+  });
+});


### PR DESCRIPTION
## What

- `CALL_TIMEOUT_MS` in `src/mcp/rest-proxy.ts` is now env-overridable via
  `AGENTMEMORY_CALL_TIMEOUT_MS`, with a default of 600 000 ms (was 15 000 ms).
  Mirrors the existing `AGENTMEMORY_PROBE_TIMEOUT_MS` pattern already in the
  same file.
- `iii-config.yaml` `default_timeout` raised from 180 000 ms to 600 000 ms.
- `callTimeoutMs()` is exported; `test/mcp-call-timeout.test.ts` covers the
  default value, env-var parsing, malformed-value fallback, and the abort
  behaviour under a hanging server response (9 new tests, all pass).

## Why

On stores with 1 100+ semantic memories and 630+ insights,
`memory_consolidate` and `memory_reflect` reliably time out because the
proxy's HTTP client aborts the request after 15 s — before the server
finishes the LLM-backed operation.

Making the timeout env-overridable is a non-breaking improvement: users who
don't set the env var get the new 600 s default; anyone who needs a
different ceiling can set `AGENTMEMORY_CALL_TIMEOUT_MS` in their MCP server
env config.

Related to #655 (which addresses the server-side sequential KV bottleneck).
This addresses the client-side transport ceiling — both fixes are needed for
large stores to complete reliably.

## How to verify

1. Point the server at a large memory store (500+ semantic entries).
2. Run `memory_consolidate` — it should complete instead of returning a
   timeout error.
3. Set `AGENTMEMORY_CALL_TIMEOUT_MS=5000` and confirm a small store still
   respects the override.
4. `npm test` — the new suite at `test/mcp-call-timeout.test.ts` passes (9
   tests); no regressions in the existing suite.

Fixes #866

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Increased HTTP worker default timeout to support longer-running operations (now 600s).
  * Proxied request timeout is now configurable and resilient to invalid values, with safe clamping to platform limits.

* **Tests**
  * Added comprehensive tests validating timeout parsing, clamping, defaults, and proxy abort behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->