### PR TITLE
fix: reindex search after import (fix #938)

### DIFF
--- a/src/functions/export-import.ts
+++ b/src/functions/export-import.ts
@@ -29,6 +29,7 @@ import { KV } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
 import { VERSION } from "../version.js";
 import { recordAudit } from "./audit.js";
+import { rebuildIndex } from "./search.js";
 import { logger } from "../logger.js";
 
 export function registerExportImportFunction(sdk: ISdk, kv: StateKV): void {
@@ -574,6 +575,24 @@ export function registerExportImportFunction(sdk: ISdk, kv: StateKV): void {
           }
           await kv.set(KV.accessLog, log.memoryId, log);
         }
+      }
+
+      // KV is now the source of truth, but the in-memory search indices still
+      // reflect the pre-import state: a "replace" wipe leaves ghosts of deleted
+      // entries in BM25/vector, and freshly imported entries from any strategy
+      // were written straight to KV without being indexed. Rebuild both indices
+      // from KV so smart-search reflects the imported data immediately instead
+      // of only after a process restart.
+      try {
+        const indexed = await rebuildIndex(kv);
+        logger.info("Import reindex complete", { strategy, indexed });
+      } catch (err) {
+        // The import itself succeeded and is durable in KV; a reindex failure
+        // must not fail the import. Surface it so the gap is diagnosable.
+        logger.warn("Import reindex failed", {
+          strategy,
+          error: err instanceof Error ? err.message : String(err),
+        });
       }
 
       logger.info("Import complete", { strategy, ...stats });

--- a/test/export-import.test.ts
+++ b/test/export-import.test.ts
@@ -5,6 +5,7 @@ vi.mock("../src/logger.js", () => ({
 }));
 
 import { registerExportImportFunction } from "../src/functions/export-import.js";
+import { getSearchIndex, rebuildIndex } from "../src/functions/search.js";
 import type {
   Session,
   CompressedObservation,
@@ -248,5 +249,45 @@ describe("Export/Import Functions", () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toContain("Unsupported export version");
+  });
+
+  it("replace import reindexes search: drops ghosts and indexes imported data", async () => {
+    // Live search index starts reflecting the pre-import KV state.
+    const index = getSearchIndex();
+    index.clear();
+    await rebuildIndex(kv);
+    // Sanity: the existing memory ("Always validate tokens") is searchable.
+    expect(index.search("validate").length).toBeGreaterThan(0);
+
+    const importedMemory: Memory = {
+      ...testMemory,
+      id: "mem_imported",
+      title: "Database connection pooling",
+      content: "Reuse postgres connections efficiently",
+      concepts: ["database"],
+    };
+    const exportData: ExportData = {
+      version: "0.3.0",
+      exportedAt: new Date().toISOString(),
+      sessions: [],
+      observations: {},
+      memories: [importedMemory],
+      summaries: [],
+    };
+
+    const result = (await sdk.trigger("mem::import", {
+      exportData,
+      strategy: "replace",
+    })) as { success: boolean; memories: number };
+
+    expect(result.success).toBe(true);
+    expect(result.memories).toBe(1);
+
+    // Ghost gone: the replaced-out memory must no longer surface from search.
+    expect(index.search("validate")).toEqual([]);
+    // Imported data is searchable immediately, without a process restart.
+    const hits = index.search("postgres");
+    expect(hits.length).toBeGreaterThan(0);
+    expect(hits.some((h) => h.obsId === "mem_imported")).toBe(true);
   });
 });


### PR DESCRIPTION
## Problem
After `mem::import`, `smart-search` is wrong until the process restarts (#938):

- `replace` strategy wipes KV across every namespace in `src/functions/export-import.ts`, but never touches the search indices — BM25 and the vector index keep holding the deleted entries, so search returns **ghosts** of records that no longer exist.
- Data imported by **any** strategy is written straight to KV via `kv.set(...)` without being indexed, so freshly imported memories/observations are **invisible** to search.

The net effect for a replace-import: search surfaces deleted records and misses everything just imported, for the whole process lifetime.

## Solution
Rebuild both indices from KV at the end of a successful import, using the existing `rebuildIndex(kv)` helper exported from `search.ts`. It clears BM25 + vector and repopulates them from KV, which is exactly the correct post-import state and fixes both halves (ghosts removed, imported data indexed) for every strategy.

A reindex failure is caught and logged rather than failing the import — the imported data is already durable in KV, so the import itself should still report success.

## Testing
- New regression test in `test/export-import.test.ts`: after a `replace` import, a replaced-out memory no longer surfaces from `getSearchIndex().search(...)`, and an imported memory is searchable immediately (no restart).
- Negative control: reverting the `rebuildIndex` call makes the new test fail.
- Full suite green: 1416 tests across 128 files (`npm test`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Imported data is now immediately searchable in search results, fixing a previous issue where search indices remained stale after import operations.

* **Tests**
  * Added test case verifying that importing data correctly rebuilds search indices, confirming imported content is immediately accessible in search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->