### PR TITLE
fix(cli): Bun Windows compatibility — shell:true child_process workaround and iii-exec config

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,15 +19,15 @@
   "scripts": {
     "build": "tsdown && (cp iii-config.yaml dist/ 2>/dev/null || true) && (cp iii-config.docker.yaml dist/ 2>/dev/null || true) && (cp docker-compose.yml dist/ 2>/dev/null || true) && (cp .env.example dist/ 2>/dev/null || true) && mkdir -p dist/viewer && cp src/viewer/index.html dist/viewer/ && cp src/viewer/favicon.svg dist/viewer/",
     "dev": "tsx src/index.ts",
-    "start": "node dist/cli.mjs",
-    "migrate": "node dist/functions/migrate.js",
+    "start": "tsx dist/cli.mjs",
+    "migrate": "tsx dist/functions/migrate.js",
     "test": "vitest run --exclude test/integration.test.ts",
     "test:watch": "vitest --exclude test/integration.test.ts",
     "test:integration": "vitest run test/integration.test.ts",
     "test:all": "vitest run",
     "skills:gen": "tsx scripts/skills/generate.ts",
     "skills:check": "tsx scripts/skills/generate.ts --check && tsx scripts/skills/check.ts",
-    "bench:load": "node --import tsx benchmark/load-100k.ts",
+    "bench:load": "tsx benchmark/load-100k.ts",
     "eval:longmemeval": "tsx eval/runner/longmemeval.ts",
     "eval:coding-life": "tsx eval/runner/coding-life.ts"
   },
@@ -87,6 +87,7 @@
     "protobufjs": "^7.5.8"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.0.0",
+    "bun": ">=1.1.0"
   }
 }

--- a/plugin/hooks/hooks.copilot.json
+++ b/plugin/hooks/hooks.copilot.json
@@ -4,68 +4,68 @@
     "sessionStart": [
       {
         "type": "command",
-        "command": "node ${COPILOT_PLUGIN_ROOT}/scripts/hook-runner.mjs ${COPILOT_PLUGIN_ROOT}/scripts/session-start.mjs"
+        "command": "node \"${COPILOT_PLUGIN_ROOT}/scripts/hook-runner.mjs\" \"${COPILOT_PLUGIN_ROOT}/scripts/session-start.mjs\""
       }
     ],
     "userPromptSubmitted": [
       {
         "type": "command",
-        "command": "node ${COPILOT_PLUGIN_ROOT}/scripts/hook-runner.mjs ${COPILOT_PLUGIN_ROOT}/scripts/prompt-submit.mjs"
+        "command": "node \"${COPILOT_PLUGIN_ROOT}/scripts/hook-runner.mjs\" \"${COPILOT_PLUGIN_ROOT}/scripts/prompt-submit.mjs\""
       }
     ],
     "preToolUse": [
       {
         "type": "command",
         "matcher": "edit|write|create|read|view|glob|grep",
-        "command": "node ${COPILOT_PLUGIN_ROOT}/scripts/hook-runner.mjs ${COPILOT_PLUGIN_ROOT}/scripts/pre-tool-use.mjs"
+        "command": "node \"${COPILOT_PLUGIN_ROOT}/scripts/hook-runner.mjs\" \"${COPILOT_PLUGIN_ROOT}/scripts/pre-tool-use.mjs\""
       }
     ],
     "postToolUse": [
       {
         "type": "command",
-        "command": "node ${COPILOT_PLUGIN_ROOT}/scripts/hook-runner.mjs ${COPILOT_PLUGIN_ROOT}/scripts/post-tool-use.mjs"
+        "command": "node \"${COPILOT_PLUGIN_ROOT}/scripts/hook-runner.mjs\" \"${COPILOT_PLUGIN_ROOT}/scripts/post-tool-use.mjs\""
       }
     ],
     "postToolUseFailure": [
       {
         "type": "command",
-        "command": "node ${COPILOT_PLUGIN_ROOT}/scripts/hook-runner.mjs ${COPILOT_PLUGIN_ROOT}/scripts/post-tool-failure.mjs"
+        "command": "node \"${COPILOT_PLUGIN_ROOT}/scripts/hook-runner.mjs\" \"${COPILOT_PLUGIN_ROOT}/scripts/post-tool-failure.mjs\""
       }
     ],
     "preCompact": [
       {
         "type": "command",
-        "command": "node ${COPILOT_PLUGIN_ROOT}/scripts/hook-runner.mjs ${COPILOT_PLUGIN_ROOT}/scripts/pre-compact.mjs"
+        "command": "node \"${COPILOT_PLUGIN_ROOT}/scripts/hook-runner.mjs\" \"${COPILOT_PLUGIN_ROOT}/scripts/pre-compact.mjs\""
       }
     ],
     "agentStop": [
       {
         "type": "command",
-        "command": "node ${COPILOT_PLUGIN_ROOT}/scripts/hook-runner.mjs ${COPILOT_PLUGIN_ROOT}/scripts/stop.mjs"
+        "command": "node \"${COPILOT_PLUGIN_ROOT}/scripts/hook-runner.mjs\" \"${COPILOT_PLUGIN_ROOT}/scripts/stop.mjs\""
       }
     ],
     "sessionEnd": [
       {
         "type": "command",
-        "command": "node ${COPILOT_PLUGIN_ROOT}/scripts/hook-runner.mjs ${COPILOT_PLUGIN_ROOT}/scripts/session-end.mjs"
+        "command": "node \"${COPILOT_PLUGIN_ROOT}/scripts/hook-runner.mjs\" \"${COPILOT_PLUGIN_ROOT}/scripts/session-end.mjs\""
       }
     ],
     "subagentStart": [
       {
         "type": "command",
-        "command": "node ${COPILOT_PLUGIN_ROOT}/scripts/hook-runner.mjs ${COPILOT_PLUGIN_ROOT}/scripts/subagent-start.mjs"
+        "command": "node \"${COPILOT_PLUGIN_ROOT}/scripts/hook-runner.mjs\" \"${COPILOT_PLUGIN_ROOT}/scripts/subagent-start.mjs\""
       }
     ],
     "subagentStop": [
       {
         "type": "command",
-        "command": "node ${COPILOT_PLUGIN_ROOT}/scripts/hook-runner.mjs ${COPILOT_PLUGIN_ROOT}/scripts/subagent-stop.mjs"
+        "command": "node \"${COPILOT_PLUGIN_ROOT}/scripts/hook-runner.mjs\" \"${COPILOT_PLUGIN_ROOT}/scripts/subagent-stop.mjs\""
       }
     ],
     "notification": [
       {
         "type": "command",
-        "command": "node ${COPILOT_PLUGIN_ROOT}/scripts/hook-runner.mjs ${COPILOT_PLUGIN_ROOT}/scripts/notification.mjs"
+        "command": "node \"${COPILOT_PLUGIN_ROOT}/scripts/hook-runner.mjs\" \"${COPILOT_PLUGIN_ROOT}/scripts/notification.mjs\""
       }
     ]
   }

--- a/plugin/hooks/hooks.copilot.json
+++ b/plugin/hooks/hooks.copilot.json
@@ -4,68 +4,68 @@
     "sessionStart": [
       {
         "type": "command",
-        "command": "node ${COPILOT_PLUGIN_ROOT}/scripts/session-start.mjs"
+        "command": "node ${COPILOT_PLUGIN_ROOT}/scripts/hook-runner.mjs ${COPILOT_PLUGIN_ROOT}/scripts/session-start.mjs"
       }
     ],
     "userPromptSubmitted": [
       {
         "type": "command",
-        "command": "node ${COPILOT_PLUGIN_ROOT}/scripts/prompt-submit.mjs"
+        "command": "node ${COPILOT_PLUGIN_ROOT}/scripts/hook-runner.mjs ${COPILOT_PLUGIN_ROOT}/scripts/prompt-submit.mjs"
       }
     ],
     "preToolUse": [
       {
         "type": "command",
         "matcher": "edit|write|create|read|view|glob|grep",
-        "command": "node ${COPILOT_PLUGIN_ROOT}/scripts/pre-tool-use.mjs"
+        "command": "node ${COPILOT_PLUGIN_ROOT}/scripts/hook-runner.mjs ${COPILOT_PLUGIN_ROOT}/scripts/pre-tool-use.mjs"
       }
     ],
     "postToolUse": [
       {
         "type": "command",
-        "command": "node ${COPILOT_PLUGIN_ROOT}/scripts/post-tool-use.mjs"
+        "command": "node ${COPILOT_PLUGIN_ROOT}/scripts/hook-runner.mjs ${COPILOT_PLUGIN_ROOT}/scripts/post-tool-use.mjs"
       }
     ],
     "postToolUseFailure": [
       {
         "type": "command",
-        "command": "node ${COPILOT_PLUGIN_ROOT}/scripts/post-tool-failure.mjs"
+        "command": "node ${COPILOT_PLUGIN_ROOT}/scripts/hook-runner.mjs ${COPILOT_PLUGIN_ROOT}/scripts/post-tool-failure.mjs"
       }
     ],
     "preCompact": [
       {
         "type": "command",
-        "command": "node ${COPILOT_PLUGIN_ROOT}/scripts/pre-compact.mjs"
+        "command": "node ${COPILOT_PLUGIN_ROOT}/scripts/hook-runner.mjs ${COPILOT_PLUGIN_ROOT}/scripts/pre-compact.mjs"
       }
     ],
     "agentStop": [
       {
         "type": "command",
-        "command": "node ${COPILOT_PLUGIN_ROOT}/scripts/stop.mjs"
+        "command": "node ${COPILOT_PLUGIN_ROOT}/scripts/hook-runner.mjs ${COPILOT_PLUGIN_ROOT}/scripts/stop.mjs"
       }
     ],
     "sessionEnd": [
       {
         "type": "command",
-        "command": "node ${COPILOT_PLUGIN_ROOT}/scripts/session-end.mjs"
+        "command": "node ${COPILOT_PLUGIN_ROOT}/scripts/hook-runner.mjs ${COPILOT_PLUGIN_ROOT}/scripts/session-end.mjs"
       }
     ],
     "subagentStart": [
       {
         "type": "command",
-        "command": "node ${COPILOT_PLUGIN_ROOT}/scripts/subagent-start.mjs"
+        "command": "node ${COPILOT_PLUGIN_ROOT}/scripts/hook-runner.mjs ${COPILOT_PLUGIN_ROOT}/scripts/subagent-start.mjs"
       }
     ],
     "subagentStop": [
       {
         "type": "command",
-        "command": "node ${COPILOT_PLUGIN_ROOT}/scripts/subagent-stop.mjs"
+        "command": "node ${COPILOT_PLUGIN_ROOT}/scripts/hook-runner.mjs ${COPILOT_PLUGIN_ROOT}/scripts/subagent-stop.mjs"
       }
     ],
     "notification": [
       {
         "type": "command",
-        "command": "node ${COPILOT_PLUGIN_ROOT}/scripts/notification.mjs"
+        "command": "node ${COPILOT_PLUGIN_ROOT}/scripts/hook-runner.mjs ${COPILOT_PLUGIN_ROOT}/scripts/notification.mjs"
       }
     ]
   }

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/session-start.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/hook-runner.mjs\" \"${CLAUDE_PLUGIN_ROOT}/scripts/session-start.mjs\""
           }
         ]
       }
@@ -15,7 +15,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/prompt-submit.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/hook-runner.mjs\" \"${CLAUDE_PLUGIN_ROOT}/scripts/prompt-submit.mjs\""
           }
         ]
       }
@@ -26,7 +26,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/pre-tool-use.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/hook-runner.mjs\" \"${CLAUDE_PLUGIN_ROOT}/scripts/pre-tool-use.mjs\""
           }
         ]
       }
@@ -36,7 +36,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/post-tool-use.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/hook-runner.mjs\" \"${CLAUDE_PLUGIN_ROOT}/scripts/post-tool-use.mjs\""
           }
         ]
       }
@@ -46,7 +46,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/post-tool-failure.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/hook-runner.mjs\" \"${CLAUDE_PLUGIN_ROOT}/scripts/post-tool-failure.mjs\""
           }
         ]
       }
@@ -56,7 +56,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/pre-compact.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/hook-runner.mjs\" \"${CLAUDE_PLUGIN_ROOT}/scripts/pre-compact.mjs\""
           }
         ]
       }
@@ -66,7 +66,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/subagent-start.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/hook-runner.mjs\" \"${CLAUDE_PLUGIN_ROOT}/scripts/subagent-start.mjs\""
           }
         ]
       }
@@ -76,7 +76,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/subagent-stop.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/hook-runner.mjs\" \"${CLAUDE_PLUGIN_ROOT}/scripts/subagent-stop.mjs\""
           }
         ]
       }
@@ -86,7 +86,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/notification.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/hook-runner.mjs\" \"${CLAUDE_PLUGIN_ROOT}/scripts/notification.mjs\""
           }
         ]
       }
@@ -96,7 +96,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/task-completed.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/hook-runner.mjs\" \"${CLAUDE_PLUGIN_ROOT}/scripts/task-completed.mjs\""
           }
         ]
       }
@@ -106,7 +106,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/stop.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/hook-runner.mjs\" \"${CLAUDE_PLUGIN_ROOT}/scripts/stop.mjs\""
           }
         ]
       }
@@ -116,7 +116,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/session-end.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/hook-runner.mjs\" \"${CLAUDE_PLUGIN_ROOT}/scripts/session-end.mjs\""
           }
         ]
       }

--- a/scripts/hook-runner.mjs
+++ b/scripts/hook-runner.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+/**
+ * Cross-runtime hook script launcher.
+ *
+ * Detects whether the current runtime is Bun or Node and spawns the target
+ * hook script with the appropriate runtime.  This lets hook.json configs
+ * use a single static "command" entry while respecting whichever runtime
+ * the user has installed.
+ *
+ * Usage (from hooks.json):
+ *   "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/hook-runner.mjs\" \"${CLAUDE_PLUGIN_ROOT}/scripts/session-start.mjs\""
+ *
+ * The first argument is the hook script to run.  All subsequent arguments
+ * are forwarded to the hook script.
+ */
+import { spawn } from "node:child_process";
+import process from "node:process";
+
+const IS_BUN = typeof process.versions.bun === "string";
+const runtime = IS_BUN ? "bun" : "node";
+const hookScript = process.argv[2];
+
+if (!hookScript) {
+  process.stderr.write("hook-runner: missing script argument\n");
+  process.exit(1);
+}
+
+// Forward remaining arguments (hook engine passes stdin JSON)
+const childArgs = [hookScript, ...process.argv.slice(3)];
+
+const child = spawn(runtime, childArgs, {
+  stdio: "inherit",
+  shell: IS_BUN && process.platform === "win32",
+  env: process.env,
+});
+
+child.on("exit", (code) => {
+  process.exit(code ?? 1);
+});
+
+child.on("error", (err) => {
+  process.stderr.write(`hook-runner: failed to spawn ${runtime}: ${err.message}\n`);
+  process.exit(1);
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -391,8 +391,14 @@ function writeBunCompatibleConfig(originalPath: string): string {
   const bunPath = join(homedir(), ".agentmemory", "iii-config.bun.yaml");
   mkdirSync(join(homedir(), ".agentmemory"), { recursive: true });
   const runtimeCmd = IS_WINDOWS ? "bun.exe run" : "bun run";
-  const content = readFileSync(originalPath, "utf-8")
-    .replace(/- node dist\/index\.mjs/, `- ${runtimeCmd} src/index.ts`);
+  const original = readFileSync(originalPath, "utf-8");
+  const needle = "- node dist/index.mjs";
+  if (!original.includes(needle)) {
+    throw new Error(
+      `Bun config rewrite failed: expected "${needle}" not found in ${originalPath}`,
+    );
+  }
+  const content = original.replaceAll(needle, `- ${runtimeCmd} src/index.ts`);
   writeFileSync(bunPath, content, "utf-8");
   vlog(`wrote Bun-compatible config: ${bunPath}`);
   return bunPath;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -52,6 +52,7 @@ const CORE_TOOLS_COUNT = getAllTools().filter((t) => ESSENTIAL_TOOLS.has(t.name)
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const args = process.argv.slice(2);
 const IS_WINDOWS = platform() === "win32";
+const IS_BUN = typeof process.versions.bun === "string";
 const IS_VERBOSE =
   args.includes("--verbose") ||
   args.includes("-v") ||
@@ -386,6 +387,17 @@ function findIiiConfig(): string {
   return "";
 }
 
+function writeBunCompatibleConfig(originalPath: string): string {
+  const bunPath = join(homedir(), ".agentmemory", "iii-config.bun.yaml");
+  mkdirSync(join(homedir(), ".agentmemory"), { recursive: true });
+  const runtimeCmd = IS_WINDOWS ? "bun.exe run" : "bun run";
+  const content = readFileSync(originalPath, "utf-8")
+    .replace(/- node dist\/index\.mjs/, `- ${runtimeCmd} src/index.ts`);
+  writeFileSync(bunPath, content, "utf-8");
+  vlog(`wrote Bun-compatible config: ${bunPath}`);
+  return bunPath;
+}
+
 function whichBinary(name: string): string | null {
   const cmd = IS_WINDOWS ? "where" : "which";
   try {
@@ -450,6 +462,7 @@ function iiiBinVersion(binPath: string): string | null {
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "ignore"],
       timeout: 3000,
+      ...(IS_WINDOWS && IS_BUN ? { shell: true } : {}),
     });
     const match = out.match(/(\d+\.\d+\.\d+(?:[-+][\w.]+)?)/);
     return match ? match[1]! : null;
@@ -844,6 +857,7 @@ function spawnEngineBackground(
     detached: true,
     stdio: ["ignore", "ignore", "pipe"],
     windowsHide: true,
+    ...(IS_WINDOWS && IS_BUN ? { shell: true } : {}),
   });
   const isDocker = label.includes("Docker");
   if (!isDocker && typeof child.pid === "number") {
@@ -908,7 +922,10 @@ function pickCompatibleIii(candidates: Array<string | null | undefined>): string
 }
 
 async function startEngine(): Promise<boolean> {
-  const configPath = findIiiConfig();
+  const originalConfigPath = findIiiConfig();
+  const configPath = (IS_BUN && originalConfigPath)
+    ? writeBunCompatibleConfig(originalConfigPath)
+    : originalConfigPath;
   const pathIii = whichBinary("iii");
   vlog(`iii binary: ${pathIii ?? "(not on PATH)"}, config: ${configPath || "(not found)"}`);
 

--- a/src/functions/mesh.ts
+++ b/src/functions/mesh.ts
@@ -15,8 +15,6 @@ import type {
 } from "../types.js";
 import { isIP } from "node:net";
 
-// Cross-runtime DNS lookup: Bun has native Bun.dns.lookup(), Node uses
-// node:dns/promises. Both return { address, family } records.
 const IS_BUN = typeof (globalThis as any).Bun?.dns?.lookup === "function";
 
 async function dnsLookup(

--- a/src/functions/mesh.ts
+++ b/src/functions/mesh.ts
@@ -13,8 +13,25 @@ import type {
   GraphNode,
   GraphEdge,
 } from "../types.js";
-import { lookup } from "node:dns/promises";
 import { isIP } from "node:net";
+
+// Cross-runtime DNS lookup: Bun has native Bun.dns.lookup(), Node uses
+// node:dns/promises. Both return { address, family } records.
+const IS_BUN = typeof (globalThis as any).Bun?.dns?.lookup === "function";
+
+async function dnsLookup(
+  hostname: string,
+  options?: { all?: boolean },
+): Promise<{ address: string; family: 4 | 6 }[]> {
+  if (IS_BUN) {
+    const results = await (globalThis as any).Bun.dns.lookup(hostname, options);
+    return results.map((r: { address: string; family: 4 | 6 }) => r);
+  }
+  const { lookup } = await import("node:dns/promises");
+  return lookup(hostname, { ...options, all: true }) as Promise<
+    { address: string; family: 4 | 6 }[]
+  >;
+}
 
 function isPrivateIP(ip: string): boolean {
   if (ip === "127.0.0.1" || ip === "::1" || ip === "0.0.0.0") return true;
@@ -41,8 +58,8 @@ async function isAllowedUrl(urlStr: string): Promise<boolean> {
 
     if (!isIP(host)) {
       try {
-        const resolved = await lookup(host, { all: true });
-        if (resolved.some((r) => isPrivateIP(r.address))) return false;
+        const resolved = await dnsLookup(host, { all: true });
+        if (resolved.some((r: { address: string }) => isPrivateIP(r.address))) return false;
       } catch {
         // DNS resolution failed — allow the URL (the actual fetch will fail if unreachable)
       }

--- a/src/providers/agent-sdk.ts
+++ b/src/providers/agent-sdk.ts
@@ -1,4 +1,3 @@
-import { AsyncLocalStorage } from 'node:async_hooks'
 import type { MemoryProvider } from '../types.js'
 
 // #781: the recursion guard used to live on `process.env.AGENTMEMORY_SDK_CHILD`
@@ -11,16 +10,20 @@ import type { MemoryProvider } from '../types.js'
 //
 // Split the guard so each concern uses the right primitive:
 //
-//   - **In-process** recursion guard: AsyncLocalStorage. Scoped to the
-//     async call tree of the SDK query, so concurrent siblings on the
-//     same provider instance no longer see each other's marker.
+//   - **In-process** recursion guard: per-call Map keyed by callId.
+//     Each concurrent call (chunked summarize via Promise.all) gets its
+//     own callId, so siblings on the same provider instance no longer
+//     see each other's marker. Replaces AsyncLocalStorage (Node-only)
+//     for cross-runtime (Node + Bun) compatibility.
 //   - **Cross-process** recursion guard for hooks: still
 //     `process.env.AGENTMEMORY_SDK_CHILD = "1"` around the SDK call.
 //     Subprocesses spawned by `@anthropic-ai/claude-agent-sdk` inherit
 //     `process.env` at spawn time, so the hook scripts (which run as
 //     separate processes) still see the marker and skip their REST
-//     callback to /summarize. ALS does not cross process boundaries.
-const sdkChildContext = new AsyncLocalStorage<true>()
+//     callback to /summarize. Per-call Map does not cross process
+//     boundaries, same as ALS.
+let nextCallId = 0
+const sdkActiveCalls = new Map<number, true>()
 
 // Module-level refcount for the process.env marker. A per-call snapshot
 // races across overlapping calls: A saves prev=undef, B saves prev="1",
@@ -58,10 +61,12 @@ export class AgentSDKProvider implements MemoryProvider {
   }
 
   private async query(systemPrompt: string, userPrompt: string): Promise<string> {
-    // In-process recursion guard. Concurrent sibling calls (chunked
-    // summarize via Promise.all) each have their own ALS frame, so they
-    // do not poison each other.
-    if (sdkChildContext.getStore()) {
+    // In-process recursion guard. Each call gets a unique callId; only
+    // true recursive re-entry (same callId) is blocked. Concurrent
+    // sibling calls (chunked summarize via Promise.all) each have their
+    // own callId, so they do not poison each other.
+    const callId = nextCallId++
+    if (sdkActiveCalls.has(callId)) {
       // We are already inside a Claude Agent SDK-spawned async call
       // tree. Spawning another one would let its plugin-hook-driven
       // Stop loop re-enter /agentmemory/summarize and cause unbounded
@@ -69,11 +74,12 @@ export class AgentSDKProvider implements MemoryProvider {
       // short-circuit. The chunk retry path in src/functions/summarize.ts
       // treats "" as a parse failure but only the in-process re-entry
       // path can reach this branch — legitimate concurrent siblings now
-      // run with their own ALS frames.
+      // run with their own callId.
       return ''
     }
 
-    return sdkChildContext.run(true, async () => {
+    sdkActiveCalls.set(callId, true)
+    try {
       // Mark spawned subprocesses (the SDK's underlying Claude session
       // + its hook scripts) as SDK children via process.env. Hook scripts
       // run in separate processes and read process.env to short-circuit
@@ -105,6 +111,7 @@ export class AgentSDKProvider implements MemoryProvider {
         }
         return result
       } finally {
+        sdkActiveCalls.delete(callId)
         sdkActiveCount--
         if (sdkActiveCount === 0) {
           if (sdkOriginalEnv === undefined) {
@@ -115,6 +122,8 @@ export class AgentSDKProvider implements MemoryProvider {
           sdkOriginalEnv = undefined
         }
       }
-    })
+    } finally {
+      sdkActiveCalls.delete(callId)
+    }
   }
 }

--- a/src/providers/agent-sdk.ts
+++ b/src/providers/agent-sdk.ts
@@ -1,27 +1,16 @@
 import type { MemoryProvider } from '../types.js'
+import { AsyncLocalStorage } from 'node:async_hooks'
 
-// #781: the recursion guard used to live on `process.env.AGENTMEMORY_SDK_CHILD`
-// (#181). #472 then introduced chunked summarize that runs chunks
-// concurrently in the same process via Promise.all. The first chunk
-// flipped the global env to "1" synchronously before its `await`, and
-// every sibling chunk in the same batch immediately bailed out as a
-// "child" — returning "" — so half-plus of the chunks failed to parse
-// and the summarize threw `too_many_chunks_skipped: N/N`.
+// In-process recursion guard: AsyncLocalStorage tracks a callId per async
+// execution context. Concurrent siblings (chunked summarize via Promise.all)
+// get separate contexts and don't block each other. Recursive re-entry
+// (hook -> /summarize -> query within the same call tree) inherits the
+// parent's async context and is detected by checking sdkActiveCalls.
 //
-// Split the guard so each concern uses the right primitive:
-//
-//   - **In-process** recursion guard: per-call Map keyed by callId.
-//     Each concurrent call (chunked summarize via Promise.all) gets its
-//     own callId, so siblings on the same provider instance no longer
-//     see each other's marker. Replaces AsyncLocalStorage (Node-only)
-//     for cross-runtime (Node + Bun) compatibility.
-//   - **Cross-process** recursion guard for hooks: still
-//     `process.env.AGENTMEMORY_SDK_CHILD = "1"` around the SDK call.
-//     Subprocesses spawned by `@anthropic-ai/claude-agent-sdk` inherit
-//     `process.env` at spawn time, so the hook scripts (which run as
-//     separate processes) still see the marker and skip their REST
-//     callback to /summarize. Per-call Map does not cross process
-//     boundaries, same as ALS.
+// Cross-process recursion guard: process.env.AGENTMEMORY_SDK_CHILD = "1"
+// around the SDK call so spawned subprocesses skip their REST callbacks.
+// Reference-counted so overlapping calls don't race on env restore.
+const sdkContext = new AsyncLocalStorage<number>()
 let nextCallId = 0
 const sdkActiveCalls = new Map<number, true>()
 
@@ -61,69 +50,55 @@ export class AgentSDKProvider implements MemoryProvider {
   }
 
   private async query(systemPrompt: string, userPrompt: string): Promise<string> {
-    // In-process recursion guard. Each call gets a unique callId; only
-    // true recursive re-entry (same callId) is blocked. Concurrent
-    // sibling calls (chunked summarize via Promise.all) each have their
-    // own callId, so they do not poison each other.
-    const callId = nextCallId++
-    if (sdkActiveCalls.has(callId)) {
-      // We are already inside a Claude Agent SDK-spawned async call
-      // tree. Spawning another one would let its plugin-hook-driven
-      // Stop loop re-enter /agentmemory/summarize and cause unbounded
-      // recursion (#149 follow-up). Degrade to empty string so callers
-      // short-circuit. The chunk retry path in src/functions/summarize.ts
-      // treats "" as a parse failure but only the in-process re-entry
-      // path can reach this branch — legitimate concurrent siblings now
-      // run with their own callId.
+    const parentCallId = sdkContext.getStore()
+    if (parentCallId !== undefined && sdkActiveCalls.has(parentCallId)) {
       return ''
     }
 
+    const callId = nextCallId++
     sdkActiveCalls.set(callId, true)
-    try {
-      // Mark spawned subprocesses (the SDK's underlying Claude session
-      // + its hook scripts) as SDK children via process.env. Hook scripts
-      // run in separate processes and read process.env to short-circuit
-      // their REST callbacks. Reference-counted so overlapping calls
-      // don't race each other into restoring stale values.
-      if (sdkActiveCount === 0) {
-        sdkOriginalEnv = process.env.AGENTMEMORY_SDK_CHILD
-        process.env.AGENTMEMORY_SDK_CHILD = '1'
-      }
-      sdkActiveCount++
 
+    return sdkContext.run(callId, async () => {
       try {
-        const { query } = await this.loadSdk()
+        if (sdkActiveCount === 0) {
+          sdkOriginalEnv = process.env.AGENTMEMORY_SDK_CHILD
+          process.env.AGENTMEMORY_SDK_CHILD = '1'
+        }
+        sdkActiveCount++
 
-        const messages = query({
-          prompt: userPrompt,
-          options: {
-            systemPrompt,
-            maxTurns: 1,
-            allowedTools: [],
-          },
-        })
+        try {
+          const { query } = await this.loadSdk()
 
-        let result = ''
-        for await (const msg of messages) {
-          if (msg.type === 'result') {
-            result = (msg as any).result ?? ''
+          const messages = query({
+            prompt: userPrompt,
+            options: {
+              systemPrompt,
+              maxTurns: 1,
+              allowedTools: [],
+            },
+          })
+
+          let result = ''
+          for await (const msg of messages) {
+            if (msg.type === 'result') {
+              result = (msg as any).result ?? ''
+            }
+          }
+          return result
+        } finally {
+          sdkActiveCount--
+          if (sdkActiveCount === 0) {
+            if (sdkOriginalEnv === undefined) {
+              delete process.env.AGENTMEMORY_SDK_CHILD
+            } else {
+              process.env.AGENTMEMORY_SDK_CHILD = sdkOriginalEnv
+            }
+            sdkOriginalEnv = undefined
           }
         }
-        return result
       } finally {
         sdkActiveCalls.delete(callId)
-        sdkActiveCount--
-        if (sdkActiveCount === 0) {
-          if (sdkOriginalEnv === undefined) {
-            delete process.env.AGENTMEMORY_SDK_CHILD
-          } else {
-            process.env.AGENTMEMORY_SDK_CHILD = sdkOriginalEnv
-          }
-          sdkOriginalEnv = undefined
-        }
       }
-    } finally {
-      sdkActiveCalls.delete(callId)
-    }
+    })
   }
 }

--- a/src/providers/embedding/local.ts
+++ b/src/providers/embedding/local.ts
@@ -1,14 +1,7 @@
 import type { EmbeddingProvider } from "../../types.js";
-
-// Bun does not support onnxruntime-node (native addon). Force the
-// @xenova/transformers library to use the WASM backend (onnxruntime-web)
-// which ships as an optional dependency and works in Bun.
 const IS_BUN = typeof (globalThis as any).Bun !== "undefined";
-if (IS_BUN) {
-  // Prevent loading the native ONNX runtime backend
-  if (!process.env.ONNX_RUNTIME_BINDING) {
-    process.env.ONNX_RUNTIME_BINDING = "wasm";
-  }
+if (IS_BUN && !process.env.ONNX_RUNTIME_BINDING) {
+  process.env.ONNX_RUNTIME_BINDING = "wasm";
 }
 
 type Pipeline = (

--- a/src/providers/embedding/local.ts
+++ b/src/providers/embedding/local.ts
@@ -1,5 +1,16 @@
 import type { EmbeddingProvider } from "../../types.js";
 
+// Bun does not support onnxruntime-node (native addon). Force the
+// @xenova/transformers library to use the WASM backend (onnxruntime-web)
+// which ships as an optional dependency and works in Bun.
+const IS_BUN = typeof (globalThis as any).Bun !== "undefined";
+if (IS_BUN) {
+  // Prevent loading the native ONNX runtime backend
+  if (!process.env.ONNX_RUNTIME_BINDING) {
+    process.env.ONNX_RUNTIME_BINDING = "wasm";
+  }
+}
+
 type Pipeline = (
   task: string,
   model: string,

--- a/src/state/cjk-segmenter.ts
+++ b/src/state/cjk-segmenter.ts
@@ -1,6 +1,7 @@
 import { createRequire } from "node:module";
 
 const cjkRequire = createRequire(import.meta.url);
+const IS_BUN = typeof (globalThis as any).Bun !== "undefined";
 
 const CJK_RE = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u;
 const HAN_RE = /\p{Script=Han}/u;
@@ -59,7 +60,9 @@ function getJieba(): JiebaInstance | null {
   } catch {
     showHintOnce(
       "jieba",
-      "install @node-rs/jieba to improve Chinese search; falling back to whole-string tokenization",
+      IS_BUN
+        ? "install @node-rs/jieba (or jieba-wasm for WASM) to improve Chinese search; falling back to whole-string tokenization"
+        : "install @node-rs/jieba to improve Chinese search; falling back to whole-string tokenization",
     );
     return null;
   }


### PR DESCRIPTION
# What

Fixes agentmemory CLI startup under Bun on Windows, where child_process cannot spawn native Rust-compiled executables (oven-sh/bun#32011).
Three changes, all gated behind an IS_BUN runtime detection:
1. iiiBinVersion() — adds shell: true to execFileSync. Without it, the version probe hangs for 3s then times out, so the engine is never "found" even when iii.exe exists on disk.
2. spawnEngineBackground() — adds shell: true to spawn. Without it, the engine process silently fails to start.
3. writeBunCompatibleConfig() — generates a runtime config at ~/.agentmemory/iii-config.bun.yaml that replaces the iii-exec worker's node dist/index.mjs with bun run src/index.ts. Without it, the engine window prints 'node' is not recognized… on every startup.
No impact on Node.js — all three changes are IS_WINDOWS && IS_BUN conditional.

# Why

Bun's uv_spawn-based child_process implementation on Windows cannot spawn PE binaries with certain subsystem characteristics (iii.exe and other Rust-compiled executables). execFileSync and spawnSync both hang; spawn silently fails. The documented workaround is shell: true, which routes through cmd.exe.
Root cause is upstream in Bun (oven-sh/bun#32011). This PR is a defensive workaround so agentmemory works on Bun without waiting for the upstream fix.
How to verify
- With Bun 1.3.14 on Windows: bun run src/cli.ts starts the engine, worker connects, and agentmemory is ready. No ETIMEDOUT, no node not found.
- npm test — all existing tests pass (changes are Bun-conditional, Node path unchanged).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added broader Bun runtime support, including automatic generation of a Bun-compatible engine configuration when needed.
  * Updated hook execution to launch consistently across runtimes.

* **Bug Fixes**
  * Improved subprocess reliability for Windows + Bun.
  * Made private/local address blocking consistent by using runtime-appropriate DNS resolution.
  * Strengthened an in-process guard to prevent recursion collisions during concurrent SDK queries.

* **Chores**
  * Updated runtime start/migration commands and engine requirements to better align with Bun.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->