### PR TITLE
fix: avoid overwriting invalid MCP JSON configs

### DIFF
--- a/src/cli/connect/json-mcp-adapter.ts
+++ b/src/cli/connect/json-mcp-adapter.ts
@@ -60,7 +60,15 @@ export function createJsonMcpAdapter(
     },
 
     async install(opts: ConnectOptions): Promise<ConnectResult> {
+      const configExists = existsSync(config.configPath);
       const existing = readJsonSafe<McpConfig>(config.configPath);
+      if (configExists && existing === null) {
+        p.log.error(
+          `Could not parse ${config.configPath}; leaving it unchanged. Fix the JSON and retry.`,
+        );
+        return { kind: "skipped", reason: "invalid-json" };
+      }
+
       const next: McpConfig = existing ? { ...existing } : {};
       const servers: Record<string, McpEntry> = {
         ...((next[wrapperKey] as Record<string, McpEntry>) ?? {}),
@@ -80,7 +88,7 @@ export function createJsonMcpAdapter(
       }
 
       let backupPath: string | undefined;
-      if (existsSync(config.configPath)) {
+      if (configExists) {
         backupPath = backupFile(config.configPath, config.name);
         logBackup(backupPath);
       } else {

--- a/test/connect-new-agents.test.ts
+++ b/test/connect-new-agents.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdtempSync, mkdirSync, rmSync, readFileSync, existsSync } from "node:fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  readFileSync,
+  existsSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir, platform } from "node:os";
 import { join } from "node:path";
 
@@ -218,13 +225,16 @@ describe("connect: Droid (Factory.ai)", () => {
 describe("connect: Zed", () => {
   let home: string;
   const ORIG = process.env["HOME"];
+  const ORIG_USERPROFILE = process.env["USERPROFILE"];
   beforeEach(() => {
     home = freshHome();
     vi.resetModules();
     process.env["HOME"] = home;
+    process.env["USERPROFILE"] = home;
   });
   afterEach(() => {
     process.env["HOME"] = ORIG;
+    process.env["USERPROFILE"] = ORIG_USERPROFILE;
     rmSync(home, { recursive: true, force: true });
   });
 
@@ -245,6 +255,49 @@ describe("connect: Zed", () => {
     expect(cfg.context_servers.agentmemory.command).toBe("npx");
     expect(cfg.context_servers.agentmemory.args).toContain("@agentmemory/mcp");
     expect(cfg.mcpServers).toBeUndefined();
+  });
+
+  it("preserves existing Zed settings and context servers", async () => {
+    const zedDir = join(home, ".config", "zed");
+    const settingsPath = join(zedDir, "settings.json");
+    mkdirSync(zedDir, { recursive: true });
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        theme: "One Dark",
+        context_servers: {
+          other: {
+            command: "node",
+            args: ["server.js"],
+          },
+        },
+      }),
+    );
+
+    const { adapter } = await import("../src/cli/connect/zed.js");
+    const result = await adapter.install({ dryRun: false, force: false });
+
+    expect(result.kind).toBe("installed");
+    const cfg = JSON.parse(readFileSync(settingsPath, "utf-8"));
+    expect(cfg.theme).toBe("One Dark");
+    expect(cfg.context_servers.other.command).toBe("node");
+    expect(cfg.context_servers.agentmemory.command).toBe("npx");
+    expect(cfg.context_servers.agentmemory.args).toContain("@agentmemory/mcp");
+  });
+
+  it("does not overwrite existing Zed settings when the file cannot be parsed", async () => {
+    const zedDir = join(home, ".config", "zed");
+    const settingsPath = join(zedDir, "settings.json");
+    const originalSettings = '{\n  // Zed allows JSONC-style settings\n  "theme": "One Dark",\n}\n';
+    mkdirSync(zedDir, { recursive: true });
+    writeFileSync(settingsPath, originalSettings);
+
+    const { adapter } = await import("../src/cli/connect/zed.js");
+    const result = await adapter.install({ dryRun: false, force: false });
+
+    expect(result).toEqual({ kind: "skipped", reason: "invalid-json" });
+    expect(readFileSync(settingsPath, "utf-8")).toBe(originalSettings);
+    expect(existsSync(join(home, ".agentmemory", "backups"))).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- stop JSON MCP adapters from treating an unreadable existing config as an empty config
- leave invalid or JSONC-style settings files unchanged and return a skipped result instead
- add Zed regression tests for preserving existing settings/context servers and for the parse-failure path
- make the Zed test home override work on Windows by setting USERPROFILE as well as HOME

## Verification
- npx vitest run test/connect-new-agents.test.ts -t "connect: Zed"

Notes:
- npx tsc --noEmit currently reports project-wide TypeScript errors outside this change.
- npm run build reaches tsdown bundling on Windows but the package script later fails on Unix shell commands: cp ... || true.

Closes #952


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of corrupted or invalid configuration files—now gracefully skipped with clear error reporting instead of being overwritten.
  * Enhanced preservation of existing settings when installing new agent connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->