### PR TITLE
fix: prefer OPENAI_EMBEDDING_API_KEY over OPENAI_API_KEY for embeddings

### DIFF
--- a/src/providers/embedding/index.ts
+++ b/src/providers/embedding/index.ts
@@ -35,7 +35,7 @@ export function createEmbeddingProvider(): EmbeddingProvider | null {
     case "gemini":
       return withDimensionGuard(new GeminiEmbeddingProvider(getEnvVar("GEMINI_API_KEY")!));
     case "openai":
-      return withDimensionGuard(new OpenAIEmbeddingProvider(getEnvVar("OPENAI_EMBEDDING_API_KEY") || getEnvVar("OPENAI_API_KEY")!));
+      return withDimensionGuard(new OpenAIEmbeddingProvider());
     case "voyage":
       return withDimensionGuard(new VoyageEmbeddingProvider(getEnvVar("VOYAGE_API_KEY")!));
     case "cohere":

--- a/src/providers/embedding/index.ts
+++ b/src/providers/embedding/index.ts
@@ -35,7 +35,7 @@ export function createEmbeddingProvider(): EmbeddingProvider | null {
     case "gemini":
       return withDimensionGuard(new GeminiEmbeddingProvider(getEnvVar("GEMINI_API_KEY")!));
     case "openai":
-      return withDimensionGuard(new OpenAIEmbeddingProvider(getEnvVar("OPENAI_API_KEY")!));
+      return withDimensionGuard(new OpenAIEmbeddingProvider(getEnvVar("OPENAI_EMBEDDING_API_KEY") || getEnvVar("OPENAI_API_KEY")!));
     case "voyage":
       return withDimensionGuard(new VoyageEmbeddingProvider(getEnvVar("VOYAGE_API_KEY")!));
     case "cohere":

--- a/src/providers/embedding/openai.ts
+++ b/src/providers/embedding/openai.ts
@@ -86,10 +86,7 @@ export class OpenAIEmbeddingProvider implements EmbeddingProvider {
   readonly debugApiKeySource: "constructor" | "OPENAI_EMBEDDING_API_KEY" | "OPENAI_API_KEY";
 
   constructor(apiKey?: string) {
-    // Separate API key path: caller-passed wins, then OPENAI_EMBEDDING_API_KEY,
-    // then fall back to OPENAI_API_KEY. Allows e.g. a placeholder key for
-    // local endpoints that ignore Authorization (most do).
-    if (apiKey) {
+    if (apiKey !== undefined) {
       this.apiKey = apiKey;
       this.debugApiKeySource = "constructor";
     } else if (getEnvVar("OPENAI_EMBEDDING_API_KEY")) {
@@ -107,10 +104,6 @@ export class OpenAIEmbeddingProvider implements EmbeddingProvider {
         "API key is required (via constructor, OPENAI_EMBEDDING_API_KEY, or OPENAI_API_KEY)",
       );
     }
-    // Embedding-specific base URL override; falls back to OPENAI_BASE_URL,
-    // then normalizeBaseUrl's default. The chat-LLM path (src/providers/openai.ts)
-    // still reads only OPENAI_BASE_URL, so setting OPENAI_EMBEDDING_BASE_URL
-    // alone moves embeddings to the new endpoint without affecting chat.
     this.baseUrl = normalizeBaseUrl(
       getEnvVar("OPENAI_EMBEDDING_BASE_URL") || getEnvVar("OPENAI_BASE_URL"),
     );

--- a/src/providers/embedding/openai.ts
+++ b/src/providers/embedding/openai.ts
@@ -82,20 +82,26 @@ export class OpenAIEmbeddingProvider implements EmbeddingProvider {
   private isAzure: boolean;
   private azureApiVersion: string;
 
-  /** Exposes the resolved API key for testing/debugging. */
-  get debugApiKey(): string {
-    return this.apiKey;
-  }
+  /** Indicates which source the API key was resolved from (for testing/debugging, no secret exposure). */
+  readonly debugApiKeySource: "constructor" | "OPENAI_EMBEDDING_API_KEY" | "OPENAI_API_KEY";
 
   constructor(apiKey?: string) {
     // Separate API key path: caller-passed wins, then OPENAI_EMBEDDING_API_KEY,
     // then fall back to OPENAI_API_KEY. Allows e.g. a placeholder key for
     // local endpoints that ignore Authorization (most do).
-    this.apiKey =
-      apiKey ||
-      getEnvVar("OPENAI_EMBEDDING_API_KEY") ||
-      getEnvVar("OPENAI_API_KEY") ||
-      "";
+    if (apiKey) {
+      this.apiKey = apiKey;
+      this.debugApiKeySource = "constructor";
+    } else if (getEnvVar("OPENAI_EMBEDDING_API_KEY")) {
+      this.apiKey = getEnvVar("OPENAI_EMBEDDING_API_KEY")!;
+      this.debugApiKeySource = "OPENAI_EMBEDDING_API_KEY";
+    } else if (getEnvVar("OPENAI_API_KEY")) {
+      this.apiKey = getEnvVar("OPENAI_API_KEY")!;
+      this.debugApiKeySource = "OPENAI_API_KEY";
+    } else {
+      this.apiKey = "";
+      this.debugApiKeySource = "constructor";
+    }
     if (!this.apiKey) {
       throw new Error(
         "API key is required (via constructor, OPENAI_EMBEDDING_API_KEY, or OPENAI_API_KEY)",

--- a/src/providers/embedding/openai.ts
+++ b/src/providers/embedding/openai.ts
@@ -89,7 +89,7 @@ export class OpenAIEmbeddingProvider implements EmbeddingProvider {
     // Separate API key path: caller-passed wins, then OPENAI_EMBEDDING_API_KEY,
     // then fall back to OPENAI_API_KEY. Allows e.g. a placeholder key for
     // local endpoints that ignore Authorization (most do).
-    if (apiKey) {
+    if (apiKey !== undefined) {
       this.apiKey = apiKey;
       this.debugApiKeySource = "constructor";
     } else if (getEnvVar("OPENAI_EMBEDDING_API_KEY")) {

--- a/src/providers/embedding/openai.ts
+++ b/src/providers/embedding/openai.ts
@@ -86,7 +86,10 @@ export class OpenAIEmbeddingProvider implements EmbeddingProvider {
   readonly debugApiKeySource: "constructor" | "OPENAI_EMBEDDING_API_KEY" | "OPENAI_API_KEY";
 
   constructor(apiKey?: string) {
-    if (apiKey !== undefined) {
+    // Separate API key path: caller-passed wins, then OPENAI_EMBEDDING_API_KEY,
+    // then fall back to OPENAI_API_KEY. Allows e.g. a placeholder key for
+    // local endpoints that ignore Authorization (most do).
+    if (apiKey) {
       this.apiKey = apiKey;
       this.debugApiKeySource = "constructor";
     } else if (getEnvVar("OPENAI_EMBEDDING_API_KEY")) {
@@ -104,6 +107,10 @@ export class OpenAIEmbeddingProvider implements EmbeddingProvider {
         "API key is required (via constructor, OPENAI_EMBEDDING_API_KEY, or OPENAI_API_KEY)",
       );
     }
+    // Embedding-specific base URL override; falls back to OPENAI_BASE_URL,
+    // then normalizeBaseUrl's default. The chat-LLM path (src/providers/openai.ts)
+    // still reads only OPENAI_BASE_URL, so setting OPENAI_EMBEDDING_BASE_URL
+    // alone moves embeddings to the new endpoint without affecting chat.
     this.baseUrl = normalizeBaseUrl(
       getEnvVar("OPENAI_EMBEDDING_BASE_URL") || getEnvVar("OPENAI_BASE_URL"),
     );

--- a/src/providers/embedding/openai.ts
+++ b/src/providers/embedding/openai.ts
@@ -82,6 +82,11 @@ export class OpenAIEmbeddingProvider implements EmbeddingProvider {
   private isAzure: boolean;
   private azureApiVersion: string;
 
+  /** Exposes the resolved API key for testing/debugging. */
+  get debugApiKey(): string {
+    return this.apiKey;
+  }
+
   constructor(apiKey?: string) {
     // Separate API key path: caller-passed wins, then OPENAI_EMBEDDING_API_KEY,
     // then fall back to OPENAI_API_KEY. Allows e.g. a placeholder key for

--- a/test/embedding-provider.test.ts
+++ b/test/embedding-provider.test.ts
@@ -43,6 +43,16 @@ describe("createEmbeddingProvider", () => {
     expect(provider!.name).toBe("openai");
   });
 
+  it("prefers OPENAI_EMBEDDING_API_KEY over OPENAI_API_KEY for OpenAI embeddings", () => {
+    process.env["OPENAI_API_KEY"] = "llm-chat-key";
+    process.env["OPENAI_EMBEDDING_API_KEY"] = "embedding-specific-key";
+    process.env["EMBEDDING_PROVIDER"] = "openai";
+    const provider = createEmbeddingProvider();
+    expect(provider).toBeInstanceOf(OpenAIEmbeddingProvider);
+    // The provider should use the embedding-specific key, not the LLM key
+    expect((provider as OpenAIEmbeddingProvider).apiKey).toBe("embedding-specific-key");
+  });
+
   it("EMBEDDING_PROVIDER override takes precedence", () => {
     process.env["GEMINI_API_KEY"] = "test-key-123";
     process.env["OPENAI_API_KEY"] = "test-key-456";

--- a/test/embedding-provider.test.ts
+++ b/test/embedding-provider.test.ts
@@ -14,6 +14,7 @@ describe("createEmbeddingProvider", () => {
     process.env = { ...originalEnv };
     delete process.env["GEMINI_API_KEY"];
     delete process.env["OPENAI_API_KEY"];
+    delete process.env["OPENAI_EMBEDDING_API_KEY"];
     delete process.env["VOYAGE_API_KEY"];
     delete process.env["COHERE_API_KEY"];
     delete process.env["OPENROUTER_API_KEY"];
@@ -41,6 +42,16 @@ describe("createEmbeddingProvider", () => {
     const provider = createEmbeddingProvider();
     expect(provider).toBeInstanceOf(OpenAIEmbeddingProvider);
     expect(provider!.name).toBe("openai");
+  });
+
+  it("prefers OPENAI_EMBEDDING_API_KEY over OPENAI_API_KEY for OpenAI embeddings", () => {
+    process.env["OPENAI_API_KEY"] = "llm-chat-key";
+    process.env["OPENAI_EMBEDDING_API_KEY"] = "embedding-specific-key";
+    process.env["EMBEDDING_PROVIDER"] = "openai";
+    const provider = createEmbeddingProvider();
+    expect(provider).toBeInstanceOf(OpenAIEmbeddingProvider);
+    // The provider should use the embedding-specific key, not the LLM key
+    expect((provider as OpenAIEmbeddingProvider).apiKey).toBe("embedding-specific-key");
   });
 
   it("EMBEDDING_PROVIDER override takes precedence", () => {

--- a/test/embedding-provider.test.ts
+++ b/test/embedding-provider.test.ts
@@ -51,7 +51,7 @@ describe("createEmbeddingProvider", () => {
     const provider = createEmbeddingProvider();
     expect(provider).toBeInstanceOf(OpenAIEmbeddingProvider);
     // The provider should use the embedding-specific key, not the LLM key
-    expect(provider!.debugApiKey).toBe("embedding-specific-key");
+    expect(provider!.debugApiKeySource).toBe("OPENAI_EMBEDDING_API_KEY");
   });
 
   it("EMBEDDING_PROVIDER override takes precedence", () => {

--- a/test/embedding-provider.test.ts
+++ b/test/embedding-provider.test.ts
@@ -51,7 +51,7 @@ describe("createEmbeddingProvider", () => {
     const provider = createEmbeddingProvider();
     expect(provider).toBeInstanceOf(OpenAIEmbeddingProvider);
     // The provider should use the embedding-specific key, not the LLM key
-    expect((provider as OpenAIEmbeddingProvider).apiKey).toBe("embedding-specific-key");
+    expect(provider!.debugApiKey).toBe("embedding-specific-key");
   });
 
   it("EMBEDDING_PROVIDER override takes precedence", () => {

--- a/test/embedding-provider.test.ts
+++ b/test/embedding-provider.test.ts
@@ -43,16 +43,6 @@ describe("createEmbeddingProvider", () => {
     expect(provider!.name).toBe("openai");
   });
 
-  it("prefers OPENAI_EMBEDDING_API_KEY over OPENAI_API_KEY for OpenAI embeddings", () => {
-    process.env["OPENAI_API_KEY"] = "llm-chat-key";
-    process.env["OPENAI_EMBEDDING_API_KEY"] = "embedding-specific-key";
-    process.env["EMBEDDING_PROVIDER"] = "openai";
-    const provider = createEmbeddingProvider();
-    expect(provider).toBeInstanceOf(OpenAIEmbeddingProvider);
-    // The provider should use the embedding-specific key, not the LLM key
-    expect((provider as OpenAIEmbeddingProvider).apiKey).toBe("embedding-specific-key");
-  });
-
   it("EMBEDDING_PROVIDER override takes precedence", () => {
     process.env["GEMINI_API_KEY"] = "test-key-123";
     process.env["OPENAI_API_KEY"] = "test-key-456";


### PR DESCRIPTION
## Summary

When `EMBEDDING_PROVIDER=openai`, `createEmbeddingProvider()` was passing `OPENAI_API_KEY` directly to `OpenAIEmbeddingProvider` constructor. Since the constructor receives a non-null `apiKey` parameter, it skips the internal fallback to `OPENAI_EMBEDDING_API_KEY`.

This breaks setups with separate LLM and embedding providers, because the LLM key gets sent to the embedding endpoint.

## Fix

Pass `OPENAI_EMBEDDING_API_KEY || OPENAI_API_KEY` to the constructor, so the embedding-specific key takes precedence.

## Changes

- `src/providers/embedding/index.ts`: Use `OPENAI_EMBEDDING_API_KEY` with fallback to `OPENAI_API_KEY`
- `test/embedding-provider.test.ts`: Add test case for key precedence

Fixes #863


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Embedding provider now prefers a dedicated embedding API key when present; other provider behavior is unchanged.
  * Adds a debug indicator that records which API key source was used to aid troubleshooting.
* **Tests**
  * Added tests verifying embedding-specific key precedence and improved test isolation for environment keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->