### PR TITLE
fix: prefer OPENAI_EMBEDDING_API_KEY over OPENAI_API_KEY for embeddings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,8 +74,11 @@
 # COHERE_API_KEY=...                             # General-purpose embeddings
 
 # Reuses OPENAI_API_KEY / OPENAI_BASE_URL above when EMBEDDING_PROVIDER=openai.
-# OPENAI_EMBEDDING_MODEL=text-embedding-3-small  # Embedding model when EMBEDDING_PROVIDER=openai
-# OPENAI_EMBEDDING_DIMENSIONS=1536               # Required when the model is not in the known-models table
+# Set OPENAI_EMBEDDING_API_KEY to use a different key for embeddings than for LLM.
+# OPENAI_EMBEDDING_API_KEY=sk-...                  # Dedicated embedding key (falls back to OPENAI_API_KEY)
+# OPENAI_EMBEDDING_BASE_URL=https://api.openai.com # Override for embedding API base URL (falls back to OPENAI_BASE_URL)
+# OPENAI_EMBEDDING_MODEL=text-embedding-3-small    # Embedding model when EMBEDDING_PROVIDER=openai
+# OPENAI_EMBEDDING_DIMENSIONS=1536                 # Required when the model is not in the known-models table
 
 # OPENROUTER_EMBEDDING_MODEL=openai/text-embedding-3-small  # When EMBEDDING_PROVIDER=openrouter
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1687,7 +1687,7 @@ async function passiveServerChecks(): Promise<DoctorCheck[]> {
       ok: hasEmbed,
       hint: hasEmbed
         ? undefined
-        : "Running BM25-only. Add OPENAI_API_KEY / VOYAGE_API_KEY / COHERE_API_KEY / OLLAMA_HOST",
+        : "Running BM25-only. Add OPENAI_API_KEY / OPENAI_EMBEDDING_API_KEY / VOYAGE_API_KEY / COHERE_API_KEY / OLLAMA_HOST",
     },
   );
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -241,7 +241,7 @@ export function detectEmbeddingProvider(
   if (forced) return forced;
 
   if (source["GEMINI_API_KEY"]) return "gemini";
-  if (source["OPENAI_API_KEY"]) return "openai";
+  if (source["OPENAI_EMBEDDING_API_KEY"] || source["OPENAI_API_KEY"]) return "openai";
   if (source["VOYAGE_API_KEY"]) return "voyage";
   if (source["COHERE_API_KEY"]) return "cohere";
   if (source["OPENROUTER_API_KEY"]) return "openrouter";

--- a/src/providers/embedding/index.ts
+++ b/src/providers/embedding/index.ts
@@ -35,7 +35,7 @@ export function createEmbeddingProvider(): EmbeddingProvider | null {
     case "gemini":
       return withDimensionGuard(new GeminiEmbeddingProvider(getEnvVar("GEMINI_API_KEY")!));
     case "openai":
-      return withDimensionGuard(new OpenAIEmbeddingProvider(getEnvVar("OPENAI_API_KEY")!));
+      return withDimensionGuard(new OpenAIEmbeddingProvider());
     case "voyage":
       return withDimensionGuard(new VoyageEmbeddingProvider(getEnvVar("VOYAGE_API_KEY")!));
     case "cohere":


### PR DESCRIPTION
Closes #863

## What changed

| File | Change |
|------|--------|
| `src/providers/embedding/index.ts` | Stop passing `OPENAI_API_KEY` to `OpenAIEmbeddingProvider()` constructor; let it resolve its own key from env vars (already done in `0908d6e`) |
| `src/config.ts` | `detectEmbeddingProvider()` now also checks `OPENAI_EMBEDDING_API_KEY` when auto-detecting the embedding provider |
| `.env.example` | Document `OPENAI_EMBEDDING_API_KEY` and `OPENAI_EMBEDDING_BASE_URL` |
| `src/cli.ts` | Passive doctor check hint now includes `OPENAI_EMBEDDING_API_KEY` |

## Why

When `EMBEDDING_PROVIDER=openai` is used with both:

- `OPENAI_API_KEY` for an OpenAI-compatible chat provider
- `OPENAI_EMBEDDING_API_KEY` / `OPENAI_EMBEDDING_BASE_URL` for a separate local embedding endpoint (e.g. LM Studio, vLLM, Ollama)

the embedding provider used `OPENAI_API_KEY` instead of `OPENAI_EMBEDDING_API_KEY`, making it impossible to split chat and embedding endpoints.

### Root cause

Two issues:

1. **Factory override** (`src/providers/embedding/index.ts`): `createEmbeddingProvider()` passed `getEnvVar("OPENAI_API_KEY")!` as a constructor argument. Since constructor arguments take highest priority, `OpenAIEmbeddingProvider`'s internal fallback chain (`OPENAI_EMBEDDING_API_KEY` → `OPENAI_API_KEY`) was never reached.

2. **Auto-detection gap** (`src/config.ts`): `detectEmbeddingProvider()` only checked `OPENAI_API_KEY`, not `OPENAI_EMBEDDING_API_KEY`. If a user only set the latter (e.g. using Anthropic for LLM + local OpenAI-compatible for embeddings), the function returned `null` and the embedding provider was never created at all.

### After the fix

API key resolution for OpenAI embeddings follows this precedence:

1. Explicit constructor argument (if provided)
2. `OPENAI_EMBEDDING_API_KEY`
3. `OPENAI_API_KEY`

Base URL resolution follows this precedence:

1. `OPENAI_EMBEDDING_BASE_URL`
2. `OPENAI_BASE_URL`

Auto-detection now recognizes `OPENAI_EMBEDDING_API_KEY` as a valid signal to enable the `openai` embedding provider.

## Reproduction

Config that was broken before this fix:

```env
# Hosted OpenAI-compatible chat provider
OPENAI_API_KEY=hosted-chat-key
OPENAI_BASE_URL=https://example-chat-provider/v1
OPENAI_MODEL=some-chat-model

# Local OpenAI-compatible embedding provider
EMBEDDING_PROVIDER=openai
OPENAI_EMBEDDING_API_KEY=local-embedding-key
OPENAI_EMBEDDING_BASE_URL=http://127.0.0.1:1234/v1
OPENAI_EMBEDDING_MODEL=text-embedding-bge-m3
OPENAI_EMBEDDING_DIMENSIONS=1024
```

Before: `hosted-chat-key` was sent to the local embedding endpoint. LM Studio rejects it with an invalid token error.

After: `local-embedding-key` is used for embeddings, `hosted-chat-key` is used for chat. Each endpoint gets the correct key.

## Backward compatibility

- Users who only set `OPENAI_API_KEY` continue to work — `OpenAIEmbeddingProvider` falls back to it.
- Users who don't set any embedding key continue to get BM25-only mode.
- No behavior change for other embedding providers (gemini, voyage, cohere, openrouter).
