### PR TITLE
feat(providers): route graph extraction via AGENTMEMORY_GRAPH_MODEL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,17 @@
 # OPENAI_TIMEOUT_MS alias for back-compat with v0.9.17 (precedence).
 # AGENTMEMORY_LLM_TIMEOUT_MS=60000                # Default: 60 000 ms (60 s)
 
+# AGENTMEMORY_GRAPH_MODEL=                       # Route mem::graph-extract to a
+#                                                # dedicated provider whose model
+#                                                # overrides the active provider
+#                                                # model. When unset, the active
+#                                                # provider model is used (current
+#                                                # behavior). Graph runs on its own
+#                                                # ResilientProvider instance, so
+#                                                # its concurrency limiter and
+#                                                # circuit breaker are independent
+#                                                # of summarize.
+
 # Opt-in Claude-subscription fallback (spawns @anthropic-ai/claude-agent-sdk
 # child sessions). Off by default — the agent-sdk fallback can trigger
 # Stop-hook recursion (#149 follow-up) when invoked from inside Claude Code.

--- a/README.md
+++ b/README.md
@@ -1228,6 +1228,7 @@ agentmemory auto-detects from your environment. By default, no LLM calls are mad
 | Gemini | `GEMINI_API_KEY` | Also enables embeddings |
 | OpenRouter | `OPENROUTER_API_KEY` | Any model |
 | OpenAI API | `OPENAI_API_KEY` | Default `gpt-4o-mini`, override with `OPENAI_MODEL` |
+| **Graph extraction (optional)** | `AGENTMEMORY_GRAPH_MODEL` | Routes `mem::graph-extract` to a dedicated provider whose model overrides the active provider model. Independent ResilientProvider, so its concurrency limiter and circuit breaker are not shared with summarize. |
 | **Local (Ollama / LM Studio / vLLM / llama.cpp)** | `OPENAI_API_KEY=local` + `OPENAI_BASE_URL=http://localhost:11434/v1` (Ollama) or `http://localhost:1234/v1` (LM Studio) + `OPENAI_MODEL=<your model>` | Anything OpenAI-API-compatible. Zero cost, runs on your hardware. See [Local models](#local-models-ollama-lm-studio-vllm) below. |
 | Claude subscription fallback | `AGENTMEMORY_ALLOW_AGENT_SDK=true` | Opt-in only. Spawns `@anthropic-ai/claude-agent-sdk` sessions — used to cause unbounded Stop-hook recursion (#149 follow-up) so it is no longer the default. |
 

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -92,6 +92,15 @@ export function createFallbackProvider(
   return new ResilientProvider(providers[0]);
 }
 
+// #blockers: graph extraction can run on a different model than summarize so a
+// relation-native or smaller model can be paired with the heavier summary
+// model. Falls back to the base model when AGENTMEMORY_GRAPH_MODEL is unset.
+export function resolveGraphProviderConfig(
+  base: ProviderConfig,
+): ProviderConfig {
+  return { ...base, model: getEnvVar("AGENTMEMORY_GRAPH_MODEL") || base.model };
+}
+
 function createBaseProvider(config: ProviderConfig): MemoryProvider {
   switch (config.provider) {
     case "minimax":

--- a/test/graph-provider-routing.test.ts
+++ b/test/graph-provider-routing.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+import { resolveGraphProviderConfig } from "../src/providers/index.js";
+import type { ProviderConfig } from "../src/types.js";
+
+describe("resolveGraphProviderConfig", () => {
+  const ORIGINAL_ENV = { ...process.env };
+  const base: ProviderConfig = {
+    provider: "openai",
+    model: "base-model",
+    maxTokens: 4096,
+    baseURL: "http://example/v1",
+  };
+
+  beforeEach(() => {
+    delete process.env.AGENTMEMORY_GRAPH_MODEL;
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it("returns the base model when AGENTMEMORY_GRAPH_MODEL is unset", () => {
+    const result = resolveGraphProviderConfig(base);
+    expect(result.model).toBe("base-model");
+    expect(result.provider).toBe("openai");
+    expect(result.maxTokens).toBe(4096);
+    expect(result.baseURL).toBe("http://example/v1");
+  });
+
+  it("overrides only the model when AGENTMEMORY_GRAPH_MODEL is set", () => {
+    process.env.AGENTMEMORY_GRAPH_MODEL = "graph-model";
+    const result = resolveGraphProviderConfig(base);
+    expect(result.model).toBe("graph-model");
+    expect(result.provider).toBe("openai");
+    expect(result.maxTokens).toBe(4096);
+    expect(result.baseURL).toBe("http://example/v1");
+  });
+});


### PR DESCRIPTION
## What

Add an optional `AGENTMEMORY_GRAPH_MODEL` env that routes `mem::graph-extract` through a dedicated provider whose model overrides the active provider model. When unset, the active provider's model is used (current behavior). The graph provider is a separate `ResilientProvider` instance, so its concurrency limiter and circuit breaker are independent of the summarize provider.

## Why

A relation-native or lighter graph model often outperforms the main reasoning model on graph extraction. With one shared provider there is no way to mix them; the summarize model is forced on the extraction step too.

## How

`resolveGraphProviderConfig` derives a graph config by overriding model on the active config. `main()` constructs the dedicated graph provider with the same fallback chain.

Side effect: `AGENTMEMORY_LLM_CONCURRENCY` no longer bottlenecks the pair; summarize and graph-extract can now issue outbound calls in parallel up to one per provider.

## Complementarity with #900

Complementary to open PR #900 (`AGENTMEMORY_COMPRESS_MODEL`): compress and graph operate at distinct stages. Both can coexist after #900 lands - the two model overrides are independent fields on `ProviderConfig`.

## Tests

`test/graph-provider-routing.test.ts` (new file, 2 cases). Targeted suite: 2/2 pass.

## Compatibility

Unset env = no behavior change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for dedicated graph extraction provider routing via optional `AGENTMEMORY_GRAPH_MODEL` environment variable. When configured, graph extraction can use a different provider/model than other operations.
  * Graph extraction now operates with independent concurrency limiting and circuit breaker isolation.

* **Documentation**
  * Updated environment configuration examples and provider documentation for graph extraction routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->