### PR TITLE
fix(smart-search): apply the project filter to results, not just lessons

### DIFF
--- a/src/functions/smart-search.ts
+++ b/src/functions/smart-search.ts
@@ -115,6 +115,10 @@ export function registerSmartSearchFunction(
       const filterAgentId = wildcardAgent
         ? undefined
         : explicitAgentId ?? envAgentId;
+      const filterProject =
+        typeof data.project === "string" && data.project.trim().length > 0
+          ? data.project.trim()
+          : undefined;
       if (
         isolated &&
         !wildcardAgent &&
@@ -156,9 +160,9 @@ export function registerSmartSearchFunction(
           if (r) expanded.push(r);
         }
 
-        const scoped = filterAgentId
-          ? expanded.filter((e) => e.observation.agentId === filterAgentId)
-          : expanded;
+        const scoped = expanded
+          .filter((e) => !filterAgentId || e.observation.agentId === filterAgentId)
+          .filter((e) => !filterProject || e.observation.project === filterProject);
 
         void recordAccessBatch(
           kv,
@@ -187,12 +191,12 @@ export function registerSmartSearchFunction(
       const includeLessons = data.includeLessons !== false;
 
       // Over-fetch when filtering. Hybrid search can't filter on
-      // agentId (BM25/vector indexes don't carry it), so we ask the
-      // searcher for more hits than we need and trim post-filter. 3×
-      // is a defensible middle ground: enough headroom for a small
-      // workload, capped at 300 so a 100-limit request never asks for
-      // thousands of hits.
-      const overFetchLimit = filterAgentId
+      // agentId or project (BM25/vector indexes carry neither), so we
+      // ask the searcher for more hits than we need and trim
+      // post-filter. 3× is a defensible middle ground: enough headroom
+      // for a small workload, capped at 300 so a 100-limit request
+      // never asks for thousands of hits.
+      const overFetchLimit = filterAgentId || filterProject
         ? Math.min(limit * 3, 300)
         : limit;
 
@@ -203,11 +207,10 @@ export function registerSmartSearchFunction(
           : Promise.resolve([]),
       ]);
 
-      const filteredHybrid = filterAgentId
-        ? hybridResults
-            .filter((r) => r.observation.agentId === filterAgentId)
-            .slice(0, limit)
-        : hybridResults.slice(0, limit);
+      const filteredHybrid = hybridResults
+        .filter((r) => !filterAgentId || r.observation.agentId === filterAgentId)
+        .filter((r) => !filterProject || r.observation.project === filterProject)
+        .slice(0, limit);
 
       const compact: CompactSearchResult[] = filteredHybrid.map((r) => ({
         obsId: r.observation.id,

--- a/src/functions/smart-search.ts
+++ b/src/functions/smart-search.ts
@@ -88,7 +88,8 @@ function makeProjectResolver(kv: StateKV) {
   const memoryProjectCache = new Map<string, string | null>();
   return async (sessionId: string, obsId: string): Promise<string | null> => {
     if (!sessionCache.has(sessionId)) {
-      sessionCache.set(sessionId, (await kv.get<Session>(KV.sessions, sessionId)) ?? null);
+      const session = await kv.get<Session>(KV.sessions, sessionId).catch(() => null);
+      sessionCache.set(sessionId, session ?? null);
     }
     const session = sessionCache.get(sessionId)!;
     if (session) return session.project;
@@ -194,12 +195,12 @@ export function registerSmartSearchFunction(
         let scoped = agentScoped;
         if (filterProject) {
           const resolveProject = makeProjectResolver(kv);
-          const kept: typeof expanded = [];
-          for (const e of agentScoped) {
-            const project = await resolveProject(e.sessionId, e.observation.id);
-            if (project === null || project === filterProject) kept.push(e);
-          }
-          scoped = kept;
+          const projects = await Promise.all(
+            agentScoped.map((e) => resolveProject(e.sessionId, e.observation.id)),
+          );
+          scoped = agentScoped.filter(
+            (_e, i) => projects[i] === null || projects[i] === filterProject,
+          );
         }
 
         void recordAccessBatch(
@@ -251,12 +252,12 @@ export function registerSmartSearchFunction(
       let scopedHybrid = agentFiltered;
       if (filterProject) {
         const resolveProject = makeProjectResolver(kv);
-        const kept: HybridSearchResult[] = [];
-        for (const r of agentFiltered) {
-          const project = await resolveProject(r.sessionId, r.observation.id);
-          if (project === null || project === filterProject) kept.push(r);
-        }
-        scopedHybrid = kept;
+        const projects = await Promise.all(
+          agentFiltered.map((r) => resolveProject(r.sessionId, r.observation.id)),
+        );
+        scopedHybrid = agentFiltered.filter(
+          (_r, i) => projects[i] === null || projects[i] === filterProject,
+        );
       }
       const filteredHybrid = scopedHybrid.slice(0, limit);
 

--- a/src/functions/smart-search.ts
+++ b/src/functions/smart-search.ts
@@ -5,6 +5,8 @@ import type {
   CompressedObservation,
   HybridSearchResult,
   Lesson,
+  Memory,
+  Session,
 } from "../types.js";
 import { KV } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
@@ -71,6 +73,32 @@ export function resetFollowupStatsForTests(): void {
 // Compact mode trims each lesson's content for at-a-glance display. The
 // full content is fetched via memory_lesson_recall when the caller needs it.
 const LESSON_CONTENT_PREVIEW_CHARS = 240;
+
+// Resolve the project a hit belongs to, the same way mem::search does:
+// the session's project when the session exists, otherwise the memory's
+// own project. Entries indexed via mem::remember use a synthetic
+// sessionId ('memory') with no KV.sessions row, so their project lives
+// only on the KV.memories record. Returns null when the project is
+// unknown (no session, no memory record); callers treat null as
+// "unscoped — let it through" to stay backward-compatible, matching
+// search.ts. Both lookups are cached, so a filtered page costs at most
+// one read per distinct session and per distinct unbound observation.
+function makeProjectResolver(kv: StateKV) {
+  const sessionCache = new Map<string, Session | null>();
+  const memoryProjectCache = new Map<string, string | null>();
+  return async (sessionId: string, obsId: string): Promise<string | null> => {
+    if (!sessionCache.has(sessionId)) {
+      sessionCache.set(sessionId, (await kv.get<Session>(KV.sessions, sessionId)) ?? null);
+    }
+    const session = sessionCache.get(sessionId)!;
+    if (session) return session.project;
+    if (!memoryProjectCache.has(obsId)) {
+      const memory = await kv.get<Memory>(KV.memories, obsId).catch(() => null);
+      memoryProjectCache.set(obsId, memory?.project ?? null);
+    }
+    return memoryProjectCache.get(obsId)!;
+  };
+}
 
 export function registerSmartSearchFunction(
   sdk: ISdk,
@@ -160,9 +188,19 @@ export function registerSmartSearchFunction(
           if (r) expanded.push(r);
         }
 
-        const scoped = expanded
-          .filter((e) => !filterAgentId || e.observation.agentId === filterAgentId)
-          .filter((e) => !filterProject || e.observation.project === filterProject);
+        const agentScoped = filterAgentId
+          ? expanded.filter((e) => e.observation.agentId === filterAgentId)
+          : expanded;
+        let scoped = agentScoped;
+        if (filterProject) {
+          const resolveProject = makeProjectResolver(kv);
+          const kept: typeof expanded = [];
+          for (const e of agentScoped) {
+            const project = await resolveProject(e.sessionId, e.observation.id);
+            if (project === null || project === filterProject) kept.push(e);
+          }
+          scoped = kept;
+        }
 
         void recordAccessBatch(
           kv,
@@ -203,14 +241,24 @@ export function registerSmartSearchFunction(
       const [hybridResults, lessons] = await Promise.all([
         searchFn(data.query, overFetchLimit),
         includeLessons
-          ? recallLessons(sdk, data.query, lessonLimit, data.project)
+          ? recallLessons(sdk, data.query, lessonLimit, filterProject)
           : Promise.resolve([]),
       ]);
 
-      const filteredHybrid = hybridResults
-        .filter((r) => !filterAgentId || r.observation.agentId === filterAgentId)
-        .filter((r) => !filterProject || r.observation.project === filterProject)
-        .slice(0, limit);
+      const agentFiltered = filterAgentId
+        ? hybridResults.filter((r) => r.observation.agentId === filterAgentId)
+        : hybridResults;
+      let scopedHybrid = agentFiltered;
+      if (filterProject) {
+        const resolveProject = makeProjectResolver(kv);
+        const kept: HybridSearchResult[] = [];
+        for (const r of agentFiltered) {
+          const project = await resolveProject(r.sessionId, r.observation.id);
+          if (project === null || project === filterProject) kept.push(r);
+        }
+        scopedHybrid = kept;
+      }
+      const filteredHybrid = scopedHybrid.slice(0, limit);
 
       const compact: CompactSearchResult[] = filteredHybrid.map((r) => ({
         obsId: r.observation.id,

--- a/test/smart-search.test.ts
+++ b/test/smart-search.test.ts
@@ -291,4 +291,63 @@ describe("Smart Search Function", () => {
       expect(result.lessons).toEqual([]);
     });
   });
+
+  describe("project scoping", () => {
+    function seedTwoProjects() {
+      const builderObs = makeObs({
+        id: "obs_builder",
+        sessionId: "ses_1",
+        title: "Planner model choice",
+        project: "builder",
+      });
+      const reviewObs = makeObs({
+        id: "obs_review",
+        sessionId: "ses_1",
+        title: "Reviewer escalation",
+        project: "review",
+      });
+      searchResults = [
+        {
+          observation: builderObs,
+          bm25Score: 0.8,
+          vectorScore: 0,
+          combinedScore: 0.8,
+          sessionId: "ses_1",
+        },
+        {
+          observation: reviewObs,
+          bm25Score: 0.7,
+          vectorScore: 0,
+          combinedScore: 0.7,
+          sessionId: "ses_1",
+        },
+      ];
+    }
+
+    it("compact mode returns only observations from the requested project", async () => {
+      seedTwoProjects();
+
+      const result = (await sdk.trigger("mem::smart-search", {
+        query: "model",
+        project: "builder",
+        includeLessons: false,
+      })) as { results: CompactSearchResult[] };
+
+      expect(result.results.map((r) => r.obsId)).toEqual(["obs_builder"]);
+    });
+
+    it("omitting project returns observations from every project", async () => {
+      seedTwoProjects();
+
+      const result = (await sdk.trigger("mem::smart-search", {
+        query: "model",
+        includeLessons: false,
+      })) as { results: CompactSearchResult[] };
+
+      expect(result.results.map((r) => r.obsId).sort()).toEqual([
+        "obs_builder",
+        "obs_review",
+      ]);
+    });
+  });
 });

--- a/test/smart-search.test.ts
+++ b/test/smart-search.test.ts
@@ -293,17 +293,28 @@ describe("Smart Search Function", () => {
   });
 
   describe("project scoping", () => {
-    function seedTwoProjects() {
+    // Mirror what mem::remember produces: observations indexed under a
+    // synthetic sessionId ("memory") with no KV.sessions row, and the
+    // project carried on the KV.memories record. This exercises the real
+    // resolver path (session miss -> KV.memories lookup) rather than a
+    // synthetic observation that already carries `project`.
+    async function seedTwoProjects() {
       const builderObs = makeObs({
         id: "obs_builder",
-        sessionId: "ses_1",
+        sessionId: "memory",
         title: "Planner model choice",
-        project: "builder",
       });
       const reviewObs = makeObs({
         id: "obs_review",
-        sessionId: "ses_1",
+        sessionId: "memory",
         title: "Reviewer escalation",
+      });
+      await kv.set("mem:memories", "obs_builder", {
+        id: "obs_builder",
+        project: "builder",
+      });
+      await kv.set("mem:memories", "obs_review", {
+        id: "obs_review",
         project: "review",
       });
       searchResults = [
@@ -312,20 +323,20 @@ describe("Smart Search Function", () => {
           bm25Score: 0.8,
           vectorScore: 0,
           combinedScore: 0.8,
-          sessionId: "ses_1",
+          sessionId: "memory",
         },
         {
           observation: reviewObs,
           bm25Score: 0.7,
           vectorScore: 0,
           combinedScore: 0.7,
-          sessionId: "ses_1",
+          sessionId: "memory",
         },
       ];
     }
 
     it("compact mode returns only observations from the requested project", async () => {
-      seedTwoProjects();
+      await seedTwoProjects();
 
       const result = (await sdk.trigger("mem::smart-search", {
         query: "model",
@@ -337,7 +348,7 @@ describe("Smart Search Function", () => {
     });
 
     it("omitting project returns observations from every project", async () => {
-      seedTwoProjects();
+      await seedTwoProjects();
 
       const result = (await sdk.trigger("mem::smart-search", {
         query: "model",


### PR DESCRIPTION
## What

`mem::smart-search` accepts a `project` argument but never applies it to its observation results — a project-scoped search returns observations from **every** project (the cross-project leak reported in #787). `mem::search` already scopes correctly; this brings `smart-search` in line, which also covers the MCP `memory_smart_search` / `memory_recall` tools and `/smart-search` that route through it.

## How

Resolve each hit's project the way `mem::search` does — the session's project when the session exists, otherwise the memory's own `KV.memories` record (entries indexed via `mem::remember` use a synthetic sessionId with no session row). A `null` result means the project is unknown and the hit passes through (backward-compatible). Applied in the expand-ids branch, the hybrid/compact path, and the over-fetch trigger; the normalized `filterProject` is also passed to lesson recall. Resolution is cached and runs concurrently.

## Verify

- `npm run build` clean; `test/smart-search.test.ts` + `test/agent-isolation-search.test.ts` green (the tests seed `KV.memories` and use a synthetic `memory` sessionId so they exercise the real resolver path, not a synthetic observation that already carries `project`).
- Live on a running instance: `smart-search {project: "review"}` returns the review observation; `{project: "builder"}` excludes it.

Fixes #787
