### PR TITLE
Serve docs at agent-memory.dev/docs via Mintlify rewrite

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,0 +1,12 @@
+{
+  "rewrites": [
+    {
+      "source": "/docs",
+      "destination": "https://agentmemory.mintlify.dev/docs"
+    },
+    {
+      "source": "/docs/:match*",
+      "destination": "https://agentmemory.mintlify.dev/docs/:match*"
+    }
+  ]
+}


### PR DESCRIPTION
Follows Mintlify's Vercel deploy guide. Adds `website/vercel.json` rewriting `/docs` and `/docs/:match*` to the Mintlify-hosted subdomain so docs serve under the main domain with the URL unchanged.

## Before this works
1. Mintlify dashboard, Domain setup: "Host at /docs" ON, enter `agent-memory.dev`, Add domain (already in progress per the screenshots).
2. Confirm the Mintlify subdomain. This PR assumes `agentmemory.mintlify.dev` (matches the dashboard project name). If yours differs, change the host in `website/vercel.json`.
3. Confirm the Vercel project's root directory is `website/` (where this file lives). If the project root is the repo root instead, move `vercel.json` there.

Redeploy after merge; `/docs` then proxies to Mintlify.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated routing configuration to ensure documentation paths are properly served from the external documentation service, including support for nested documentation routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->