### PR TITLE
fix(viewer): count dashboard memory corpus

### DIFF
--- a/src/viewer/index.html
+++ b/src/viewer/index.html
@@ -1110,7 +1110,7 @@
 
     var state = {
       activeTab: 'dashboard',
-      dashboard: { loaded: false, health: null, sessions: [], memories: [], graphStats: null, recentAudit: [], lessons: [], crystals: [] },
+      dashboard: { loaded: false, health: null, sessions: [], memoryCount: null, graphStats: null, recentAudit: [], lessons: [], crystals: [] },
       graph: { loaded: false, nodes: [], edges: [], stats: null, filters: {}, selectedNode: null, queryError: null, truncated: false, totalNodes: 0, totalEdges: 0 },
       memories: { loaded: false, items: [], search: '', typeFilter: '' },
       timeline: { loaded: false, observations: [], sessionId: '', minImportance: 0, page: 0, pageSize: 50 },
@@ -1346,7 +1346,7 @@
         var results = await Promise.all([
           apiGet('health'),
           apiGet('sessions'),
-          apiGet('memories?latest=true&limit=500'),
+          apiGet('memories?latest=true&count=true'),
           apiGet('graph/stats'),
           apiGet('audit?limit=5'),
           apiGet('semantic'),
@@ -1357,7 +1357,7 @@
         ]);
         state.dashboard.health = results[0];
         state.dashboard.sessions = (results[1] && results[1].sessions) || [];
-        state.dashboard.memories = (results[2] && results[2].memories) || [];
+        state.dashboard.memoryCount = (results[2] && typeof results[2].latestCount === 'number') ? results[2].latestCount : null;
         state.dashboard.graphStats = results[3];
         state.dashboard.recentAudit = (results[4] && results[4].entries) || [];
         state.dashboard.semantic = (results[5] && results[5].facts) || (results[5] && results[5].semantic) || [];
@@ -1402,6 +1402,19 @@
       var fMetrics = h.functionMetrics || [];
       var cb = h.circuitBreaker || null;
       var workers = snap.workers || [];
+      var savedMemoryCount = typeof d.memoryCount === 'number' ? d.memoryCount : 0;
+      var summaryCount = (d.sessions || []).filter(function(s) { return !!s.summary; }).length;
+      var semanticCount = (d.semantic || []).length;
+      var proceduralCount = (d.procedural || []).length;
+      var lessonCount = (d.lessons || []).length;
+      var crystalCount = (d.crystals || []).length;
+      var memoryCount = savedMemoryCount + summaryCount + semanticCount + proceduralCount;
+      var memoryKinds = [];
+      if (savedMemoryCount) memoryKinds.push('saved');
+      if (semanticCount) memoryKinds.push('semantic');
+      if (summaryCount) memoryKinds.push('summaries');
+      if (proceduralCount) memoryKinds.push('procedural');
+      var memorySub = memoryKinds.length ? memoryKinds.join(' + ') : 'long-term corpus';
 
       var html = '';
       // First-run hero: empty dashboard = guided next step
@@ -1416,9 +1429,7 @@
       }
       html += '<div class="stats-grid">';
       html += '<div class="stat-card"><div class="label">Sessions</div><div class="value">' + d.sessions.length + '</div><div class="sub">' + activeSessions + ' active</div></div>';
-      html += '<div class="stat-card"><div class="label">Memories</div><div class="value">' + d.memories.length + '</div><div class="sub">latest versions</div></div>';
-      var lessonCount = (d.lessons || []).length;
-      var crystalCount = (d.crystals || []).length;
+      html += '<div class="stat-card"><div class="label">Memories</div><div class="value">' + memoryCount + '</div><div class="sub">' + esc(memorySub) + '</div></div>';
       html += '<div class="stat-card"><div class="label">Lessons</div><div class="value">' + lessonCount + '</div><div class="sub">confidence-scored</div></div>';
       html += '<div class="stat-card"><div class="label">Crystals</div><div class="value">' + crystalCount + '</div><div class="sub">action digests</div></div>';
       html += '<div class="stat-card"><div class="label">Graph Nodes</div><div class="value">' + nodeCount + '</div><div class="sub">' + edgeCount + ' edges</div></div>';

--- a/test/memories-pagination.test.ts
+++ b/test/memories-pagination.test.ts
@@ -35,9 +35,10 @@ describe("memories + export pagination (#544)", () => {
     );
   });
 
-  it("viewer dashboard caps memories?latest fetch with limit", () => {
+  it("viewer dashboard uses the count-only memories endpoint", () => {
     const viewer = readFileSync("src/viewer/index.html", "utf-8");
-    expect(viewer).toMatch(/memories\?latest=true&limit=500/);
+    expect(viewer).toMatch(/memories\?latest=true&count=true/);
+    expect(viewer).not.toMatch(/memories\?latest=true&limit=500/);
     expect(viewer).toMatch(/memories\?latest=true&limit=2000/);
   });
 });

--- a/test/viewer-session-id.test.ts
+++ b/test/viewer-session-id.test.ts
@@ -223,6 +223,35 @@ describe("viewer session rendering", () => {
     expect(getElement("view-dashboard").innerHTML).toContain("Unknown session");
   });
 
+  it("renders the dashboard Memories tile from the loaded long-term corpus", () => {
+    const { sandbox, getElement } = loadViewerSandbox();
+    sandbox.state.dashboard = {
+      loaded: true,
+      health: { status: "healthy", health: {} },
+      sessions: [
+        { id: "sess_1", status: "active", observationCount: 3, summary: { title: "Session summary" } },
+        { id: "sess_2", status: "done", observationCount: 1 },
+      ],
+      memoryCount: 1,
+      graphStats: null,
+      recentAudit: [],
+      semantic: [{ id: "sem_1" }, { id: "sem_2" }],
+      procedural: [{ id: "proc_1" }],
+      relations: [],
+      lessons: [{ id: "lesson_1" }, { id: "lesson_2" }],
+      crystals: [{ id: "crystal_1" }],
+    };
+
+    sandbox.renderDashboard();
+
+    const html = getElement("view-dashboard").innerHTML;
+    expect(html).toContain('<div class="label">Memories</div><div class="value">5</div>');
+    expect(html).toContain('<div class="label">Lessons</div><div class="value">2</div>');
+    expect(html).toContain('<div class="label">Crystals</div><div class="value">1</div>');
+    expect(html).toContain("saved + semantic + summaries + procedural");
+    expect(html).not.toContain('<div class="label">Memories</div><div class="value">1</div>');
+  });
+
   it("does not throw when timeline and sessions tabs receive sessions missing ids", () => {
     const { sandbox, getElement } = loadViewerSandbox();
     const sessions = [{ status: "active", observationCount: 1, startedAt: "2026-05-13T12:00:00Z" }];


### PR DESCRIPTION
Fixes #951

## Summary
- Use the existing count-only memories endpoint for the dashboard saved-memory count instead of fetching a capped latest-memory list.
- Count the Memories tile from the loaded long-term corpus: saved memories, session summaries, semantic facts, and procedural knowledge.
- Keep Lessons and Crystals on their own tiles so their capped dashboard payloads do not distort the Memories total.
- Add regression coverage for the dashboard request and rendered Memories tile.

## Verification
- npx vitest run test/viewer-session-id.test.ts test/memories-pagination.test.ts
- npm run skills:check
- npm test
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The viewer dashboard now shows a unified **Memories** total that combines saved memories, session summaries, semantic facts, and procedural items.
  * A new descriptive sublabel explains which memory types are included in the total.

* **Bug Fixes**
  * The Memories card now reflects the broader long-term corpus instead of only showing the latest saved versions, giving a more accurate dashboard count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->