### PR TITLE
feat(search): add temporal decay to recall ranking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,6 +96,11 @@
 # BM25_WEIGHT=0.4                                # Hybrid search weight for BM25 leg
 # VECTOR_WEIGHT=0.6                              # Hybrid search weight for vector leg
 # AGENTMEMORY_GRAPH_WEIGHT=0.2                   # Graph traversal bonus on smart-search ranking
+# AGENTMEMORY_TEMPORAL_DECAY=true                # Blend a recency factor into recall ranking so fresh/reinforced memories outrank equally-relevant stale ones. Default off (changes recall ordering).
+# AGENTMEMORY_TEMPORAL_DECAY_HALF_LIFE_DAYS=14   # Days after which an un-accessed memory's recency weight halves. Recall refreshes the clock (use-it-or-lose-it).
+# AGENTMEMORY_TEMPORAL_DECAY_RECENCY_WEIGHT=0.5  # Blend weight for the recency factor [0,1]. Higher = time dominates ranking.
+# AGENTMEMORY_TEMPORAL_DECAY_IMPORTANCE_WEIGHT=0.2 # Blend weight for importance [0,1]. Higher = important memories resist decay. recency+importance should stay <= 1.
+# AGENTMEMORY_TEMPORAL_DECAY_FLOOR=0.2           # Minimum decay multiplier [0,1]. Decay demotes but never erases: a stale hit keeps at least this fraction of its relevance.
 # TOKEN_BUDGET=2000                              # Max tokens injected via mem::context per session
 # MAX_OBS_PER_SESSION=500                        # Per-session observation cap before consolidation kicks in
 # SUMMARIZE_CHUNK_SIZE=400                       # When mem::summarize sees a session larger than this, it chunks observations and map-reduces (chunk-summarize → reduce-merge) to stay within the LLM's context window. Default 400 ≈ 50k tokens per chunk at ~110 tok/obs. Native sessions are capped by MAX_OBS_PER_SESSION; chunking primarily matters for bulk-imported jsonl sessions, which bypass that cap.

--- a/ENHANCEMENTS.md
+++ b/ENHANCEMENTS.md
@@ -1,0 +1,978 @@
+# AgentMemory Enhancement Opportunities
+
+## Executive Summary
+
+AgentMemory is a mature, production-grade persistent memory system for AI coding agents (v0.9.27). After analyzing the codebase, architecture, and feature set, this document identifies 11 high-impact enhancement opportunities to improve memory retention, retrieval quality, security, and usability.
+
+**Key Findings (verified against source):**
+- 95.2% retrieval accuracy on benchmarks, but no feedback loop to maintain/improve this metric
+- Powerful hybrid search (BM25 + vector + graph); weights are env-configurable (`BM25_WEIGHT`) but not query-adaptive
+- Hook-captured observations ARE secrets-scrubbed (`stripPrivateData`, 15 patterns), but manual saves, imports, lessons, and slots bypass scrubbing entirely
+- Decay machinery exists for `SemanticMemory`/`ProceduralMemory`/`Insight` (`decayRate`, `lastAccessedAt`, `DecayConfig`), but the core `Memory` type and hybrid-search ranking don't use it
+- Deduplication is exact-hash only (5-minute TTL) — semantically identical observations stored separately
+- `stale` flags exist on graph nodes/edges but not on `Memory`; no automatic conflict detection between memories
+
+---
+
+## Current System Architecture (v0.9.27)
+
+### Core Capabilities
+- **Storage:** SQLite-backed KV store (`~/.agentmemory/state_store.db`)
+- **Observation Pipeline:** Hook capture → Compression (LLM or synthetic) → Storage
+- **Retrieval:** Hybrid search (BM25 + vector embeddings + knowledge graph)
+- **Consolidation:** Session-end LLM synthesis into long-term memories
+- **Integrations:** 16+ agents (Claude Code, Copilot, Cursor, Gemini, etc.)
+- **API Surface:** 128 REST endpoints + 53 MCP tools
+- **Test Coverage:** 950+ tests across 129 test files
+
+### Data Model
+```typescript
+Session → RawObservation → CompressedObservation → Memory
+         (capture)         (compress)              (consolidate)
+```
+
+**Key fields:**
+- `Memory`: type (pattern|preference|architecture|bug|workflow|fact), strength (1–10), files[], concepts[], supersedes[], isLatest, forgetAfter (TTL)
+- `CompressedObservation`: title, facts[], narrative, importance (0–1), type, concepts, files
+- `Session`: project, cwd, status, observationCount, tags, model, agentId
+
+---
+
+## What Already Exists (Verification Notes)
+
+Before proposing changes, these capabilities were verified in the source — proposals below build on them rather than duplicating them:
+
+| Capability | Where | Notes |
+|---|---|---|
+| Secrets scrubbing | `src/functions/privacy.ts`, applied in `observe.ts:80-87` | 15 regex patterns (OpenAI `sk-`/`sk-proj-`, Anthropic `sk-ant-`, GitHub `ghp_`/`github_pat_`, AWS `AKIA`, Google `AIza`, JWT, Slack `xoxb-`, npm, GitLab `glpat-`, DigitalOcean, Bearer, generic `key=value`) run over the **full serialized payload** before field extraction. Also strips `<private>` tags. |
+| Exact-hash dedup | `src/functions/dedup.ts` | SHA-256 of `sessionId:toolName:toolInput[:500]`, 5-minute TTL. Exact-match only. |
+| Decay fields | `src/types.ts` | `SemanticMemory` has `accessCount`/`lastAccessedAt`/`strength`; `ProceduralMemory` and `Insight` have `decayRate`/`lastDecayedAt`/`reinforcements`; a `DecayConfig` (lambda, sigma, hot/warm tier thresholds) and retention scoring (`temporalDecay`, `reinforcementBoost`, `salience`) exist for `mem::retention-evict`. |
+| Supersession | `src/types.ts` | `Memory.supersedes[]`/`isLatest`/`version` exist (manual only). `GraphEdge` is bitemporal (`tcommit`, `tvalid`, `tvalidEnd`) with `supersededBy`/`isLatest` and a `succeeded_by` edge type. |
+| Staleness | `src/types.ts` | `stale?: boolean` exists on `GraphNode` and `GraphEdge` — not on `Memory`. |
+| Scope | `src/types.ts:233` | `MemorySlot` has `scope: "project" \| "global"` plus a global-slots KV scope — `Memory` itself has only `project?`. |
+| Search weights | `src/config.ts:223` | `BM25_WEIGHT` env var with validation (default 0.4); weights are static per-process, not per-query. |
+| TTL forgetting | `src/types.ts:100` | `Memory.forgetAfter` exists for hard expiry. |
+
+---
+
+## Enhancement Recommendations
+
+### 1. **Temporal Memory Decay** (Priority: High)
+**Impact:** Improves relevance of recall results | **Effort:** Low | **Breaking:** No
+
+#### Problem
+The system already has decay machinery — `DecayConfig` (lambda, sigma, hot/warm tiers), `temporalDecay`/`reinforcementBoost` retention scoring, and `decayRate`/`lastAccessedAt` fields on `SemanticMemory`, `ProceduralMemory`, and `Insight`. But the **core `Memory` type** (output of consolidation) has none of these, and **hybrid-search ranking ignores decay entirely**. A consolidated memory about a deleted file from 6 months ago has the same retrieval weight as one from yesterday. `Memory.forgetAfter` provides hard TTL expiry, but nothing in between full strength and deletion.
+
+#### Solution
+Extend the existing decay machinery to `Memory` and wire it into search ranking — no new decay framework needed:
+
+1. **Add the same fields the other memory types already have:**
+   ```typescript
+   interface Memory {
+     // existing...
+     lastAccessedAt?: string;
+     accessCount?: number;
+     decayRate?: number; // reuse DecayConfig.lambda as default
+   }
+   ```
+
+2. **Compute decayed strength at query time:**
+   ```typescript
+   const daysSinceAccess = (Date.now() - new Date(memory.lastAccessedAt).getTime()) / (1000 * 60 * 60 * 24);
+   const decayedStrength = memory.strength * Math.exp(-0.01 * daysSinceAccess);
+   ```
+
+3. **Bump strength + update `lastAccessedAt` when recalled:**
+   - In `search.ts`, after a memory is returned in results, trigger a background update
+   - Increase `strength` by 0.2 (up to 10) and set `lastAccessedAt = now()`
+   - This implements spaced repetition: frequently accessed memories stay fresh
+
+#### Files to Change
+- `src/types.ts` — Add `lastAccessedAt`, `accessCount`, `decayRate` to `Memory` (mirror `SemanticMemory` fields)
+- `src/state/hybrid-search.ts` — Apply decayed strength in RRF result ranking
+- `src/functions/search.ts` / recall path — Update memory on access (fire-and-forget background task)
+- Reuse the existing `DecayConfig` from the retention-evict pipeline as the source of lambda — do not introduce a second decay constant
+
+#### Testing
+- Unit test: verify decay formula with known timestamps
+- Integration test: recall same memory twice, verify strength increased on second call
+
+---
+
+### 2. **Semantic Deduplication** (Priority: High)
+**Impact:** Reduces index bloat, improves precision | **Effort:** Medium | **Breaking:** No
+
+#### Problem
+Observations with identical or near-identical meaning are stored separately. Example:
+- "Fixed JWT expiry bug in auth middleware"
+- "Resolved token expiration issue in `src/auth/jwt.ts`"
+- "Bug: JWT tokens expiring too early"
+
+These appear as 3 separate observations instead of 1, inflating the index and making recall results noisier.
+
+The existing `DedupMap` ([dedup.ts](src/functions/dedup.ts)) only catches **exact** repeats: SHA-256 of `sessionId:toolName:toolInput` with a 5-minute TTL. It exists to absorb hook double-fires, not semantic duplicates — anything phrased differently, arriving later than 5 minutes, or from another session passes through.
+
+#### Solution
+At compress time, compare new observation embedding against recent observations; if cosine similarity > 0.92, merge instead of creating new entry.
+
+1. **Add to `CompressedObservation`:**
+   ```typescript
+   interface CompressedObservation {
+     // existing...
+     mergedFromIds?: string[]; // Track provenance
+     isDuplicate?: boolean;
+   }
+   ```
+
+2. **In `compress.ts` (after LLM compression):**
+   ```typescript
+   // Get embedding for new observation
+   const embedding = await embeddingProvider.embed(newObs.narrative);
+   
+   // Find recent observations in same session
+   const recentObs = await kv.list<CompressedObservation>(
+     KV.obs(sessionId),
+     { limit: 50, sortBy: "timestamp:desc" }
+   );
+   
+   // Check for duplicates
+   for (const existing of recentObs) {
+     const similarity = cosineSimilarity(embedding, existing.embedding);
+     if (similarity > 0.92) {
+       // Merge: append facts, bump importance
+       existing.facts.push(...newObs.facts);
+       existing.importance = Math.max(existing.importance, newObs.importance);
+       existing.mergedFromIds = [...(existing.mergedFromIds || []), newObs.id];
+       await kv.set(KV.obs(sessionId), existing.id, existing);
+       return { success: true, merged: true, targetId: existing.id };
+     }
+   }
+   
+   // No duplicate found, save normally
+   ```
+
+3. **Web viewer enhancement:**
+   - Show badge "merged from 3 observations" on deduplicated entries
+   - Expandable list of merged observation titles
+
+#### Files to Change
+- `src/types.ts` — Add `mergedFromIds`, `isDuplicate`
+- `src/functions/compress.ts` — Add dedup logic before saving
+- `src/viewer/document.ts` — Show merge metadata in UI
+
+#### Testing
+- Unit test: mock embeddings with known similarities, verify dedup threshold
+- Integration test: consolidate session with 5 near-identical observations, verify only 1 survives
+
+---
+
+### 3. **Memory Conflict Detection & Auto-Supersede** (Priority: High)
+**Impact:** Prevents contradictory recall | **Effort:** High | **Breaking:** No
+
+#### Problem
+Two memories can contradict without being detected:
+- Memory A: "Auth uses JWT tokens stored in localStorage"
+- Memory B: "Auth was migrated to server-side session cookies"
+
+Both survive in the store. A future search might return both, confusing the agent about the current state.
+
+The building blocks already exist: `Memory.supersedes[]`/`isLatest`/`version`, and the knowledge graph is bitemporal — `GraphEdge` carries `tcommit`/`tvalid`/`tvalidEnd`, `supersededBy`, `isLatest`, and a `succeeded_by` edge type. What's missing is anything that populates these **automatically** at the memory level.
+
+#### Solution
+During consolidation, detect contradictions and auto-populate the existing `supersedes` field (no schema change needed).
+
+1. **New function: `detect-contradictions.ts`**
+   ```typescript
+   export async function detectMemoryContradictions(
+     memories: Memory[],
+     provider: MemoryProvider
+   ): Promise<{ primary: Memory; superseded: Memory[] }[]> {
+     const conflicts: { primary: Memory; superseded: Memory[] }[] = [];
+     
+     // Group by shared concepts
+     const byConceptId = new Map<string, Memory[]>();
+     for (const mem of memories) {
+       for (const concept of mem.concepts) {
+         if (!byConceptId.has(concept)) byConceptId.set(concept, []);
+         byConceptId.get(concept)!.push(mem);
+       }
+     }
+     
+     // For each concept group, check for contradictions
+     for (const [concept, group] of byConceptId) {
+       if (group.length < 2) continue;
+       
+       // Use LLM to detect contradictions
+       const conflict = await provider.detectContradiction(group);
+       if (conflict) {
+         conflicts.push({
+           primary: conflict.newer,
+           superseded: [conflict.older]
+         });
+       }
+     }
+     
+     return conflicts;
+   }
+   ```
+
+2. **In `consolidation-pipeline.ts`:**
+   ```typescript
+   // After consolidating observations into memories...
+   const conflicts = await detectMemoryContradictions(newMemories, provider);
+   for (const { primary, superseded } of conflicts) {
+     primary.supersedes = (primary.supersedes || []).concat(superseded.map(m => m.id));
+     await kv.set(KV.memories, primary.id, primary);
+     
+     // Mark superseded memories
+     for (const old of superseded) {
+       old.isLatest = false;
+       await kv.set(KV.memories, old.id, old);
+     }
+   }
+   ```
+
+3. **In `hybrid-search.ts`:**
+   ```typescript
+   // Filter out superseded memories from results
+   const results = await bm25.search(query);
+   return results.filter(r => !r.memory.supersedes?.includes(r.memory.id));
+   ```
+
+4. **Web viewer:**
+   - Show "Superseded by [newer memory]" badge on old memories
+   - Timeline view showing evolution of a concept
+
+#### Files to Change
+- `src/functions/detect-contradictions.ts` — New file
+- `src/functions/consolidation-pipeline.ts` — Call contradiction detector
+- `src/state/hybrid-search.ts` — Filter superseded memories
+- `src/viewer/document.ts` — Show supersession relationships
+
+#### Testing
+- Unit test: mock LLM conflict detection, verify supersedes field populated
+- Integration test: consolidate two sessions with conflicting auth implementations, verify newer supersedes older
+
+---
+
+### 4. **Close Secrets-Scrubbing Bypass Paths** (Priority: Critical)
+**Impact:** Prevents accidental credential leakage | **Effort:** Low–Medium | **Breaking:** No
+
+#### What Already Works (verified)
+`src/functions/privacy.ts` has a solid `stripPrivateData` with 15 patterns (OpenAI, Anthropic, GitHub, AWS, Google, JWT, Slack, npm, GitLab, DigitalOcean, Bearer tokens, generic `key=value`, `<private>` tags). [observe.ts:80-87](src/functions/observe.ts#L80-L87) runs it over the **full serialized payload** before `toolInput`/`toolOutput` are extracted — so the hook capture path is well covered. Do **not** build a parallel `secrets-detector.ts`.
+
+#### Actual Gaps
+1. **Bypass paths:** `grep -rn stripPrivateData src/` shows only `privacy.ts` and `observe.ts` reference it. Every other ingestion path stores content **unscrubbed**:
+   - `memory_save` MCP tool / `POST /agentmemory/memories/save` (explicit saves)
+   - `POST /agentmemory/import` (bulk import)
+   - Lessons (`memory_lesson_save`), slots (`memory_slot_*`), team share, sketches
+   - LLM compression output (`compress.ts`) — a model could echo a secret from context into `narrative`/`facts` even though the raw input was scrubbed
+2. **Missing patterns:** PEM private key blocks (`-----BEGIN ... PRIVATE KEY-----`) and DB connection strings with embedded credentials (`postgres://user:pass@host`) are not in `SECRET_PATTERN_SOURCES`.
+3. **No observability:** scrubbing is silent — no `sanitized` flag, no redaction count, no audit event, so there's no way to confirm coverage in production.
+
+#### Solution
+1. **Add the two missing patterns to `privacy.ts`:**
+   ```typescript
+   // append to SECRET_PATTERN_SOURCES
+   /-----BEGIN (?:RSA |EC |OPENSSH |DSA )?PRIVATE KEY-----[\s\S]*?-----END (?:RSA |EC |OPENSSH |DSA )?PRIVATE KEY-----/g,
+   /(?:postgres(?:ql)?|mysql|mongodb(?:\+srv)?|redis|amqp):\/\/[^\/\s:]+:[^@\s]+@/gi,
+   ```
+
+2. **Apply `stripPrivateData` at every write boundary**, not just hook capture. Cleanest approach: a single chokepoint in `StateKV` write helpers for the content-bearing scopes (`mem:memories`, `mem:slots`, lessons, team-shared), or explicitly in each save function:
+   - `memory-save.ts`, `export-import.ts` (import path), `lessons.ts`, `slots.ts`, `team.ts`, `sketches.ts`
+   - `compress.ts` — scrub the LLM output (`title`, `facts`, `narrative`) before persisting
+
+3. **Make redaction observable:**
+   ```typescript
+   // privacy.ts — return count alongside output
+   export function stripPrivateDataWithStats(input: string): { output: string; redactions: number };
+   ```
+   - Set `sanitized: true` + `redactionCount` on `RawObservation`
+   - Emit `recordAudit("SECRETS_REDACTED", { count, scope })` when count > 0
+   - Add `sanitizationStats` to `GET /agentmemory/health`
+
+#### Files to Change
+- `src/functions/privacy.ts` — Add 2 patterns, add stats-returning variant
+- `src/functions/memory-save.ts`, `export-import.ts`, `lessons.ts`, `slots.ts`, `team.ts`, `sketches.ts`, `compress.ts` — Apply scrubbing at write
+- `src/types.ts` — Add `sanitized`, `redactionCount` to `RawObservation`
+- `src/triggers/api.ts` — Sanitization stats in health endpoint
+
+#### Testing
+- Unit test: PEM block and `postgres://user:pass@host` are redacted
+- Integration test: save memory via MCP `memory_save` containing a fake `ghp_` token, verify `[REDACTED_SECRET]` in storage
+- Integration test: import a JSON export containing secrets, verify scrubbed on ingest
+- Security audit: scan stored database for all 17 patterns (should find none)
+
+---
+
+### 5. **Cross-Project Memory Scope** (Priority: Medium)
+**Impact:** Enables reuse across projects | **Effort:** Medium | **Breaking:** No
+
+#### Problem
+Memories are scoped to a single `project` (`Memory.project?`). If you solve the same problem in Project A and later work on Project B, the solution isn't found—you must re-learn it.
+
+A scope model already exists for slots: `MemorySlot` has `scope: "project" | "global"` (types.ts:233) plus a dedicated `mem:global-slots` KV scope. The gap is that `Memory` records — the bulk of long-term knowledge — have no equivalent.
+
+#### Solution
+Extend the existing slot scope model to `Memory`: `project` (current) | `workspace` (user's machine) | `global` (team). Reuse the slot scoping conventions rather than inventing a new mechanism.
+
+1. **Extend `Memory` type:**
+   ```typescript
+   interface Memory {
+     // existing...
+     scope: "project" | "workspace" | "global";
+     // project-scoped: visibility limited to one project
+     // workspace-scoped: visible across projects on this machine
+     // global-scoped: shared with entire team (requires governance)
+   }
+   ```
+
+2. **Update `memory_save` MCP tool:**
+   ```typescript
+   export interface MemorySaveInput {
+     title: string;
+     content: string;
+     type: "pattern" | "preference" | "architecture" | "bug" | "workflow" | "fact";
+     concepts?: string[];
+     files?: string[];
+     scope?: "project" | "workspace" | "global"; // New
+     // ... existing
+   }
+   ```
+
+3. **In `recall` / `smart-search`:**
+   ```typescript
+   async function recall(query: string, options?: { scope?: "project" | "workspace" | "global" }) {
+     let searchMemories = allMemories;
+     
+     if (options?.scope === "project") {
+       searchMemories = searchMemories.filter(m => m.project === currentProject && m.scope !== "global");
+     } else if (options?.scope === "workspace") {
+       searchMemories = searchMemories.filter(m => m.project === currentProject || m.scope === "workspace");
+     } else {
+       // default: project + workspace scopes
+       searchMemories = searchMemories.filter(m => 
+         m.project === currentProject || m.scope === "workspace"
+       );
+     }
+     
+     return hybridSearch(query, searchMemories);
+   }
+   ```
+
+4. **UI enhancements:**
+   - Badge on memories showing scope: `[PROJECT]`, `[WORKSPACE]`, `[TEAM]`
+   - When saving, offer scope selector: "Remember this for... [this project] [my machine] [my team]"
+
+#### Files to Change
+- `src/types.ts` — Add `scope` field
+- `src/functions/memory-save.ts` — Accept scope parameter
+- `src/state/hybrid-search.ts` — Filter by scope
+- `src/mcp/tools-registry.ts` — Update `memory_save` schema
+- `src/viewer/document.ts` — Show scope badge
+
+#### Testing
+- Integration test: save memory with scope=workspace, verify it surfaces in different project
+- Integration test: global memory requires governance approval (mock)
+
+---
+
+### 6. **Retrieval Feedback Loop** (Priority: Medium)
+**Impact:** Enables continuous improvement of 95.2% R@5 metric | **Effort:** Medium | **Breaking:** No
+
+#### Problem
+No signal flows back from agent outcomes to retrieval quality. If a recalled memory led the agent in the wrong direction, that information is lost forever.
+
+#### Solution
+Explicit feedback MCP tool + online learning on weights.
+
+1. **New MCP tool: `memory_feedback`**
+   ```typescript
+   export interface MemoryFeedbackInput {
+     sessionId: string;
+     memoryId: string;
+     searchQuery: string;
+     helpful: boolean; // true = "this helped me", false = "this was wrong/irrelevant"
+     context?: string; // e.g., "memory said X but we discovered Y"
+   }
+
+   export interface FeedbackRecord {
+     id: string;
+     sessionId: string;
+     memoryId: string;
+     searchQuery: string;
+     helpful: boolean;
+     context?: string;
+     timestamp: string;
+   }
+   ```
+
+2. **Store in KV:**
+   ```typescript
+   const KV_scope = "mem:feedback";
+   await kv.set(KV_scope, feedbackId, feedback);
+   ```
+
+3. **Online weight tuning (background job):**
+   ```typescript
+   // Called periodically (e.g., post-session-end)
+   export async function updateSearchWeights(kv: StateKV) {
+     const feedbacks = await kv.list<FeedbackRecord>(KV.feedback, { limit: 1000 });
+     
+     // Compute helpfulness by search type
+     const keywordHelpful = feedbacks.filter(f => 
+       f.searchQuery.match(/[a-z_]+\.[a-z_]+/) // identifiers
+     ).filter(f => f.helpful).length;
+     const conceptualHelpful = feedbacks.filter(f => 
+       f.searchQuery.split(' ').length > 3 && !f.searchQuery.match(/\//)
+     ).filter(f => f.helpful).length;
+     
+     // Adjust weights: keyword queries doing better? boost BM25
+     const newBm25Weight = 0.4 + (keywordHelpful > conceptualHelpful ? 0.1 : -0.05);
+     await config.set('BM25_WEIGHT', newBm25Weight);
+   }
+   ```
+
+4. **UI feedback button:**
+   - When result is displayed, show thumbs-up/thumbs-down
+   - Click → fires `memory_feedback` tool
+
+#### Files to Change
+- `src/functions/feedback.ts` — New file
+- `src/types.ts` — Add `FeedbackRecord`
+- `src/mcp/tools-registry.ts` — Add `memory_feedback` tool
+- `src/functions/update-weights.ts` — New file, online learning
+- `src/viewer/document.ts` — Add feedback UI buttons
+
+#### Testing
+- Unit test: verify weight update direction based on feedback distribution
+- Integration test: 100 feedback records, 70% keyword queries helpful → verify BM25 weight increases
+
+---
+
+### 7. **Proactive Warnings in `pre-tool-use` Hook** (Priority: Medium)
+**Impact:** Prevents repeated mistakes | **Effort:** Low | **Breaking:** No
+
+#### Problem
+The `pre-tool-use` hook exists but is passive—it only injects context when explicitly queried. It could proactively warn the agent before repeating a known mistake.
+
+#### Solution
+Pattern-match against `bug` memories and surface warnings.
+
+1. **Enhance `src/hooks/pre-tool-use.ts`:**
+   ```typescript
+   // Existing: inject context on demand
+   // New: also check for warnings
+   
+   export async function preToolUse(payload: ToolUsePayload) {
+     const sessionId = payload.sessionId;
+     const toolName = payload.toolName;
+     const toolInput = JSON.stringify(payload.toolInput);
+     
+     // Search for related bug memories
+     const bugMemories = await search('bugs about ' + toolName, { type: ['bug'] });
+     
+     // Pattern match against tool input
+     const warnings: string[] = [];
+     for (const bug of bugMemories) {
+       // Extract patterns from bug content (e.g., "avoid: rm -rf", "don't: git push --force")
+       const patterns = extractDangerPatterns(bug.content);
+       for (const pattern of patterns) {
+         if (toolInput.includes(pattern)) {
+           warnings.push(`⚠️ Warning: Past session noted: ${bug.title}`);
+         }
+       }
+     }
+     
+     if (warnings.length > 0 && process.env.AGENTMEMORY_PROACTIVE_WARNINGS === 'true') {
+       return {
+         context: injectedContext,
+         warnings,
+       };
+     }
+     
+     return { context: injectedContext };
+   }
+
+   function extractDangerPatterns(content: string): string[] {
+     // Extract sentences starting with "avoid:", "don't:", "never:"
+     const match = content.match(/(?:avoid|don't|never):\s*(.+?)(?:\.|$)/gi);
+     return match ? match.map(m => m.replace(/(?:avoid|don't|never):\s*/, '')) : [];
+   }
+   ```
+
+2. **Config flag:**
+   ```bash
+   AGENTMEMORY_PROACTIVE_WARNINGS=true
+   ```
+
+#### Files to Change
+- `src/hooks/pre-tool-use.ts` — Add warning logic
+- `src/config.ts` — Add `AGENTMEMORY_PROACTIVE_WARNINGS` flag
+- `src/types.ts` — Extend HookResponse to include warnings[]
+
+#### Testing
+- Unit test: mock bug memory about `rm -rf`, verify warning on matching tool input
+- Integration test: run agent that calls dangerous command, verify warning injected
+
+---
+
+### 8. **Staleness Detection for File Paths** (Priority: Medium)
+**Impact:** Improves accuracy of file-related recall | **Effort:** Low | **Breaking:** No
+
+#### Problem
+`Memory.files[]` stores file paths. If those files are deleted or renamed, the memory silently becomes stale. A memory about `/src/auth/jwt.ts` is misleading if that file was deleted 3 months ago.
+
+A `stale?: boolean` flag already exists on `GraphNode` and `GraphEdge` — but nothing sets it from filesystem reality, and `Memory` has no equivalent field.
+
+#### Solution
+Background staleness check at session-start; reuse the existing `stale` convention from the graph layer.
+
+1. **New function: `check-file-staleness.ts`**
+   ```typescript
+   export async function checkFilesStaleness(
+     memories: Memory[],
+     projectCwd: string
+   ): Promise<Map<string, boolean>> {
+     const staleness = new Map<string, boolean>();
+     
+     for (const mem of memories) {
+       for (const filePath of mem.files || []) {
+         const fullPath = path.join(projectCwd, filePath);
+         const exists = fs.existsSync(fullPath);
+         if (!exists) {
+           staleness.set(mem.id, true);
+           break;
+         }
+       }
+     }
+     
+     return staleness;
+   }
+   ```
+
+2. **In `session-start.ts` hook:**
+   ```typescript
+   const sessionMemories = await search('...', { sessionId });
+   const staleMemories = await checkFilesStaleness(sessionMemories, cwd);
+   
+   for (const [memId, isStale] of staleMemories) {
+     if (isStale) {
+       await updateMemory(memId, { stale: true });
+     }
+   }
+   ```
+
+3. **Add to `Memory`:**
+   ```typescript
+   interface Memory {
+     // existing...
+     stale?: boolean;
+     staleReason?: "file_deleted" | "file_renamed" | "codebase_refactored";
+     staledAt?: string;
+   }
+   ```
+
+4. **In search results:**
+   ```typescript
+   // Lower score for stale memories
+   if (result.memory.stale) {
+     result.combinedScore *= 0.5;
+   }
+   ```
+
+5. **UI warning:**
+   - Show badge "⚠️ File deleted" on stale memories in viewer
+
+#### Files to Change
+- `src/functions/check-file-staleness.ts` — New file
+- `src/types.ts` — Add `stale`, `staleReason`, `staledAt`
+- `src/hooks/session-start.ts` — Call staleness check
+- `src/state/hybrid-search.ts` — Apply stale penalty
+- `src/viewer/document.ts` — Show stale badge
+
+#### Testing
+- Unit test: verify staleness detection for deleted files
+- Integration test: create memory with file reference, delete file, verify stale flag on next session-start
+
+---
+
+### 9. **Adaptive Search Weight Tuning** (Priority: Medium)
+**Impact:** Improves recall precision without manual tuning | **Effort:** Medium | **Breaking:** No
+
+#### Problem
+[hybrid-search.ts:27-31](src/state/hybrid-search.ts#L27-L31) defaults weights to `bm25=0.4, vector=0.6, graph=0.3`. These are already overridable via env (`BM25_WEIGHT` in [config.ts:223](src/config.ts#L223)), but they're static per-process: a query full of exact identifiers gets the same vector-heavy blend as a vague conceptual question. The gap is **per-query** adaptation, not configurability.
+
+#### Solution
+Classify query type and adjust weights dynamically.
+
+1. **Query classifier:**
+   ```typescript
+   type QueryType = "keyword" | "conceptual" | "temporal" | "entity";
+
+   function classifyQuery(query: string): { type: QueryType; confidence: number } {
+     // Keyword: many specific identifiers, file paths, function names
+     const identifierDensity = (query.match(/[a-z_]+\.[a-z_]+/g) || []).length / query.split(' ').length;
+     if (identifierDensity > 0.3) return { type: "keyword", confidence: 0.9 };
+     
+     // Temporal: dates, "last week", "when did"
+     if (/\b(last|this|when did|recently|ago)\b/i.test(query)) return { type: "temporal", confidence: 0.8 };
+     
+     // Entity: specific names, "author said", "in file X"
+     if (/\b(in|by|from|author)\b/i.test(query)) return { type: "entity", confidence: 0.7 };
+     
+     // Conceptual: vague, multi-word, natural language
+     return { type: "conceptual", confidence: 0.6 };
+   }
+   ```
+
+2. **Adaptive weights:**
+   ```typescript
+   async tripleStreamSearch(query: string, limit: number) {
+     const classification = classifyQuery(query);
+     
+     let weights = { bm25: 0.4, vector: 0.6, graph: 0.3 };
+     
+     if (classification.type === "keyword") {
+       weights = { bm25: 0.7, vector: 0.2, graph: 0.1 };
+     } else if (classification.type === "conceptual") {
+       weights = { bm25: 0.2, vector: 0.7, graph: 0.1 };
+     } else if (classification.type === "entity") {
+       weights = { bm25: 0.3, vector: 0.4, graph: 0.3 };
+     } else if (classification.type === "temporal") {
+       weights = { bm25: 0.5, vector: 0.3, graph: 0.2 };
+     }
+     
+     // Optionally use feedback history to fine-tune further
+     const learnedWeights = await getLearnedWeights(classification.type);
+     Object.assign(weights, learnedWeights);
+     
+     return this.fusion(bm25Results, vectorResults, graphResults, weights);
+   }
+   ```
+
+3. **Telemetry:**
+   ```typescript
+   // Track which weights work best per query type
+   await recordTelemetry('search_weight_applied', {
+     queryType: classification.type,
+     weights,
+     resultCount,
+     topResultRelevance,
+   });
+   ```
+
+#### Files to Change
+- `src/state/hybrid-search.ts` — Add query classification and adaptive weights
+- `src/telemetry/setup.ts` — Record weight application events
+- `src/functions/update-weights.ts` — Use telemetry to learn optimal weights per query type
+
+#### Testing
+- Unit test: verify keyword query gets high BM25 weight
+- Unit test: verify conceptual query gets high vector weight
+- Integration test: run 100 mixed queries, verify each type gets appropriate weight
+
+---
+
+### 10. **Importance Calibration by Observation Type** (Priority: Low)
+**Impact:** Improves consistency of importance scoring | **Effort:** Low | **Breaking:** No
+
+#### Problem
+The `importance` field (0–1) on `CompressedObservation` is set by the LLM during compression but there's no calibration. The model may consistently over- or under-rate certain tool types (e.g., `file_read` observations always 0.2, but they should average 0.5).
+
+#### Solution
+Track importance distribution per type and apply floor/ceiling.
+
+1. **In telemetry:**
+   ```typescript
+   // After compress, record importance
+   await recordTelemetry('observation_importance', {
+     type: obs.type,
+     importance: obs.importance,
+     toolName: obs.toolName,
+   });
+   ```
+
+2. **Calibration routine (background job):**
+   ```typescript
+   export async function calibrateImportance() {
+     const events = await telemetry.query({
+       metric: 'observation_importance',
+       limit: 10000,
+     });
+     
+     // Compute median per type
+     const medianByType = new Map<ObservationType, number>();
+     for (const type of ALL_TYPES) {
+       const values = events
+         .filter(e => e.type === type)
+         .map(e => e.importance)
+         .sort((a, b) => a - b);
+       medianByType.set(type, values[Math.floor(values.length / 2)]);
+     }
+     
+     // Store calibration
+     await config.set('IMPORTANCE_MEDIAN', medianByType);
+   }
+   ```
+
+3. **Apply floor/ceiling during compress:**
+   ```typescript
+   const calibration = await config.get('IMPORTANCE_MEDIAN');
+   const median = calibration.get(obs.type) ?? 0.5;
+   const range = 0.3; // ±30% around median
+   
+   obs.importance = Math.max(median - range, Math.min(median + range, obs.importance));
+   ```
+
+4. **Health endpoint:**
+   ```typescript
+   GET /agentmemory/health
+   → { ..., importanceStats: {
+       file_read: { median: 0.3, samples: 450 },
+       file_write: { median: 0.7, samples: 280 },
+       ...
+     }
+   }
+   ```
+
+#### Files to Change
+- `src/functions/compress.ts` — Apply calibration floor/ceiling
+- `src/telemetry/setup.ts` — Record importance by type
+- `src/functions/calibrate-importance.ts` — New file, compute medians
+- `src/triggers/api.ts` — Add importance stats to health endpoint
+
+#### Testing
+- Unit test: mock telemetry with known distribution, verify calibration limits applied
+- Integration test: compress 100 observations, verify importance in range [median ± 30%]
+
+---
+
+### 11. **Graph Export to Standard Formats** (Priority: Low)
+**Impact:** Enables external analysis | **Effort:** Medium | **Breaking:** No
+
+#### Problem
+The knowledge graph (nodes in `mem:graph:nodes`, edges in `mem:graph:edges`) is only accessible via MCP tools. It can't be analyzed in Gephi, Neo4j, or other graph tools.
+
+#### Solution
+Export to GraphML (Gephi/yEd) and Cypher (Neo4j) formats.
+
+1. **New endpoint: `POST /agentmemory/export/graphml`**
+   ```typescript
+   export async function exportGraphML(kv: StateKV): Promise<string> {
+     const nodes = await kv.list<GraphNode>(KV.graphNodes);
+     const edges = await kv.list<GraphEdge>(KV.graphEdges);
+     
+     let xml = `<?xml version="1.0" encoding="UTF-8"?>
+   <graphml xmlns="http://graphml.graphdrawing.org/xmlformat/graphmlml.xsd">
+     <graph edgedefault="undirected">`;
+     
+     for (const node of nodes) {
+       xml += `\n      <node id="${node.id}" label="${escapeXml(node.name)}">
+         <data key="type">${node.type}</data>
+         <data key="occurrences">${node.occurrences}</data>
+       </node>`;
+     }
+     
+     for (const edge of edges) {
+       xml += `\n      <edge source="${edge.sourceNodeId}" target="${edge.targetNodeId}" label="${edge.type}">
+         <data key="weight">${edge.weight}</data>
+         <data key="frequency">${edge.frequency}</data>
+       </edge>`;
+     }
+     
+     xml += `\n    </graph>\n  </graphml>`;
+     return xml;
+   }
+   ```
+
+2. **New endpoint: `POST /agentmemory/export/cypher`**
+   ```typescript
+   export async function exportCypher(kv: StateKV): Promise<string> {
+     const nodes = await kv.list<GraphNode>(KV.graphNodes);
+     const edges = await kv.list<GraphEdge>(KV.graphEdges);
+     
+     let cypher = '';
+     
+     for (const node of nodes) {
+       cypher += `CREATE (${node.id}:${capitalize(node.type)} {name: "${escapeCypher(node.name)}", occurrences: ${node.occurrences}});\n`;
+     }
+     
+     for (const edge of edges) {
+       cypher += `MATCH (a {name: "${escapeCypher(edge.sourceNodeId)}"}), (b {name: "${escapeCypher(edge.targetNodeId)}"}) CREATE (a)-[:${edge.type} {weight: ${edge.weight}, frequency: ${edge.frequency}}]->(b);\n`;
+     }
+     
+     return cypher;
+   }
+   ```
+
+3. **In `api.ts`:**
+   ```typescript
+   sdk.registerEndpoint("POST", "/agentmemory/export/graphml", async (req, res) => {
+     const graphml = await exportGraphML(kv);
+     res.set('Content-Type', 'application/xml');
+     res.send(graphml);
+   });
+
+   sdk.registerEndpoint("POST", "/agentmemory/export/cypher", async (req, res) => {
+     const cypher = await exportCypher(kv);
+     res.set('Content-Type', 'text/plain');
+     res.send(cypher);
+   });
+   ```
+
+#### Files to Change
+- `src/functions/export-graph.ts` — New file, GraphML and Cypher formatters
+- `src/triggers/api.ts` — Register `/export/graphml` and `/export/cypher` endpoints
+- Documentation: add export format examples
+
+#### Testing
+- Unit test: verify GraphML output is valid XML
+- Unit test: verify Cypher syntax is valid (can parse with regex)
+- Integration test: export graph, import to Neo4j, verify node/edge counts match
+
+---
+
+## Implementation Roadmap
+
+### Phase 1 (Weeks 1–2): Security & Correctness
+1. **Close Scrubbing Bypass Paths** (#4) — Critical; scrubbing exists but only on the hook path
+2. **Temporal Decay on `Memory`** (#1) — Extend existing decay machinery into search ranking
+3. **Semantic Deduplication** (#2) — Improve index quality
+
+### Phase 2 (Weeks 3–4): Intelligence & Detection
+4. **Conflict Detection** (#3) — Prevent contradictory recall
+5. **Staleness Detection** (#8) — Mark stale information
+6. **Proactive Warnings** (#7) — Prevent mistakes
+
+### Phase 3 (Weeks 5–6): Feedback & Learning
+7. **Feedback Loop** (#6) — Enable online learning
+8. **Adaptive Weights** (#9) — Query-aware tuning
+9. **Importance Calibration** (#10) — Consistency
+
+### Phase 4 (Weeks 7–8): Scope & Portability
+10. **Cross-Project Scope** (#5) — Multi-project reuse
+11. **Graph Export** (#11) — External analysis
+
+---
+
+## Effort & Impact Matrix
+
+| # | Feature | Impact | Effort | Duration | Blocking |
+|---|---|---|---|---|---|
+| 4 | Close Scrubbing Bypass Paths | Critical | Low–Medium | 2–3 days | No |
+| 1 | Temporal Decay | High | Low | 2–3 days | No |
+| 2 | Semantic Dedup | High | Medium | 4–5 days | No |
+| 3 | Conflict Detection | High | High | 5–6 days | No |
+| 8 | Staleness Detection | Medium | Low | 2 days | No |
+| 6 | Feedback Loop | Medium | Medium | 4–5 days | No |
+| 7 | Proactive Warnings | Medium | Low | 2 days | No |
+| 9 | Adaptive Weights | Medium | Medium | 3–4 days | No |
+| 5 | Cross-Project Scope | Medium | Medium | 4 days | No |
+| 10 | Importance Calibration | Low | Low | 1–2 days | No |
+| 11 | Graph Export | Low | Medium | 3–4 days | No |
+
+**Total Estimated Effort:** 8–9 weeks for all 11 enhancements.  
+**Critical Path (must do first):** #4 (PII), #1 (Decay), #2 (Dedup) — together form retrieval quality foundation.
+
+---
+
+## Testing Strategy
+
+### Unit Tests (Per Feature)
+- Regex pattern detection (secrets)
+- Decay formula (temporal)
+- Similarity threshold (dedup)
+- Query classification (adaptive weights)
+
+### Integration Tests (Cross-System)
+- End-to-end observation → compress → search → recall
+- Session-end consolidation with conflict detection
+- Feedback loop: simulate helpful/unhelpful feedback, verify weight adjustment
+
+### Benchmarking
+- **Baseline:** 95.2% R@5 on LongMemEval
+- **Post-Dedup:** Expected R@5 → 96.5% (fewer noise results)
+- **Post-Feedback:** Expected R@5 → 97.0% (learned weights)
+- **Post-Decay:** Expected R@5 → 97.2% (recent memories ranked higher)
+
+### Security Audit
+- Scrub test database with 10 known secret patterns
+- Verify 100% redaction in stored observations
+- No secrets in exports or audit logs
+
+---
+
+## Configuration & Defaults
+
+New environment variables:
+
+```bash
+# Feature flags
+AGENTMEMORY_TEMPORAL_DECAY=true                 # Enable decay formula
+AGENTMEMORY_SEMANTIC_DEDUP=true                 # Enable dedup check
+AGENTMEMORY_CONFLICT_DETECTION=true             # Enable contradiction detection
+AGENTMEMORY_PROACTIVE_WARNINGS=true             # Warn before mistakes
+AGENTMEMORY_FILE_STALENESS_CHECK=true           # Check file existence
+AGENTMEMORY_ADAPTIVE_SEARCH_WEIGHTS=true        # Query-adaptive tuning
+
+# Tuning parameters
+TEMPORAL_DECAY_LAMBDA=0.01                      # Decay rate (0.01 = 1% per day)
+DEDUP_SIMILARITY_THRESHOLD=0.92                 # Cosine similarity for merge
+IMPORTANCE_CALIBRATION_RANGE=0.3                # ±30% around median
+FEEDBACK_WEIGHT_UPDATE_INTERVAL=86400           # 1 day in seconds
+```
+
+Defaults: all features enabled except those with runtime costs (dedup, conflicts search, weight tuning).
+
+---
+
+## Monitoring & Observability
+
+### New Metrics (OpenTelemetry)
+- `observation.semantic_dedup.merged` — Counter, dedup merge events
+- `memory.conflict_detection.found` — Counter, contradictions found
+- `search.adaptive_weights.applied` — Gauge, actual weights per query type
+- `observation.secrets_detected` — Counter, secrets found and redacted
+- `memory.staleness.files_missing` — Gauge, stale files per session
+
+### Dashboard (Prometheus)
+```
+Temporal Decay
+├─ avg_decayed_strength (over time)
+└─ recall_freshness (% results < 30 days old)
+
+Dedup & Quality
+├─ merge_rate (merged / total observations)
+├─ unique_concept_coverage (new concepts / total)
+└─ result_noise (duplicate concepts in top-5)
+
+Feedback Loop
+├─ helpful_feedback_ratio (helpful / total)
+├─ weight_adjustment_magnitude (Δ per update)
+└─ r@5_trend (toward 97%+ goal)
+
+Security
+├─ secrets_detected (absolute count)
+└─ sanitization_rate (% of observations scrubbed)
+```
+
+---
+
+## Summary of Value
+
+Implementing these 11 enhancements would transform AgentMemory from a "capture and search" system into a **self-improving, safety-first, context-aware memory layer**:
+
+- **Security:** Close the unscrubbed ingestion paths (manual saves, imports, lessons, slots, LLM compression output)
+- **Relevance:** Improve R@5 from 95.2% to 97%+ (decay + dedup + feedback)
+- **Correctness:** Prevent contradictory recall (conflict detection)
+- **Usability:** Warn before mistakes (proactive warnings), work across projects (cross-project scope)
+- **Portability:** Analyze memory in external tools (graph export)
+- **Sustainability:** Detect and flag stale information (staleness detection)
+
+**Recommended Quick Wins (Weeks 1–2):**
+1. Close Scrubbing Bypass Paths (#4) — mostly wiring an existing function into 7 more write paths
+2. Temporal Decay on `Memory` (#1) — extending existing `DecayConfig` machinery, not building new
+3. Semantic Deduplication (#2)
+
+These three alone would resolve the biggest risks (security, quality, noise) and establish the foundation for the rest. Notably, #4 and #1 are cheaper than they first appear because the underlying primitives (`stripPrivateData`, `DecayConfig`, retention scoring) already exist — the work is integration, not invention.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,198 @@
+# AgentMemory — Architecture & Component Guide
+
+> A developer's map of the codebase: how it's built, what each component does, and **when to use which piece**. Pairs with `AGENTS.md` (contributor rules) and `DESIGN.md` (website styling, unrelated to the engine).
+
+AgentMemory (`@agentmemory/agentmemory`, v0.9.27) is a **persistent memory server for AI coding agents**. It runs locally, captures what an agent does, compresses and consolidates those events into durable memories, indexes them for hybrid retrieval, and serves them back over **REST + MCP** so any agent (Claude Code, Copilot, Cursor, Gemini, …) can recall prior context.
+
+---
+
+## 1. The Mental Model
+
+Everything is built on **iii-engine's three primitives**. There is no bespoke plugin framework — new capability is always *a new function + a trigger*.
+
+| Primitive | What it is | In this repo |
+|---|---|---|
+| **Worker** | The process that registers everything and connects to the engine | `src/index.ts` boots it via `registerWorker` (iii-sdk) |
+| **Function** | A named, callable unit of logic (`mem::*`) | `src/functions/*.ts`, invoked via `sdk.trigger({ function_id, payload })` |
+| **Trigger** | An entry point that routes external calls to functions (`api::*`, hooks, cron) | `src/triggers/*.ts` |
+| **State** | Durable key-value store, file-backed SQLite | `src/state/kv.ts` over `./data/state_store.db` |
+
+**Golden rule (from `AGENTS.md`):** never bypass iii-engine with standalone SQLite or in-process shortcuts. Read/write state through `StateKV`, do work in `mem::*` functions, expose it through triggers.
+
+```
+External caller (agent / hook / HTTP / MCP)
+        │
+        ▼
+   Trigger  (api::*  or  MCP server  or  hook script)
+        │  sdk.trigger({ function_id, payload })
+        ▼
+   Function (mem::*)  ──reads/writes──►  StateKV (SQLite KV scopes)
+        │                                     ▲
+        ├── Providers (LLM + embeddings) ─────┘
+        └── returns JSON result
+```
+
+---
+
+## 2. The Data Lifecycle — the heart of the system
+
+This is the single most important flow to internalize. A raw agent action travels through four stages, each producing a richer artifact:
+
+```
+Session → RawObservation → CompressedObservation → Memory
+         (capture)         (compress)              (consolidate)         → (forget)
+```
+
+| Stage | Function(s) | Produces | When it runs |
+|---|---|---|---|
+| **1. Capture** | `mem::observe` ([observe.ts](../src/functions/observe.ts)) | `RawObservation` (tool call + I/O, **secrets-scrubbed** via `privacy.ts`) | On every tool-use hook fire |
+| **2. Compress** | `mem::compress` ([compress.ts](../src/functions/compress.ts)), synthetic fallback ([compress-synthetic.ts](../src/functions/compress-synthetic.ts)) | `CompressedObservation` (title, facts[], narrative, importance 0–1, concepts, files) | Auto after capture (LLM or synthetic) |
+| **3. Consolidate** | `mem::consolidate` / `mem::consolidate-pipeline` ([consolidation-pipeline.ts](../src/functions/consolidation-pipeline.ts)) | `Memory` (durable, typed, scored, linked) | Session-end |
+| **4. Forget** | `mem::evict`, `mem::auto-forget`, `mem::retention` | TTL expiry + decay eviction | Background / on `forgetAfter` |
+
+**The four core data types** (in [src/types.ts](../src/types.ts)):
+- `RawObservation` — raw, scrubbed tool I/O tied to a session.
+- `CompressedObservation` — the LLM/synthetic summary; carries `importance`, `concepts`, `facts[]`.
+- `Memory` — the long-term unit: `type` (pattern | preference | architecture | bug | workflow | fact), `strength` (1–10), `concepts[]`, `files[]`, `supersedes[]`, `isLatest`, `forgetAfter`, `project`.
+- `Session` — groups observations: project, cwd, status, model, agentId, optional commit links.
+
+**When you care:** if you're changing *what gets remembered*, you're touching stage 1–3. If you're changing *what survives over time*, you're in stage 4 (decay/retention).
+
+---
+
+## 3. Retrieval — how recall works
+
+Recall is **hybrid search** = three streams fused, in [src/state/hybrid-search.ts](../src/state/hybrid-search.ts):
+
+1. **BM25** keyword search (`search-index.ts`, no API key needed)
+2. **Vector** similarity (`vector-index.ts` + an embedding provider; on-device by default)
+3. **Graph** expansion over linked concepts (`graph-retrieval.ts`)
+
+The three result lists are merged with **Reciprocal Rank Fusion** (`RRF_K = 60`). Default weights: `bm25 = 0.4`, `vector = 0.6`, `graph = 0.3` (override with `BM25_WEIGHT` etc.). Optional **temporal decay** down-ranks stale results (`DEFAULT_TEMPORAL_DECAY`), and an optional **reranker** (`reranker.ts`, `RERANK_ENABLED=true`) reorders the top set.
+
+**The key insight:** the default install needs **no API key** — BM25 needs none and embeddings run on-device (`providers/embedding/local.ts`). An LLM provider only adds richer compression/summaries and auto-injection, both opt-in.
+
+| You want to… | Use |
+|---|---|
+| Plain keyword/vector recall | `mem::search` ([search.ts](../src/functions/search.ts)) |
+| Best-quality recall (query expansion + fusion + rerank) | `mem::smart-search` ([smart-search.ts](../src/functions/smart-search.ts)) |
+| Recall over the concept graph | `mem::graph-query`, `mem::get-related` |
+| Time-ordered recall | `mem::timeline` |
+
+---
+
+## 4. Component Map — directory by directory
+
+### `src/functions/` (65 files) — the verbs of the system
+Each file registers one or more `mem::*` functions. Grouped by purpose:
+
+- **Lifecycle:** `observe`, `compress`, `compress-synthetic`, `consolidate`, `consolidation-pipeline`, `remember`, `summarize`.
+- **Retrieval:** `search`, `smart-search`, `query-expansion`, `graph-retrieval`, `graph`, `relations`, `timeline`, `context` (context injection), `facets`, `frontier`.
+- **Forgetting / hygiene:** `evict`, `auto-forget`, `retention`, `temporal-decay`, `dedup`, `disk-size-manager`, `cascade`, `recent-searches-sweep`.
+- **Higher-order memory:** `crystallize` (distill stable knowledge), `lessons`, `reflect`, `skill-extract`, `patterns`, `insights` (via `signals`), `sketches`.
+- **Knowledge graph:** `graph`, `temporal-graph`, `graph-retrieval`, `mesh` (peer sync).
+- **Org / collaboration:** `team`, `governance` (delete/redact policy), `leases`, `routines`, `checkpoints`, `branch-aware`.
+- **Safety / privacy:** `privacy` (15-pattern secrets scrubbing), `audit`, `sentinels`, `verify`.
+- **I/O & portability:** `export-import`, `obsidian-export`, `snapshot`, `profile`, `enrich`.
+- **Media:** `image-refs`, `vision-search`, `image-quota-cleanup`, `compress-file`.
+
+> **When to add a function vs. extend one:** if the new behavior is a distinct verb callers will invoke, add a `mem::new-thing` function + REST endpoint + (optionally) MCP tool. If it's a tweak to existing logic, extend in place. Either way, follow the multi-file consistency checklist in `AGENTS.md`.
+
+### `src/state/` (12 files) — durability + indexing
+- `kv.ts` — `StateKV`, the only sanctioned door to persistence. All scopes are enumerated in `schema.ts` (`mem:sessions`, `mem:memories`, `mem:graph:nodes`, `mem:slots`, `mem:audit`, …).
+- `hybrid-search.ts` — the fusion engine (§3).
+- `search-index.ts` / `stemmer.ts` / `synonyms.ts` / `cjk-segmenter.ts` — BM25 + tokenization (incl. CJK).
+- `vector-index.ts` / `reranker.ts` — embedding ANN + reranking.
+- `index-persistence.ts` — keeps indexes on disk and rebuilds on boot.
+- `keyed-mutex.ts` — per-key locking for safe concurrent writes.
+
+> **When you touch state:** adding a new KV scope means updating both `schema.ts` and a matching interface in `types.ts` (consistency rule).
+
+### `src/providers/` (20 files) — pluggable LLM + embeddings
+- LLM: `anthropic`, `openai`, `openrouter`, `minimax`, `agent-sdk` (Claude Agent SDK), `noop`.
+- Embeddings (`providers/embedding/`): `local` (on-device, default), `openai`, `gemini`, `cohere`, `voyage`, `openrouter`, `clip` (images).
+- Resilience: `resilient.ts`, `circuit-breaker.ts`, `fallback-chain.ts` — wrap providers so a failing primary falls back without crashing recall.
+
+> **When to use which:** default = on-device embeddings + `noop`/no LLM (zero-config, private). Add an LLM provider only when you want richer compression or auto-injected summaries. Configure a fallback chain for production reliability.
+
+### `src/hooks/` (15 files) — automatic capture
+Standalone Node scripts (no iii-sdk import) that read JSON from stdin and HTTP-call the REST API. Two patterns (see `AGENTS.md`):
+- **Context-injecting** (`session-start`, `pre-tool-use`, `pre-compact`) — *await* the response and write recalled context to stdout for the agent to inject.
+- **Telemetry-only** (`post-tool-use`, `post-tool-failure`, `prompt-submit`, `stop`, `session-end`, `notification`, `subagent-*`, `task-completed`, `post-commit`) — fire-and-forget, force-exit after flush.
+
+> **When to use:** hooks are how memory gets captured/recalled *without manual calls*. Wire them via the plugin/connect adapters. Touch them only to change automatic behavior.
+
+### `src/mcp/` (6 files) — the MCP surface
+- `tools-registry.ts` — all 53 MCP tool definitions (8 visible by default; `AGENTMEMORY_TOOLS=all` exposes all).
+- `server.ts` — the `mcp::tools::call` dispatch switch.
+- `transport.ts` / `standalone.ts` / `rest-proxy.ts` / `in-memory-kv.ts` — transports and a REST-backed proxy mode.
+
+### `src/triggers/` (2 files) — the HTTP surface
+- `api.ts` — registers **128 REST endpoints** (`/agentmemory/*`). Each auth-checks, whitelists body fields, then `sdk.trigger()`s a `mem::*` function.
+- `events.ts` — event/stream triggers.
+
+### `src/cli/` (28 files) — operator surface
+`connect/` (adapters that install AgentMemory into ~16 host agents), `onboarding.ts`, `doctor-diagnostics.ts`, `preferences.ts`, `splash.ts`, `remove-plan.ts`. Entry: `src/cli.ts` → `agentmemory` bin.
+
+### Supporting dirs
+`src/config.ts` (all env flags + ports), `src/auth.ts`, `src/telemetry/` (OpenTelemetry), `src/health/`, `src/prompts/` (LLM prompt templates), `src/replay/`, `src/viewer/` (real-time web UI), `src/eval/` + top-level `eval/` (LongMemEval, coding-life benchmarks).
+
+---
+
+## 5. Ports & Runtime
+
+REST is the anchor; the rest are offsets. `--instance N` shifts the whole block by `N*100`.
+
+| Service | Port | Notes |
+|---|---|---|
+| REST API | **3111** | Primary surface, all hooks talk here |
+| Streams | 3112 | N+1 |
+| Web viewer | **3113** | `http://localhost:3113` — watch memory build live |
+| iii engine | 49134 | N+46023, WebSocket |
+
+Storage: file-backed SQLite at `./data/state_store.db` (docs sometimes call it `~/.agentmemory/state_store.db`). Build: TypeScript → ESM via `tsdown` into `dist/`. Tests: `vitest` (`npm test` = 950+ unit tests, excludes integration).
+
+---
+
+## 6. "When do I use which surface?" — decision guide
+
+| Situation | Reach for |
+|---|---|
+| An agent should auto-remember & auto-recall | **Hooks** (via plugin/connect) — zero manual calls |
+| Calling from an MCP-speaking host (Claude Code, etc.) | **MCP tools** (`memory_*`) |
+| Calling from any HTTP client / non-MCP host / debugging | **REST API** (`/agentmemory/*` on :3111) |
+| Adding new memory capability | **New `mem::*` function** + trigger (never standalone state) |
+| Quick keyword/vector recall | `mem::search` |
+| Highest-quality recall | `mem::smart-search` |
+| Save a fact explicitly | `mem::remember` (MCP `memory_save`) |
+| Pin always-available context | **Slots** (`mem:slots` / `mem:slots:global`) |
+| Distill durable, reusable knowledge | `crystallize` / `lessons` |
+| Share across a team | `team` + `governance` |
+| Confirm capture is working / demo | **Web viewer** :3113 |
+| Move data in/out | `export-import`, `obsidian-export`, `snapshot` |
+
+---
+
+## 7. Extending Safely — the checklist
+
+Because one capability spans many files, `AGENTS.md` defines hard consistency rules. The short version:
+
+- **New MCP tool** → update `tools-registry.ts`, `server.ts`, `api.ts`, `index.ts`, `test/mcp-standalone.test.ts`, `README.md`, and the plugin manifests.
+- **New REST endpoint** → `api.ts`, `index.ts` (log count), `README.md`.
+- **New KV scope** → `state/schema.ts` + `types.ts` interface.
+- **Version bump** → `package.json`, `version.ts`, `types.ts`, `export-import.ts`, tests, plugin manifests.
+- **State-changing op** → always call `recordAudit()`.
+- **REST handlers** → auth-check + whitelist fields; never pass raw body to `sdk.trigger()`.
+
+See [ENHANCEMENTS.md](../ENHANCEMENTS.md) for 11 concrete, verified improvement opportunities (temporal decay on `Memory`, semantic dedup, conflict detection, closing secrets-scrub bypass paths, etc.) — a good source of "what to build next" with file-level pointers.
+
+---
+
+## 8. Where to start reading the code
+
+1. `AGENTS.md` — the rules and patterns (read first).
+2. `src/index.ts` — see everything get wired up (the worker boot).
+3. `src/types.ts` — the data model (especially `RawObservation`, `CompressedObservation`, `Memory`, `Session`).
+4. `src/functions/observe.ts` → `compress.ts` → `consolidation-pipeline.ts` — follow one observation end to end.
+5. `src/state/hybrid-search.ts` — follow one query end to end.
+6. `src/triggers/api.ts` + `src/mcp/server.ts` — see how the outside calls in.

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,7 +18,13 @@ function safeParseInt(value: string | undefined, fallback: number): number {
 
 function safeParseFloat(value: string | undefined, fallback: number): number {
   if (!value) return fallback;
-  const parsed = parseFloat(value);
+  // Strict parse: parseFloat would accept trailing junk ("0.2oops" -> 0.2),
+  // silently honoring a malformed env value instead of falling back. Number()
+  // rejects partial matches. Guard the empty-after-trim case too, since
+  // Number("") is 0 (not NaN) and a whitespace-only value should fall back.
+  const normalized = value.trim();
+  if (!normalized) return fallback;
+  const parsed = Number(normalized);
   return Number.isFinite(parsed) ? parsed : fallback;
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,6 +16,12 @@ function safeParseInt(value: string | undefined, fallback: number): number {
   return Number.isNaN(parsed) ? fallback : parsed;
 }
 
+function safeParseFloat(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
 const DATA_DIR = join(homedir(), ".agentmemory");
 const ENV_FILE = join(DATA_DIR, ".env");
 
@@ -401,6 +407,54 @@ export function isContextInjectionEnabled(): boolean {
 
 export function getConsolidationDecayDays(): number {
   return safeParseInt(getMergedEnv()["CONSOLIDATION_DECAY_DAYS"], 30);
+}
+
+// Temporal decay for recall ranking (see functions/temporal-decay.ts).
+// OFF by default — like auto-compress and context-injection, anything that
+// changes recall ordering is opt-in so existing deployments keep their
+// current behavior until a user explicitly enables it. Enable with
+// AGENTMEMORY_TEMPORAL_DECAY=true. When on, recall blends an exponential
+// recency factor (and optional importance term) into the relevance score so
+// fresh/reinforced memories outrank equally-relevant stale ones.
+export function isTemporalDecayEnabled(): boolean {
+  const v = getMergedEnv()["AGENTMEMORY_TEMPORAL_DECAY"];
+  return v === "true" || v === "1";
+}
+
+// Recency half-life in days: a memory un-accessed for this long has its
+// recency weight halved. Default 14 days — two weeks balances "this week's
+// work is hot" against not aggressively forgetting month-old context.
+export function getTemporalDecayHalfLifeDays(): number {
+  return safeParseFloat(
+    getMergedEnv()["AGENTMEMORY_TEMPORAL_DECAY_HALF_LIFE_DAYS"],
+    14,
+  );
+}
+
+// Blend weight for the recency factor in [0,1]. Higher = time dominates.
+export function getTemporalDecayRecencyWeight(): number {
+  return safeParseFloat(
+    getMergedEnv()["AGENTMEMORY_TEMPORAL_DECAY_RECENCY_WEIGHT"],
+    0.5,
+  );
+}
+
+// Blend weight for importance in [0,1]. Higher = important memories resist
+// decay more. recencyWeight + importanceWeight should stay <= 1.
+export function getTemporalDecayImportanceWeight(): number {
+  return safeParseFloat(
+    getMergedEnv()["AGENTMEMORY_TEMPORAL_DECAY_IMPORTANCE_WEIGHT"],
+    0.2,
+  );
+}
+
+// Floor on the decay multiplier in [0,1]. Guarantees decay demotes but
+// never erases: a stale hit keeps at least this fraction of its relevance.
+export function getTemporalDecayFloor(): number {
+  return safeParseFloat(
+    getMergedEnv()["AGENTMEMORY_TEMPORAL_DECAY_FLOOR"],
+    0.2,
+  );
 }
 
 export function isStandaloneMcp(): boolean {

--- a/src/functions/temporal-decay.ts
+++ b/src/functions/temporal-decay.ts
@@ -1,0 +1,181 @@
+// Temporal decay for recall ranking.
+//
+// Memory recall in agentmemory fuses BM25, vector, and graph signals into
+// a single RRF relevance score (see HybridSearch). Pure relevance has no
+// notion of time: a year-old note and one written this morning rank purely
+// on lexical/semantic match. Temporal decay layers a "use it or lose it"
+// recency signal on top — the same principle the Generative Agents
+// retrieval model and LangChain's time-weighted retriever encode — so that
+// recent and reinforced memories surface ahead of stale ones of equal
+// relevance, without ever fully suppressing an old-but-highly-relevant hit.
+//
+// Design choices (best-practice notes):
+//   - Exponential decay with a configurable HALF-LIFE rather than a raw
+//     decay-per-hour constant. Half-life is the interpretable knob: "after
+//     N days an un-accessed memory's recency weight halves." This is the
+//     standard parameterization for forgetting curves.
+//   - Multiplicative reweight of the relevance score (not additive). The
+//     RRF relevance score is small and unnormalized; adding a [0,1] recency
+//     term would swamp it. A bounded multiplier keeps relevance the
+//     dominant signal and applies decay as a graded demotion.
+//   - A FLOOR on the multiplier so decay can demote but never erase. An
+//     ancient memory that is the single best lexical+semantic match still
+//     gets at least `floor` of its relevance, preserving recall safety.
+//   - Reinforcement via last-access time ("use it or lose it"): the
+//     effective age is measured from the most recent of creation or last
+//     access, so retrieving a memory refreshes its recency. The caller
+//     supplies the effective timestamp; this module stays pure.
+//   - Importance slows decay: callers may blend a memory's importance into
+//     the multiplier so consequential memories resist forgetting, matching
+//     the importance term in the Generative Agents score.
+
+export interface TemporalDecayParams {
+  /** Master switch. When false, applyTemporalDecay is a no-op pass-through. */
+  enabled: boolean;
+  /**
+   * Recency half-life in days. After this many days without access an
+   * un-reinforced memory's recency factor halves. Must be > 0.
+   */
+  halfLifeDays: number;
+  /**
+   * Blend weight for the recency factor, in [0, 1]. Higher means time
+   * matters more in the final multiplier.
+   */
+  recencyWeight: number;
+  /**
+   * Blend weight for normalized importance, in [0, 1]. Higher means
+   * important memories resist decay more strongly. recencyWeight +
+   * importanceWeight should be <= 1; the residual is the relevance-only
+   * floor of the blend (time- and importance-agnostic).
+   */
+  importanceWeight: number;
+  /**
+   * Minimum multiplier, in [0, 1]. Guarantees finalScore >= floor *
+   * relevance so decay never fully erases a relevant hit. Default keeps a
+   * stale, unimportant memory at a fraction of its relevance rather than 0.
+   */
+  floor: number;
+}
+
+export const DEFAULT_TEMPORAL_DECAY: TemporalDecayParams = {
+  enabled: false,
+  halfLifeDays: 14,
+  recencyWeight: 0.5,
+  importanceWeight: 0.2,
+  floor: 0.2,
+};
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}
+
+/**
+ * Exponential recency factor in (0, 1].
+ *   - 1.0 at age 0 (or negative age, e.g. clock skew),
+ *   - 0.5 at exactly one half-life,
+ *   - asymptotically 0 as age grows.
+ *
+ * `ageMs` is the elapsed time since the memory's effective timestamp
+ * (creation or last access, whichever is later). A non-positive or
+ * non-finite half-life disables decay (returns 1).
+ */
+export function recencyFactor(ageMs: number, halfLifeDays: number): number {
+  if (!Number.isFinite(halfLifeDays) || halfLifeDays <= 0) return 1;
+  if (!Number.isFinite(ageMs) || ageMs <= 0) return 1;
+  const ageDays = ageMs / MS_PER_DAY;
+  return Math.pow(0.5, ageDays / halfLifeDays);
+}
+
+/**
+ * Normalize the per-memory params into a guaranteed-sane shape so the
+ * multiplier is provably in [floor, 1]. Weights are clamped to [0,1] and,
+ * if they sum above 1, scaled down proportionally so the relevance-only
+ * residual never goes negative.
+ */
+function normalizeParams(params: TemporalDecayParams): {
+  halfLifeDays: number;
+  recencyWeight: number;
+  importanceWeight: number;
+  floor: number;
+} {
+  const halfLifeDays =
+    Number.isFinite(params.halfLifeDays) && params.halfLifeDays > 0
+      ? params.halfLifeDays
+      : DEFAULT_TEMPORAL_DECAY.halfLifeDays;
+  let recencyWeight = clamp01(params.recencyWeight);
+  let importanceWeight = clamp01(params.importanceWeight);
+  const weightSum = recencyWeight + importanceWeight;
+  if (weightSum > 1) {
+    recencyWeight /= weightSum;
+    importanceWeight /= weightSum;
+  }
+  return {
+    halfLifeDays,
+    recencyWeight,
+    importanceWeight,
+    floor: clamp01(params.floor),
+  };
+}
+
+/**
+ * Compute the bounded decay multiplier in [floor, 1] for a single memory.
+ * Exposed for testing and for callers that want the factor without applying
+ * it to a score.
+ */
+export function decayMultiplier(
+  ageMs: number,
+  importance: number,
+  params: TemporalDecayParams,
+): number {
+  const { halfLifeDays, recencyWeight, importanceWeight, floor } =
+    normalizeParams(params);
+  const recency = recencyFactor(ageMs, halfLifeDays);
+  const importanceNorm = clamp01(importance);
+  // Relevance-only residual: the share of the blend that ignores both time
+  // and importance, so a stale unimportant hit still scores on relevance.
+  const baseWeight = 1 - recencyWeight - importanceWeight;
+  const blend =
+    baseWeight + recencyWeight * recency + importanceWeight * importanceNorm;
+  // blend is in [0, 1]; lift it into [floor, 1].
+  return floor + (1 - floor) * clamp01(blend);
+}
+
+/**
+ * Reweight a relevance score by temporal decay. Returns the relevance
+ * unchanged when decay is disabled. `nowMs` defaults to Date.now() and is a
+ * parameter only so tests can pin time.
+ */
+export function applyTemporalDecay(
+  relevance: number,
+  memory: { effectiveTimestampMs: number; importance: number },
+  params: TemporalDecayParams,
+  nowMs: number = Date.now(),
+): number {
+  if (!params.enabled) return relevance;
+  const ageMs = nowMs - memory.effectiveTimestampMs;
+  return relevance * decayMultiplier(ageMs, memory.importance, params);
+}
+
+/**
+ * Resolve a memory's effective timestamp (ms since epoch) as the later of
+ * its creation/observation time and its last-access time. Reinforcement
+ * (recall) refreshes recency: a frequently-retrieved old memory ages from
+ * its last touch, not its birth. Invalid inputs fall back gracefully.
+ */
+export function effectiveTimestampMs(
+  observationTimestamp: string | undefined,
+  lastAccessIso?: string,
+): number {
+  const obsMs = observationTimestamp
+    ? Date.parse(observationTimestamp)
+    : NaN;
+  const accessMs = lastAccessIso ? Date.parse(lastAccessIso) : NaN;
+  const obs = Number.isFinite(obsMs) ? obsMs : 0;
+  const access = Number.isFinite(accessMs) ? accessMs : 0;
+  return Math.max(obs, access);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,11 @@ import {
   isConsolidationEnabled,
   isContextInjectionEnabled,
   isDropStaleIndexEnabled,
+  isTemporalDecayEnabled,
+  getTemporalDecayHalfLifeDays,
+  getTemporalDecayRecencyWeight,
+  getTemporalDecayImportanceWeight,
+  getTemporalDecayFloor,
 } from "./config.js";
 import {
   createProvider,
@@ -354,6 +359,13 @@ async function main() {
 
   const bm25Index = getSearchIndex();
   const graphWeight = parseFloat(getEnvVar("AGENTMEMORY_GRAPH_WEIGHT") || "0.3");
+  const temporalDecay = {
+    enabled: isTemporalDecayEnabled(),
+    halfLifeDays: getTemporalDecayHalfLifeDays(),
+    recencyWeight: getTemporalDecayRecencyWeight(),
+    importanceWeight: getTemporalDecayImportanceWeight(),
+    floor: getTemporalDecayFloor(),
+  };
   const hybridSearch = new HybridSearch(
     bm25Index,
     vectorIndex,
@@ -362,6 +374,11 @@ async function main() {
     embeddingConfig.bm25Weight,
     embeddingConfig.vectorWeight,
     graphWeight,
+    process.env.RERANK_ENABLED === "true",
+    temporalDecay,
+  );
+  bootLog(
+    `Temporal decay: ${temporalDecay.enabled ? `enabled (half-life ${temporalDecay.halfLifeDays}d)` : "disabled"}`,
   );
 
   registerSmartSearchFunction(sdk, kv, (query, limit) =>

--- a/src/state/hybrid-search.ts
+++ b/src/state/hybrid-search.ts
@@ -16,6 +16,13 @@ import {
 } from "../functions/graph-retrieval.js";
 import { extractEntitiesFromQuery } from "../functions/query-expansion.js";
 import { rerank } from "./reranker.js";
+import {
+  type TemporalDecayParams,
+  DEFAULT_TEMPORAL_DECAY,
+  applyTemporalDecay,
+  effectiveTimestampMs,
+} from "../functions/temporal-decay.js";
+import { type AccessLog } from "../functions/access-tracker.js";
 
 const RRF_K = 60;
 
@@ -31,6 +38,7 @@ export class HybridSearch {
     private vectorWeight = 0.6,
     private graphWeight = 0.3,
     private rerankEnabled = process.env.RERANK_ENABLED === "true",
+    private decayParams: TemporalDecayParams = DEFAULT_TEMPORAL_DECAY,
   ) {
     this.graphRetrieval = new GraphRetrieval(kv);
   }
@@ -225,18 +233,64 @@ export class HybridSearch {
     const diversified = this.diversifyBySession(combined, retrievalDepth);
     const enriched = await this.enrichResults(diversified, retrievalDepth);
 
-    if (this.rerankEnabled && enriched.length > 1) {
+    // Temporal decay reweight. Applied after enrichment (where each result
+    // carries its observation timestamp + importance) and before rerank, so
+    // recency acts as a retrieval prior that shapes which hits enter the
+    // rerank window; the cross-encoder then refines precision within it.
+    // No-op when disabled — guarded inside applyDecayReweight.
+    const decayed = await this.applyDecayReweight(enriched);
+
+    if (this.rerankEnabled && decayed.length > 1) {
       try {
-        const head = enriched.slice(0, rerankWindow);
-        const tail = enriched.slice(rerankWindow);
+        const head = decayed.slice(0, rerankWindow);
+        const tail = decayed.slice(rerankWindow);
         const reranked = await rerank(query, head, rerankWindow);
         return reranked.concat(tail).slice(0, limit);
       } catch {
-        return enriched.slice(0, limit);
+        return decayed.slice(0, limit);
       }
     }
 
-    return enriched.slice(0, limit);
+    return decayed.slice(0, limit);
+  }
+
+  // Multiply each result's combinedScore by its temporal-decay factor and
+  // re-sort. Recency is measured from the later of the observation's
+  // timestamp and its last-access time (reinforcement refreshes recency),
+  // so frequently-recalled memories age from their last touch. A single
+  // batched access-log read keeps this to one extra KV round-trip per query
+  // when enabled, and the whole method short-circuits when it isn't.
+  private async applyDecayReweight(
+    results: HybridSearchResult[],
+  ): Promise<HybridSearchResult[]> {
+    if (!this.decayParams.enabled || results.length === 0) return results;
+
+    const now = Date.now();
+    const accessLogs = await Promise.all(
+      results.map((r) =>
+        this.kv
+          .get<AccessLog>(KV.accessLog, r.observation.id)
+          .catch(() => null),
+      ),
+    );
+
+    const reweighted = results.map((r, i) => {
+      const lastAt = accessLogs[i]?.lastAt || undefined;
+      const effectiveTs = effectiveTimestampMs(
+        r.observation.timestamp,
+        lastAt,
+      );
+      const combinedScore = applyTemporalDecay(
+        r.combinedScore,
+        { effectiveTimestampMs: effectiveTs, importance: r.observation.importance },
+        this.decayParams,
+        now,
+      );
+      return { ...r, combinedScore };
+    });
+
+    reweighted.sort((a, b) => b.combinedScore - a.combinedScore);
+    return reweighted;
   }
 
   private diversifyBySession(

--- a/test/temporal-decay.test.ts
+++ b/test/temporal-decay.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from "vitest";
+import {
+  recencyFactor,
+  decayMultiplier,
+  applyTemporalDecay,
+  effectiveTimestampMs,
+  DEFAULT_TEMPORAL_DECAY,
+  type TemporalDecayParams,
+} from "../src/functions/temporal-decay.js";
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+function params(overrides: Partial<TemporalDecayParams> = {}): TemporalDecayParams {
+  return { ...DEFAULT_TEMPORAL_DECAY, enabled: true, ...overrides };
+}
+
+describe("recencyFactor", () => {
+  it("is 1.0 at age zero", () => {
+    expect(recencyFactor(0, 14)).toBe(1);
+  });
+
+  it("is 0.5 at exactly one half-life", () => {
+    expect(recencyFactor(14 * MS_PER_DAY, 14)).toBeCloseTo(0.5, 10);
+  });
+
+  it("is 0.25 at two half-lives", () => {
+    expect(recencyFactor(28 * MS_PER_DAY, 14)).toBeCloseTo(0.25, 10);
+  });
+
+  it("decreases monotonically with age", () => {
+    const a = recencyFactor(1 * MS_PER_DAY, 14);
+    const b = recencyFactor(5 * MS_PER_DAY, 14);
+    const c = recencyFactor(30 * MS_PER_DAY, 14);
+    expect(a).toBeGreaterThan(b);
+    expect(b).toBeGreaterThan(c);
+  });
+
+  it("treats negative age (clock skew) as fresh", () => {
+    expect(recencyFactor(-1000, 14)).toBe(1);
+  });
+
+  it("disables decay for a non-positive half-life", () => {
+    expect(recencyFactor(100 * MS_PER_DAY, 0)).toBe(1);
+    expect(recencyFactor(100 * MS_PER_DAY, -5)).toBe(1);
+  });
+
+  it("never returns a value outside (0, 1]", () => {
+    for (const days of [0.5, 1, 7, 90, 365, 3650]) {
+      const f = recencyFactor(days * MS_PER_DAY, 14);
+      expect(f).toBeGreaterThan(0);
+      expect(f).toBeLessThanOrEqual(1);
+    }
+  });
+});
+
+describe("decayMultiplier", () => {
+  it("is bounded in [floor, 1]", () => {
+    const p = params({ floor: 0.2 });
+    for (const days of [0, 1, 14, 100, 1000]) {
+      for (const imp of [0, 0.5, 1]) {
+        const m = decayMultiplier(days * MS_PER_DAY, imp, p);
+        expect(m).toBeGreaterThanOrEqual(0.2 - 1e-9);
+        expect(m).toBeLessThanOrEqual(1 + 1e-9);
+      }
+    }
+  });
+
+  it("reaches the floor asymptotically for an ancient unimportant memory", () => {
+    const p = params({ floor: 0.2, importanceWeight: 0.2 });
+    // 1000 half-lives: recency ~0, importance 0 -> multiplier -> floor +
+    // (1-floor)*baseWeight. baseWeight = 1 - 0.5 - 0.2 = 0.3.
+    const m = decayMultiplier(14000 * MS_PER_DAY, 0, p);
+    expect(m).toBeCloseTo(0.2 + 0.8 * 0.3, 6);
+  });
+
+  it("is 1.0 for a fresh maximally-important memory", () => {
+    const p = params({ floor: 0.2, recencyWeight: 0.5, importanceWeight: 0.2 });
+    const m = decayMultiplier(0, 1, p);
+    expect(m).toBeCloseTo(1, 6);
+  });
+
+  it("ranks a fresh memory above an old one of equal importance", () => {
+    const p = params();
+    const fresh = decayMultiplier(0, 0.5, p);
+    const old = decayMultiplier(60 * MS_PER_DAY, 0.5, p);
+    expect(fresh).toBeGreaterThan(old);
+  });
+
+  it("lets importance slow decay (important old > unimportant old)", () => {
+    const p = params({ importanceWeight: 0.4 });
+    const important = decayMultiplier(60 * MS_PER_DAY, 1, p);
+    const trivial = decayMultiplier(60 * MS_PER_DAY, 0, p);
+    expect(important).toBeGreaterThan(trivial);
+  });
+
+  it("normalizes weights that sum above 1 without going below floor", () => {
+    const p = params({ recencyWeight: 0.9, importanceWeight: 0.9, floor: 0.1 });
+    const m = decayMultiplier(1000 * MS_PER_DAY, 0, p);
+    expect(m).toBeGreaterThanOrEqual(0.1 - 1e-9);
+  });
+});
+
+describe("applyTemporalDecay", () => {
+  const now = Date.parse("2026-06-13T00:00:00.000Z");
+
+  it("is a pass-through when disabled", () => {
+    const p = params({ enabled: false });
+    const out = applyTemporalDecay(
+      0.05,
+      { effectiveTimestampMs: 0, importance: 0 },
+      p,
+      now,
+    );
+    expect(out).toBe(0.05);
+  });
+
+  it("scales relevance down for stale memories", () => {
+    const p = params();
+    const old = now - 90 * MS_PER_DAY;
+    const out = applyTemporalDecay(
+      0.05,
+      { effectiveTimestampMs: old, importance: 0.3 },
+      p,
+      now,
+    );
+    expect(out).toBeLessThan(0.05);
+    expect(out).toBeGreaterThan(0);
+  });
+
+  it("preserves relevance ordering it cannot invert within the floor", () => {
+    // A vastly more relevant but old hit should still be able to beat a
+    // marginally relevant fresh hit, thanks to the floor.
+    const p = params({ floor: 0.3 });
+    const oldButRelevant = applyTemporalDecay(
+      0.1,
+      { effectiveTimestampMs: now - 120 * MS_PER_DAY, importance: 0.5 },
+      p,
+      now,
+    );
+    const freshButWeak = applyTemporalDecay(
+      0.02,
+      { effectiveTimestampMs: now, importance: 0.5 },
+      p,
+      now,
+    );
+    expect(oldButRelevant).toBeGreaterThan(freshButWeak);
+  });
+});
+
+describe("effectiveTimestampMs", () => {
+  it("uses the observation timestamp when there is no access", () => {
+    const ts = "2026-06-01T00:00:00.000Z";
+    expect(effectiveTimestampMs(ts)).toBe(Date.parse(ts));
+  });
+
+  it("uses last access when it is more recent (reinforcement)", () => {
+    const created = "2026-01-01T00:00:00.000Z";
+    const accessed = "2026-06-10T00:00:00.000Z";
+    expect(effectiveTimestampMs(created, accessed)).toBe(Date.parse(accessed));
+  });
+
+  it("keeps creation time when it is more recent than a stale access row", () => {
+    const created = "2026-06-10T00:00:00.000Z";
+    const accessed = "2026-01-01T00:00:00.000Z";
+    expect(effectiveTimestampMs(created, accessed)).toBe(Date.parse(created));
+  });
+
+  it("handles missing/invalid timestamps without throwing", () => {
+    expect(effectiveTimestampMs(undefined)).toBe(0);
+    expect(effectiveTimestampMs("not-a-date")).toBe(0);
+    expect(effectiveTimestampMs("not-a-date", "also-bad")).toBe(0);
+  });
+});


### PR DESCRIPTION
Recall fuses BM25 + vector + graph into a single RRF relevance score with no notion of time, so an equally-relevant note from this morning and one from a year ago rank identically. This adds an opt-in temporal decay reweight that blends an exponential recency factor (and optional importance term) into the relevance score, so fresh and reinforced memories surface ahead of equally-relevant stale ones.

Design:
- Exponential decay parameterized by a configurable HALF-LIFE (days), the interpretable forgetting-curve knob.
- Multiplicative reweight of the (small, unnormalized) RRF score rather than additive, so relevance stays the dominant signal.
- A floor on the multiplier so decay demotes but never erases an old-but-highly-relevant hit.
- "Use it or lose it": effective age is measured from the later of creation or last access (reuses the existing AccessLog), so recall refreshes recency.
- Importance slows decay, mirroring the Generative Agents importance term.

OFF by default (AGENTMEMORY_TEMPORAL_DECAY=true), matching the project's opt-in posture for changes that alter recall ordering. When disabled the reweight short-circuits with zero added cost.

Adds src/functions/temporal-decay.ts (pure, fully unit-tested), config getters + safeParseFloat, HybridSearch integration, and .env.example docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added temporal decay to memory recall scoring, combining recency and importance to improve result ordering.
  * Preserved relevance with a configurable minimum decay floor, including support for recently accessed memories.

* **Configuration**
  * Added controls for enabling temporal decay and tuning half-life, recency/importance weighting, and decay limits.

* **Documentation & Tests**
  * Added architecture and enhancement documentation.
  * Added automated coverage for decay behavior, scoring bounds, and timestamp handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->