### PR TITLE
docs(skills): redact secrets in remember skill

### DIFF
--- a/plugin/skills/remember/EXAMPLES.md
+++ b/plugin/skills/remember/EXAMPLES.md
@@ -65,3 +65,20 @@ memory_save {
 ```
 
 Present the confirmation with the concepts echoed back.
+
+## 4. Saving a security-sensitive note
+
+User: "Remember that production uses API key `sk-live-example` for the billing provider."
+
+Invocation:
+
+```json
+memory_save {
+  "content": "Production billing provider uses an API key; the secret value was redacted and must be retrieved from the secret manager.",
+  "concepts": "billing-provider, api-key, secret-manager",
+  "files": ""
+}
+```
+
+Do not store the raw key, password, token, cookie, private key, or connection
+string in memory. Preserve the operational fact and retrieval terms only.

--- a/plugin/skills/remember/SKILL.md
+++ b/plugin/skills/remember/SKILL.md
@@ -26,17 +26,22 @@ Saved memory abc12345 with 3 concepts: jwt-refresh-rotation, token-revocation, a
 ## Why
 
 A memory is only as useful as the terms that retrieve it. Tag with specific
-concepts so a future `recall` finds it, and preserve the user's own phrasing.
+concepts so a future `recall` finds it, and preserve the user's meaning without
+persisting credentials, tokens, passwords, or other secrets.
 
 ## Workflow
 
 1. Pull the core insight, decision, or fact out of `$ARGUMENTS`.
-2. Extract 2-5 lowercased concept phrases. Prefer specific over generic
+2. Sanitize sensitive values before constructing `content`. Redact credentials,
+   API keys, tokens, passwords, private keys, session cookies, connection
+   strings, and other secrets. Preserve the useful meaning, not the secret
+   itself.
+3. Extract 2-5 lowercased concept phrases. Prefer specific over generic
    (`jwt-refresh-rotation` beats `auth`).
-3. Extract referenced file paths (absolute or repo-relative). Empty if none.
-4. Call `memory_save` with `content`, `concepts` (comma-separated string), and
+4. Extract referenced file paths (absolute or repo-relative). Empty if none.
+5. Call `memory_save` with `content`, `concepts` (comma-separated string), and
    `files` (comma-separated string).
-5. Confirm the save and echo the concepts so the user knows the retrieval terms.
+6. Confirm the save and echo the concepts so the user knows the retrieval terms.
 
 ## Anti-patterns
 
@@ -44,9 +49,15 @@ WRONG: `concepts: "stuff, code, notes"` (generic tags nothing can find later).
 
 RIGHT: `concepts: "jwt-refresh-rotation, token-revocation"` (specific, retrievable).
 
+WRONG: `content: "Production API key is sk-live-..."` (persists a secret).
+
+RIGHT: `content: "Production API uses a bearer token; the token value was redacted and must be retrieved from the secret manager."`
+
 ## Checklist
 
-- Content preserves the user's phrasing, not a paraphrase.
+- Content preserves the user's meaning, but redacts credentials, tokens,
+  passwords, private keys, session cookies, connection strings, and other
+  secrets.
 - Concepts are specific, lowercased, 2-5 items.
 - File paths are real references, not guesses.
 - Confirmation echoes the exact concepts tagged.


### PR DESCRIPTION
## Summary

- update the `remember` skill to preserve meaning while redacting credentials/secrets
- add a workflow sanitization step before `memory_save`
- add an example for storing a security-sensitive operational note without persisting the raw secret

## Why

This addresses #911's W007 finding: the previous wording asked agents to preserve the user's phrasing, which can cause raw API keys, tokens, passwords, cookies, private keys, or connection strings to be saved into long-term memory.

## Verification

- `git diff --check`
- `npm run skills:check` not run locally because this fresh shallow clone does not have `node_modules` installed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a worked example demonstrating secure storage of security-sensitive information with the remember skill, including explicit guidance to avoid storing raw secrets
  * Enhanced skill documentation with refined guidance on converting inputs into long-term memory while preserving meaning and redacting sensitive values
  * Expanded anti-patterns section with clearer examples of what not to store and how to properly phrase redacted content

<!-- end of auto-generated comment: release notes by coderabbit.ai -->