### PR TITLE
Adapters declare their own category (finish #872 DRY)

### DIFF
--- a/src/cli/connect/claude-code.ts
+++ b/src/cli/connect/claude-code.ts
@@ -39,6 +39,7 @@ function entryMatches(entry: unknown): boolean {
 export const adapter: ConnectAdapter = {
   name: "claude-code",
   displayName: "Claude Code",
+  category: "native",
   docs: "https://github.com/rohitg00/agentmemory#claude-code-one-block-paste-it",
   protocolNote:
     "→ Using MCP. Hooks are also available — see docs/claude-code.md.",

--- a/src/cli/connect/codex.ts
+++ b/src/cli/connect/codex.ts
@@ -63,6 +63,7 @@ function stripExistingBlock(toml: string): string {
 export const adapter: ConnectAdapter = {
   name: "codex",
   displayName: "Codex CLI",
+  category: "native",
   docs: "https://github.com/rohitg00/agentmemory#codex-cli-codex-plugin-platform",
   protocolNote:
     "→ Using MCP. Hooks ship via the Codex plugin; on Codex Desktop, also pass --with-hooks to install the global hooks.json workaround for openai/codex#16430.",

--- a/src/cli/connect/continue.ts
+++ b/src/cli/connect/continue.ts
@@ -73,6 +73,7 @@ function renderFreshYaml(): string {
 export const adapter: ConnectAdapter = {
   name: "continue",
   displayName: "Continue",
+  category: "mcp",
   docs: "https://github.com/rohitg00/agentmemory#other-agents",
   protocolNote:
     "→ Using MCP via ~/.continue/config.yaml (preferred) or config.json (legacy, only when no yaml).",

--- a/src/cli/connect/copilot-cli.ts
+++ b/src/cli/connect/copilot-cli.ts
@@ -30,6 +30,7 @@ function entryMatches(entry: unknown): boolean {
 export const adapter: ConnectAdapter = {
   name: "copilot-cli",
   displayName: "GitHub Copilot CLI",
+  category: "native",
   docs: "https://github.com/rohitg00/agentmemory#github-copilot-cli",
   protocolNote:
     "→ Using MCP. Install the plugin too for full hooks/skills coverage.",

--- a/src/cli/connect/hermes.ts
+++ b/src/cli/connect/hermes.ts
@@ -11,6 +11,7 @@ const DOCS = "https://github.com/rohitg00/agentmemory/tree/main/integrations/her
 export const adapter: ConnectAdapter = {
   name: "hermes",
   displayName: "Hermes Agent",
+  category: "native",
   docs: DOCS,
   protocolNote:
     "→ Using MCP. Hooks are also available — see docs/hermes.md.",

--- a/src/cli/connect/json-mcp-adapter.ts
+++ b/src/cli/connect/json-mcp-adapter.ts
@@ -19,6 +19,10 @@ export type JsonMcpAdapterConfig = {
   configPath: string;
   docs?: string;
   protocolNote?: string;
+  // Integration style for onboarding grouping. Defaults to "mcp" since a
+  // JSON MCP config writer is MCP-only by construction; hosts that also
+  // ship hooks (e.g. OpenClaw) pass "native".
+  category?: "native" | "mcp";
   // Wrapper key under which servers live. Default "mcpServers".
   // Zed uses "context_servers"; otherwise same shape.
   wrapperKey?: string;
@@ -45,6 +49,7 @@ export function createJsonMcpAdapter(
   return {
     name: config.name,
     displayName: config.displayName,
+    category: config.category ?? "mcp",
     ...(config.docs !== undefined && { docs: config.docs }),
     ...(config.protocolNote !== undefined && {
       protocolNote: config.protocolNote,

--- a/src/cli/connect/openclaw.ts
+++ b/src/cli/connect/openclaw.ts
@@ -5,6 +5,7 @@ import { createJsonMcpAdapter } from "./json-mcp-adapter.js";
 export const adapter = createJsonMcpAdapter({
   name: "openclaw",
   displayName: "OpenClaw",
+  category: "native",
   detectDir: join(homedir(), ".openclaw"),
   configPath: join(homedir(), ".openclaw", "openclaw.json"),
   docs: "https://github.com/rohitg00/agentmemory/tree/main/integrations/openclaw",

--- a/src/cli/connect/opencode.ts
+++ b/src/cli/connect/opencode.ts
@@ -44,6 +44,7 @@ function entryMatches(entry: unknown): boolean {
 export const adapter: ConnectAdapter = {
   name: "opencode",
   displayName: "OpenCode",
+  category: "mcp",
   docs: "https://github.com/rohitg00/agentmemory#other-agents",
   protocolNote:
     "Using MCP via ~/.config/opencode/opencode.json (top-level `mcp` key). For full auto-capture, also install the bundled plugin in plugin/opencode/.",

--- a/src/cli/connect/openhuman.ts
+++ b/src/cli/connect/openhuman.ts
@@ -10,6 +10,7 @@ const DOCS = "https://github.com/tinyhumansai/openhuman";
 export const adapter: ConnectAdapter = {
   name: "openhuman",
   displayName: "OpenHuman",
+  category: "native",
   docs: DOCS,
   protocolNote:
     "→ Using native hooks (REST API at :3111). MCP not required.",

--- a/src/cli/connect/pi.ts
+++ b/src/cli/connect/pi.ts
@@ -11,6 +11,7 @@ const DOCS = "https://github.com/rohitg00/agentmemory/tree/main/integrations/pi"
 export const adapter: ConnectAdapter = {
   name: "pi",
   displayName: "pi",
+  category: "native",
   docs: DOCS,
   protocolNote:
     "→ Using native hooks (REST API at :3111). MCP not required.",

--- a/src/cli/connect/types.ts
+++ b/src/cli/connect/types.ts
@@ -21,6 +21,13 @@ export type ConnectAdapter = {
    * opt-in bridge for MCP-only clients.
    */
   protocolNote?: string;
+  /**
+   * Integration style, used by onboarding to group agents. "native" =
+   * ships a first-party plugin / lifecycle hooks; "mcp" = wires the MCP
+   * server only. Declared on the adapter so the picker never needs a
+   * separate hardcoded list (#872). Defaults to "mcp" when omitted.
+   */
+  category?: "native" | "mcp";
   detect(): boolean;
   install(opts: ConnectOptions): Promise<ConnectResult>;
 };

--- a/src/cli/onboarding.ts
+++ b/src/cli/onboarding.ts
@@ -48,19 +48,6 @@ const AGENT_GLYPH: Record<string, string> = {
   opencode: "⬡",
 };
 
-// Agents wired through a native plugin / lifecycle hooks rather than the
-// MCP server. Cosmetic grouping only; everything still goes through an
-// adapter.
-const NATIVE_AGENTS = new Set([
-  "claude-code",
-  "copilot-cli",
-  "codex",
-  "openhuman",
-  "openclaw",
-  "hermes",
-  "pi",
-]);
-
 const PROVIDERS: { value: string; label: string; envKey: string | null }[] = [
   { value: "anthropic", label: "Anthropic — claude", envKey: "ANTHROPIC_API_KEY" },
   { value: "openai", label: "OpenAI — gpt", envKey: "OPENAI_API_KEY" },
@@ -82,7 +69,7 @@ export function buildAgentOptions(): { value: string; label: string; hint?: stri
   const options = ADAPTERS.map((a) => ({
     value: a.name,
     label: `${AGENT_GLYPH[a.name] ?? "◇"} ${a.displayName}`,
-    hint: NATIVE_AGENTS.has(a.name) ? "native plugin" : "MCP server",
+    hint: a.category === "native" ? "native plugin" : "MCP server",
   }));
   return [
     ...options.filter((o) => o.hint === "native plugin"),

--- a/test/cli-connect.test.ts
+++ b/test/cli-connect.test.ts
@@ -74,6 +74,15 @@ describe("agentmemory connect — dispatcher", () => {
       expect(typeof a.displayName).toBe("string");
     }
   });
+
+  it("every adapter declares a category so onboarding never needs a separate list (#872)", () => {
+    for (const a of ADAPTERS) {
+      expect(
+        ["native", "mcp"].includes(a.category as string),
+        `adapter ${a.name} must set category to "native" or "mcp"`,
+      ).toBe(true);
+    }
+  });
 });
 
 describe("agentmemory connect — claude-code adapter (mock filesystem)", () => {


### PR DESCRIPTION
Follow-up to #883 (reporter feedback). The onboarding picker now derives its agent *set* from connect's ADAPTERS, but it still kept a hardcoded NATIVE_AGENTS set to choose the "native plugin" vs "MCP server" hint, decoupled from the adapters and prone to the same drift class as the original bug. It had even mislabeled openclaw (a factory/MCP adapter) as native.

## Change
- Add `category?: "native" | "mcp"` to ConnectAdapter (defaults to mcp).
- `createJsonMcpAdapter` sets `mcp` (MCP-only by construction; OpenClaw passes `native`).
- The 7 native plugin/hook adapters (claude-code, copilot-cli, codex, hermes, openhuman, pi, openclaw) declare `category: "native"`; opencode/continue declare `mcp`.
- Onboarding reads `a.category` and the hardcoded set is gone — ADAPTERS is now the single source for both the agent set and its grouping.
- Regression test: every adapter must declare a category, so a future adapter missing one fails CI (this caught a missing `continue` category during development).

Displayed grouping is unchanged (same 7 native); only the source of truth moved onto the adapters. build + full suite (1413) pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added adapter categorization system to distinguish between native plugins and MCP servers, improving organization during onboarding.

* **Tests**
  * Added validation test ensuring all adapters declare a valid category type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->