### PR TITLE
Hermes plugin: stable project scoping + close sessions on process exit

### DIFF
--- a/integrations/hermes/__init__.py
+++ b/integrations/hermes/__init__.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 import threading
 import time
@@ -19,6 +20,76 @@ from typing import Any, Callable
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 from urllib.error import URLError
+
+
+def _project_from_remote(path: str) -> str:
+    """Repo name from ``git remote get-url origin``, or "" if unavailable.
+
+    Parses both remote forms: ``git@host:owner/repo(.git)`` and
+    ``https://host/owner/repo(.git)`` -> ``repo``.
+    """
+    try:
+        url = subprocess.run(
+            ["git", "-C", path, "remote", "get-url", "origin"],
+            capture_output=True, text=True, timeout=2,
+        ).stdout.strip()
+    except Exception:
+        return ""
+    if not url:
+        return ""
+    url = url.rstrip("/")
+    if url.endswith(".git"):
+        url = url[:-4]
+    seg = url.replace(":", "/").rstrip("/").split("/")
+    return seg[-1] if seg and seg[-1] else ""
+
+
+def _resolve_project(cwd: str) -> str:
+    """Stable project id for memory scoping.
+
+    The session cwd path is not a stable project identity: ephemeral
+    checkouts (git worktrees, CI runners, agent-orchestrator workdirs) put
+    the SAME repo under throwaway paths that often share one basename
+    ("workdir", "workspace", ...), which both fragments a project's memory
+    across paths and cross-bleeds memory between different repos that
+    happen to share a checkout dirname. The git origin remote name is
+    stable across all checkouts of a repo, so prefer it.
+
+    Resolution order:
+      1. AGENTMEMORY_PROJECT_NAME env var (explicit override).
+      2. git origin remote repo name of cwd, or of a direct child repo
+         (covers sessions started one level above the checkout).
+      3. git toplevel basename.
+      4. cwd basename (previous behavior, last resort).
+    """
+    explicit = os.environ.get("AGENTMEMORY_PROJECT_NAME", "").strip()
+    if explicit:
+        return explicit
+    cwd = cwd or os.getcwd()
+    candidates = [cwd]
+    try:
+        for name in sorted(os.listdir(cwd)):
+            sub = os.path.join(cwd, name)
+            if os.path.exists(os.path.join(sub, ".git")):
+                candidates.append(sub)
+    except OSError:
+        pass
+    for cand in candidates:
+        name = _project_from_remote(cand)
+        if name:
+            return name
+    for cand in candidates:
+        try:
+            top = subprocess.run(
+                ["git", "-C", cand, "rev-parse", "--show-toplevel"],
+                capture_output=True, text=True, timeout=2,
+            ).stdout.strip()
+        except Exception:
+            continue
+        if top and os.path.basename(top):
+            return os.path.basename(top)
+    return os.path.basename(cwd.rstrip("/")) or "unknown"
+
 
 try:
     from agent.memory_provider import MemoryProvider
@@ -188,14 +259,15 @@ class AgentMemoryProvider(MemoryProvider):
     def initialize(self, session_id: str, **kwargs: Any) -> None:
         self._base = os.environ.get("AGENTMEMORY_URL", DEFAULT_BASE_URL)
         self._session_id = session_id
-        self._project = kwargs.get("cwd", os.getcwd())
+        self._cwd = kwargs.get("cwd") or os.getcwd()
+        self._project = _resolve_project(self._cwd)
         if os.environ.get("AGENTMEMORY_REQUIRE_HTTPS") == "1":
             _check_plaintext_bearer_guard(self._base, os.environ.get("AGENTMEMORY_SECRET", ""))
 
         _api(self._base, "session/start", {
             "sessionId": session_id,
             "project": self._project,
-            "cwd": self._project,
+            "cwd": self._cwd,
         })
 
     def get_config_schema(self) -> list[dict]:
@@ -302,6 +374,7 @@ class AgentMemoryProvider(MemoryProvider):
             result = _api(self._base, "search", {
                 "query": args["query"],
                 "limit": args.get("limit", 10),
+                "project": self._project,
             })
             if not result:
                 return json.dumps({"results": []})
@@ -321,6 +394,7 @@ class AgentMemoryProvider(MemoryProvider):
             result = _api(self._base, "remember", {
                 "content": args["content"],
                 "type": args.get("type", "fact"),
+                "project": self._project,
             })
             return json.dumps(result or {"success": False})
 
@@ -328,6 +402,7 @@ class AgentMemoryProvider(MemoryProvider):
             result = _api(self._base, "smart-search", {
                 "query": args["query"],
                 "limit": args.get("limit", 5),
+                "project": self._project,
             })
             if not result:
                 return json.dumps({"results": []})
@@ -348,7 +423,7 @@ class AgentMemoryProvider(MemoryProvider):
             "hookType": "post_tool_use",
             "sessionId": kwargs.get("session_id", self._session_id),
             "project": self._project,
-            "cwd": self._project,
+            "cwd": self._cwd,
             "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
             "data": {
                 "tool_name": "conversation",

--- a/integrations/hermes/__init__.py
+++ b/integrations/hermes/__init__.py
@@ -9,6 +9,7 @@ Requires agentmemory server running: npx @agentmemory/agentmemory
 
 from __future__ import annotations
 
+import atexit
 import json
 import os
 import subprocess
@@ -264,11 +265,18 @@ class AgentMemoryProvider(MemoryProvider):
         if os.environ.get("AGENTMEMORY_REQUIRE_HTTPS") == "1":
             _check_plaintext_bearer_guard(self._base, os.environ.get("AGENTMEMORY_SECRET", ""))
 
+        self._session_closed = False
         _api(self._base, "session/start", {
             "sessionId": session_id,
             "project": self._project,
             "cwd": self._cwd,
         })
+        # Not every Hermes host path calls on_session_end()/shutdown() - the
+        # ACP adapter (headless editors/daemons) tears the process down without
+        # them, leaving the session dangling "active" server-side. Close it on
+        # any graceful interpreter exit instead; SIGKILL is the server-side
+        # idle sweep's job.
+        atexit.register(self._close_session)
 
     def get_config_schema(self) -> list[dict]:
         return [
@@ -433,9 +441,26 @@ class AgentMemoryProvider(MemoryProvider):
         })
 
     def on_session_end(self, messages: list, **kwargs: Any) -> None:
-        _api(self._base, "session/end", {
-            "sessionId": kwargs.get("session_id", self._session_id),
-        })
+        self._close_session(kwargs.get("session_id"))
+
+    def _close_session(self, session_id: str | None = None) -> None:
+        """Idempotently end the agentmemory session.
+
+        Every teardown path converges here - on_session_end()/shutdown() on
+        the cli/gateway paths and the atexit hook on the ACP/headless path -
+        so the session is ended exactly once and never left dangling.
+        """
+        if getattr(self, "_session_closed", False):
+            return
+        sid = session_id or getattr(self, "_session_id", None)
+        if not sid or not getattr(self, "_base", None):
+            return
+        self._session_closed = True
+        try:
+            atexit.unregister(self._close_session)
+        except Exception:
+            pass
+        _api(self._base, "session/end", {"sessionId": sid})
 
     def on_pre_compress(self, messages: list, **kwargs: Any) -> None:
         result = _api(self._base, "context", {
@@ -456,7 +481,7 @@ class AgentMemoryProvider(MemoryProvider):
             })
 
     def shutdown(self, **kwargs: Any) -> None:
-        pass
+        self._close_session(kwargs.get("session_id"))
 
 
 def register(ctx: Any) -> None:


### PR DESCRIPTION
## What

Two independent fixes to the Hermes integration (`integrations/hermes/__init__.py`), found by running the plugin in production under a headless ACP-driven Hermes deployment that checks every task out into an ephemeral git worktree. Both are generic - any worktree/CI/orchestrator layout hits them.

### 1. Scope memory by git remote name, not the checkout path (commit 1)

**Problem:** `initialize()` used the session cwd as the agentmemory `project` id. A checkout path is not a stable repo identity: ephemeral checkouts (git worktrees, CI runners, agent-orchestrator workdirs) place the *same* repo under throwaway paths, and *different* repos often share one checkout basename (`workdir`, `workspace`, ...). In our deployment every task ran in `.../<task-hash>/workdir` - all projects collapsed into one shared `workdir` memory bucket, and recall started returning Go lessons inside TypeScript tasks.

**Fix:** resolve the project id as

1. `AGENTMEMORY_PROJECT_NAME` env var (explicit override),
2. git `origin` remote repo name - of the cwd or of a direct child checkout (covers sessions started one level above the repo),
3. git toplevel basename,
4. cwd basename (the previous behavior, as last resort).

The real cwd is still sent as `cwd`, and the resolved project is now passed explicitly on the `search` / `remember` / `smart-search` calls so recall and save stay inside the project bucket.

### 2. End the session on interpreter exit (commit 2)

**Problem:** Hermes' cli and gateway paths call `on_session_end()` / `shutdown()`, but the ACP adapter path (headless editors / daemons) tears the process down without either - every such run leaked its agentmemory session as permanently "active" on the server.

**Fix:** register an `atexit` hook at `initialize()` and route all teardown paths (`on_session_end`, `shutdown`, atexit) through an idempotent `_close_session()`, so `session/end` is POSTed exactly once on any graceful exit regardless of which host path ran. Hard kills (SIGKILL) can't be caught - that remains the server-side idle sweep's job.

## How to verify

1. Project scoping: `git worktree add /tmp/wt-a <repo-a>` and start a Hermes session there, repeat with a second repo in `/tmp/wt-b`; with this patch `session/start` carries `project: <repo-a-name>` / `project: <repo-b-name>` instead of `wt-a` / `wt-b` (or one shared basename). A dir without any git remote falls back to its basename exactly as before.
2. Session close: run a Hermes session through the ACP adapter (e.g. Zed), exit the editor, and check the server's active sessions - the session is now ended instead of dangling.
3. Python-only change; `npm run build` / `npm test` unaffected. `python3 -m py_compile integrations/hermes/__init__.py` passes; `_resolve_project()` exercised against the four layouts above (worktree-with-remote, parent-of-checkout, plain dir, env override).

Both commits are DCO signed-off. No issue filed for these - happy to split this into two issues/PRs if you prefer one logical change per PR taken strictly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved session lifecycle management to ensure graceful shutdowns are handled reliably with proper cleanup on interpreter exit
  * Enhanced project identification logic using git remote metadata with intelligent fallback mechanisms

* **New Features**
  * Automatic preloading of environment configuration files at startup for consistent setup across sessions
  * Better scoping of tool requests to include proper project and working directory context

<!-- end of auto-generated comment: release notes by coderabbit.ai -->