### PR TITLE
fix: bound sdk.shutdown() so a hung telemetry flush can't block exit

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -598,16 +598,18 @@ async function main() {
     await indexPersistence.save().catch((err) => {
       console.warn(`[agentmemory] Failed to save index on shutdown:`, err);
     });
-    // #909 / iii-hq/iii#1835: when the iii engine is already gone, the OTel
-    // exporter retries forever and sdk.shutdown() never resolves, hanging the
-    // process until it's force-killed. Race it against a 3s timeout so we always
-    // reach process.exit(); any un-flushed telemetry is dropped on shutdown.
-    await Promise.race([
-      sdk.shutdown(),
-      new Promise<void>((resolve) => setTimeout(resolve, 3000)),
-    ]).catch((err) => {
-      console.warn(`[agentmemory] sdk.shutdown() timed out or errored:`, err);
+    // #909 / iii-hq/iii#1835: defensive timeout prevents an indefinite hang when
+    // the OTel exporter is stuck retrying; un-flushed telemetry is dropped on exit.
+    const shutdownPromise = sdk.shutdown().catch((err) => {
+      console.warn(`[agentmemory] sdk.shutdown() errored:`, err);
     });
+    const timeoutPromise = new Promise<void>((resolve) =>
+      setTimeout(() => {
+        console.warn(`[agentmemory] sdk.shutdown() exceeded 3s timeout, proceeding to exit`);
+        resolve();
+      }, 3000),
+    );
+    await Promise.race([shutdownPromise, timeoutPromise]);
     clearWorkerPidfile();
     process.exit(0);
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -598,7 +598,16 @@ async function main() {
     await indexPersistence.save().catch((err) => {
       console.warn(`[agentmemory] Failed to save index on shutdown:`, err);
     });
-    await sdk.shutdown();
+    // #909 / iii-hq/iii#1835: when the iii engine is already gone, the OTel
+    // exporter retries forever and sdk.shutdown() never resolves, hanging the
+    // process until it's force-killed. Race it against a 3s timeout so we always
+    // reach process.exit(); any un-flushed telemetry is dropped on shutdown.
+    await Promise.race([
+      sdk.shutdown(),
+      new Promise<void>((resolve) => setTimeout(resolve, 3000)),
+    ]).catch((err) => {
+      console.warn(`[agentmemory] sdk.shutdown() timed out or errored:`, err);
+    });
     clearWorkerPidfile();
     process.exit(0);
   };


### PR DESCRIPTION
## What

Wraps `sdk.shutdown()` in the SIGTERM/SIGINT handler with a 3s timeout so a hung telemetry flush can't block process exit.

## Why

When the bundled iii engine has already exited, `sdk.shutdown()` → iii-sdk's `shutdownOtel()` calls `tracerProvider.forceFlush()`, which queues spans onto a WebSocket exporter stuck in an infinite reconnect loop (`maxRetries: -1`). The flush never resolves, so the handler never reaches `process.exit(0)`. Under systemd this is a ~90s hang on every shutdown/reboot before the process is SIGKILLed.

Root cause is upstream in iii-sdk (filed as iii-hq/iii#1835). This PR is a defensive stopgap so agentmemory exits cleanly regardless of the telemetry layer's state.

## How to verify

- With the engine already stopped, send SIGTERM to the worker: it exits within ~3s instead of hanging until force-kill.
- `npm run build` compiles clean.

Fixes #909


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker shutdown reliability by adding a timeout to prevent indefinite hangs.
  * Logs warnings when shutdown errors occur or when the timeout elapses.
  * Ensures cleanup proceeds and the process exits even if shutdown does not complete (may drop un‑flushed telemetry on timeout).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->