### PR TITLE
feat(providers): optional cheaper model for compress() via AGENTMEMORY_COMPRESS_MODEL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,15 @@
 
 # MAX_TOKENS=4096                                # Cap LLM completion tokens for compression / summarise calls
 
+# Optional cheaper model for compress() work only: per-observation compression,
+# graph extraction, query expansion — the bulk of background LLM volume (one
+# call per tool use under AGENTMEMORY_AUTO_COMPRESS=true). Summarisation,
+# consolidation synthesis, and reflection stay on the main model above.
+# The value must be a model name valid for the detected provider. Ignored by
+# the agent-sdk / noop providers and by FALLBACK_PROVIDERS chains (model names
+# are provider-specific — same reasoning as #778).
+# AGENTMEMORY_COMPRESS_MODEL=gpt-5.4-nano
+
 # Outbound LLM / embedding timeout — shared across every raw-fetch provider
 # (Gemini, OpenRouter, MiniMax, OpenAI LLM, and OpenAI/Cohere/Voyage/OpenRouter
 # embedding). The OpenAI LLM path also honours the OpenAI-scoped

--- a/.env.example
+++ b/.env.example
@@ -47,7 +47,7 @@
 
 # Optional cheaper model for compress() work only: per-observation compression,
 # graph extraction, query expansion — the bulk of background LLM volume (one
-# call per tool use under AGENTMEMORY_AUTO_COMPRESS=true). Summarisation,
+# call per tool use under AGENTMEMORY_AUTO_COMPRESS=true). Summarization,
 # consolidation synthesis, and reflection stay on the main model above.
 # The value must be a model name valid for the detected provider. Ignored by
 # the agent-sdk / noop providers and by FALLBACK_PROVIDERS chains (model names

--- a/README.md
+++ b/README.md
@@ -1292,6 +1292,15 @@ agentmemory prints a runtime warning when `OPENROUTER_MODEL` matches a premium-t
 
 Quality vs cost tradeoff for memory work: compression is a summarization task with relatively loose quality bars (the agent re-reads the summary, not the user). DeepSeek-V4-Pro / Qwen3-Coder land within rounding error of Sonnet on this task while costing ~10× less. Save the premium-tier models for queries you read directly.
 
+You can also split the workload instead of downgrading everything: `AGENTMEMORY_COMPRESS_MODEL` routes `compress()`-side work (per-observation compression, graph extraction, query expansion — the bulk of background call volume) to a cheaper model while summarization, consolidation synthesis, and reflection stay on your main model.
+
+```env
+OPENAI_MODEL=your-main-model                  # summaries, consolidation, lessons
+AGENTMEMORY_COMPRESS_MODEL=your-cheap-model   # per-observation compression etc.
+```
+
+The value must be a model name valid for the detected provider. It is ignored by the agent-sdk / noop providers and by `FALLBACK_PROVIDERS` chains (model names are provider-specific).
+
 Sources: [OpenRouter pricing for Sonnet 4.6](https://openrouter.ai/anthropic/claude-sonnet-4.6/pricing), [DeepSeek V4 Pro](https://openrouter.ai/deepseek/deepseek-v4-pro), [DeepSeek pricing notes](https://api-docs.deepseek.com/quick_start/pricing/).
 
 ### Multi-agent memory (`AGENT_ID` + `AGENTMEMORY_AGENT_SCOPE`)
@@ -1408,6 +1417,11 @@ Create `~/.agentmemory/.env`:
 #                                          # but no content.
 # OPENAI_API_KEY_FOR_LLM=false             # Optional: set to false to skip OpenAI auto-detection
 #                                          # for LLM (useful if you only want OpenAI for embeddings)
+# Optional cheaper model for compress()-side work only (per-observation
+# compression, graph extraction, query expansion); summaries / consolidation /
+# reflection stay on the main model. Must be valid for the detected provider.
+# AGENTMEMORY_COMPRESS_MODEL=gpt-5.4-nano
+
 # Opt-in Claude-subscription fallback (spawns @anthropic-ai/claude-agent-sdk);
 # leave OFF unless you understand the Stop-hook recursion risk (#149 follow-up):
 # AGENTMEMORY_ALLOW_AGENT_SDK=true

--- a/src/config.ts
+++ b/src/config.ts
@@ -51,12 +51,20 @@ function hasRealValue(v: string | undefined): v is string {
 
 function detectProvider(env: Record<string, string>): ProviderConfig {
   const maxTokens = parseInt(env["MAX_TOKENS"] || "4096", 10);
+  // Compression dominates background LLM volume (one call per observation),
+  // so it gets an optional dedicated model while summarize/consolidate/reflect
+  // stay on the main one. Provider-agnostic: the value must be a model name
+  // valid for whichever provider is detected below.
+  const compressModel = hasRealValue(env["AGENTMEMORY_COMPRESS_MODEL"])
+    ? { compressModel: env["AGENTMEMORY_COMPRESS_MODEL"] }
+    : {};
 
   // OpenAI-compatible: supports OpenAI, DeepSeek, SiliconFlow, Azure, vLLM, LM Studio
   if (hasRealValue(env["OPENAI_API_KEY"]) && env["OPENAI_API_KEY_FOR_LLM"] !== "false") {
     return {
       provider: "openai",
       model: env["OPENAI_MODEL"] || "gpt-4o-mini",
+      ...compressModel,
       maxTokens,
       baseURL: env["OPENAI_BASE_URL"],
     };
@@ -67,6 +75,7 @@ function detectProvider(env: Record<string, string>): ProviderConfig {
     return {
       provider: "minimax",
       model: env["MINIMAX_MODEL"] || "MiniMax-M2.7",
+      ...compressModel,
       maxTokens,
     };
   }
@@ -75,6 +84,7 @@ function detectProvider(env: Record<string, string>): ProviderConfig {
     return {
       provider: "anthropic",
       model: env["ANTHROPIC_MODEL"] || "claude-sonnet-4-20250514",
+      ...compressModel,
       maxTokens,
       baseURL: env["ANTHROPIC_BASE_URL"],
     };
@@ -89,6 +99,7 @@ function detectProvider(env: Record<string, string>): ProviderConfig {
     return {
       provider: "gemini",
       model: env["GEMINI_MODEL"] || "gemini-2.5-flash",
+      ...compressModel,
       maxTokens,
     };
   }
@@ -119,6 +130,7 @@ function detectProvider(env: Record<string, string>): ProviderConfig {
     return {
       provider: "openrouter",
       model,
+      ...compressModel,
       maxTokens,
     };
   }
@@ -182,7 +194,7 @@ export function loadConfig(): AgentMemoryConfig {
     provider,
     tokenBudget: safeParseInt(env["TOKEN_BUDGET"], 2000),
     maxObservationsPerSession: safeParseInt(env["MAX_OBS_PER_SESSION"], 500),
-    compressionModel: provider.model,
+    compressionModel: provider.compressModel ?? provider.model,
     dataDir: DATA_DIR,
   };
 }

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -5,16 +5,24 @@ export class AnthropicProvider implements MemoryProvider {
   name = 'anthropic'
   private client: Anthropic
   private model: string
+  private compressModel?: string
   private maxTokens: number
 
-  constructor(apiKey: string, model: string, maxTokens: number, baseURL?: string) {
+  constructor(
+    apiKey: string,
+    model: string,
+    maxTokens: number,
+    baseURL?: string,
+    compressModel?: string,
+  ) {
     this.client = new Anthropic({ apiKey, ...(baseURL ? { baseURL } : {}) })
     this.model = model
+    this.compressModel = compressModel
     this.maxTokens = maxTokens
   }
 
   async compress(systemPrompt: string, userPrompt: string): Promise<string> {
-    return this.call(systemPrompt, userPrompt)
+    return this.call(systemPrompt, userPrompt, this.compressModel)
   }
 
   async summarize(systemPrompt: string, userPrompt: string): Promise<string> {
@@ -41,9 +49,13 @@ export class AnthropicProvider implements MemoryProvider {
     return textBlock?.text ?? ''
   }
 
-  private async call(systemPrompt: string, userPrompt: string): Promise<string> {
+  private async call(
+    systemPrompt: string,
+    userPrompt: string,
+    modelOverride?: string,
+  ): Promise<string> {
     const response = await this.client.messages.create({
-      model: this.model,
+      model: modelOverride ?? this.model,
       max_tokens: this.maxTokens,
       system: systemPrompt,
       messages: [{ role: 'user', content: userPrompt }],

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -74,7 +74,8 @@ export function createFallbackProvider(
       // override) rather than copying config.model from the primary.
       // Without this, FALLBACK_PROVIDERS=gemini on an OpenAI primary
       // would call Gemini with `gpt-4o-mini`, get a 404 every time,
-      // and trip the circuit breaker.
+      // and trip the circuit breaker. AGENTMEMORY_COMPRESS_MODEL is
+      // excluded for the same reason: model names are provider-specific.
       const fbConfig: ProviderConfig = {
         provider: providerType,
         model: defaultModelFor(providerType),
@@ -99,6 +100,7 @@ function createBaseProvider(config: ProviderConfig): MemoryProvider {
         requireEnvVar("MINIMAX_API_KEY"),
         config.model,
         config.maxTokens,
+        config.compressModel,
       );
     case "anthropic":
       return new AnthropicProvider(
@@ -106,6 +108,7 @@ function createBaseProvider(config: ProviderConfig): MemoryProvider {
         config.model,
         config.maxTokens,
         config.baseURL,
+        config.compressModel,
       );
     case "gemini": {
       const geminiKey =
@@ -120,6 +123,7 @@ function createBaseProvider(config: ProviderConfig): MemoryProvider {
         config.model,
         config.maxTokens,
         "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions",
+        config.compressModel,
       );
     }
     case "openrouter":
@@ -128,6 +132,7 @@ function createBaseProvider(config: ProviderConfig): MemoryProvider {
         config.model,
         config.maxTokens,
         "https://openrouter.ai/api/v1/chat/completions",
+        config.compressModel,
       );
     case "openai": {
       const openaiKey = getEnvVar("OPENAI_API_KEY");
@@ -141,6 +146,7 @@ function createBaseProvider(config: ProviderConfig): MemoryProvider {
         config.model,
         config.maxTokens,
         config.baseURL,
+        config.compressModel,
       );
     }
     case "noop":

--- a/src/providers/minimax.ts
+++ b/src/providers/minimax.ts
@@ -20,26 +20,32 @@ export class MinimaxProvider implements MemoryProvider {
   name = 'minimax'
   private apiKey: string
   private model: string
+  private compressModel?: string
   private maxTokens: number
   private baseUrl: string
 
-  constructor(apiKey: string, model: string, maxTokens: number) {
+  constructor(apiKey: string, model: string, maxTokens: number, compressModel?: string) {
     this.apiKey = apiKey
     this.model = model
+    this.compressModel = compressModel
     this.maxTokens = maxTokens
     this.baseUrl =
       getEnvVar('MINIMAX_BASE_URL') || 'https://api.minimax.io/anthropic'
   }
 
   async compress(systemPrompt: string, userPrompt: string): Promise<string> {
-    return this.call(systemPrompt, userPrompt)
+    return this.call(systemPrompt, userPrompt, this.compressModel)
   }
 
   async summarize(systemPrompt: string, userPrompt: string): Promise<string> {
     return this.call(systemPrompt, userPrompt)
   }
 
-  private async call(systemPrompt: string, userPrompt: string): Promise<string> {
+  private async call(
+    systemPrompt: string,
+    userPrompt: string,
+    modelOverride?: string,
+  ): Promise<string> {
     const url = `${this.baseUrl}/v1/messages`
     const response = await fetchWithTimeout(url, {
       method: 'POST',
@@ -49,7 +55,7 @@ export class MinimaxProvider implements MemoryProvider {
         'anthropic-version': '2023-06-01',
       },
       body: JSON.stringify({
-        model: this.model,
+        model: modelOverride ?? this.model,
         max_tokens: this.maxTokens,
         system: systemPrompt,
         messages: [{ role: 'user', content: userPrompt }],

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -48,6 +48,7 @@ export class OpenAIProvider implements MemoryProvider {
   name = "openai";
   private apiKey: string;
   private model: string;
+  private compressModel?: string;
   private maxTokens: number;
   private baseUrl: string;
   private reasoningEffort?: string;
@@ -55,9 +56,16 @@ export class OpenAIProvider implements MemoryProvider {
   private isAzure: boolean;
   private azureApiVersion: string;
 
-  constructor(apiKey: string, model: string, maxTokens: number, baseURL?: string) {
+  constructor(
+    apiKey: string,
+    model: string,
+    maxTokens: number,
+    baseURL?: string,
+    compressModel?: string,
+  ) {
     this.apiKey = apiKey;
     this.model = model;
+    this.compressModel = compressModel;
     this.maxTokens = maxTokens;
     this.baseUrl = normalizeBaseUrl(baseURL || getEnvVar("OPENAI_BASE_URL"));
     this.reasoningEffort = getEnvVar("OPENAI_REASONING_EFFORT") || undefined;
@@ -68,17 +76,21 @@ export class OpenAIProvider implements MemoryProvider {
   }
 
   async compress(systemPrompt: string, userPrompt: string): Promise<string> {
-    return this.call(systemPrompt, userPrompt);
+    return this.call(systemPrompt, userPrompt, this.compressModel);
   }
 
   async summarize(systemPrompt: string, userPrompt: string): Promise<string> {
     return this.call(systemPrompt, userPrompt);
   }
 
-  private async call(systemPrompt: string, userPrompt: string): Promise<string> {
+  private async call(
+    systemPrompt: string,
+    userPrompt: string,
+    modelOverride?: string,
+  ): Promise<string> {
     const url = buildChatUrl(this.baseUrl, this.isAzure, this.azureApiVersion);
     const body: Record<string, unknown> = {
-      model: this.model,
+      model: modelOverride ?? this.model,
       max_tokens: this.maxTokens,
       // OpenAI API spec defines `stream` as defaulting to false, so omitting
       // it should yield a JSON response. Some OpenAI-compatible proxies

--- a/src/providers/openrouter.ts
+++ b/src/providers/openrouter.ts
@@ -5,6 +5,7 @@ export class OpenRouterProvider implements MemoryProvider {
   name: string;
   private apiKey: string;
   private model: string;
+  private compressModel?: string;
   private maxTokens: number;
   private baseUrl: string;
 
@@ -13,16 +14,18 @@ export class OpenRouterProvider implements MemoryProvider {
     model: string,
     maxTokens: number,
     baseUrl: string,
+    compressModel?: string,
   ) {
     this.apiKey = apiKey;
     this.model = model;
+    this.compressModel = compressModel;
     this.maxTokens = maxTokens;
     this.baseUrl = baseUrl;
     this.name = baseUrl.includes("openrouter") ? "openrouter" : "gemini";
   }
 
   async compress(systemPrompt: string, userPrompt: string): Promise<string> {
-    return this.call(systemPrompt, userPrompt);
+    return this.call(systemPrompt, userPrompt, this.compressModel);
   }
 
   async summarize(systemPrompt: string, userPrompt: string): Promise<string> {
@@ -32,6 +35,7 @@ export class OpenRouterProvider implements MemoryProvider {
   private async call(
     systemPrompt: string,
     userPrompt: string,
+    modelOverride?: string,
   ): Promise<string> {
     const response = await fetchWithTimeout(this.baseUrl, {
       method: "POST",
@@ -43,7 +47,7 @@ export class OpenRouterProvider implements MemoryProvider {
           : {}),
       },
       body: JSON.stringify({
-        model: this.model,
+        model: modelOverride ?? this.model,
         max_tokens: this.maxTokens,
         messages: [
           { role: "system", content: systemPrompt },

--- a/src/types.ts
+++ b/src/types.ts
@@ -142,6 +142,8 @@ export interface HookPayload {
 export interface ProviderConfig {
   provider: ProviderType;
   model: string;
+  /** Optional cheaper model for compress() calls only; summarize() stays on `model` */
+  compressModel?: string;
   maxTokens: number;
   /** Optional base URL override (e.g. for Anthropic-compatible APIs or local proxies) */
   baseURL?: string;

--- a/test/compress-model.test.ts
+++ b/test/compress-model.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { loadConfig } from "../src/config.js";
+import { OpenAIProvider } from "../src/providers/openai.js";
+import { OpenRouterProvider } from "../src/providers/openrouter.js";
+import { MinimaxProvider } from "../src/providers/minimax.js";
+
+const openAiStyleResponse = {
+  ok: true,
+  json: async () => ({ choices: [{ message: { content: "ok" } }] }),
+} as Response;
+
+const anthropicStyleResponse = {
+  ok: true,
+  json: async () => ({ content: [{ type: "text", text: "ok" }] }),
+} as Response;
+
+function mockFetch(response: Response) {
+  const spy = vi
+    .spyOn(globalThis, "fetch")
+    .mockResolvedValue(response as Response);
+  return {
+    sentModel(callIndex = 0): string {
+      const init = spy.mock.calls[callIndex]?.[1] as RequestInit;
+      return (JSON.parse(init.body as string) as { model: string }).model;
+    },
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("AGENTMEMORY_COMPRESS_MODEL — compress() uses the override, summarize() keeps the main model", () => {
+  it("OpenAIProvider routes compress to compressModel and summarize to model", async () => {
+    const fetched = mockFetch(openAiStyleResponse);
+    const provider = new OpenAIProvider(
+      "test-key",
+      "main-model",
+      4096,
+      "https://api.example.com",
+      "cheap-model",
+    );
+
+    await provider.compress("sys", "user");
+    await provider.summarize("sys", "user");
+
+    expect(fetched.sentModel(0)).toBe("cheap-model");
+    expect(fetched.sentModel(1)).toBe("main-model");
+  });
+
+  it("OpenAIProvider without compressModel uses the main model for both", async () => {
+    const fetched = mockFetch(openAiStyleResponse);
+    const provider = new OpenAIProvider(
+      "test-key",
+      "main-model",
+      4096,
+      "https://api.example.com",
+    );
+
+    await provider.compress("sys", "user");
+    await provider.summarize("sys", "user");
+
+    expect(fetched.sentModel(0)).toBe("main-model");
+    expect(fetched.sentModel(1)).toBe("main-model");
+  });
+
+  it("OpenRouterProvider routes compress to compressModel and summarize to model", async () => {
+    const fetched = mockFetch(openAiStyleResponse);
+    const provider = new OpenRouterProvider(
+      "test-key",
+      "main-model",
+      4096,
+      "https://openrouter.ai/api/v1/chat/completions",
+      "cheap-model",
+    );
+
+    await provider.compress("sys", "user");
+    await provider.summarize("sys", "user");
+
+    expect(fetched.sentModel(0)).toBe("cheap-model");
+    expect(fetched.sentModel(1)).toBe("main-model");
+  });
+
+  it("MinimaxProvider routes compress to compressModel and summarize to model", async () => {
+    const fetched = mockFetch(anthropicStyleResponse);
+    const provider = new MinimaxProvider(
+      "test-key",
+      "main-model",
+      4096,
+      "cheap-model",
+    );
+
+    await provider.compress("sys", "user");
+    await provider.summarize("sys", "user");
+
+    expect(fetched.sentModel(0)).toBe("cheap-model");
+    expect(fetched.sentModel(1)).toBe("main-model");
+  });
+});
+
+describe("loadConfig picks up AGENTMEMORY_COMPRESS_MODEL", () => {
+  const TOUCHED_ENVS = [
+    "AGENTMEMORY_COMPRESS_MODEL",
+    "OPENAI_API_KEY",
+    "OPENAI_API_KEY_FOR_LLM",
+    "OPENAI_MODEL",
+  ] as const;
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of TOUCHED_ENVS) {
+      saved[k] = process.env[k];
+    }
+    process.env["OPENAI_API_KEY"] = "test-key";
+    process.env["OPENAI_API_KEY_FOR_LLM"] = "true";
+    process.env["OPENAI_MODEL"] = "main-model";
+  });
+
+  afterEach(() => {
+    for (const k of TOUCHED_ENVS) {
+      if (saved[k] === undefined) {
+        delete process.env[k];
+      } else {
+        process.env[k] = saved[k];
+      }
+    }
+  });
+
+  it("sets provider.compressModel and reports it as config.compressionModel", () => {
+    process.env["AGENTMEMORY_COMPRESS_MODEL"] = "cheap-model";
+
+    const config = loadConfig();
+
+    expect(config.provider.compressModel).toBe("cheap-model");
+    expect(config.compressionModel).toBe("cheap-model");
+  });
+
+  it("leaves compressModel unset and compressionModel on the main model by default", () => {
+    delete process.env["AGENTMEMORY_COMPRESS_MODEL"];
+
+    const config = loadConfig();
+
+    expect(config.provider.compressModel).toBeUndefined();
+    expect(config.compressionModel).toBe("main-model");
+  });
+});

--- a/test/compress-model.test.ts
+++ b/test/compress-model.test.ts
@@ -3,6 +3,7 @@ import { loadConfig } from "../src/config.js";
 import { OpenAIProvider } from "../src/providers/openai.js";
 import { OpenRouterProvider } from "../src/providers/openrouter.js";
 import { MinimaxProvider } from "../src/providers/minimax.js";
+import { AnthropicProvider } from "../src/providers/anthropic.js";
 
 const openAiStyleResponse = {
   ok: true,
@@ -25,6 +26,34 @@ function mockFetch(response: Response) {
     },
   };
 }
+
+// The Anthropic SDK consumes the body stream and reads headers, so it needs
+// a fresh real Response per call rather than a reused plain object.
+function mockFetchSdk(body: () => unknown) {
+  const spy = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+    return new Response(JSON.stringify(body()), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+  return {
+    sentModel(callIndex = 0): string {
+      const init = spy.mock.calls[callIndex]?.[1] as RequestInit;
+      return (JSON.parse(init.body as string) as { model: string }).model;
+    },
+  };
+}
+
+const anthropicSdkMessage = () => ({
+  id: "msg_test",
+  type: "message",
+  role: "assistant",
+  model: "main-model",
+  content: [{ type: "text", text: "ok" }],
+  stop_reason: "end_turn",
+  stop_sequence: null,
+  usage: { input_tokens: 1, output_tokens: 1 },
+});
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -94,6 +123,78 @@ describe("AGENTMEMORY_COMPRESS_MODEL — compress() uses the override, summarize
     await provider.summarize("sys", "user");
 
     expect(fetched.sentModel(0)).toBe("cheap-model");
+    expect(fetched.sentModel(1)).toBe("main-model");
+  });
+
+  it("OpenRouterProvider without compressModel uses the main model for both", async () => {
+    const fetched = mockFetch(openAiStyleResponse);
+    const provider = new OpenRouterProvider(
+      "test-key",
+      "main-model",
+      4096,
+      "https://openrouter.ai/api/v1/chat/completions",
+    );
+
+    await provider.compress("sys", "user");
+    await provider.summarize("sys", "user");
+
+    expect(fetched.sentModel(0)).toBe("main-model");
+    expect(fetched.sentModel(1)).toBe("main-model");
+  });
+
+  it("MinimaxProvider without compressModel uses the main model for both", async () => {
+    const fetched = mockFetch(anthropicStyleResponse);
+    const provider = new MinimaxProvider("test-key", "main-model", 4096);
+
+    await provider.compress("sys", "user");
+    await provider.summarize("sys", "user");
+
+    expect(fetched.sentModel(0)).toBe("main-model");
+    expect(fetched.sentModel(1)).toBe("main-model");
+  });
+
+  it("gemini path (OpenRouterProvider with Google base URL) routes compress to compressModel", async () => {
+    const fetched = mockFetch(openAiStyleResponse);
+    const provider = new OpenRouterProvider(
+      "test-key",
+      "main-model",
+      4096,
+      "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions",
+      "cheap-model",
+    );
+
+    await provider.compress("sys", "user");
+    await provider.summarize("sys", "user");
+
+    expect(fetched.sentModel(0)).toBe("cheap-model");
+    expect(fetched.sentModel(1)).toBe("main-model");
+  });
+
+  it("AnthropicProvider routes compress to compressModel and summarize to model", async () => {
+    const fetched = mockFetchSdk(anthropicSdkMessage);
+    const provider = new AnthropicProvider(
+      "test-key",
+      "main-model",
+      4096,
+      undefined,
+      "cheap-model",
+    );
+
+    await provider.compress("sys", "user");
+    await provider.summarize("sys", "user");
+
+    expect(fetched.sentModel(0)).toBe("cheap-model");
+    expect(fetched.sentModel(1)).toBe("main-model");
+  });
+
+  it("AnthropicProvider without compressModel uses the main model for both", async () => {
+    const fetched = mockFetchSdk(anthropicSdkMessage);
+    const provider = new AnthropicProvider("test-key", "main-model", 4096);
+
+    await provider.compress("sys", "user");
+    await provider.summarize("sys", "user");
+
+    expect(fetched.sentModel(0)).toBe("main-model");
     expect(fetched.sentModel(1)).toBe("main-model");
   });
 });


### PR DESCRIPTION
Closes #899

## What

Adds an optional `AGENTMEMORY_COMPRESS_MODEL` env var that routes `compress()`-side work (per-observation compression, graph extraction, query expansion) to a dedicated — typically cheaper — model, while `summarize()` callers (session summaries, consolidation synthesis, reflection, crystallize) stay on the main model.

## Why

Per-observation compression dominates background LLM volume (one call per tool use under `AGENTMEMORY_AUTO_COMPRESS=true`; ~87% of calls on a measured active day — table in the linked issue), but its quality bar is the loosest of the four LLM pipelines. With a single shared model setting, the only way to cut compression cost is to downgrade summaries and lessons too — exactly the outputs that get injected into future sessions.

## How

- `ProviderConfig` gains optional `compressModel`; `detectProvider()` reads `AGENTMEMORY_COMPRESS_MODEL` and attaches it for the openai / minimax / anthropic / gemini / openrouter branches.
- Each HTTP provider's `call()` accepts an optional model override; `compress()` passes `this.compressModel`, `summarize()` does not. `describeImage()` stays on the main model.
- `createBaseProvider()` threads the value into the four provider constructors. `FALLBACK_PROVIDERS` chains deliberately do NOT inherit it — model names are provider-specific, mirroring the #778 reasoning (comment added at the exclusion site).
- `AgentMemoryConfig.compressionModel` now reports `compressModel ?? model` instead of always mirroring `provider.model`.
- Docs: `.env.example` entry + README "Cost-aware model selection" and Environment Variables sections.

No MCP tools, REST endpoints, or version fields touched, so the AGENTS.md consistency checklists don't apply.

## Field test

Ran on a real instance (OpenAI-compatible provider) for ~20 hours with the main model on `Qwen/Qwen3-30B-A3B-Instruct-2507` and `AGENTMEMORY_COMPRESS_MODEL=nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B`: ~500 observation compressions, average qualityScore 93.7 (vs 96.6 on the main model), retry rate 1.2%, zero LLM errors or circuit-breaker trips; session summaries kept flowing through the main model. Compression cost dropped ~40% on input / 20% on output.

## How to verify

- `npm run build` — clean.
- `npm test` — 1421 tests pass (1415 baseline + 6 new in `test/compress-model.test.ts`: per-provider assertions that `compress()` sends the override and `summarize()` sends the main model, plus `loadConfig()` pickup/default tests).
- Manual: set `AGENTMEMORY_COMPRESS_MODEL` to a cheaper model of your provider, restart, and watch `model` in outbound compression requests (or provider dashboard) while session summaries keep using the main model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional environment variable to route compression-related memory work to a separate, potentially cheaper model while summaries/reflection remain on the main model; supported across providers and ignored for noop/agent-sdk and fallback-provider flows.

* **Documentation**
  * Updated README and .env example to describe the compression-model setting and provider compatibility.

* **Tests**
  * Added tests verifying compress() uses the compression model (or falls back) while summarize() uses the main model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->