### PR TITLE
Add Docs link to website navbar

### DIFF
--- a/website/components/Nav.tsx
+++ b/website/components/Nav.tsx
@@ -11,6 +11,7 @@ const SECTIONS = [
   { href: "#live", label: "DEMO" },
   { href: "#compare", label: "VS" },
   { href: "#install", label: "INSTALL" },
+  { href: "/docs", label: "DOCS" },
 ];
 
 export async function Nav() {


### PR DESCRIPTION
Adds a `DOCS` entry to the site navbar pointing at `/docs`, now that the Mintlify rewrite (merged) serves docs under agent-memory.dev/docs. `SECTIONS` feeds both the desktop nav and the mobile menu, so it shows in both. No scroll-spy uses these hrefs as selectors, so the route-style `/docs` value is safe. Website typecheck passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "DOCS" navigation link in the main menu for easy access to documentation resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->