### PR TITLE
fix(viewer): prevent path-traversal SSRF in proxy (CWE-918)

### DIFF
--- a/src/viewer/server.ts
+++ b/src/viewer/server.ts
@@ -174,6 +174,33 @@ function readBody(req: IncomingMessage): Promise<string> {
   });
 }
 
+// Normalize and validate a proxy pathname so that path-traversal
+// sequences ("../", percent-encoded variants) cannot escape the
+// /agentmemory/ prefix. `new URL()` resolves ".." segments the same
+// way `fetch()` does internally, so comparing the normalized result
+// against the prefix is an authoritative check.
+//
+// Returns the safe normalized pathname, or `null` if the path is
+// invalid or escapes the allowed prefix.
+function normalizeProxyPath(raw: string): string | null {
+  try {
+    // Use a throwaway base so `new URL()` can resolve relative ".."
+    // segments. The base itself is never sent upstream.
+    const resolved = new URL(raw, "http://localhost");
+    const normalized = resolved.pathname;
+
+    // The upstream path must sit under /agentmemory/ after
+    // normalization. If ".." segments collapsed it above that prefix
+    // (e.g. /agentmemory/../../admin → /admin) the check fails.
+    if (!normalized.startsWith("/agentmemory/")) {
+      return null;
+    }
+    return normalized;
+  } catch {
+    return null;
+  }
+}
+
 const MAX_VIEWER_PORT_RETRIES = 10;
 
 let boundViewerPort: number | null = null;
@@ -396,11 +423,24 @@ async function proxyToRestApi(
   res: ServerResponse,
   secret?: string,
 ): Promise<void> {
-  const upstreamPath = pathname.startsWith("/agentmemory/")
+  // Build the candidate upstream path. Requests already under
+  // /agentmemory/ pass through; others get the prefix prepended.
+  const rawUpstreamPath = pathname.startsWith("/agentmemory/")
     ? pathname
     : `/agentmemory${pathname.startsWith("/") ? pathname : "/" + pathname}`;
 
-  const upstreamUrl = `http://127.0.0.1:${restPort}${upstreamPath}${qs ? "?" + qs : ""}`;
+  // Normalize and validate the path to prevent path-traversal attacks.
+  // Without this, a request like /agentmemory/../../secret-endpoint
+  // would be resolved by fetch()'s URL parser to /secret-endpoint,
+  // escaping the /agentmemory/ prefix while still carrying the
+  // auto-attached bearer token.
+  const safePath = normalizeProxyPath(rawUpstreamPath);
+  if (safePath === null) {
+    json(res, 400, { error: "invalid proxy path" }, req);
+    return;
+  }
+
+  const upstreamUrl = `http://127.0.0.1:${restPort}${safePath}${qs ? "?" + qs : ""}`;
 
   const headers: Record<string, string> = {};
   if (secret) {

--- a/test/viewer-proxy-path.test.ts
+++ b/test/viewer-proxy-path.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, afterAll } from "vitest";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { request as httpRequest } from "node:http";
+import { startViewerServer } from "../src/viewer/server.js";
+
+/**
+ * CWE-918: Viewer proxy path-traversal SSRF
+ *
+ * The viewer proxies /agentmemory/* requests to the local REST API,
+ * attaching the bearer token automatically. If a request path contains
+ * "../" traversal sequences the proxy must reject it, otherwise
+ * `new URL()` normalization in fetch() resolves the traversal and
+ * the request escapes the /agentmemory/ prefix on the upstream server
+ * while carrying the full bearer token.
+ */
+describe("viewer proxy path traversal defence (CWE-918)", () => {
+  const cleanups: Array<() => Promise<void>> = [];
+
+  afterAll(async () => {
+    for (const c of cleanups) await c();
+  });
+
+  /** Start a tiny upstream that records every request it receives. */
+  function startUpstream(): Promise<{
+    port: number;
+    requests: Array<{ method: string; url: string; headers: Record<string, string | string[] | undefined> }>;
+  }> {
+    const requests: Array<{
+      method: string;
+      url: string;
+      headers: Record<string, string | string[] | undefined>;
+    }> = [];
+    return new Promise((resolve) => {
+      const srv = createServer((req, res) => {
+        requests.push({
+          method: req.method ?? "GET",
+          url: req.url ?? "/",
+          headers: req.headers,
+        });
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ok: true }));
+      });
+      srv.listen(0, "127.0.0.1", () => {
+        const addr = srv.address() as AddressInfo;
+        cleanups.push(
+          () => new Promise<void>((r) => srv.close(() => r())),
+        );
+        resolve({ port: addr.port, requests });
+      });
+    });
+  }
+
+  /** Start the viewer server pointing at the given upstream REST port. */
+  async function startViewer(
+    restPort: number,
+    secret?: string,
+  ): Promise<{ port: number }> {
+    const server = startViewerServer(0, {}, {}, secret, restPort);
+    await new Promise<void>((resolve) =>
+      server.once("listening", () => resolve()),
+    );
+    const addr = server.address() as AddressInfo;
+    cleanups.push(
+      () => new Promise<void>((r) => server.close(() => r())),
+    );
+    return { port: addr.port };
+  }
+
+  /** Low-level HTTP request so we can control the Host header. */
+  function request(
+    port: number,
+    pathname: string,
+    hostHeader?: string,
+  ): Promise<{ status: number; body: string }> {
+    return new Promise((resolve, reject) => {
+      const req = httpRequest(
+        {
+          host: "127.0.0.1",
+          port,
+          path: pathname,
+          method: "GET",
+          headers: {
+            Host: hostHeader ?? `127.0.0.1:${port}`,
+          },
+        },
+        (res) => {
+          let body = "";
+          res.on("data", (chunk: Buffer) => {
+            body += chunk.toString();
+          });
+          res.on("end", () => {
+            resolve({ status: res.statusCode ?? 0, body });
+          });
+        },
+      );
+      req.on("error", reject);
+      req.end();
+    });
+  }
+
+  it("rejects path traversal via /agentmemory/../../ with 400", async () => {
+    const upstream = await startUpstream();
+    const viewer = await startViewer(upstream.port, "test-secret");
+    const res = await request(
+      viewer.port,
+      "/agentmemory/../../admin",
+    );
+    expect(res.status).toBe(400);
+    expect(upstream.requests).toHaveLength(0);
+  });
+
+  it("rejects percent-encoded traversal /agentmemory/%2e%2e/ with 400", async () => {
+    const upstream = await startUpstream();
+    const viewer = await startViewer(upstream.port, "test-secret");
+    const res = await request(
+      viewer.port,
+      "/agentmemory/%2e%2e/%2e%2e/admin",
+    );
+    expect(res.status).toBe(400);
+    expect(upstream.requests).toHaveLength(0);
+  });
+
+  it("rejects mixed-case encoded traversal /agentmemory/%2E%2E/ with 400", async () => {
+    const upstream = await startUpstream();
+    const viewer = await startViewer(upstream.port, "test-secret");
+    const res = await request(
+      viewer.port,
+      "/agentmemory/%2E%2E/%2E%2E/admin",
+    );
+    expect(res.status).toBe(400);
+    expect(upstream.requests).toHaveLength(0);
+  });
+
+  it("rejects single traversal segment /agentmemory/../ with 400", async () => {
+    const upstream = await startUpstream();
+    const viewer = await startViewer(upstream.port, "test-secret");
+    const res = await request(viewer.port, "/agentmemory/../other");
+    expect(res.status).toBe(400);
+    expect(upstream.requests).toHaveLength(0);
+  });
+
+  it("allows normal /agentmemory/livez to pass through", async () => {
+    const upstream = await startUpstream();
+    const viewer = await startViewer(upstream.port, "test-secret");
+    const res = await request(viewer.port, "/agentmemory/livez");
+    expect(res.status).toBe(200);
+    expect(upstream.requests).toHaveLength(1);
+    expect(upstream.requests[0].url).toBe("/agentmemory/livez");
+  });
+
+  it("allows normal /agentmemory/memories path to pass through", async () => {
+    const upstream = await startUpstream();
+    const viewer = await startViewer(upstream.port, "test-secret");
+    const res = await request(
+      viewer.port,
+      "/agentmemory/memories?latest=true",
+    );
+    expect(res.status).toBe(200);
+    expect(upstream.requests).toHaveLength(1);
+    expect(upstream.requests[0].url).toBe(
+      "/agentmemory/memories?latest=true",
+    );
+  });
+
+  it("rejects paths that would normalize outside /agentmemory/", async () => {
+    const upstream = await startUpstream();
+    const viewer = await startViewer(upstream.port, "test-secret");
+    // /agentmemory/foo/../../bar normalizes to /bar — escapes prefix
+    const res = await request(
+      viewer.port,
+      "/agentmemory/foo/../../bar",
+    );
+    expect(res.status).toBe(400);
+    expect(upstream.requests).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

The viewer proxy in `src/viewer/server.ts` has a path-traversal vulnerability (CWE-918) in the `proxyToRestApi()` function. An attacker with local HTTP access to the viewer port can escape the intended `/agentmemory/` path prefix and reach arbitrary upstream routes while the proxy auto-attaches the `AGENTMEMORY_SECRET` Bearer token.

This PR adds path normalization before the prefix check, closing the traversal gap.

## Vulnerability Details

**CWE:** CWE-918 (Server-Side Request Forgery)
**Affected file:** `src/viewer/server.ts`, function `proxyToRestApi()` (line 417)
**Severity:** Medium (exploitable under specific but realistic preconditions)

### Data flow

1. The viewer receives an HTTP request and extracts `req.url` at line 278.
2. The raw pathname is split from the query string at line 280 — no normalization occurs.
3. In `proxyToRestApi()`, the pathname is checked with `startsWith("/agentmemory/")` to decide routing.
4. A path like `/agentmemory/../../secret-route` passes this prefix check (it literally starts with `/agentmemory/`).
5. The path is then embedded into a URL string and passed to `fetch()`, which internally normalizes `..` segments via its URL parser — resolving `/agentmemory/../../secret-route` to `/secret-route`.
6. The request reaches the upstream REST API at `/secret-route` (outside `/agentmemory/`) with the privileged Bearer token attached.

The core issue is a TOCTOU mismatch: the prefix check operates on the raw path, but `fetch()` normalizes it before making the request.

### Threat model

The vulnerability is exploitable when:

- `AGENTMEMORY_SECRET` is set (REST API authentication is enabled)
- The viewer is running in default loopback mode (no inbound Bearer required for the viewer itself)
- An attacker has local HTTP access to the viewer port (3113) but does not know the secret
- The upstream iii engine exposes routes outside `/agentmemory/`

In this configuration, the viewer intentionally acts as an unauthenticated bridge to the authenticated `/agentmemory/*` API surface. The path traversal breaks that constraint by allowing requests to non-`/agentmemory/` routes with the auto-attached Bearer token.

Before submitting, we verified that this isn't blocked by other defenses: the host-header allowlist and CORS restrictions prevent cross-origin attacks but don't prevent a local process from sending raw HTTP requests. The loopback bind prevents remote exploitation but doesn't protect against other processes on the same machine. In non-loopback (Fly) deployments, inbound Bearer is required, which makes the traversal redundant since the attacker would already know the secret.

## Proof of Concept

```bash
# Precondition: agentmemory running with AGENTMEMORY_SECRET set,
# viewer on default loopback mode (port 3113).
#
# curl normalizes ".." by default, so --path-as-is is needed to
# send the raw traversal path to Node's HTTP server:

curl --path-as-is http://127.0.0.1:3113/agentmemory/../../some-internal-route

# Without the fix: the viewer passes the startsWith("/agentmemory/")
# check, then fetch() resolves the path to /some-internal-route and
# forwards the request WITH the Bearer token.
#
# With the fix: the viewer normalizes the path first, sees it resolves
# outside /agentmemory/, and returns HTTP 400.
```

Node.js's built-in HTTP server passes raw `..` segments through in `req.url` without normalization — this was confirmed experimentally and is documented Node behavior.

## Fix Description

The fix adds a `normalizeProxyPath()` function that:

1. Parses the raw path using `new URL(raw, "http://localhost")` — this applies the same URL normalization that `fetch()` uses internally, resolving all `..` segments, percent-encoded variants (`%2e%2e`, `%2E%2E`), and backslash tricks.
2. Checks that the normalized pathname still starts with `/agentmemory/`.
3. Returns the normalized path for use in the upstream URL, or `null` if the path escapes the prefix.

This eliminates the TOCTOU gap: the prefix check and the actual upstream request now operate on the same normalized path. Invalid paths are rejected with HTTP 400 before reaching `fetch()`.

## Testing

A new test file `test/viewer-proxy-path.test.ts` covers 7 scenarios:

| Test | Input | Expected |
|------|-------|----------|
| Literal traversal | `/agentmemory/../../admin` | 400, no upstream hit |
| Percent-encoded `%2e%2e` | `/agentmemory/%2e%2e/%2e%2e/admin` | 400, no upstream hit |
| Mixed-case `%2E%2E` | `/agentmemory/%2E%2E/%2E%2E/admin` | 400, no upstream hit |
| Single traversal | `/agentmemory/../other` | 400, no upstream hit |
| Deep traversal | `/agentmemory/foo/../../bar` | 400, no upstream hit |
| Normal path (livez) | `/agentmemory/livez` | 200, forwarded correctly |
| Normal path with query | `/agentmemory/memories?latest=true` | 200, forwarded correctly |

Each test spins up a recording upstream server and verifies both the HTTP status and that no request reached the upstream for blocked paths.

## Files Changed

- `src/viewer/server.ts` — Added `normalizeProxyPath()` and integrated it into `proxyToRestApi()`
- `test/viewer-proxy-path.test.ts` — New test file for path traversal defense

---




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security for the agent memory proxy endpoint by implementing path normalization and validation. The proxy now blocks directory traversal attempts (both raw and encoded variants) and rejects invalid paths with an HTTP 400 error response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->