### PR TITLE
feat(mcp): add AGENTMEMORY_TOOLS_DISABLE env to trim the MCP tool surface

### DIFF
--- a/src/mcp/standalone.ts
+++ b/src/mcp/standalone.ts
@@ -2,7 +2,7 @@
 
 import { InMemoryKV } from "./in-memory-kv.js";
 import { createStdioTransport } from "./transport.js";
-import { getAllTools } from "./tools-registry.js";
+import { getAllTools, parseToolDisableList } from "./tools-registry.js";
 import { getStandalonePersistPath } from "../config.js";
 import { VERSION } from "../version.js";
 import { generateId } from "../state/schema.js";
@@ -394,6 +394,15 @@ export async function handleToolCall(
   return handleLocal(validated, kvInstance);
 }
 
+function applyToolDisable<T>(tools: T[], nameOf: (t: T) => string | undefined): T[] {
+  const disable = parseToolDisableList(process.env["AGENTMEMORY_TOOLS_DISABLE"]);
+  if (disable.size === 0) return tools;
+  return tools.filter((t) => {
+    const name = nameOf(t);
+    return name === undefined || !disable.has(name);
+  });
+}
+
 export async function handleToolsList(): Promise<{ tools: unknown[] }> {
   const debug = process.env["AGENTMEMORY_DEBUG"] === "1" || process.env["AGENTMEMORY_DEBUG"] === "true";
   const handle = await resolveHandle();
@@ -419,12 +428,18 @@ export async function handleToolsList(): Promise<{ tools: unknown[] }> {
         );
       }
       if (remote && Array.isArray(remote.tools)) {
+        const filtered = applyToolDisable(remote.tools, (t) =>
+          typeof t === "object" && t !== null && typeof (t as { name?: unknown }).name === "string"
+            ? ((t as { name: string }).name)
+            : undefined,
+        );
         if (debug) {
+          const dropped = remote.tools.length - filtered.length;
           process.stderr.write(
-            `[@agentmemory/mcp] tools/list: returning ${remote.tools.length} tools from server\n`,
+            `[@agentmemory/mcp] tools/list: returning ${filtered.length} tools from server${dropped > 0 ? ` (${dropped} dropped via AGENTMEMORY_TOOLS_DISABLE)` : ""}\n`,
           );
         }
-        return { tools: remote.tools };
+        return { tools: filtered };
       }
       process.stderr.write(
         `[@agentmemory/mcp] tools/list: server returned unexpected shape (no .tools array); falling back to local IMPLEMENTED_TOOLS list. Set AGENTMEMORY_DEBUG=1 to inspect response.\n`,
@@ -436,7 +451,10 @@ export async function handleToolsList(): Promise<{ tools: unknown[] }> {
       invalidateHandle();
     }
   }
-  const fallback = getAllTools().filter((t) => IMPLEMENTED_TOOLS.has(t.name));
+  const fallback = applyToolDisable(
+    getAllTools().filter((t) => IMPLEMENTED_TOOLS.has(t.name)),
+    (t) => t.name,
+  );
   if (debug) {
     process.stderr.write(
       `[@agentmemory/mcp] tools/list: returning ${fallback.length} local fallback tools (${fallback.map((t) => t.name).join(",")})\n`,

--- a/src/mcp/tools-registry.ts
+++ b/src/mcp/tools-registry.ts
@@ -954,8 +954,28 @@ export function getAllTools(): McpToolDef[] {
 // advertised 53 tools "in proxy mode"; the old default left OpenCode /
 // Claude Code users seeing 8 with no indication the other tools existed.
 // Users who want the lean essentials can still set AGENTMEMORY_TOOLS=core.
+//
+// AGENTMEMORY_TOOLS_DISABLE (comma- or whitespace-separated tool names)
+// drops tools from the surface AFTER the mode filter. Use it to remove
+// definitively-non-functional tools (server-disabled features, no-peer
+// fan-out, sandboxed exports) without rebuilding the registry. Unknown
+// names are silently ignored so the env is forward-compatible.
+export function parseToolDisableList(raw: string | undefined | null): Set<string> {
+  if (!raw) return new Set();
+  return new Set(
+    raw
+      .split(/[\s,]+/)
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0),
+  );
+}
+
 export function getVisibleTools(): McpToolDef[] {
   const mode = process.env["AGENTMEMORY_TOOLS"] || "all";
-  if (mode === "core") return getAllTools().filter((t) => ESSENTIAL_TOOLS.has(t.name));
-  return getAllTools();
+  const base = mode === "core"
+    ? getAllTools().filter((t) => ESSENTIAL_TOOLS.has(t.name))
+    : getAllTools();
+  const disable = parseToolDisableList(process.env["AGENTMEMORY_TOOLS_DISABLE"]);
+  if (disable.size === 0) return base;
+  return base.filter((t) => !disable.has(t.name));
 }

--- a/test/standalone-tools-disable.test.ts
+++ b/test/standalone-tools-disable.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { handleToolsList } from "../src/mcp/standalone.js";
+import { resetHandleForTests } from "../src/mcp/rest-proxy.js";
+
+type FetchMock = ReturnType<typeof vi.fn>;
+
+function installFetch(handler: (url: string, init?: RequestInit) => Response): FetchMock {
+  const fn = vi.fn(async (url: string | URL, init?: RequestInit) =>
+    handler(url.toString(), init),
+  );
+  (globalThis as { fetch: typeof fetch }).fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+const BASE = "http://localhost:3111";
+
+function fullToolsResponse() {
+  return {
+    tools: [
+      { name: "memory_save", description: "save", inputSchema: { type: "object", properties: {} } },
+      { name: "memory_recall", description: "recall", inputSchema: { type: "object", properties: {} } },
+      { name: "memory_smart_search", description: "search", inputSchema: { type: "object", properties: {} } },
+      { name: "memory_vision_search", description: "vision", inputSchema: { type: "object", properties: {} } },
+      { name: "memory_team_share", description: "team", inputSchema: { type: "object", properties: {} } },
+      { name: "memory_obsidian_export", description: "obsidian", inputSchema: { type: "object", properties: {} } },
+      { name: "memory_mesh_sync", description: "mesh", inputSchema: { type: "object", properties: {} } },
+      { name: "memory_compress_file", description: "compress", inputSchema: { type: "object", properties: {} } },
+    ],
+  };
+}
+
+describe("standalone bridge: AGENTMEMORY_TOOLS_DISABLE proxy filter (#blocker)", () => {
+  const originalFetch = globalThis.fetch;
+  const originalDisable = process.env["AGENTMEMORY_TOOLS_DISABLE"];
+
+  beforeEach(() => {
+    resetHandleForTests();
+    process.env["AGENTMEMORY_URL"] = BASE;
+    delete process.env["AGENTMEMORY_SECRET"];
+    delete process.env["AGENTMEMORY_TOOLS_DISABLE"];
+  });
+
+  afterEach(() => {
+    resetHandleForTests();
+    globalThis.fetch = originalFetch;
+    delete process.env["AGENTMEMORY_URL"];
+    if (originalDisable === undefined) delete process.env["AGENTMEMORY_TOOLS_DISABLE"];
+    else process.env["AGENTMEMORY_TOOLS_DISABLE"] = originalDisable;
+  });
+
+  it("returns server tools verbatim when AGENTMEMORY_TOOLS_DISABLE is unset", async () => {
+    installFetch((url) => {
+      if (url.endsWith("/agentmemory/livez")) return new Response("ok", { status: 200 });
+      if (url.endsWith("/agentmemory/mcp/tools")) {
+        return new Response(JSON.stringify(fullToolsResponse()), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const result = await handleToolsList();
+    const tools = result.tools as Array<{ name: string }>;
+    expect(tools).toHaveLength(8);
+    expect(tools.map((t) => t.name)).toContain("memory_vision_search");
+    expect(tools.map((t) => t.name)).toContain("memory_obsidian_export");
+  });
+
+  it("drops named tools from proxy response when env is set", async () => {
+    installFetch((url) => {
+      if (url.endsWith("/agentmemory/livez")) return new Response("ok", { status: 200 });
+      if (url.endsWith("/agentmemory/mcp/tools")) {
+        return new Response(JSON.stringify(fullToolsResponse()), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    });
+    process.env["AGENTMEMORY_TOOLS_DISABLE"] =
+      "memory_vision_search,memory_team_share,memory_obsidian_export";
+
+    const result = await handleToolsList();
+    const tools = result.tools as Array<{ name: string }>;
+    expect(tools).toHaveLength(5);
+    const names = tools.map((t) => t.name).sort();
+    expect(names).toEqual([
+      "memory_compress_file",
+      "memory_mesh_sync",
+      "memory_recall",
+      "memory_save",
+      "memory_smart_search",
+    ]);
+    expect(names).not.toContain("memory_vision_search");
+    expect(names).not.toContain("memory_team_share");
+    expect(names).not.toContain("memory_obsidian_export");
+  });
+
+  it("accepts whitespace- or newline-separated tool names", async () => {
+    installFetch((url) => {
+      if (url.endsWith("/agentmemory/livez")) return new Response("ok", { status: 200 });
+      if (url.endsWith("/agentmemory/mcp/tools")) {
+        return new Response(JSON.stringify(fullToolsResponse()), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    });
+    process.env["AGENTMEMORY_TOOLS_DISABLE"] = "memory_vision_search   memory_team_share\nmemory_mesh_sync";
+
+    const result = await handleToolsList();
+    const names = (result.tools as Array<{ name: string }>).map((t) => t.name);
+    expect(names).not.toContain("memory_vision_search");
+    expect(names).not.toContain("memory_team_share");
+    expect(names).not.toContain("memory_mesh_sync");
+    expect(names).toHaveLength(5);
+  });
+
+  it("silently ignores unknown tool names", async () => {
+    installFetch((url) => {
+      if (url.endsWith("/agentmemory/livez")) return new Response("ok", { status: 200 });
+      if (url.endsWith("/agentmemory/mcp/tools")) {
+        return new Response(JSON.stringify(fullToolsResponse()), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    });
+    process.env["AGENTMEMORY_TOOLS_DISABLE"] = "memory_does_not_exist,memory_vision_search,another_phantom";
+
+    const result = await handleToolsList();
+    const names = (result.tools as Array<{ name: string }>).map((t) => t.name);
+    expect(names).toHaveLength(7);
+    expect(names).not.toContain("memory_vision_search");
+  });
+
+  it("keeps malformed entries (missing .name) for forward compatibility", async () => {
+    installFetch((url) => {
+      if (url.endsWith("/agentmemory/livez")) return new Response("ok", { status: 200 });
+      if (url.endsWith("/agentmemory/mcp/tools")) {
+        return new Response(
+          JSON.stringify({
+            tools: [
+              { name: "memory_save", description: "s", inputSchema: {} },
+              { description: "no name", inputSchema: {} },
+              null,
+              { name: "memory_vision_search", description: "v", inputSchema: {} },
+            ],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    });
+    process.env["AGENTMEMORY_TOOLS_DISABLE"] = "memory_vision_search";
+
+    const result = await handleToolsList();
+    expect(result.tools).toHaveLength(3);
+    expect((result.tools as Array<{ name?: string }>).map((t) => t?.name)).toEqual([
+      "memory_save",
+      undefined,
+      undefined,
+    ]);
+  });
+
+  it("applies the filter to the local fallback path when server is unreachable", async () => {
+    installFetch(() => {
+      throw new Error("ECONNREFUSED");
+    });
+    process.env["AGENTMEMORY_TOOLS_DISABLE"] = "memory_save,memory_export";
+
+    const result = await handleToolsList();
+    const names = (result.tools as Array<{ name: string }>).map((t) => t.name).sort();
+    expect(names).not.toContain("memory_save");
+    expect(names).not.toContain("memory_export");
+    expect(names.length).toBe(5);
+    expect(names).toContain("memory_recall");
+  });
+});

--- a/test/tool-disable-env.test.ts
+++ b/test/tool-disable-env.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, afterEach } from "vitest";
+
+import {
+  getAllTools,
+  getVisibleTools,
+  parseToolDisableList,
+} from "../src/mcp/tools-registry.js";
+
+const ENV = "AGENTMEMORY_TOOLS_DISABLE";
+
+describe("parseToolDisableList", () => {
+  it("returns empty set for nullish/empty input", () => {
+    expect(parseToolDisableList(undefined).size).toBe(0);
+    expect(parseToolDisableList(null).size).toBe(0);
+    expect(parseToolDisableList("").size).toBe(0);
+    expect(parseToolDisableList("   ").size).toBe(0);
+  });
+
+  it("parses comma-separated tool names", () => {
+    const set = parseToolDisableList("memory_vision_search,memory_mesh_sync");
+    expect(set.has("memory_vision_search")).toBe(true);
+    expect(set.has("memory_mesh_sync")).toBe(true);
+    expect(set.size).toBe(2);
+  });
+
+  it("parses whitespace-separated tool names", () => {
+    const set = parseToolDisableList("memory_vision_search   memory_mesh_sync\nmemory_team_share");
+    expect(set.size).toBe(3);
+  });
+
+  it("trims whitespace and tolerates trailing commas", () => {
+    const set = parseToolDisableList("  memory_a , memory_b ,, ");
+    expect(set.has("memory_a")).toBe(true);
+    expect(set.has("memory_b")).toBe(true);
+    expect(set.size).toBe(2);
+  });
+});
+
+describe("getVisibleTools env filter", () => {
+  const originalDisable = process.env[ENV];
+  const originalMode = process.env["AGENTMEMORY_TOOLS"];
+
+  afterEach(() => {
+    if (originalDisable === undefined) delete process.env[ENV];
+    else process.env[ENV] = originalDisable;
+    if (originalMode === undefined) delete process.env["AGENTMEMORY_TOOLS"];
+    else process.env["AGENTMEMORY_TOOLS"] = originalMode;
+  });
+
+  it("returns the full set when env is unset", () => {
+    delete process.env[ENV];
+    delete process.env["AGENTMEMORY_TOOLS"];
+    expect(getVisibleTools().length).toBe(getAllTools().length);
+  });
+
+  it("drops named tools from default 'all' mode", () => {
+    delete process.env["AGENTMEMORY_TOOLS"];
+    process.env[ENV] =
+      "memory_vision_search,memory_mesh_sync,memory_obsidian_export";
+    const visible = getVisibleTools().map((t) => t.name);
+    expect(visible).not.toContain("memory_vision_search");
+    expect(visible).not.toContain("memory_mesh_sync");
+    expect(visible).not.toContain("memory_obsidian_export");
+    expect(visible).toContain("memory_save");
+    expect(visible).toContain("memory_smart_search");
+    expect(visible.length).toBe(getAllTools().length - 3);
+  });
+
+  it("applies on top of 'core' mode", () => {
+    process.env["AGENTMEMORY_TOOLS"] = "core";
+    process.env[ENV] = "memory_reflect";
+    const visible = getVisibleTools().map((t) => t.name);
+    expect(visible).not.toContain("memory_reflect");
+    expect(visible).toContain("memory_save");
+    expect(visible).toContain("memory_recall");
+  });
+
+  it("silently ignores unknown tool names", () => {
+    delete process.env["AGENTMEMORY_TOOLS"];
+    process.env[ENV] = "memory_does_not_exist,memory_save";
+    const visible = getVisibleTools().map((t) => t.name);
+    expect(visible).not.toContain("memory_save");
+    expect(visible.length).toBe(getAllTools().length - 1);
+  });
+});


### PR DESCRIPTION
## What

Add a comma- or whitespace-separated denylist read from the `AGENTMEMORY_TOOLS_DISABLE` env. Applied after the existing `AGENTMEMORY_TOOLS=all|core` mode filter so it composes cleanly with both modes, in two places:

- `getVisibleTools()` - server-side, `src/mcp/tools-registry.ts`
- `handleToolsList()` - bridge proxy + fallback paths in `src/mcp/standalone.ts`

## Why

Deployments often want to drop tools whose handlers are gated by feature flags (`memory_vision_search`, `memory_team_share`, `memory_team_feed`, `memory_claude_bridge_sync`, `memory_snapshot_create`), peer fan-out features no host actually configures (`memory_mesh_sync`), sandboxed exports (`memory_obsidian_export`), or the markdown-compress utility (`memory_compress_file`). Today the only path is a fork. This adds a single env knob.

## How

The bridge filters the remote response inline, so the env is useful without redeploying the server. Unknown tool names are silently ignored to keep the value forward-compatible.

## Tests

- `test/tool-disable-env.test.ts` (8 cases): `parseToolDisableList` + `getVisibleTools` under all/core modes and unknown names.
- `test/standalone-tools-disable.test.ts` (6 cases): bridge filter on the standalone shim (proxy + local fallback paths).
- Existing `test/tool-count-consistency.test.ts` and `test/mcp-standalone.test.ts` pass unchanged.
- Targeted suite: 20/20 pass.

## Compatibility

Unset env = no behavior change. No new dependencies.

## How to verify

```bash
# fallback path
AGENTMEMORY_TOOLS_DISABLE='memory_mesh_sync,memory_team_share' \
  node dist/standalone.mjs < tools-list.jsonl | jq '.result.tools | length'

# proxy path against a running server
AGENTMEMORY_URL=http://localhost:3111 \
  AGENTMEMORY_TOOLS_DISABLE='memory_vision_search memory_snapshot_create' \
  node dist/standalone.mjs < tools-list.jsonl | jq '.result.tools | length'
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP tools can now be selectively disabled through environment variable configuration for both proxy and local operation modes.

* **Tests**
  * Added comprehensive test coverage validating tool disabling across various configurations and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->