### PR TITLE
fix(cli): add clear warning when import-jsonl brings zero files

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2739,6 +2739,12 @@ async function runImportJsonl(): Promise<void> {
     spinner.stop(
       `imported ${json.imported ?? 0} file(s), ${json.observations ?? 0} observation(s) across ${json.sessionIds?.length || 0} session(s)`,
     );
+    if(!json.imported || json.imported === 0) {
+      p.log.warn('\n Warning: No valid JSONL session logs were imported.');
+      p.log.info(`Note: Claude Code's default 'cleanupPeriodDays' setting auto-purges logs older than 30 days.`);
+      p.log.info(`If your historical logs were cleaned up by Claude, use the recommended live auto-capture hooks instead:`);
+      p.log.info(`agentmemory connect claude-code --with-hooks\n`);
+    }
     if (json.truncated) {
       const cap = json.maxFiles ?? 200;
       const upper = json.maxFilesUpperBound ?? 1000;


### PR DESCRIPTION
### Purpose
This PR addresses a silent data-loss scenario where running `agentmemory import-jsonl` completes successfully with a deceptive success status even when `0` valid historical session logs are imported (often due to Claude Code's native `cleanupPeriodDays: 30` auto-purge setting).

### Changes
- Added an explicit validation check after the import request resolves inside `runImportJsonl()`.
- If `json.imported` evaluates to `0` or is undefined, the CLI now prints a clean warning (`p.log.warn`) alerting the user about the missing files and the Claude Code cleanup policy.
- Suggests the user connect live auto-capture hooks instead via `agentmemory connect claude-code --with-hooks`.

### Verification Done
- Verified compilation with `npm run build`.
- Ran the entire test pipeline (`npm test`) locally, ensuring all 1423+ unit and integration tests continue to pass seamlessly without any regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * When imports detect no records, the CLI now displays a warning explaining why historical logs may be missing and recommends enabling auto-capture hooks for better continuity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->