### PR TITLE
Join session summaries into GET /agentmemory/sessions

### DIFF
--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -1,5 +1,5 @@
 import { TriggerAction, type ISdk, type ApiRequest } from "iii-sdk";
-import type { Session, CompressedObservation, HookPayload, CommitLink } from "../types.js";
+import type { Session, CompressedObservation, HookPayload, CommitLink, SessionSummary } from "../types.js";
 import { withKeyedLock } from "../state/keyed-mutex.js";
 import { KV } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
@@ -823,7 +823,15 @@ export function registerApiTriggers(
       const filtered = filterAgentId
         ? sessions.filter((s) => s.agentId === filterAgentId)
         : sessions;
-      return { status_code: 200, body: { sessions: filtered } };
+      const summaries = await Promise.all(
+        filtered.map((s) =>
+          kv.get<SessionSummary>(KV.summaries, s.id).catch(() => null),
+        ),
+      );
+      const withSummary = filtered.map((s, i) =>
+        summaries[i] ? { ...s, summary: summaries[i] } : s,
+      );
+      return { status_code: 200, body: { sessions: withSummary } };
     },
   );
   sdk.registerTrigger({


### PR DESCRIPTION
Fixes #879.

## Problem
`POST /agentmemory/summarize` persists summaries to `KV.summaries`, but `api::sessions` listed sessions straight from `KV.sessions` and never read `KV.summaries`. So `GET /agentmemory/sessions` (and the viewer #sessions tab) never showed a summary, even after a successful summarize.

## Fix
Join `KV.summaries` onto the returned sessions, after agent-id filtering so we only fetch summaries for sessions actually returned. Mirrors the existing join in `mem::context` (`src/functions/context.ts`). Sessions without a summary are returned unchanged.

## Verification
- Verified against current source (not the dist line numbers in the report): the handler at `src/triggers/api.ts` only read `KV.sessions`; `mem::context` already does the same join, so the pattern and `SessionSummary` type are reused.
- `npm run build` + full suite (1410 tests) pass.
- No automated join test added: seeding a summary requires the LLM-backed `/summarize` path, which CI has no provider for. The join logic is identical to the covered `mem::context` path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session data from the API endpoint now includes optional summary information, providing richer context when retrieving sessions. Summaries are added dynamically when available; sessions without summaries are still returned normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->