### PR TITLE
fix(slots): reconcile pinned flag on existing default-label slots

### DIFF
--- a/src/functions/slots.ts
+++ b/src/functions/slots.ts
@@ -159,7 +159,16 @@ async function seedDefaults(kv: StateKV): Promise<void> {
   for (const tmpl of DEFAULT_SLOTS) {
     const target = scopeKv(tmpl.scope);
     const existing = await kv.get<MemorySlot>(target, tmpl.label);
-    if (existing) continue;
+    if (existing) {
+      if (existing.pinned !== tmpl.pinned) {
+        await kv.set(target, tmpl.label, {
+          ...existing,
+          pinned: tmpl.pinned,
+          updatedAt: ts,
+        });
+      }
+      continue;
+    }
     const slot: MemorySlot = {
       ...tmpl,
       createdAt: ts,

--- a/src/functions/slots.ts
+++ b/src/functions/slots.ts
@@ -166,6 +166,11 @@ async function seedDefaults(kv: StateKV): Promise<void> {
           pinned: tmpl.pinned,
           updatedAt: ts,
         });
+        await recordAudit(kv, "slot_seed_reconcile", "seedDefaults", [tmpl.label], {
+          scope: tmpl.scope,
+          fromPinned: existing.pinned,
+          toPinned: tmpl.pinned,
+        });
       }
       continue;
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -608,7 +608,8 @@ export interface AuditEntry {
     | "slot_replace"
     | "slot_create"
     | "slot_delete"
-    | "slot_reflect";
+    | "slot_reflect"
+    | "slot_seed_reconcile";
   userId?: string;
   functionId: string;
   targetIds: string[];

--- a/test/slots.test.ts
+++ b/test/slots.test.ts
@@ -255,3 +255,59 @@ describe("slots — reflect", () => {
     expect(patterns.slot.content).toMatch(/errors: 2/);
   });
 });
+
+
+describe("slots — seedDefaults reconciles pinned on existing default-label slots", () => {
+  function wireWith(kv: ReturnType<typeof mockKV>) {
+    const handlers: Record<string, (d: Record<string, unknown>) => Promise<Record<string, unknown>>> = {};
+    const sdk = {
+      registerFunction: vi.fn((id: string, cb) => {
+        handlers[id] = cb;
+      }),
+    } as unknown as import("iii-sdk").ISdk;
+    registerSlotsFunctions(sdk, kv as never);
+    return handlers;
+  }
+
+  it("re-pins a default-label slot that was stored with pinned:false, preserving content", async () => {
+    const kv = mockKV();
+    await kv.set(KV.globalSlots, "persona", {
+      label: "persona",
+      content: "senior engineer persona",
+      sizeLimit: 1000,
+      description: "old description",
+      pinned: false,
+      readOnly: false,
+      scope: "global",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+    wireWith(kv);
+    await waitForSeed(kv);
+    const persona = (await kv.get(KV.globalSlots, "persona")) as {
+      pinned: boolean;
+      content: string;
+    };
+    expect(persona.pinned).toBe(true);
+    expect(persona.content).toBe("senior engineer persona");
+  });
+
+  it("leaves a non-default custom slot untouched", async () => {
+    const kv = mockKV();
+    await kv.set(KV.slots, "my_custom", {
+      label: "my_custom",
+      content: "custom",
+      sizeLimit: 2000,
+      description: "",
+      pinned: false,
+      readOnly: false,
+      scope: "project",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+    wireWith(kv);
+    await waitForSeed(kv);
+    const custom = (await kv.get(KV.slots, "my_custom")) as { pinned: boolean };
+    expect(custom.pinned).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

`seedDefaults` (the slots default-label seeder) now reconciles the `pinned` flag on existing default-label slots to match the current template, while preserving user content.

## Why

Pre-fix: default slots seeded before the current `pinned: true` defaults kept `pinned: false` forever and never reached SessionStart injection. The seeder only ran on missing slots, so existing slots stayed stale across version bumps.

## Tests

`test/slots.test.ts` extended (2 new cases): re-pins a default-label slot stored with `pinned: false` while preserving content; leaves a non-default custom slot untouched. Targeted suite: 16/16 pass.

## Compatibility

Idempotent. User-written content on default-label slots is preserved; only the `pinned` flag is reconciled. Custom (non-default-label) slots are not touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed default slot synchronization so existing default-labeled slots have their pinned status reconciled to match template defaults (updating pinned and timestamps while preserving existing content).
  * Custom slots are left unchanged during seeding.
* **Tests**
  * Added coverage to verify pinned reconciliation behavior for existing default slots and immutability for custom slots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->