### PR TITLE
Fix: unified environment behavior

### DIFF
--- a/plugin/scripts/notification.mjs
+++ b/plugin/scripts/notification.mjs
@@ -1,23 +1,10 @@
 #!/usr/bin/env node
 import { execSync } from "node:child_process";
 import { basename, join } from "node:path";
-import { readFileSync } from "node:fs";
+import dotenv from "dotenv";
 import { homedir } from "node:os";
 //#region src/hooks/_env.ts
-const envPath = join(homedir(), ".agentmemory", ".env");
-try {
-	const raw = readFileSync(envPath, "utf8");
-	for (const line of raw.split("\n")) {
-		const trimmed = line.trim();
-		if (!trimmed || trimmed.startsWith("#")) continue;
-		const eq = trimmed.indexOf("=");
-		if (eq < 1) continue;
-		const key = trimmed.slice(0, eq).trim();
-		let val = trimmed.slice(eq + 1).trim();
-		if (val.startsWith("\"") && val.endsWith("\"") || val.startsWith("'") && val.endsWith("'")) val = val.slice(1, -1);
-		if (!(key in process.env)) process.env[key] = val;
-	}
-} catch {}
+dotenv.config({ path: join(homedir(), ".agentmemory", ".env") });
 //#endregion
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {

--- a/plugin/scripts/notification.mjs
+++ b/plugin/scripts/notification.mjs
@@ -1,7 +1,24 @@
 #!/usr/bin/env node
 import { execSync } from "node:child_process";
-import { basename } from "node:path";
-
+import { basename, join } from "node:path";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+//#region src/hooks/_env.ts
+const envPath = join(homedir(), ".agentmemory", ".env");
+try {
+	const raw = readFileSync(envPath, "utf8");
+	for (const line of raw.split("\n")) {
+		const trimmed = line.trim();
+		if (!trimmed || trimmed.startsWith("#")) continue;
+		const eq = trimmed.indexOf("=");
+		if (eq < 1) continue;
+		const key = trimmed.slice(0, eq).trim();
+		let val = trimmed.slice(eq + 1).trim();
+		if (val.startsWith("\"") && val.endsWith("\"") || val.startsWith("'") && val.endsWith("'")) val = val.slice(1, -1);
+		if (!(key in process.env)) process.env[key] = val;
+	}
+} catch {}
+//#endregion
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {
 	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
@@ -21,7 +38,6 @@ function resolveProject(cwd) {
 	} catch {}
 	return basename(dir);
 }
-
 //#endregion
 //#region src/hooks/notification.ts
 function isSdkChildContext(payload) {
@@ -70,7 +86,7 @@ async function main() {
 	setTimeout(() => process.exit(0), 500).unref();
 }
 main();
-
 //#endregion
-export {  };
+export {};
+
 //# sourceMappingURL=notification.mjs.map

--- a/plugin/scripts/notification.mjs
+++ b/plugin/scripts/notification.mjs
@@ -4,7 +4,10 @@ import { basename, join } from "node:path";
 import dotenv from "dotenv";
 import { homedir } from "node:os";
 //#region src/hooks/_env.ts
-dotenv.config({ path: join(homedir(), ".agentmemory", ".env") });
+dotenv.config({
+	path: join(homedir(), ".agentmemory", ".env"),
+	quiet: true
+});
 //#endregion
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {

--- a/plugin/scripts/post-commit.mjs
+++ b/plugin/scripts/post-commit.mjs
@@ -5,7 +5,10 @@ import { join } from "node:path";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 //#region src/hooks/_env.ts
-dotenv.config({ path: join(homedir(), ".agentmemory", ".env") });
+dotenv.config({
+	path: join(homedir(), ".agentmemory", ".env"),
+	quiet: true
+});
 //#endregion
 //#region src/hooks/post-commit.ts
 const exec = promisify(execFile);

--- a/plugin/scripts/post-commit.mjs
+++ b/plugin/scripts/post-commit.mjs
@@ -1,7 +1,25 @@
 #!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-
+//#region src/hooks/_env.ts
+const envPath = join(homedir(), ".agentmemory", ".env");
+try {
+	const raw = readFileSync(envPath, "utf8");
+	for (const line of raw.split("\n")) {
+		const trimmed = line.trim();
+		if (!trimmed || trimmed.startsWith("#")) continue;
+		const eq = trimmed.indexOf("=");
+		if (eq < 1) continue;
+		const key = trimmed.slice(0, eq).trim();
+		let val = trimmed.slice(eq + 1).trim();
+		if (val.startsWith("\"") && val.endsWith("\"") || val.startsWith("'") && val.endsWith("'")) val = val.slice(1, -1);
+		if (!(key in process.env)) process.env[key] = val;
+	}
+} catch {}
+//#endregion
 //#region src/hooks/post-commit.ts
 const exec = promisify(execFile);
 function isSdkChildContext(payload) {
@@ -96,7 +114,7 @@ async function main() {
 	} catch {}
 }
 main();
-
 //#endregion
-export {  };
+export {};
+
 //# sourceMappingURL=post-commit.mjs.map

--- a/plugin/scripts/post-commit.mjs
+++ b/plugin/scripts/post-commit.mjs
@@ -1,24 +1,11 @@
 #!/usr/bin/env node
-import { readFileSync } from "node:fs";
+import dotenv from "dotenv";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 //#region src/hooks/_env.ts
-const envPath = join(homedir(), ".agentmemory", ".env");
-try {
-	const raw = readFileSync(envPath, "utf8");
-	for (const line of raw.split("\n")) {
-		const trimmed = line.trim();
-		if (!trimmed || trimmed.startsWith("#")) continue;
-		const eq = trimmed.indexOf("=");
-		if (eq < 1) continue;
-		const key = trimmed.slice(0, eq).trim();
-		let val = trimmed.slice(eq + 1).trim();
-		if (val.startsWith("\"") && val.endsWith("\"") || val.startsWith("'") && val.endsWith("'")) val = val.slice(1, -1);
-		if (!(key in process.env)) process.env[key] = val;
-	}
-} catch {}
+dotenv.config({ path: join(homedir(), ".agentmemory", ".env") });
 //#endregion
 //#region src/hooks/post-commit.ts
 const exec = promisify(execFile);

--- a/plugin/scripts/post-tool-failure.mjs
+++ b/plugin/scripts/post-tool-failure.mjs
@@ -1,23 +1,10 @@
 #!/usr/bin/env node
 import { execSync } from "node:child_process";
 import { basename, join } from "node:path";
-import { readFileSync } from "node:fs";
+import dotenv from "dotenv";
 import { homedir } from "node:os";
 //#region src/hooks/_env.ts
-const envPath = join(homedir(), ".agentmemory", ".env");
-try {
-	const raw = readFileSync(envPath, "utf8");
-	for (const line of raw.split("\n")) {
-		const trimmed = line.trim();
-		if (!trimmed || trimmed.startsWith("#")) continue;
-		const eq = trimmed.indexOf("=");
-		if (eq < 1) continue;
-		const key = trimmed.slice(0, eq).trim();
-		let val = trimmed.slice(eq + 1).trim();
-		if (val.startsWith("\"") && val.endsWith("\"") || val.startsWith("'") && val.endsWith("'")) val = val.slice(1, -1);
-		if (!(key in process.env)) process.env[key] = val;
-	}
-} catch {}
+dotenv.config({ path: join(homedir(), ".agentmemory", ".env") });
 //#endregion
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {

--- a/plugin/scripts/post-tool-failure.mjs
+++ b/plugin/scripts/post-tool-failure.mjs
@@ -4,7 +4,10 @@ import { basename, join } from "node:path";
 import dotenv from "dotenv";
 import { homedir } from "node:os";
 //#region src/hooks/_env.ts
-dotenv.config({ path: join(homedir(), ".agentmemory", ".env") });
+dotenv.config({
+	path: join(homedir(), ".agentmemory", ".env"),
+	quiet: true
+});
 //#endregion
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {

--- a/plugin/scripts/post-tool-failure.mjs
+++ b/plugin/scripts/post-tool-failure.mjs
@@ -1,7 +1,24 @@
 #!/usr/bin/env node
 import { execSync } from "node:child_process";
-import { basename } from "node:path";
-
+import { basename, join } from "node:path";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+//#region src/hooks/_env.ts
+const envPath = join(homedir(), ".agentmemory", ".env");
+try {
+	const raw = readFileSync(envPath, "utf8");
+	for (const line of raw.split("\n")) {
+		const trimmed = line.trim();
+		if (!trimmed || trimmed.startsWith("#")) continue;
+		const eq = trimmed.indexOf("=");
+		if (eq < 1) continue;
+		const key = trimmed.slice(0, eq).trim();
+		let val = trimmed.slice(eq + 1).trim();
+		if (val.startsWith("\"") && val.endsWith("\"") || val.startsWith("'") && val.endsWith("'")) val = val.slice(1, -1);
+		if (!(key in process.env)) process.env[key] = val;
+	}
+} catch {}
+//#endregion
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {
 	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
@@ -21,7 +38,6 @@ function resolveProject(cwd) {
 	} catch {}
 	return basename(dir);
 }
-
 //#endregion
 //#region src/hooks/post-tool-failure.ts
 function isSdkChildContext(payload) {
@@ -71,7 +87,7 @@ async function main() {
 	setTimeout(() => process.exit(0), 500).unref();
 }
 main();
-
 //#endregion
-export {  };
+export {};
+
 //# sourceMappingURL=post-tool-failure.mjs.map

--- a/plugin/scripts/post-tool-use.mjs
+++ b/plugin/scripts/post-tool-use.mjs
@@ -1,7 +1,24 @@
 #!/usr/bin/env node
 import { execSync } from "node:child_process";
-import { basename } from "node:path";
-
+import { basename, join } from "node:path";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+//#region src/hooks/_env.ts
+const envPath = join(homedir(), ".agentmemory", ".env");
+try {
+	const raw = readFileSync(envPath, "utf8");
+	for (const line of raw.split("\n")) {
+		const trimmed = line.trim();
+		if (!trimmed || trimmed.startsWith("#")) continue;
+		const eq = trimmed.indexOf("=");
+		if (eq < 1) continue;
+		const key = trimmed.slice(0, eq).trim();
+		let val = trimmed.slice(eq + 1).trim();
+		if (val.startsWith("\"") && val.endsWith("\"") || val.startsWith("'") && val.endsWith("'")) val = val.slice(1, -1);
+		if (!(key in process.env)) process.env[key] = val;
+	}
+} catch {}
+//#endregion
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {
 	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
@@ -21,7 +38,6 @@ function resolveProject(cwd) {
 	} catch {}
 	return basename(dir);
 }
-
 //#endregion
 //#region src/hooks/post-tool-use.ts
 function isSdkChildContext(payload) {
@@ -116,7 +132,7 @@ function truncate(value, max) {
 	return value;
 }
 main();
-
 //#endregion
-export {  };
+export {};
+
 //# sourceMappingURL=post-tool-use.mjs.map

--- a/plugin/scripts/post-tool-use.mjs
+++ b/plugin/scripts/post-tool-use.mjs
@@ -1,23 +1,10 @@
 #!/usr/bin/env node
 import { execSync } from "node:child_process";
 import { basename, join } from "node:path";
-import { readFileSync } from "node:fs";
+import dotenv from "dotenv";
 import { homedir } from "node:os";
 //#region src/hooks/_env.ts
-const envPath = join(homedir(), ".agentmemory", ".env");
-try {
-	const raw = readFileSync(envPath, "utf8");
-	for (const line of raw.split("\n")) {
-		const trimmed = line.trim();
-		if (!trimmed || trimmed.startsWith("#")) continue;
-		const eq = trimmed.indexOf("=");
-		if (eq < 1) continue;
-		const key = trimmed.slice(0, eq).trim();
-		let val = trimmed.slice(eq + 1).trim();
-		if (val.startsWith("\"") && val.endsWith("\"") || val.startsWith("'") && val.endsWith("'")) val = val.slice(1, -1);
-		if (!(key in process.env)) process.env[key] = val;
-	}
-} catch {}
+dotenv.config({ path: join(homedir(), ".agentmemory", ".env") });
 //#endregion
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {

--- a/plugin/scripts/post-tool-use.mjs
+++ b/plugin/scripts/post-tool-use.mjs
@@ -4,7 +4,10 @@ import { basename, join } from "node:path";
 import dotenv from "dotenv";
 import { homedir } from "node:os";
 //#region src/hooks/_env.ts
-dotenv.config({ path: join(homedir(), ".agentmemory", ".env") });
+dotenv.config({
+	path: join(homedir(), ".agentmemory", ".env"),
+	quiet: true
+});
 //#endregion
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {

--- a/plugin/scripts/pre-compact.mjs
+++ b/plugin/scripts/pre-compact.mjs
@@ -1,7 +1,24 @@
 #!/usr/bin/env node
 import { execSync } from "node:child_process";
-import { basename } from "node:path";
-
+import { basename, join } from "node:path";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+//#region src/hooks/_env.ts
+const envPath = join(homedir(), ".agentmemory", ".env");
+try {
+	const raw = readFileSync(envPath, "utf8");
+	for (const line of raw.split("\n")) {
+		const trimmed = line.trim();
+		if (!trimmed || trimmed.startsWith("#")) continue;
+		const eq = trimmed.indexOf("=");
+		if (eq < 1) continue;
+		const key = trimmed.slice(0, eq).trim();
+		let val = trimmed.slice(eq + 1).trim();
+		if (val.startsWith("\"") && val.endsWith("\"") || val.startsWith("'") && val.endsWith("'")) val = val.slice(1, -1);
+		if (!(key in process.env)) process.env[key] = val;
+	}
+} catch {}
+//#endregion
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {
 	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
@@ -21,7 +38,6 @@ function resolveProject(cwd) {
 	} catch {}
 	return basename(dir);
 }
-
 //#endregion
 //#region src/hooks/pre-compact.ts
 function isSdkChildContext(payload) {
@@ -74,7 +90,7 @@ async function main() {
 	} catch {}
 }
 main();
-
 //#endregion
-export {  };
+export {};
+
 //# sourceMappingURL=pre-compact.mjs.map

--- a/plugin/scripts/pre-compact.mjs
+++ b/plugin/scripts/pre-compact.mjs
@@ -1,23 +1,10 @@
 #!/usr/bin/env node
 import { execSync } from "node:child_process";
 import { basename, join } from "node:path";
-import { readFileSync } from "node:fs";
+import dotenv from "dotenv";
 import { homedir } from "node:os";
 //#region src/hooks/_env.ts
-const envPath = join(homedir(), ".agentmemory", ".env");
-try {
-	const raw = readFileSync(envPath, "utf8");
-	for (const line of raw.split("\n")) {
-		const trimmed = line.trim();
-		if (!trimmed || trimmed.startsWith("#")) continue;
-		const eq = trimmed.indexOf("=");
-		if (eq < 1) continue;
-		const key = trimmed.slice(0, eq).trim();
-		let val = trimmed.slice(eq + 1).trim();
-		if (val.startsWith("\"") && val.endsWith("\"") || val.startsWith("'") && val.endsWith("'")) val = val.slice(1, -1);
-		if (!(key in process.env)) process.env[key] = val;
-	}
-} catch {}
+dotenv.config({ path: join(homedir(), ".agentmemory", ".env") });
 //#endregion
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {

--- a/plugin/scripts/pre-compact.mjs
+++ b/plugin/scripts/pre-compact.mjs
@@ -4,7 +4,10 @@ import { basename, join } from "node:path";
 import dotenv from "dotenv";
 import { homedir } from "node:os";
 //#region src/hooks/_env.ts
-dotenv.config({ path: join(homedir(), ".agentmemory", ".env") });
+dotenv.config({
+	path: join(homedir(), ".agentmemory", ".env"),
+	quiet: true
+});
 //#endregion
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {

--- a/plugin/scripts/pre-tool-use.mjs
+++ b/plugin/scripts/pre-tool-use.mjs
@@ -1,4 +1,23 @@
 #!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+//#region src/hooks/_env.ts
+const envPath = join(homedir(), ".agentmemory", ".env");
+try {
+	const raw = readFileSync(envPath, "utf8");
+	for (const line of raw.split("\n")) {
+		const trimmed = line.trim();
+		if (!trimmed || trimmed.startsWith("#")) continue;
+		const eq = trimmed.indexOf("=");
+		if (eq < 1) continue;
+		const key = trimmed.slice(0, eq).trim();
+		let val = trimmed.slice(eq + 1).trim();
+		if (val.startsWith("\"") && val.endsWith("\"") || val.startsWith("'") && val.endsWith("'")) val = val.slice(1, -1);
+		if (!(key in process.env)) process.env[key] = val;
+	}
+} catch {}
+//#endregion
 //#region src/hooks/pre-tool-use.ts
 function isSdkChildContext(payload) {
 	if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -78,7 +97,7 @@ async function main() {
 	} catch {}
 }
 main();
-
 //#endregion
-export {  };
+export {};
+
 //# sourceMappingURL=pre-tool-use.mjs.map

--- a/plugin/scripts/pre-tool-use.mjs
+++ b/plugin/scripts/pre-tool-use.mjs
@@ -1,22 +1,9 @@
 #!/usr/bin/env node
-import { readFileSync } from "node:fs";
+import dotenv from "dotenv";
 import { homedir } from "node:os";
 import { join } from "node:path";
 //#region src/hooks/_env.ts
-const envPath = join(homedir(), ".agentmemory", ".env");
-try {
-	const raw = readFileSync(envPath, "utf8");
-	for (const line of raw.split("\n")) {
-		const trimmed = line.trim();
-		if (!trimmed || trimmed.startsWith("#")) continue;
-		const eq = trimmed.indexOf("=");
-		if (eq < 1) continue;
-		const key = trimmed.slice(0, eq).trim();
-		let val = trimmed.slice(eq + 1).trim();
-		if (val.startsWith("\"") && val.endsWith("\"") || val.startsWith("'") && val.endsWith("'")) val = val.slice(1, -1);
-		if (!(key in process.env)) process.env[key] = val;
-	}
-} catch {}
+dotenv.config({ path: join(homedir(), ".agentmemory", ".env") });
 //#endregion
 //#region src/hooks/pre-tool-use.ts
 function isSdkChildContext(payload) {

--- a/plugin/scripts/pre-tool-use.mjs
+++ b/plugin/scripts/pre-tool-use.mjs
@@ -3,7 +3,10 @@ import dotenv from "dotenv";
 import { homedir } from "node:os";
 import { join } from "node:path";
 //#region src/hooks/_env.ts
-dotenv.config({ path: join(homedir(), ".agentmemory", ".env") });
+dotenv.config({
+	path: join(homedir(), ".agentmemory", ".env"),
+	quiet: true
+});
 //#endregion
 //#region src/hooks/pre-tool-use.ts
 function isSdkChildContext(payload) {

--- a/plugin/scripts/prompt-submit.mjs
+++ b/plugin/scripts/prompt-submit.mjs
@@ -1,23 +1,10 @@
 #!/usr/bin/env node
 import { execSync } from "node:child_process";
 import { basename, join } from "node:path";
-import { readFileSync } from "node:fs";
+import dotenv from "dotenv";
 import { homedir } from "node:os";
 //#region src/hooks/_env.ts
-const envPath = join(homedir(), ".agentmemory", ".env");
-try {
-	const raw = readFileSync(envPath, "utf8");
-	for (const line of raw.split("\n")) {
-		const trimmed = line.trim();
-		if (!trimmed || trimmed.startsWith("#")) continue;
-		const eq = trimmed.indexOf("=");
-		if (eq < 1) continue;
-		const key = trimmed.slice(0, eq).trim();
-		let val = trimmed.slice(eq + 1).trim();
-		if (val.startsWith("\"") && val.endsWith("\"") || val.startsWith("'") && val.endsWith("'")) val = val.slice(1, -1);
-		if (!(key in process.env)) process.env[key] = val;
-	}
-} catch {}
+dotenv.config({ path: join(homedir(), ".agentmemory", ".env") });
 //#endregion
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {

--- a/plugin/scripts/prompt-submit.mjs
+++ b/plugin/scripts/prompt-submit.mjs
@@ -1,7 +1,24 @@
 #!/usr/bin/env node
 import { execSync } from "node:child_process";
-import { basename } from "node:path";
-
+import { basename, join } from "node:path";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+//#region src/hooks/_env.ts
+const envPath = join(homedir(), ".agentmemory", ".env");
+try {
+	const raw = readFileSync(envPath, "utf8");
+	for (const line of raw.split("\n")) {
+		const trimmed = line.trim();
+		if (!trimmed || trimmed.startsWith("#")) continue;
+		const eq = trimmed.indexOf("=");
+		if (eq < 1) continue;
+		const key = trimmed.slice(0, eq).trim();
+		let val = trimmed.slice(eq + 1).trim();
+		if (val.startsWith("\"") && val.endsWith("\"") || val.startsWith("'") && val.endsWith("'")) val = val.slice(1, -1);
+		if (!(key in process.env)) process.env[key] = val;
+	}
+} catch {}
+//#endregion
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {
 	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
@@ -21,7 +38,6 @@ function resolveProject(cwd) {
 	} catch {}
 	return basename(dir);
 }
-
 //#endregion
 //#region src/hooks/prompt-submit.ts
 function isSdkChildContext(payload) {
@@ -63,7 +79,7 @@ async function main() {
 	setTimeout(() => process.exit(0), 500).unref();
 }
 main();
-
 //#endregion
-export {  };
+export {};
+
 //# sourceMappingURL=prompt-submit.mjs.map

--- a/plugin/scripts/prompt-submit.mjs
+++ b/plugin/scripts/prompt-submit.mjs
@@ -4,7 +4,10 @@ import { basename, join } from "node:path";
 import dotenv from "dotenv";
 import { homedir } from "node:os";
 //#region src/hooks/_env.ts
-dotenv.config({ path: join(homedir(), ".agentmemory", ".env") });
+dotenv.config({
+	path: join(homedir(), ".agentmemory", ".env"),
+	quiet: true
+});
 //#endregion
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {

--- a/plugin/scripts/session-end.mjs
+++ b/plugin/scripts/session-end.mjs
@@ -1,4 +1,23 @@
 #!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+//#region src/hooks/_env.ts
+const envPath = join(homedir(), ".agentmemory", ".env");
+try {
+	const raw = readFileSync(envPath, "utf8");
+	for (const line of raw.split("\n")) {
+		const trimmed = line.trim();
+		if (!trimmed || trimmed.startsWith("#")) continue;
+		const eq = trimmed.indexOf("=");
+		if (eq < 1) continue;
+		const key = trimmed.slice(0, eq).trim();
+		let val = trimmed.slice(eq + 1).trim();
+		if (val.startsWith("\"") && val.endsWith("\"") || val.startsWith("'") && val.endsWith("'")) val = val.slice(1, -1);
+		if (!(key in process.env)) process.env[key] = val;
+	}
+} catch {}
+//#endregion
 //#region src/hooks/session-end.ts
 function isSdkChildContext(payload) {
 	if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -54,7 +73,7 @@ async function main() {
 	setTimeout(() => process.exit(0), 1500).unref();
 }
 main();
-
 //#endregion
-export {  };
+export {};
+
 //# sourceMappingURL=session-end.mjs.map

--- a/plugin/scripts/session-end.mjs
+++ b/plugin/scripts/session-end.mjs
@@ -1,22 +1,9 @@
 #!/usr/bin/env node
-import { readFileSync } from "node:fs";
+import dotenv from "dotenv";
 import { homedir } from "node:os";
 import { join } from "node:path";
 //#region src/hooks/_env.ts
-const envPath = join(homedir(), ".agentmemory", ".env");
-try {
-	const raw = readFileSync(envPath, "utf8");
-	for (const line of raw.split("\n")) {
-		const trimmed = line.trim();
-		if (!trimmed || trimmed.startsWith("#")) continue;
-		const eq = trimmed.indexOf("=");
-		if (eq < 1) continue;
-		const key = trimmed.slice(0, eq).trim();
-		let val = trimmed.slice(eq + 1).trim();
-		if (val.startsWith("\"") && val.endsWith("\"") || val.startsWith("'") && val.endsWith("'")) val = val.slice(1, -1);
-		if (!(key in process.env)) process.env[key] = val;
-	}
-} catch {}
+dotenv.config({ path: join(homedir(), ".agentmemory", ".env") });
 //#endregion
 //#region src/hooks/session-end.ts
 function isSdkChildContext(payload) {

--- a/plugin/scripts/session-end.mjs
+++ b/plugin/scripts/session-end.mjs
@@ -3,7 +3,10 @@ import dotenv from "dotenv";
 import { homedir } from "node:os";
 import { join } from "node:path";
 //#region src/hooks/_env.ts
-dotenv.config({ path: join(homedir(), ".agentmemory", ".env") });
+dotenv.config({
+	path: join(homedir(), ".agentmemory", ".env"),
+	quiet: true
+});
 //#endregion
 //#region src/hooks/session-end.ts
 function isSdkChildContext(payload) {

--- a/plugin/scripts/session-start.mjs
+++ b/plugin/scripts/session-start.mjs
@@ -1,7 +1,24 @@
 #!/usr/bin/env node
 import { execSync } from "node:child_process";
-import { basename } from "node:path";
-
+import { basename, join } from "node:path";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+//#region src/hooks/_env.ts
+const envPath = join(homedir(), ".agentmemory", ".env");
+try {
+	const raw = readFileSync(envPath, "utf8");
+	for (const line of raw.split("\n")) {
+		const trimmed = line.trim();
+		if (!trimmed || trimmed.startsWith("#")) continue;
+		const eq = trimmed.indexOf("=");
+		if (eq < 1) continue;
+		const key = trimmed.slice(0, eq).trim();
+		let val = trimmed.slice(eq + 1).trim();
+		if (val.startsWith("\"") && val.endsWith("\"") || val.startsWith("'") && val.endsWith("'")) val = val.slice(1, -1);
+		if (!(key in process.env)) process.env[key] = val;
+	}
+} catch {}
+//#endregion
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {
 	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
@@ -21,7 +38,6 @@ function resolveProject(cwd) {
 	} catch {}
 	return basename(dir);
 }
-
 //#endregion
 //#region src/hooks/session-start.ts
 function isSdkChildContext(payload) {
@@ -81,7 +97,7 @@ async function main() {
 	} catch {}
 }
 main();
-
 //#endregion
-export {  };
+export {};
+
 //# sourceMappingURL=session-start.mjs.map

--- a/plugin/scripts/session-start.mjs
+++ b/plugin/scripts/session-start.mjs
@@ -1,23 +1,10 @@
 #!/usr/bin/env node
 import { execSync } from "node:child_process";
 import { basename, join } from "node:path";
-import { readFileSync } from "node:fs";
+import dotenv from "dotenv";
 import { homedir } from "node:os";
 //#region src/hooks/_env.ts
-const envPath = join(homedir(), ".agentmemory", ".env");
-try {
-	const raw = readFileSync(envPath, "utf8");
-	for (const line of raw.split("\n")) {
-		const trimmed = line.trim();
-		if (!trimmed || trimmed.startsWith("#")) continue;
-		const eq = trimmed.indexOf("=");
-		if (eq < 1) continue;
-		const key = trimmed.slice(0, eq).trim();
-		let val = trimmed.slice(eq + 1).trim();
-		if (val.startsWith("\"") && val.endsWith("\"") || val.startsWith("'") && val.endsWith("'")) val = val.slice(1, -1);
-		if (!(key in process.env)) process.env[key] = val;
-	}
-} catch {}
+dotenv.config({ path: join(homedir(), ".agentmemory", ".env") });
 //#endregion
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {

--- a/plugin/scripts/session-start.mjs
+++ b/plugin/scripts/session-start.mjs
@@ -4,7 +4,10 @@ import { basename, join } from "node:path";
 import dotenv from "dotenv";
 import { homedir } from "node:os";
 //#region src/hooks/_env.ts
-dotenv.config({ path: join(homedir(), ".agentmemory", ".env") });
+dotenv.config({
+	path: join(homedir(), ".agentmemory", ".env"),
+	quiet: true
+});
 //#endregion
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {

--- a/plugin/scripts/stop.mjs
+++ b/plugin/scripts/stop.mjs
@@ -1,22 +1,9 @@
 #!/usr/bin/env node
-import { readFileSync } from "node:fs";
+import dotenv from "dotenv";
 import { homedir } from "node:os";
 import { join } from "node:path";
 //#region src/hooks/_env.ts
-const envPath = join(homedir(), ".agentmemory", ".env");
-try {
-	const raw = readFileSync(envPath, "utf8");
-	for (const line of raw.split("\n")) {
-		const trimmed = line.trim();
-		if (!trimmed || trimmed.startsWith("#")) continue;
-		const eq = trimmed.indexOf("=");
-		if (eq < 1) continue;
-		const key = trimmed.slice(0, eq).trim();
-		let val = trimmed.slice(eq + 1).trim();
-		if (val.startsWith("\"") && val.endsWith("\"") || val.startsWith("'") && val.endsWith("'")) val = val.slice(1, -1);
-		if (!(key in process.env)) process.env[key] = val;
-	}
-} catch {}
+dotenv.config({ path: join(homedir(), ".agentmemory", ".env") });
 //#endregion
 //#region src/hooks/stop.ts
 function isSdkChildContext(payload) {

--- a/plugin/scripts/stop.mjs
+++ b/plugin/scripts/stop.mjs
@@ -3,7 +3,10 @@ import dotenv from "dotenv";
 import { homedir } from "node:os";
 import { join } from "node:path";
 //#region src/hooks/_env.ts
-dotenv.config({ path: join(homedir(), ".agentmemory", ".env") });
+dotenv.config({
+	path: join(homedir(), ".agentmemory", ".env"),
+	quiet: true
+});
 //#endregion
 //#region src/hooks/stop.ts
 function isSdkChildContext(payload) {

--- a/plugin/scripts/stop.mjs
+++ b/plugin/scripts/stop.mjs
@@ -1,4 +1,23 @@
 #!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+//#region src/hooks/_env.ts
+const envPath = join(homedir(), ".agentmemory", ".env");
+try {
+	const raw = readFileSync(envPath, "utf8");
+	for (const line of raw.split("\n")) {
+		const trimmed = line.trim();
+		if (!trimmed || trimmed.startsWith("#")) continue;
+		const eq = trimmed.indexOf("=");
+		if (eq < 1) continue;
+		const key = trimmed.slice(0, eq).trim();
+		let val = trimmed.slice(eq + 1).trim();
+		if (val.startsWith("\"") && val.endsWith("\"") || val.startsWith("'") && val.endsWith("'")) val = val.slice(1, -1);
+		if (!(key in process.env)) process.env[key] = val;
+	}
+} catch {}
+//#endregion
 //#region src/hooks/stop.ts
 function isSdkChildContext(payload) {
 	if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -38,7 +57,7 @@ async function main() {
 	setTimeout(() => process.exit(0), 1500).unref();
 }
 main();
-
 //#endregion
-export {  };
+export {};
+
 //# sourceMappingURL=stop.mjs.map

--- a/plugin/scripts/subagent-start.mjs
+++ b/plugin/scripts/subagent-start.mjs
@@ -1,7 +1,24 @@
 #!/usr/bin/env node
 import { execSync } from "node:child_process";
-import { basename } from "node:path";
-
+import { basename, join } from "node:path";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+//#region src/hooks/_env.ts
+const envPath = join(homedir(), ".agentmemory", ".env");
+try {
+	const raw = readFileSync(envPath, "utf8");
+	for (const line of raw.split("\n")) {
+		const trimmed = line.trim();
+		if (!trimmed || trimmed.startsWith("#")) continue;
+		const eq = trimmed.indexOf("=");
+		if (eq < 1) continue;
+		const key = trimmed.slice(0, eq).trim();
+		let val = trimmed.slice(eq + 1).trim();
+		if (val.startsWith("\"") && val.endsWith("\"") || val.startsWith("'") && val.endsWith("'")) val = val.slice(1, -1);
+		if (!(key in process.env)) process.env[key] = val;
+	}
+} catch {}
+//#endregion
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {
 	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
@@ -21,7 +38,6 @@ function resolveProject(cwd) {
 	} catch {}
 	return basename(dir);
 }
-
 //#endregion
 //#region src/hooks/subagent-start.ts
 function isSdkChildContext(payload) {
@@ -69,7 +85,7 @@ async function main() {
 	setTimeout(() => process.exit(0), 500).unref();
 }
 main();
-
 //#endregion
-export {  };
+export {};
+
 //# sourceMappingURL=subagent-start.mjs.map

--- a/plugin/scripts/subagent-start.mjs
+++ b/plugin/scripts/subagent-start.mjs
@@ -1,23 +1,10 @@
 #!/usr/bin/env node
 import { execSync } from "node:child_process";
 import { basename, join } from "node:path";
-import { readFileSync } from "node:fs";
+import dotenv from "dotenv";
 import { homedir } from "node:os";
 //#region src/hooks/_env.ts
-const envPath = join(homedir(), ".agentmemory", ".env");
-try {
-	const raw = readFileSync(envPath, "utf8");
-	for (const line of raw.split("\n")) {
-		const trimmed = line.trim();
-		if (!trimmed || trimmed.startsWith("#")) continue;
-		const eq = trimmed.indexOf("=");
-		if (eq < 1) continue;
-		const key = trimmed.slice(0, eq).trim();
-		let val = trimmed.slice(eq + 1).trim();
-		if (val.startsWith("\"") && val.endsWith("\"") || val.startsWith("'") && val.endsWith("'")) val = val.slice(1, -1);
-		if (!(key in process.env)) process.env[key] = val;
-	}
-} catch {}
+dotenv.config({ path: join(homedir(), ".agentmemory", ".env") });
 //#endregion
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {

--- a/plugin/scripts/subagent-start.mjs
+++ b/plugin/scripts/subagent-start.mjs
@@ -4,7 +4,10 @@ import { basename, join } from "node:path";
 import dotenv from "dotenv";
 import { homedir } from "node:os";
 //#region src/hooks/_env.ts
-dotenv.config({ path: join(homedir(), ".agentmemory", ".env") });
+dotenv.config({
+	path: join(homedir(), ".agentmemory", ".env"),
+	quiet: true
+});
 //#endregion
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {

--- a/plugin/scripts/subagent-stop.mjs
+++ b/plugin/scripts/subagent-stop.mjs
@@ -1,7 +1,24 @@
 #!/usr/bin/env node
 import { execSync } from "node:child_process";
-import { basename } from "node:path";
-
+import { basename, join } from "node:path";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+//#region src/hooks/_env.ts
+const envPath = join(homedir(), ".agentmemory", ".env");
+try {
+	const raw = readFileSync(envPath, "utf8");
+	for (const line of raw.split("\n")) {
+		const trimmed = line.trim();
+		if (!trimmed || trimmed.startsWith("#")) continue;
+		const eq = trimmed.indexOf("=");
+		if (eq < 1) continue;
+		const key = trimmed.slice(0, eq).trim();
+		let val = trimmed.slice(eq + 1).trim();
+		if (val.startsWith("\"") && val.endsWith("\"") || val.startsWith("'") && val.endsWith("'")) val = val.slice(1, -1);
+		if (!(key in process.env)) process.env[key] = val;
+	}
+} catch {}
+//#endregion
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {
 	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
@@ -21,7 +38,6 @@ function resolveProject(cwd) {
 	} catch {}
 	return basename(dir);
 }
-
 //#endregion
 //#region src/hooks/subagent-stop.ts
 function isSdkChildContext(payload) {
@@ -70,7 +86,7 @@ async function main() {
 	setTimeout(() => process.exit(0), 500).unref();
 }
 main();
-
 //#endregion
-export {  };
+export {};
+
 //# sourceMappingURL=subagent-stop.mjs.map

--- a/plugin/scripts/subagent-stop.mjs
+++ b/plugin/scripts/subagent-stop.mjs
@@ -1,23 +1,10 @@
 #!/usr/bin/env node
 import { execSync } from "node:child_process";
 import { basename, join } from "node:path";
-import { readFileSync } from "node:fs";
+import dotenv from "dotenv";
 import { homedir } from "node:os";
 //#region src/hooks/_env.ts
-const envPath = join(homedir(), ".agentmemory", ".env");
-try {
-	const raw = readFileSync(envPath, "utf8");
-	for (const line of raw.split("\n")) {
-		const trimmed = line.trim();
-		if (!trimmed || trimmed.startsWith("#")) continue;
-		const eq = trimmed.indexOf("=");
-		if (eq < 1) continue;
-		const key = trimmed.slice(0, eq).trim();
-		let val = trimmed.slice(eq + 1).trim();
-		if (val.startsWith("\"") && val.endsWith("\"") || val.startsWith("'") && val.endsWith("'")) val = val.slice(1, -1);
-		if (!(key in process.env)) process.env[key] = val;
-	}
-} catch {}
+dotenv.config({ path: join(homedir(), ".agentmemory", ".env") });
 //#endregion
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {

--- a/plugin/scripts/subagent-stop.mjs
+++ b/plugin/scripts/subagent-stop.mjs
@@ -4,7 +4,10 @@ import { basename, join } from "node:path";
 import dotenv from "dotenv";
 import { homedir } from "node:os";
 //#region src/hooks/_env.ts
-dotenv.config({ path: join(homedir(), ".agentmemory", ".env") });
+dotenv.config({
+	path: join(homedir(), ".agentmemory", ".env"),
+	quiet: true
+});
 //#endregion
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {

--- a/plugin/scripts/task-completed.mjs
+++ b/plugin/scripts/task-completed.mjs
@@ -1,7 +1,24 @@
 #!/usr/bin/env node
 import { execSync } from "node:child_process";
-import { basename } from "node:path";
-
+import { basename, join } from "node:path";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+//#region src/hooks/_env.ts
+const envPath = join(homedir(), ".agentmemory", ".env");
+try {
+	const raw = readFileSync(envPath, "utf8");
+	for (const line of raw.split("\n")) {
+		const trimmed = line.trim();
+		if (!trimmed || trimmed.startsWith("#")) continue;
+		const eq = trimmed.indexOf("=");
+		if (eq < 1) continue;
+		const key = trimmed.slice(0, eq).trim();
+		let val = trimmed.slice(eq + 1).trim();
+		if (val.startsWith("\"") && val.endsWith("\"") || val.startsWith("'") && val.endsWith("'")) val = val.slice(1, -1);
+		if (!(key in process.env)) process.env[key] = val;
+	}
+} catch {}
+//#endregion
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {
 	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
@@ -21,7 +38,6 @@ function resolveProject(cwd) {
 	} catch {}
 	return basename(dir);
 }
-
 //#endregion
 //#region src/hooks/task-completed.ts
 function isSdkChildContext(payload) {
@@ -69,7 +85,7 @@ async function main() {
 	setTimeout(() => process.exit(0), 500).unref();
 }
 main();
-
 //#endregion
-export {  };
+export {};
+
 //# sourceMappingURL=task-completed.mjs.map

--- a/plugin/scripts/task-completed.mjs
+++ b/plugin/scripts/task-completed.mjs
@@ -1,23 +1,10 @@
 #!/usr/bin/env node
 import { execSync } from "node:child_process";
 import { basename, join } from "node:path";
-import { readFileSync } from "node:fs";
+import dotenv from "dotenv";
 import { homedir } from "node:os";
 //#region src/hooks/_env.ts
-const envPath = join(homedir(), ".agentmemory", ".env");
-try {
-	const raw = readFileSync(envPath, "utf8");
-	for (const line of raw.split("\n")) {
-		const trimmed = line.trim();
-		if (!trimmed || trimmed.startsWith("#")) continue;
-		const eq = trimmed.indexOf("=");
-		if (eq < 1) continue;
-		const key = trimmed.slice(0, eq).trim();
-		let val = trimmed.slice(eq + 1).trim();
-		if (val.startsWith("\"") && val.endsWith("\"") || val.startsWith("'") && val.endsWith("'")) val = val.slice(1, -1);
-		if (!(key in process.env)) process.env[key] = val;
-	}
-} catch {}
+dotenv.config({ path: join(homedir(), ".agentmemory", ".env") });
 //#endregion
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {

--- a/plugin/scripts/task-completed.mjs
+++ b/plugin/scripts/task-completed.mjs
@@ -4,7 +4,10 @@ import { basename, join } from "node:path";
 import dotenv from "dotenv";
 import { homedir } from "node:os";
 //#region src/hooks/_env.ts
-dotenv.config({ path: join(homedir(), ".agentmemory", ".env") });
+dotenv.config({
+	path: join(homedir(), ".agentmemory", ".env"),
+	quiet: true
+});
 //#endregion
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {

--- a/src/hooks/_env.ts
+++ b/src/hooks/_env.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// Load ~/.agentmemory/.env into process.env before any hook reads env vars.
+// Keys already set in the environment (e.g. via Claude Code settings.json or
+// the shell) take priority — this only fills gaps.
+const envPath = join(homedir(), ".agentmemory", ".env");
+try {
+  const raw = readFileSync(envPath, "utf8");
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq < 1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    let val = trimmed.slice(eq + 1).trim();
+    if (
+      (val.startsWith('"') && val.endsWith('"')) ||
+      (val.startsWith("'") && val.endsWith("'"))
+    ) {
+      val = val.slice(1, -1);
+    }
+    if (!(key in process.env)) {
+      process.env[key] = val;
+    }
+  }
+} catch {
+  // file absent or unreadable — skip silently
+}

--- a/src/hooks/_env.ts
+++ b/src/hooks/_env.ts
@@ -1,30 +1,8 @@
-import { readFileSync } from "node:fs";
+import dotenv from "dotenv";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
 // Load ~/.agentmemory/.env into process.env before any hook reads env vars.
 // Keys already set in the environment (e.g. via Claude Code settings.json or
-// the shell) take priority — this only fills gaps.
-const envPath = join(homedir(), ".agentmemory", ".env");
-try {
-  const raw = readFileSync(envPath, "utf8");
-  for (const line of raw.split("\n")) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith("#")) continue;
-    const eq = trimmed.indexOf("=");
-    if (eq < 1) continue;
-    const key = trimmed.slice(0, eq).trim();
-    let val = trimmed.slice(eq + 1).trim();
-    if (
-      (val.startsWith('"') && val.endsWith('"')) ||
-      (val.startsWith("'") && val.endsWith("'"))
-    ) {
-      val = val.slice(1, -1);
-    }
-    if (!(key in process.env)) {
-      process.env[key] = val;
-    }
-  }
-} catch {
-  // file absent or unreadable — skip silently
-}
+// the shell) take priority — dotenv.config() does not override by default.
+dotenv.config({ path: join(homedir(), ".agentmemory", ".env") });

--- a/src/hooks/_env.ts
+++ b/src/hooks/_env.ts
@@ -5,4 +5,4 @@ import { join } from "node:path";
 // Load ~/.agentmemory/.env into process.env before any hook reads env vars.
 // Keys already set in the environment (e.g. via Claude Code settings.json or
 // the shell) take priority — dotenv.config() does not override by default.
-dotenv.config({ path: join(homedir(), ".agentmemory", ".env") });
+dotenv.config({ path: join(homedir(), ".agentmemory", ".env"), quiet: true });

--- a/src/hooks/_project.ts
+++ b/src/hooks/_project.ts
@@ -1,5 +1,6 @@
 import { execSync } from "node:child_process";
 import { basename } from "node:path";
+import "./_env.js";
 
 // Resolution order: AGENTMEMORY_PROJECT_NAME env → git toplevel basename → cwd basename.
 export function resolveProject(cwd?: string): string {

--- a/src/hooks/post-commit.ts
+++ b/src/hooks/post-commit.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import "./_env.js";
 
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";

--- a/src/hooks/pre-tool-use.ts
+++ b/src/hooks/pre-tool-use.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import "./_env.js";
 
 function isSdkChildContext(payload: unknown): boolean {
   if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;

--- a/src/hooks/session-end.ts
+++ b/src/hooks/session-end.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import "./_env.js";
 
 function isSdkChildContext(payload: unknown): boolean {
   if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;

--- a/src/hooks/stop.ts
+++ b/src/hooks/stop.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import "./_env.js";
 
 // Inlined — see src/hooks/sdk-guard.ts for canonical version. Kept local
 // per-hook so tsdown does not emit a shared hashed chunk that would churn


### PR DESCRIPTION
fix(hooks): load ~/.agentmemory/.env before reading process.env

All hook scripts read AGENTMEMORY_* vars at module level (const declarations before main()). If those vars live only in ~/.agentmemory/.env and not in the shell environment or settings.json, they were silently ignored.

Fix:
- Add src/hooks/_env.ts: synchronous .env parser that populates process.env for keys not already set (explicit env takes priority).
- Import side-effect in src/hooks/_project.ts (already inlined first by the bundler into every hook that imports _project).
- Direct import in the four hooks that bypass _project.ts: pre-tool-use, session-end, post-commit, stop.
- Patch all 14 compiled plugin/scripts/*.mjs with an inline equivalent so the installed plugin works without a rebuild.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hook and script workflows now auto-load user-local environment settings from `~/.agentmemory/.env` at startup (quietly), before configuration is read—covering session, tool, stop, and related hooks.
  * Pre-set environment variables still override values from the file.

* **Bug Fixes**
  * Improved startup consistency by initializing environment settings earlier across affected scripts/hooks.
  * Normalized end-of-module export formatting to improve reliable ES module behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->