### PR TITLE
[codex] Add offline Codex memory pipeline

### DIFF
--- a/plugin/scripts/notification.mjs
+++ b/plugin/scripts/notification.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import { execSync } from "node:child_process";
 import { basename } from "node:path";
-
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {
 	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
@@ -21,7 +20,6 @@ function resolveProject(cwd) {
 	} catch {}
 	return basename(dir);
 }
-
 //#endregion
 //#region src/hooks/notification.ts
 function isSdkChildContext(payload) {
@@ -70,7 +68,7 @@ async function main() {
 	setTimeout(() => process.exit(0), 500).unref();
 }
 main();
-
 //#endregion
-export {  };
+export {};
+
 //# sourceMappingURL=notification.mjs.map

--- a/plugin/scripts/post-commit.mjs
+++ b/plugin/scripts/post-commit.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-
 //#region src/hooks/post-commit.ts
 const exec = promisify(execFile);
 function isSdkChildContext(payload) {
@@ -96,7 +95,7 @@ async function main() {
 	} catch {}
 }
 main();
-
 //#endregion
-export {  };
+export {};
+
 //# sourceMappingURL=post-commit.mjs.map

--- a/plugin/scripts/post-tool-failure.mjs
+++ b/plugin/scripts/post-tool-failure.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import { execSync } from "node:child_process";
 import { basename } from "node:path";
-
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {
 	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
@@ -21,7 +20,6 @@ function resolveProject(cwd) {
 	} catch {}
 	return basename(dir);
 }
-
 //#endregion
 //#region src/hooks/post-tool-failure.ts
 function isSdkChildContext(payload) {
@@ -71,7 +69,7 @@ async function main() {
 	setTimeout(() => process.exit(0), 500).unref();
 }
 main();
-
 //#endregion
-export {  };
+export {};
+
 //# sourceMappingURL=post-tool-failure.mjs.map

--- a/plugin/scripts/post-tool-use.mjs
+++ b/plugin/scripts/post-tool-use.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import { execSync } from "node:child_process";
 import { basename } from "node:path";
-
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {
 	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
@@ -21,7 +20,6 @@ function resolveProject(cwd) {
 	} catch {}
 	return basename(dir);
 }
-
 //#endregion
 //#region src/hooks/post-tool-use.ts
 function isSdkChildContext(payload) {
@@ -116,7 +114,7 @@ function truncate(value, max) {
 	return value;
 }
 main();
-
 //#endregion
-export {  };
+export {};
+
 //# sourceMappingURL=post-tool-use.mjs.map

--- a/plugin/scripts/pre-compact.mjs
+++ b/plugin/scripts/pre-compact.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import { execSync } from "node:child_process";
 import { basename } from "node:path";
-
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {
 	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
@@ -21,7 +20,6 @@ function resolveProject(cwd) {
 	} catch {}
 	return basename(dir);
 }
-
 //#endregion
 //#region src/hooks/pre-compact.ts
 function isSdkChildContext(payload) {
@@ -74,7 +72,7 @@ async function main() {
 	} catch {}
 }
 main();
-
 //#endregion
-export {  };
+export {};
+
 //# sourceMappingURL=pre-compact.mjs.map

--- a/plugin/scripts/pre-tool-use.mjs
+++ b/plugin/scripts/pre-tool-use.mjs
@@ -78,7 +78,7 @@ async function main() {
 	} catch {}
 }
 main();
-
 //#endregion
-export {  };
+export {};
+
 //# sourceMappingURL=pre-tool-use.mjs.map

--- a/plugin/scripts/prompt-submit.mjs
+++ b/plugin/scripts/prompt-submit.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import { execSync } from "node:child_process";
 import { basename } from "node:path";
-
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {
 	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
@@ -21,7 +20,6 @@ function resolveProject(cwd) {
 	} catch {}
 	return basename(dir);
 }
-
 //#endregion
 //#region src/hooks/prompt-submit.ts
 function isSdkChildContext(payload) {
@@ -63,7 +61,7 @@ async function main() {
 	setTimeout(() => process.exit(0), 500).unref();
 }
 main();
-
 //#endregion
-export {  };
+export {};
+
 //# sourceMappingURL=prompt-submit.mjs.map

--- a/plugin/scripts/session-end.mjs
+++ b/plugin/scripts/session-end.mjs
@@ -54,7 +54,7 @@ async function main() {
 	setTimeout(() => process.exit(0), 1500).unref();
 }
 main();
-
 //#endregion
-export {  };
+export {};
+
 //# sourceMappingURL=session-end.mjs.map

--- a/plugin/scripts/session-start.mjs
+++ b/plugin/scripts/session-start.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import { execSync } from "node:child_process";
 import { basename } from "node:path";
-
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {
 	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
@@ -21,7 +20,6 @@ function resolveProject(cwd) {
 	} catch {}
 	return basename(dir);
 }
-
 //#endregion
 //#region src/hooks/session-start.ts
 function isSdkChildContext(payload) {
@@ -81,7 +79,7 @@ async function main() {
 	} catch {}
 }
 main();
-
 //#endregion
-export {  };
+export {};
+
 //# sourceMappingURL=session-start.mjs.map

--- a/plugin/scripts/stop.mjs
+++ b/plugin/scripts/stop.mjs
@@ -7,6 +7,7 @@ function isSdkChildContext(payload) {
 }
 const REST_URL = process.env["AGENTMEMORY_URL"] || "http://localhost:3111";
 const SECRET = process.env["AGENTMEMORY_SECRET"] || "";
+const SUMMARIZE_ON_STOP = process.env["AGENTMEMORY_SUMMARIZE_ON_STOP"] === "true";
 function authHeaders() {
 	const h = { "Content-Type": "application/json" };
 	if (SECRET) h["Authorization"] = `Bearer ${SECRET}`;
@@ -23,7 +24,7 @@ async function main() {
 	}
 	if (isSdkChildContext(data)) return;
 	const sessionId = data.session_id || data.sessionId || "unknown";
-	fetch(`${REST_URL}/agentmemory/summarize`, {
+	if (SUMMARIZE_ON_STOP) fetch(`${REST_URL}/agentmemory/summarize`, {
 		method: "POST",
 		headers: authHeaders(),
 		body: JSON.stringify({ sessionId }),
@@ -38,7 +39,7 @@ async function main() {
 	setTimeout(() => process.exit(0), 1500).unref();
 }
 main();
-
 //#endregion
-export {  };
+export {};
+
 //# sourceMappingURL=stop.mjs.map

--- a/plugin/scripts/subagent-start.mjs
+++ b/plugin/scripts/subagent-start.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import { execSync } from "node:child_process";
 import { basename } from "node:path";
-
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {
 	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
@@ -21,7 +20,6 @@ function resolveProject(cwd) {
 	} catch {}
 	return basename(dir);
 }
-
 //#endregion
 //#region src/hooks/subagent-start.ts
 function isSdkChildContext(payload) {
@@ -69,7 +67,7 @@ async function main() {
 	setTimeout(() => process.exit(0), 500).unref();
 }
 main();
-
 //#endregion
-export {  };
+export {};
+
 //# sourceMappingURL=subagent-start.mjs.map

--- a/plugin/scripts/subagent-stop.mjs
+++ b/plugin/scripts/subagent-stop.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import { execSync } from "node:child_process";
 import { basename } from "node:path";
-
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {
 	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
@@ -21,7 +20,6 @@ function resolveProject(cwd) {
 	} catch {}
 	return basename(dir);
 }
-
 //#endregion
 //#region src/hooks/subagent-stop.ts
 function isSdkChildContext(payload) {
@@ -70,7 +68,7 @@ async function main() {
 	setTimeout(() => process.exit(0), 500).unref();
 }
 main();
-
 //#endregion
-export {  };
+export {};
+
 //# sourceMappingURL=subagent-stop.mjs.map

--- a/plugin/scripts/task-completed.mjs
+++ b/plugin/scripts/task-completed.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import { execSync } from "node:child_process";
 import { basename } from "node:path";
-
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {
 	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
@@ -21,7 +20,6 @@ function resolveProject(cwd) {
 	} catch {}
 	return basename(dir);
 }
-
 //#endregion
 //#region src/hooks/task-completed.ts
 function isSdkChildContext(payload) {
@@ -69,7 +67,7 @@ async function main() {
 	setTimeout(() => process.exit(0), 500).unref();
 }
 main();
-
 //#endregion
-export {  };
+export {};
+
 //# sourceMappingURL=task-completed.mjs.map

--- a/schemas/codex-consolidation-delta.schema.json
+++ b/schemas/codex-consolidation-delta.schema.json
@@ -1,0 +1,156 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "exportData"
+  ],
+  "properties": {
+    "exportData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "version",
+        "sessions",
+        "observations",
+        "memories",
+        "summaries",
+        "semanticMemories",
+        "proceduralMemories"
+      ],
+      "properties": {
+        "version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sessions": {
+          "type": "array",
+          "maxItems": 0,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {}
+          }
+        },
+        "observations": {
+          "type": "object",
+          "properties": {},
+          "required": [],
+          "additionalProperties": false
+        },
+        "memories": {
+          "type": "array",
+          "maxItems": 0,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {}
+          }
+        },
+        "summaries": {
+          "type": "array",
+          "maxItems": 0,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {}
+          }
+        },
+        "semanticMemories": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "id",
+              "fact",
+              "confidence",
+              "sourceMemoryIds",
+              "sourceSessionIds"
+            ],
+            "properties": {
+              "id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "fact": {
+                "type": "string",
+                "minLength": 1
+              },
+              "confidence": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1
+              },
+              "sourceMemoryIds": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "sourceSessionIds": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            }
+          }
+        },
+        "proceduralMemories": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "id",
+              "name",
+              "triggerCondition",
+              "steps",
+              "sourceMemoryIds",
+              "sourceSessionIds"
+            ],
+            "properties": {
+              "id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "name": {
+                "type": "string",
+                "minLength": 1
+              },
+              "triggerCondition": {
+                "type": "string",
+                "minLength": 1
+              },
+              "steps": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "sourceMemoryIds": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "sourceSessionIds": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/codex-graph-delta.schema.json
+++ b/schemas/codex-graph-delta.schema.json
@@ -1,0 +1,148 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "exportData"
+  ],
+  "properties": {
+    "exportData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "version",
+        "sessions",
+        "observations",
+        "memories",
+        "summaries",
+        "graphNodes",
+        "graphEdges"
+      ],
+      "properties": {
+        "version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sessions": {
+          "type": "array",
+          "maxItems": 0,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {}
+          }
+        },
+        "observations": {
+          "type": "object",
+          "properties": {},
+          "required": [],
+          "additionalProperties": false
+        },
+        "memories": {
+          "type": "array",
+          "maxItems": 0,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {}
+          }
+        },
+        "summaries": {
+          "type": "array",
+          "maxItems": 0,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {}
+          }
+        },
+        "graphNodes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "id",
+              "type",
+              "name",
+              "properties",
+              "sourceObservationIds"
+            ],
+            "properties": {
+              "id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "type": {
+                "type": "string",
+                "minLength": 1
+              },
+              "name": {
+                "type": "string",
+                "minLength": 1
+              },
+              "properties": {
+                "type": "object",
+                "properties": {},
+                "required": [],
+                "additionalProperties": false
+              },
+              "sourceObservationIds": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            }
+          }
+        },
+        "graphEdges": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "id",
+              "type",
+              "sourceNodeId",
+              "targetNodeId",
+              "weight",
+              "sourceObservationIds"
+            ],
+            "properties": {
+              "id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "type": {
+                "type": "string",
+                "minLength": 1
+              },
+              "sourceNodeId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "targetNodeId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "weight": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1
+              },
+              "sourceObservationIds": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/codex-session-summary-batch.schema.json
+++ b/schemas/codex-session-summary-batch.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "summaries"
+  ],
+  "properties": {
+    "summaries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "content",
+          "concepts",
+          "files",
+          "project",
+          "sourceSessionId",
+          "sourcePath",
+          "followups"
+        ],
+        "properties": {
+          "content": {
+            "type": "string",
+            "minLength": 1
+          },
+          "concepts": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "files": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "project": {
+            "type": "string",
+            "minLength": 1
+          },
+          "sourceSessionId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "sourcePath": {
+            "type": "string",
+            "minLength": 1
+          },
+          "followups": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/codex-session-summary.schema.json
+++ b/schemas/codex-session-summary.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "content",
+    "concepts",
+    "files",
+    "project",
+    "sourceSessionId",
+    "sourcePath",
+    "followups"
+  ],
+  "properties": {
+    "content": {
+      "type": "string",
+      "minLength": 1
+    },
+    "concepts": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "files": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "project": {
+      "type": "string",
+      "minLength": 1
+    },
+    "sourceSessionId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "sourcePath": {
+      "type": "string",
+      "minLength": 1
+    },
+    "followups": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/scripts/codex-memory-pipeline.rb
+++ b/scripts/codex-memory-pipeline.rb
@@ -1527,7 +1527,10 @@ def command_consolidate(options)
   puts "state=#{options.state_path}"
   puts "dry_run=#{options.dry_run}"
   puts "selected_memories=#{memories.length}"
-  raise "no memories selected" if memories.empty?
+  if memories.empty?
+    puts "no_op=true"
+    return
+  end
   return if options.dry_run && !options.codex_dry_run
 
   prompt = build_consolidation_prompt(memories, version)
@@ -1563,7 +1566,10 @@ def command_graph(options)
   puts "state=#{options.state_path}"
   puts "dry_run=#{options.dry_run}"
   puts "selected_memories=#{memories.length}"
-  raise "no memories selected" if memories.empty?
+  if memories.empty?
+    puts "no_op=true"
+    return
+  end
   return if options.dry_run && !options.codex_dry_run
 
   prompt = build_graph_prompt(memories, version)

--- a/scripts/codex-memory-pipeline.rb
+++ b/scripts/codex-memory-pipeline.rb
@@ -1,0 +1,1633 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "digest/sha1"
+require "fileutils"
+require "json"
+require "net/http"
+require "open3"
+require "optparse"
+require "set"
+require "shellwords"
+require "tempfile"
+require "time"
+require "timeout"
+require "uri"
+
+$stdout.sync = true
+$stderr.sync = true
+
+DEFAULT_SOURCE = File.expand_path("~/.codex/sessions")
+DEFAULT_STATE = File.expand_path("~/.agentmemory/codex-pipeline/state.jsonl")
+DEFAULT_REPLAY_STATE = File.expand_path("~/.agentmemory/replay-enrichment/state.jsonl")
+DEFAULT_AGENTMEMORY_URL = ENV.fetch("AGENTMEMORY_URL", "http://localhost:3111")
+DEFAULT_SCHEMA_DIR = File.expand_path("~/.agentmemory/schemas")
+DEFAULT_TMP_DIR = File.expand_path("~/.agentmemory/codex-pipeline/tmp")
+DEFAULT_TRUSTED_CWD = "/home/dmartino/co/dimartino-dotfiles"
+DEFAULT_EXPORT_VERSION = "0.9.27"
+DEFAULT_MAX_EVENT_CHARS = 220
+DEFAULT_MAX_PROMPT_CHARS = 3_000
+DEFAULT_MAX_BATCH_PROMPT_CHARS = 20_000
+DEFAULT_BATCH_SIZE = 5
+DEFAULT_BATCH_MAX_EVENTS = 1_500
+DEFAULT_BATCH_SMALL_MAX_EVENTS = 75
+DEFAULT_BATCH_NORMAL_MAX_EVENTS = 250
+DEFAULT_BATCH_MEDIUM_MIN_EVENTS = 500
+DEFAULT_BATCH_OVERHEAD_CHARS = 700
+MAX_DELTA_ITEMS = 200
+SELF_IMPORT_TOOL_MARKERS = [
+  "codex-memory-pipeline.rb ingest-summaries",
+  "CODEX_PIPELINE_PHASE=ingest-summaries",
+  "RUN_CODEX_PIPELINE=1",
+  "agentmemory-cron-maintenance.sh",
+  "import-codex-sessions-replay.rb",
+  "enrich-codex-replay.rb"
+].freeze
+
+COMMANDS = %w[ingest-summaries re-enrich-ollama consolidate graph].freeze
+UNSAFE_AGENTMEMORY_FLAGS = %w[
+  AGENTMEMORY_AUTO_COMPRESS
+  AGENTMEMORY_INJECT_CONTEXT
+  CONSOLIDATION_ENABLED
+  GRAPH_EXTRACTION_ENABLED
+].freeze
+CODEX_CHILD_ENV_ALLOWLIST = %w[
+  CODEX_HOME
+  HOME
+  LANG
+  LC_ALL
+  LC_CTYPE
+  LOGNAME
+  PATH
+  SHELL
+  TERM
+  TMPDIR
+  USER
+  XDG_CACHE_HOME
+  XDG_CONFIG_HOME
+  XDG_DATA_HOME
+].freeze
+
+PipelineOptions = Struct.new(
+  :command,
+  :source,
+  :state_path,
+  :replay_state_path,
+  :agentmemory_url,
+  :schema_dir,
+  :tmp_dir,
+  :trusted_cwd,
+  :codex_add_dirs,
+  :limit,
+  :max_codex_calls,
+  :after,
+  :before,
+  :project,
+  :cwd_regex,
+  :min_events,
+  :max_events,
+  :sample_events,
+  :max_event_chars,
+  :max_prompt_chars,
+  :batch_size,
+  :max_batch_prompt_chars,
+  :batch_max_events,
+  :batch_fallback_single,
+  :sleep_seconds,
+  :snapshot_rebuild,
+  :memory_source,
+  :dry_run,
+  :codex_dry_run,
+  :skip_failed,
+  :timeout_seconds,
+  keyword_init: true
+)
+
+def usage
+  warn <<~USAGE
+    Usage: codex-memory-pipeline.rb <command> [options]
+
+    Commands:
+      ingest-summaries  Summarize Codex sessions with codex exec and remember them
+      re-enrich-ollama  Re-summarize replay-enrichment memories with codex exec
+      consolidate       Generate semantic/procedural memory deltas with codex exec
+      graph             Generate graph node/edge deltas with codex exec
+
+    Default is dry-run. Use --apply to write to agentmemory.
+  USAGE
+end
+
+def load_env_file(path)
+  return {} unless File.file?(path)
+
+  File.readlines(path, chomp: true).each_with_object({}) do |line, env|
+    stripped = line.strip
+    next if stripped.empty? || stripped.start_with?("#") || !stripped.include?("=")
+
+    key, value = stripped.split("=", 2)
+    env[key.strip] = value.to_s.strip
+  end
+end
+
+def now_iso
+  Time.now.utc.iso8601
+end
+
+def stable_id(prefix, *parts)
+  "#{prefix}_#{Digest::SHA1.hexdigest(parts.map(&:to_s).join("\0"))[0, 20]}"
+end
+
+def stable_hash(value)
+  Digest::SHA1.hexdigest(JSON.generate(value))
+end
+
+def truncate_text(value, max_chars)
+  text = value.is_a?(String) ? value : JSON.generate(value)
+  text.length > max_chars ? "#{text[0, max_chars]}...[truncated]" : text
+rescue JSON::GeneratorError
+  value.to_s
+end
+
+def content_text(content)
+  return content if content.is_a?(String)
+  return "" unless content.is_a?(Array)
+
+  content.filter_map do |entry|
+    next unless entry.is_a?(Hash)
+
+    if %w[text input_text output_text].include?(entry["type"]) && entry["text"].is_a?(String)
+      entry["text"]
+    end
+  end.join("\n")
+end
+
+def jsonl_files(source)
+  if File.file?(source)
+    source.end_with?(".jsonl") ? [source] : []
+  else
+    Dir.glob(File.join(source, "**", "*.jsonl")).sort.reverse
+  end
+end
+
+def sample_event_window(events, max_events)
+  max_events = max_events.to_i
+  return events if max_events <= 0 || events.length <= max_events
+
+  head_count = max_events / 2
+  tail_count = max_events - head_count
+  events.first(head_count) + events.last(tail_count)
+end
+
+def parse_codex_session(path, max_event_chars, sample_events = 0)
+  meta = {}
+  events = []
+  response_items = 0
+
+  File.foreach(path).with_index do |line, index|
+    next if line.strip.empty?
+
+    obj = JSON.parse(line)
+    if obj["type"] == "session_meta"
+      payload = obj["payload"] || {}
+      meta = {
+        "id" => payload["id"],
+        "cwd" => payload["cwd"],
+        "timestamp" => payload["timestamp"] || obj["timestamp"],
+        "originator" => payload["originator"],
+        "model_provider" => payload["model_provider"],
+        "agent_nickname" => payload["agent_nickname"],
+        "agent_role" => payload["agent_role"]
+      }.compact
+      next
+    end
+    next unless obj["type"] == "response_item"
+
+    response_items += 1
+    payload = obj["payload"] || {}
+    timestamp = obj["timestamp"] || payload["timestamp"] || meta["timestamp"]
+    payload_type = payload["type"]
+
+    case payload_type
+    when "message"
+      role = payload["role"]
+      next if role == "developer"
+
+      text = content_text(payload["content"]).strip
+      next if text.empty?
+
+      events << {
+        kind: "message",
+        role: role,
+        timestamp: timestamp,
+        text: truncate_text(text, max_event_chars)
+      }
+    when "function_call", "custom_tool_call", "tool_search_call", "web_search_call"
+      input = payload["arguments"] || payload["input"] || payload.reject { |key, _| %w[type call_id name].include?(key) }
+      events << {
+        kind: "tool_call",
+        name: payload["name"] || payload_type,
+        timestamp: timestamp,
+        text: truncate_text(input, max_event_chars)
+      }
+    when "function_call_output", "custom_tool_call_output", "tool_search_output", "web_search_output"
+      output = payload.key?("output") ? payload["output"] : payload.reject { |key, _| %w[type call_id].include?(key) }
+      events << {
+        kind: payload["status"] == "failed" || payload["is_error"] == true ? "tool_error" : "tool_result",
+        timestamp: timestamp,
+        text: truncate_text(output, max_event_chars)
+      }
+    end
+  rescue JSON::ParserError
+    warn "skip malformed JSON #{path}:#{index + 1}"
+  end
+
+  meta["id"] ||= File.basename(path, ".jsonl").split("-").last
+  meta["cwd"] ||= Dir.home
+  meta["timestamp"] ||= Time.at(File.mtime(path)).utc.iso8601
+  original_events = events.length
+  events = sample_event_window(events, sample_events)
+  {
+    path: path,
+    meta: meta,
+    project: File.basename(meta["cwd"].to_s),
+    response_items: response_items,
+    original_events: original_events,
+    events: events
+  }
+end
+
+def read_jsonl(path)
+  return [] unless File.file?(path)
+
+  File.readlines(path, chomp: true).filter_map do |line|
+    next if line.strip.empty?
+
+    JSON.parse(line)
+  rescue JSON::ParserError
+    nil
+  end
+end
+
+def append_state(path, row)
+  FileUtils.mkdir_p(File.dirname(path))
+  File.open(path, "a") { |file| file.puts(JSON.generate(row)) }
+end
+
+def state_identity(row)
+  source = row["source"].to_s.strip
+  return source unless source.empty?
+
+  sid = row["sessionId"].to_s.strip
+  sid unless sid.empty?
+end
+
+def latest_rows_by_identity(rows)
+  rows.each_with_object({}) do |row, index|
+    identity = state_identity(row)
+    index[identity] = row if identity
+  end
+end
+
+def state_row_for_session(index, session)
+  source = session[:path].to_s.strip
+  return index[source] if index[source]
+
+  sid = session[:meta]["id"].to_s.strip
+  return nil if sid.empty?
+
+  index[sid]
+end
+
+def date_in_range?(timestamp, after, before_)
+  return true unless timestamp
+
+  value_for_after = after&.length.to_i > 10 ? timestamp.to_s : timestamp.to_s[0, 10]
+  value_for_before = before_&.length.to_i > 10 ? timestamp.to_s : timestamp.to_s[0, 10]
+  return false if after && value_for_after < after
+  return false if before_ && value_for_before > before_
+
+  true
+end
+
+def codex_import_session?(session)
+  session[:events].any? do |event|
+    next false unless event[:kind] == "tool_call"
+
+    text = event[:text].to_s
+    SELF_IMPORT_TOOL_MARKERS.any? { |marker| text.include?(marker) }
+  end
+end
+
+def session_event_count(session)
+  session[:original_events] || session[:events].length
+end
+
+def schema_path(options, name)
+  File.join(options.schema_dir, name)
+end
+
+def build_session_prompt(session, max_prompt_chars)
+  meta = session[:meta]
+  header = [
+    "You are preparing one durable agentmemory record from a Codex session.",
+    "Return JSON matching the provided schema. No markdown fences.",
+    "Rules:",
+    "- Preserve exact paths, commands, ids, decisions, failures, and next actions.",
+    "- Do not invent facts.",
+    "- For long sessions, use both timeline start and timeline end; the middle may be omitted.",
+    "- content must start with: Codex replay session summary",
+    "- sourceSessionId must be exactly #{meta["id"]}",
+    "- sourcePath must be exactly #{session[:path]}",
+    "- project must be exactly #{session[:project]}",
+    "",
+    "Session ID: #{meta["id"]}",
+    "Project: #{session[:project]}",
+    "CWD: #{meta["cwd"]}",
+    "Started: #{meta["timestamp"]}",
+    "Source file: #{session[:path]}",
+    "Events: #{session_event_count(session)}",
+    ("Sampled events in timeline: #{session[:events].length}" if session[:original_events] && session[:original_events] != session[:events].length),
+    "",
+    "Timeline:"
+  ]
+  event_lines = session[:events].map.with_index do |event, idx|
+    prefix = format("%03d %s %s", idx + 1, event[:timestamp], event[:kind])
+    role = event[:role] ? " role=#{event[:role]}" : ""
+    name = event[:name] ? " name=#{event[:name]}" : ""
+    "#{prefix}#{role}#{name}: #{event[:text].to_s.gsub(/\s+/, " ").strip}"
+  end
+
+  header_text = header.join("\n")
+  full_text = ([header_text] + event_lines).join("\n")
+  return full_text if full_text.length <= max_prompt_chars
+
+  budget = [max_prompt_chars - header_text.length - 120, 500].max
+  head_budget = budget / 2
+  tail_budget = budget - head_budget
+  head_lines = []
+  head_chars = 0
+  event_lines.each do |line|
+    break if head_chars + line.length + 1 > head_budget
+
+    head_lines << line
+    head_chars += line.length + 1
+  end
+  tail_lines = []
+  tail_chars = 0
+  event_lines.reverse_each do |line|
+    break if tail_chars + line.length + 1 > tail_budget
+
+    tail_lines << line
+    tail_chars += line.length + 1
+  end
+  tail_lines.reverse!
+  omitted = [event_lines.length - head_lines.length - tail_lines.length, 0].max
+  sampled = head_lines + ["... omitted #{omitted} middle events ..."] + tail_lines
+  ([header_text] + sampled).join("\n")[0, max_prompt_chars]
+end
+
+def build_batch_session_prompt(sessions, options)
+  [
+    "You are preparing durable agentmemory records from multiple Codex sessions.",
+    "Return JSON matching schema. No markdown fences.",
+    "Return exactly one summary per input session in summaries[].",
+    "Match each output by exact sourcePath.",
+    "Do not merge sessions. Do not omit sessions. Do not invent facts.",
+    "Each content must start with: Codex replay session summary",
+    "",
+    sessions.map.with_index do |session, idx|
+      [
+        "=== SESSION #{idx + 1} OF #{sessions.length} ===",
+        build_session_prompt(session, options.max_prompt_chars)
+      ].join("\n")
+    end.join("\n\n")
+  ].join("\n")
+end
+
+def plan_ingest_batches(sessions, options)
+  return sessions.map { |session| [session] } if options.batch_size <= 1
+
+  batches = []
+  current = []
+  soft_limit = batch_soft_prompt_limit(options)
+
+  sessions.each do |session|
+    prompt = build_session_prompt(session, options.max_prompt_chars)
+    prompt_chars = prompt.length
+    event_count = session_event_count(session)
+    force_single = prompt_chars > (options.max_batch_prompt_chars * 0.70)
+    session_batch_limit = session_batch_limit(session, options, prompt_chars)
+    if force_single
+      batches << current unless current.empty?
+      current = []
+      batches << [session]
+      next
+    end
+
+    would_chars = build_batch_session_prompt(current + [session], options).length
+    current_batch_limit = current.empty? ? session_batch_limit : [session_batch_limit, current.map { |item| session_batch_limit(item, options) }.min].min
+    if current.length >= current_batch_limit || (!current.empty? && would_chars > soft_limit)
+      batches << current unless current.empty?
+      current = []
+    end
+
+    current << session
+  end
+
+  batches << current unless current.empty?
+  batches
+end
+
+def batch_soft_prompt_limit(options)
+  reserve = [DEFAULT_BATCH_OVERHEAD_CHARS, (options.max_batch_prompt_chars * 0.10).to_i].max
+  [options.max_batch_prompt_chars - reserve, 1].max
+end
+
+def session_batch_limit(session, options, prompt_chars = nil)
+  event_count = session_event_count(session)
+  prompt_chars ||= build_session_prompt(session, options.max_prompt_chars).length
+  prompt_ratio = prompt_chars.to_f / options.max_batch_prompt_chars
+  sampled = session[:original_events] && session[:original_events] != session[:events].length
+
+  return 1 if prompt_ratio > 0.70
+  return [options.batch_size, 2].min if prompt_ratio > 0.55
+  return [options.batch_size, 3].min if prompt_ratio > 0.42
+  if sampled || event_count > options.batch_max_events
+    high_event_cap = prompt_ratio <= 0.30 ? 5 : 4
+    return [options.batch_size, high_event_cap].min
+  end
+  return options.batch_size if prompt_ratio <= 0.30
+
+  if event_count <= DEFAULT_BATCH_SMALL_MAX_EVENTS
+    options.batch_size
+  elsif event_count <= DEFAULT_BATCH_NORMAL_MAX_EVENTS
+    [options.batch_size, 4].min
+  elsif event_count < DEFAULT_BATCH_MEDIUM_MIN_EVENTS
+    [options.batch_size, 3].min
+  else
+    [options.batch_size, 3].min
+  end
+end
+
+def build_consolidation_prompt(memories, version)
+  compact = memories.map do |memory|
+    {
+      id: memory["id"],
+      project: memory["project"],
+      content: truncate_text(memory["content"].to_s, 1_400),
+      concepts: memory["concepts"] || [],
+      sessionIds: memory["sessionIds"] || []
+    }
+  end
+
+  <<~PROMPT
+    You are generating an agentmemory export delta for semantic/procedural consolidation.
+    Return JSON matching the provided schema. No markdown fences.
+
+    Required exportData boilerplate:
+    - version: #{version}
+    - sessions: []
+    - observations: {}
+    - memories: []
+    - summaries: []
+
+    Rules:
+    - semanticMemories: stable factual knowledge only.
+    - proceduralMemories: reusable workflows only.
+    - Prefer facts/procedures supported by 2+ memories; allow one high-confidence operational rule only when explicit.
+    - Keep facts and steps concrete. Preserve exact tool names, endpoints, env vars, paths, and commands.
+    - sourceMemoryIds must use ids from input.
+    - sourceSessionIds should use sessionIds from input when available.
+    - If nothing strong exists, return empty arrays.
+    - IDs are required temporary strings; caller will replace them deterministically.
+
+    Input memories:
+    #{JSON.pretty_generate(compact)}
+  PROMPT
+end
+
+def build_graph_prompt(memories, version)
+  compact = memories.map do |memory|
+    {
+      id: memory["id"],
+      project: memory["project"],
+      content: truncate_text(memory["content"].to_s, 240),
+      concepts: memory["concepts"] || [],
+      files: memory["files"] || []
+    }
+  end
+
+  <<~PROMPT
+    You are generating an agentmemory graph export delta from session summary memories.
+    Return JSON matching the provided schema. No markdown fences.
+
+    Required exportData boilerplate:
+    - version: #{version}
+    - sessions: []
+    - observations: {}
+    - memories: []
+    - summaries: []
+
+    Rules:
+    - graphNodes should represent concrete projects, files, services, tools, commands, endpoints, configs, issues, or operational concepts.
+    - graphEdges should connect nodes with relationship types like uses, configures, mentions, depends_on, verifies, fixes, observes.
+    - sourceObservationIds must use input memory ids.
+    - Edge sourceNodeId and targetNodeId must refer to node ids in graphNodes.
+    - Keep graph small: at most 12 nodes and 16 edges.
+    - IDs may be temporary; caller will replace them deterministically.
+
+    Input memories:
+    #{JSON.pretty_generate(compact)}
+  PROMPT
+end
+
+def parse_json_text(raw)
+  text = raw.to_s.strip
+  if text.start_with?("```")
+    text = text.sub(/\A```(?:json)?\s*/i, "").sub(/```\s*\z/, "").strip
+  end
+  JSON.parse(text)
+end
+
+def valid_string?(value)
+  value.is_a?(String) && !value.strip.empty?
+end
+
+def ensure_array!(obj, key, max: nil)
+  value = obj[key]
+  raise "#{key} must be array" unless value.is_a?(Array)
+  raise "#{key} exceeds #{max} items" if max && value.length > max
+
+  value
+end
+
+def ensure_empty_array!(obj, key)
+  value = ensure_array!(obj, key)
+  raise "#{key} must be empty array" unless value.empty?
+end
+
+def string_array(value)
+  Array(value).select { |item| valid_string?(item) }.map(&:strip).uniq
+end
+
+def validate_summary!(obj, session)
+  raise "summary output must be object" unless obj.is_a?(Hash)
+
+  %w[content project sourceSessionId sourcePath].each do |key|
+    raise "summary #{key} must be non-empty string" unless valid_string?(obj[key])
+  end
+  %w[concepts files followups].each do |key|
+    raise "summary #{key} must be array" unless obj[key].is_a?(Array)
+  end
+  raise "sourceSessionId mismatch" unless obj["sourceSessionId"] == session[:meta]["id"]
+  raise "sourcePath mismatch" unless obj["sourcePath"] == session[:path]
+  raise "project mismatch" unless obj["project"] == session[:project]
+
+  obj
+end
+
+def validate_batch_summary!(obj, sessions)
+  raise "batch output must be object" unless obj.is_a?(Hash)
+
+  summaries = obj["summaries"]
+  raise "summaries must be array" unless summaries.is_a?(Array)
+
+  expected = sessions.map { |session| session[:path] }
+  by_path = summaries.group_by { |summary| summary.is_a?(Hash) ? summary["sourcePath"] : nil }
+  missing = expected.reject { |path| by_path[path]&.length == 1 }
+  extra = by_path.keys.compact - expected
+  dupes = by_path.select { |path, rows| path && rows.length > 1 }.keys
+
+  raise "missing summaries for #{missing.inspect}" unless missing.empty?
+  raise "extra summaries for #{extra.inspect}" unless extra.empty?
+  raise "duplicate summaries for #{dupes.inspect}" unless dupes.empty?
+
+  sessions.map do |session|
+    validate_summary!(by_path.fetch(session[:path]).first, session)
+  end
+end
+
+def validate_export_delta!(obj, command)
+  raise "delta output must be object" unless obj.is_a?(Hash)
+  export = obj["exportData"]
+  raise "exportData must be object" unless export.is_a?(Hash)
+  ensure_empty_array!(export, "sessions")
+  ensure_empty_array!(export, "memories")
+  ensure_empty_array!(export, "summaries")
+  raise "exportData.observations must be object" unless export["observations"].is_a?(Hash)
+  raise "exportData.observations must be empty object" unless export["observations"].empty?
+
+  case command
+  when "consolidate"
+    ensure_array!(export, "semanticMemories", max: MAX_DELTA_ITEMS)
+    ensure_array!(export, "proceduralMemories", max: MAX_DELTA_ITEMS)
+  when "graph"
+    ensure_array!(export, "graphNodes", max: MAX_DELTA_ITEMS)
+    ensure_array!(export, "graphEdges", max: MAX_DELTA_ITEMS)
+  else
+    raise "unsupported delta command=#{command}"
+  end
+
+  export
+end
+
+def canonicalize_semantic(export, version)
+  now = now_iso
+  semantic = Array(export["semanticMemories"]).filter_map do |item|
+    next unless item.is_a?(Hash)
+
+    fact = item["fact"].to_s.strip
+    next if fact.empty?
+
+    confidence = [[Float(item["confidence"] || 0.5), 0.0].max, 1.0].min
+    {
+      "id" => stable_id("sem_codex", fact.downcase),
+      "fact" => fact,
+      "confidence" => confidence,
+      "sourceSessionIds" => string_array(item["sourceSessionIds"]),
+      "sourceMemoryIds" => string_array(item["sourceMemoryIds"]),
+      "accessCount" => 1,
+      "lastAccessedAt" => now,
+      "strength" => confidence,
+      "createdAt" => now,
+      "updatedAt" => now
+    }
+  rescue ArgumentError, TypeError
+    nil
+  end
+
+  procedural = Array(export["proceduralMemories"]).filter_map do |item|
+    next unless item.is_a?(Hash)
+
+    name = item["name"].to_s.strip
+    trigger = item["triggerCondition"].to_s.strip
+    steps = string_array(item["steps"])
+    next if name.empty? || trigger.empty? || steps.empty?
+
+    {
+      "id" => stable_id("proc_codex", name.downcase, trigger.downcase, steps.join("\n").downcase),
+      "name" => name,
+      "steps" => steps,
+      "triggerCondition" => trigger,
+      "frequency" => 1,
+      "sourceSessionIds" => string_array(item["sourceSessionIds"]),
+      "sourceMemoryIds" => string_array(item["sourceMemoryIds"]),
+      "strength" => 0.5,
+      "createdAt" => now,
+      "updatedAt" => now
+    }
+  end
+
+  {
+    "version" => version,
+    "exportedAt" => now,
+    "sessions" => [],
+    "observations" => {},
+    "memories" => [],
+    "summaries" => [],
+    "semanticMemories" => semantic,
+    "proceduralMemories" => procedural
+  }
+end
+
+def canonicalize_graph(export, version)
+  now = now_iso
+  id_map = {}
+  nodes = []
+  seen_nodes = {}
+
+  Array(export["graphNodes"]).each do |item|
+    next unless item.is_a?(Hash)
+
+    type = item["type"].to_s.strip.downcase
+    name = item["name"].to_s.strip
+    next if type.empty? || name.empty?
+
+    id = stable_id("gn_codex", type, name.downcase)
+    if valid_string?(item["id"])
+      source_id = item["id"].to_s
+      existing_id = id_map[source_id]
+      raise "duplicate graph node id=#{source_id}" if existing_id && existing_id != id
+
+      id_map[source_id] = id
+    end
+    next if seen_nodes[id]
+
+    properties = item["properties"].is_a?(Hash) ? item["properties"].transform_values { |v| v.to_s } : {}
+    nodes << {
+      "id" => id,
+      "type" => type,
+      "name" => name,
+      "properties" => properties,
+      "sourceObservationIds" => string_array(item["sourceObservationIds"]),
+      "createdAt" => now
+    }
+    seen_nodes[id] = true
+  end
+
+  node_ids = nodes.map { |node| node["id"] }.to_set
+  edges = []
+  seen_edges = {}
+  Array(export["graphEdges"]).each do |item|
+    next unless item.is_a?(Hash)
+
+    type = item["type"].to_s.strip.downcase
+    source = id_map[item["sourceNodeId"].to_s] || item["sourceNodeId"].to_s
+    target = id_map[item["targetNodeId"].to_s] || item["targetNodeId"].to_s
+    raise "dangling graph edge source=#{source}" unless node_ids.include?(source)
+    raise "dangling graph edge target=#{target}" unless node_ids.include?(target)
+    next if type.empty? || source == target
+
+    weight = [[Float(item["weight"] || 0.5), 0.0].max, 1.0].min
+    id = stable_id("ge_codex", source, target, type)
+    next if seen_edges[id]
+
+    edges << {
+      "id" => id,
+      "type" => type,
+      "sourceNodeId" => source,
+      "targetNodeId" => target,
+      "weight" => weight,
+      "sourceObservationIds" => string_array(item["sourceObservationIds"]),
+      "createdAt" => now
+    }
+    seen_edges[id] = true
+  rescue ArgumentError, TypeError
+    next
+  end
+
+  {
+    "version" => version,
+    "exportedAt" => now,
+    "sessions" => [],
+    "observations" => {},
+    "memories" => [],
+    "summaries" => [],
+    "graphNodes" => nodes,
+    "graphEdges" => edges
+  }
+end
+
+def http_json(method, base_url, path, body: nil, timeout: 120)
+  uri = URI.join(base_url.end_with?("/") ? base_url : "#{base_url}/", path)
+  req = method == :get ? Net::HTTP::Get.new(uri) : Net::HTTP::Post.new(uri)
+  req["content-type"] = "application/json"
+  req["authorization"] = "Bearer #{ENV.fetch("AGENTMEMORY_SECRET")}" if ENV["AGENTMEMORY_SECRET"]
+  req.body = JSON.generate(body) if body
+
+  http = Net::HTTP.new(uri.host, uri.port)
+  http.use_ssl = uri.scheme == "https"
+  http.open_timeout = 10
+  http.write_timeout = 30 if http.respond_to?(:write_timeout=)
+  http.read_timeout = timeout
+  res = http.request(req)
+  payload = res.body.to_s.empty? ? {} : JSON.parse(res.body)
+  raise "HTTP #{res.code} #{res.body.to_s[0, 500]}" unless res.is_a?(Net::HTTPSuccess)
+
+  payload
+end
+
+def export_version(agentmemory_url)
+  json = http_json(:get, agentmemory_url, "agentmemory/export?maxSessions=1", timeout: 120)
+  json["version"].to_s.empty? ? DEFAULT_EXPORT_VERSION : json["version"].to_s
+rescue StandardError => e
+  warn "version fallback=#{DEFAULT_EXPORT_VERSION} reason=#{e.message}"
+  DEFAULT_EXPORT_VERSION
+end
+
+def remember(agentmemory_url, session, summary, extra_concepts: [], extra_lines: [])
+  concepts = (string_array(summary["concepts"]) + [
+    "codex-pipeline-summary",
+    "codex-replay-summary",
+    "codex-session-import",
+    "project:#{session[:project]}",
+    "cwd:#{session[:meta]["cwd"]}"
+  ] + extra_concepts).uniq
+  extra_text = extra_lines.empty? ? "" : "\n#{extra_lines.join("\n")}"
+  content = <<~TEXT.strip
+    #{summary["content"].strip}
+
+    Session: #{summary["sourceSessionId"]}
+    Project: #{summary["project"]}
+    CWD: #{session[:meta]["cwd"]}
+    Source: #{summary["sourcePath"]}#{extra_text}
+  TEXT
+
+  json = http_json(:post, agentmemory_url, "agentmemory/remember", body: {
+    content: content,
+    type: "workflow",
+    project: summary["project"],
+    concepts: concepts,
+    files: string_array(summary["files"])
+  })
+  raise "remember failed: #{json.inspect}" unless json["success"] == true
+
+  json["memory"] || {}
+end
+
+def fetch_memory(agentmemory_url, memory_id)
+  encoded = URI.encode_www_form_component(memory_id)
+  json = http_json(:get, agentmemory_url, "agentmemory/memories/#{encoded}", timeout: 60)
+  json["memory"] || json
+end
+
+def import_delta(agentmemory_url, export_data)
+  http_json(:post, agentmemory_url, "agentmemory/import", body: {
+    strategy: "skip",
+    exportData: export_data
+  }, timeout: 180)
+end
+
+def rebuild_graph_snapshot(agentmemory_url)
+  http_json(:post, agentmemory_url, "agentmemory/graph/snapshot-rebuild", body: {
+    force: true
+  }, timeout: 180)
+end
+
+def existing_memory_for_source(agentmemory_url, session_id, source_path)
+  json = http_json(:post, agentmemory_url, "agentmemory/smart-search", body: {
+    query: "codex replay session summary #{session_id} #{source_path}",
+    limit: 5
+  }, timeout: 60)
+  Array(json["results"]).each do |result|
+    next unless result.is_a?(Hash)
+
+    searchable = [result["title"], result["content"], result["text"], result["obsId"], result["memoryId"], result["id"]].compact.join("\n")
+    next unless searchable.include?(source_path)
+
+    memory_id = result["memoryId"] || result["obsId"] || result["id"]
+    return memory_id if valid_string?(memory_id)
+  end
+  nil
+end
+
+def git_status(dir)
+  return "" unless File.directory?(File.join(dir, ".git"))
+
+  stdout, status = Open3.capture2e("git", "-C", dir, "status", "--short")
+  status.success? ? stdout : "git-status-failed:#{stdout}"
+end
+
+def codex_child_env(options)
+  env = {}
+  CODEX_CHILD_ENV_ALLOWLIST.each do |key|
+    env[key] = ENV[key] if ENV.key?(key) && !ENV[key].to_s.empty?
+  end
+  env["HOME"] ||= Dir.home
+  env["PATH"] ||= "/usr/local/bin:/usr/bin:/bin"
+  env["TMPDIR"] = options.tmp_dir
+  env["AGENTMEMORY_CODEX_BACKEND_ACTIVE"] = "1"
+  env["AGENTMEMORY_SDK_CHILD"] = "1"
+  env["AGENTMEMORY_AUTO_COMPRESS"] = "false"
+  env["AGENTMEMORY_INJECT_CONTEXT"] = "false"
+  env["CONSOLIDATION_ENABLED"] = "false"
+  env["GRAPH_EXTRACTION_ENABLED"] = "false"
+  env
+end
+
+def unsafe_flag_allowed?(key, command)
+  key == "GRAPH_EXTRACTION_ENABLED" &&
+    %w[re-enrich-ollama consolidate graph].include?(command) &&
+    ENV["AGENTMEMORY_CODEX_ALLOW_GRAPH_ENABLED"] == "true"
+end
+
+def capture_with_timeout(env, cmd, stdin_data, cwd, timeout_seconds)
+  in_r, in_w = IO.pipe
+  out_r, out_w = IO.pipe
+  err_r, err_w = IO.pipe
+  pid = Process.spawn(env, *cmd, { unsetenv_others: true, chdir: cwd, in: in_r, out: out_w, err: err_w })
+  in_r.close
+  out_w.close
+  err_w.close
+
+  writer = Thread.new do
+    in_w.write(stdin_data)
+  ensure
+    in_w.close
+  end
+  stdout_thread = Thread.new { out_r.read }
+  stderr_thread = Thread.new { err_r.read }
+  status = nil
+
+  Timeout.timeout(timeout_seconds) do
+    _, status = Process.wait2(pid)
+  end
+  writer.join
+  [stdout_thread.value, stderr_thread.value, status]
+rescue Timeout::Error
+  begin
+    Process.kill("TERM", pid)
+    sleep 2
+    Process.kill("KILL", pid)
+  rescue StandardError
+    nil
+  end
+  raise "codex exec timed out after #{timeout_seconds}s"
+ensure
+  [in_w, out_r, err_r].each { |io| io.close unless io.closed? rescue nil }
+end
+
+def run_codex(prompt, schema, options)
+  FileUtils.mkdir_p(options.tmp_dir)
+  output_path = File.join(options.tmp_dir, "codex-output-#{Time.now.utc.strftime("%Y%m%dT%H%M%SZ")}-#{$$}-#{rand(1_000_000)}.json")
+  cmd = [
+    "codex",
+    "-c",
+    "model_reasoning_summary=\"none\"",
+    "-c",
+    "model_verbosity=\"low\"",
+    "-c",
+    "tool_output_token_limit=6000",
+    "-c",
+    "model_auto_compact_token_limit=64000",
+    "-c",
+    "agents.max_threads=10",
+    "-c",
+    "agents.max_depth=1",
+    "exec",
+    "--ignore-user-config",
+    "--ephemeral",
+    "--sandbox",
+    "read-only",
+    "--cd",
+    options.trusted_cwd,
+    "--output-schema",
+    schema,
+    "--output-last-message",
+    output_path,
+    "-"
+  ]
+  options.codex_add_dirs.each do |dir|
+    insert_at = cmd.index("--output-schema")
+    cmd.insert(insert_at, "--add-dir", dir)
+  end
+  env = codex_child_env(options)
+
+  before_status = git_status(options.trusted_cwd)
+  stdout, stderr, status = capture_with_timeout(env, cmd, prompt, options.trusted_cwd, options.timeout_seconds)
+  after_status = git_status(options.trusted_cwd)
+  raise "codex exec failed status=#{status.exitstatus} stderr=#{stderr.to_s[0, 4_000]}" unless status.success?
+  raise "codex child changed trusted worktree" unless before_status == after_status
+
+  raw = File.file?(output_path) ? File.read(output_path) : stdout
+  parsed = parse_json_text(raw)
+  {
+    "output" => parsed,
+    "promptHash" => Digest::SHA1.hexdigest(prompt),
+    "outputHash" => Digest::SHA1.hexdigest(raw.to_s),
+    "schema" => schema,
+    "outputPath" => output_path,
+    "stdoutBytes" => stdout.to_s.bytesize,
+    "stderrBytes" => stderr.to_s.bytesize
+  }
+end
+
+def parse_options(command, argv)
+  options = PipelineOptions.new(
+    command: command,
+    source: DEFAULT_SOURCE,
+    state_path: DEFAULT_STATE,
+    replay_state_path: DEFAULT_REPLAY_STATE,
+    agentmemory_url: DEFAULT_AGENTMEMORY_URL,
+    schema_dir: DEFAULT_SCHEMA_DIR,
+    tmp_dir: DEFAULT_TMP_DIR,
+    trusted_cwd: DEFAULT_TRUSTED_CWD,
+    codex_add_dirs: [],
+    limit: %w[ingest-summaries re-enrich-ollama].include?(command) ? DEFAULT_BATCH_SIZE : 10,
+    max_codex_calls: 1,
+    after: "2026-06-01",
+    before: nil,
+    project: nil,
+    cwd_regex: nil,
+    min_events: 10,
+    max_events: 50,
+    sample_events: 0,
+    max_event_chars: DEFAULT_MAX_EVENT_CHARS,
+    max_prompt_chars: DEFAULT_MAX_PROMPT_CHARS,
+    batch_size: DEFAULT_BATCH_SIZE,
+    max_batch_prompt_chars: DEFAULT_MAX_BATCH_PROMPT_CHARS,
+    batch_max_events: DEFAULT_BATCH_MAX_EVENTS,
+    batch_fallback_single: true,
+    sleep_seconds: 0,
+    snapshot_rebuild: true,
+    memory_source: nil,
+    dry_run: true,
+    codex_dry_run: false,
+    skip_failed: true,
+    timeout_seconds: 900
+  )
+
+  parser = OptionParser.new do |opts|
+    opts.banner = "Usage: codex-memory-pipeline.rb #{command} [options]"
+    opts.on("--source PATH") { |value| options.source = File.expand_path(value) }
+    opts.on("--state PATH") { |value| options.state_path = File.expand_path(value) }
+    opts.on("--replay-state PATH") { |value| options.replay_state_path = File.expand_path(value) }
+    opts.on("--agentmemory-url URL") { |value| options.agentmemory_url = value }
+    opts.on("--schema-dir PATH") { |value| options.schema_dir = File.expand_path(value) }
+    opts.on("--tmp-dir PATH") { |value| options.tmp_dir = File.expand_path(value) }
+    opts.on("--trusted-cwd PATH") { |value| options.trusted_cwd = File.expand_path(value) }
+    opts.on("--codex-add-dir PATH", "Additional explicit Codex context dir; repeatable") { |value| options.codex_add_dirs << File.expand_path(value) }
+    opts.on("--limit N", Integer) { |value| options.limit = value }
+    opts.on("--max-codex-calls N", Integer) { |value| options.max_codex_calls = value }
+    opts.on("--after VALUE") { |value| options.after = value }
+    opts.on("--before VALUE") { |value| options.before = value }
+    opts.on("--project NAME") { |value| options.project = value }
+    opts.on("--cwd-regex REGEX") { |value| options.cwd_regex = Regexp.new(value) }
+    opts.on("--min-events N", Integer) { |value| options.min_events = value }
+    opts.on("--max-events N", Integer) { |value| options.max_events = value }
+    opts.on("--sample-events N", Integer, "Sample at most N parsed events per selected session for Codex prompts") { |value| options.sample_events = value }
+    opts.on("--max-event-chars N", Integer) { |value| options.max_event_chars = value }
+    opts.on("--max-prompt-chars N", Integer) { |value| options.max_prompt_chars = value }
+    opts.on("--batch-size N", Integer, "Maximum sessions per Codex call; adaptive planner may use smaller batches") { |value| options.batch_size = value }
+    opts.on("--max-batch-prompt-chars N", Integer, "Hard prompt char cap per Codex batch") { |value| options.max_batch_prompt_chars = value }
+    opts.on("--batch-max-events N", Integer, "High-event threshold for adaptive batch caps") { |value| options.batch_max_events = value }
+    opts.on("--sleep-seconds N", Integer, "Sleep after each applied Codex batch except the final batch") { |value| options.sleep_seconds = value }
+    opts.on("--no-snapshot-rebuild", "Skip graph snapshot rebuild for this graph import batch") { options.snapshot_rebuild = false }
+    opts.on("--memory-source VALUE", "Filter consolidate/graph inputs by source state") { |value| options.memory_source = value }
+    opts.on("--no-batch-fallback-single") { options.batch_fallback_single = false }
+    opts.on("--timeout-seconds N", Integer) { |value| options.timeout_seconds = value }
+    opts.on("--dry-run") { options.dry_run = true }
+    opts.on("--codex-dry-run") { options.codex_dry_run = true }
+    opts.on("--apply") { options.dry_run = false }
+    opts.on("--no-skip-failed") { options.skip_failed = false }
+    opts.on("-h", "--help") do
+      puts opts
+      exit 0
+    end
+  end
+  parser.parse!(argv)
+  options.batch_size = [options.batch_size.to_i, 1].max
+  options.max_batch_prompt_chars = [options.max_batch_prompt_chars.to_i, 1].max
+  options.batch_max_events = [options.batch_max_events.to_i, 0].max
+  options.sample_events = [options.sample_events.to_i, 0].max
+  options.sleep_seconds = [options.sleep_seconds.to_i, 0].max
+  options
+end
+
+def session_candidate?(session, options, pipeline_state, replay_state)
+  meta = session[:meta]
+  sid = meta["id"]
+  return false unless sid
+  pipeline_row = state_row_for_session(pipeline_state, session)
+  replay_row = state_row_for_session(replay_state, session)
+  return false if pipeline_row && pipeline_row["phase"] == "ingest-summaries" && pipeline_row["status"] == "remembered"
+  return false if replay_row && replay_row["status"] == "remembered"
+  return false if options.skip_failed && pipeline_row && pipeline_row["status"] == "failed"
+  event_count = session_event_count(session)
+  return false if event_count < options.min_events
+  return false if event_count > options.max_events
+  return false if options.project && session[:project] != options.project
+  return false if options.cwd_regex && meta["cwd"].to_s !~ options.cwd_regex
+  return false unless date_in_range?(meta["timestamp"], options.after, options.before)
+  return false if codex_import_session?(session)
+
+  true
+end
+
+def select_sessions(options)
+  pipeline_state = latest_rows_by_identity(read_jsonl(options.state_path))
+  replay_state = latest_rows_by_identity(read_jsonl(options.replay_state_path))
+  selected = []
+  jsonl_files(options.source).each do |path|
+    session = parse_codex_session(path, options.max_event_chars, options.sample_events)
+    next unless session_candidate?(session, options, pipeline_state, replay_state)
+
+    selected << session
+    break if selected.length >= options.limit
+  end
+  selected
+end
+
+def select_reenrich_sessions(options)
+  rows = read_jsonl(options.replay_state_path).select do |row|
+    row["status"] == "remembered" &&
+      valid_string?(row["memoryId"]) &&
+      valid_string?(row["source"]) &&
+      File.file?(row["source"]) &&
+      date_in_range?(row["startedAt"], options.after, options.before) &&
+      (!options.project || row["project"] == options.project) &&
+      (!options.cwd_regex || row["cwd"].to_s =~ options.cwd_regex)
+  end.uniq { |row| [row["memoryId"].to_s, row["source"].to_s, row["sessionId"].to_s] }
+
+  pipeline_rows = read_jsonl(options.state_path)
+  codex_ingested = pipeline_rows.each_with_object(Set.new) do |row, ids|
+    next unless row["phase"] == "ingest-summaries" && row["status"] == "remembered"
+
+    ids << row["source"].to_s if valid_string?(row["source"])
+    ids << row["sessionId"].to_s if valid_string?(row["sessionId"])
+  end
+  reenriched = pipeline_rows.each_with_object(Set.new) do |row, ids|
+    next unless row["phase"] == "re-enrich-ollama" && row["status"] == "remembered"
+
+    ids << row["source"].to_s if valid_string?(row["source"])
+    ids << row["sessionId"].to_s if valid_string?(row["sessionId"])
+    ids << row["originalMemoryId"].to_s if valid_string?(row["originalMemoryId"])
+  end
+  failed = pipeline_rows.each_with_object(Set.new) do |row, ids|
+    next unless row["phase"] == "re-enrich-ollama" && row["status"] == "failed"
+
+    ids << row["source"].to_s if valid_string?(row["source"])
+    ids << row["sessionId"].to_s if valid_string?(row["sessionId"])
+    ids << row["originalMemoryId"].to_s if valid_string?(row["originalMemoryId"])
+  end
+
+  rows.sort_by { |row| row["startedAt"].to_s }.reverse.filter_map do |row|
+    identity_values = [row["source"].to_s, row["sessionId"].to_s, row["memoryId"].to_s]
+    next if identity_values.any? { |value| codex_ingested.include?(value) }
+    next if identity_values.any? { |value| reenriched.include?(value) }
+    next if options.skip_failed && identity_values.any? { |value| failed.include?(value) }
+
+    session = parse_codex_session(row["source"], options.max_event_chars, options.sample_events)
+    next if session_event_count(session) < options.min_events
+    next if session_event_count(session) > options.max_events
+    next if codex_import_session?(session)
+
+    session[:replay_row] = row
+    session
+  rescue StandardError => e
+    warn "skip reenrich source=#{row["source"]} reason=#{e.message}"
+    nil
+  end.first(options.limit)
+end
+
+def pipeline_memory_rows(options)
+  already_processed = processed_memory_ids(options)
+  rows = []
+  read_jsonl(options.replay_state_path).each do |row|
+    source_state = "replay-enrichment"
+    next if options.memory_source && options.memory_source != source_state
+    next unless row["status"] == "remembered" && valid_string?(row["memoryId"])
+    next if already_processed.include?(row["memoryId"])
+    next unless date_in_range?(row["startedAt"], options.after, options.before)
+    next if options.project && row["project"] != options.project
+    next if options.cwd_regex && row["cwd"].to_s !~ options.cwd_regex
+
+    rows << row.merge("sourceState" => source_state)
+  end
+  read_jsonl(options.state_path).each do |row|
+    next unless %w[ingest-summaries re-enrich-ollama].include?(row["phase"])
+    source_state = row["phase"] || "codex-pipeline"
+    next if options.memory_source && options.memory_source != source_state
+    next unless row["status"] == "remembered" && valid_string?(row["memoryId"])
+    next if already_processed.include?(row["memoryId"])
+    next unless date_in_range?(row["startedAt"], options.after, options.before)
+    next if options.project && row["project"] != options.project
+    next if options.cwd_regex && row["cwd"].to_s !~ options.cwd_regex
+
+    rows << row.merge("sourceState" => source_state)
+  end
+  rows.uniq { |row| row["memoryId"] }.sort_by { |row| row["rememberedAt"].to_s }.reverse.first(options.limit)
+end
+
+def processed_memory_ids(options)
+  return Set.new unless %w[consolidate graph].include?(options.command)
+
+  read_jsonl(options.state_path).each_with_object(Set.new) do |row, ids|
+    next unless row["phase"] == options.command
+    next unless row["status"] == "imported"
+
+    string_array(row["selectedMemoryIds"]).each { |id| ids << id }
+  end
+end
+
+def fetch_pipeline_memories(options)
+  pipeline_memory_rows(options).filter_map do |row|
+    memory = fetch_memory(options.agentmemory_url, row["memoryId"])
+    memory["id"] ||= row["memoryId"]
+    memory["project"] ||= row["project"]
+    memory["sessionIds"] = string_array(memory["sessionIds"]) | [row["sessionId"].to_s]
+    memory
+  rescue StandardError => e
+    warn "skip memory=#{row["memoryId"]} reason=#{e.message}"
+    nil
+  end
+end
+
+def ingest_result_fields(result, batch: nil, batch_index: nil)
+  fields = {
+    "schema" => result["schema"],
+    "promptHash" => result["promptHash"],
+    "outputHash" => result["outputHash"]
+  }
+  return fields unless batch
+
+  fields.merge(
+    "batch" => true,
+    "batchSize" => batch.length,
+    "batchIndex" => batch_index,
+    "batchSourcePaths" => batch.map { |session| session[:path] },
+    "batchPromptHash" => result["promptHash"],
+    "batchOutputHash" => result["outputHash"]
+  )
+end
+
+def append_ingest_failure(options, session, error, fields = {})
+  meta = session[:meta]
+  append_state(options.state_path, {
+    "phase" => "ingest-summaries",
+    "sessionId" => meta["id"],
+    "status" => "failed",
+    "project" => session[:project],
+    "cwd" => meta["cwd"],
+    "startedAt" => meta["timestamp"],
+    "source" => session[:path],
+    "error" => error.message,
+    "failedAt" => now_iso
+  }.merge(fields)) unless options.dry_run
+end
+
+def ingest_one_session(session, schema, options, result: nil, summary: nil, batch: nil, batch_index: nil)
+  meta = session[:meta]
+  state_fields = {}
+  unless result && summary
+    prompt = build_session_prompt(session, options.max_prompt_chars)
+    result = run_codex(prompt, schema, options)
+    summary = validate_summary!(result["output"], session)
+  end
+  state_fields = ingest_result_fields(result, batch: batch, batch_index: batch_index)
+  if options.dry_run
+    puts "  codex output_hash=#{result["outputHash"]} content_chars=#{summary["content"].length}"
+    return nil
+  end
+
+  existing_memory_id = if ENV["CODEX_PIPELINE_EXISTING_LOOKUP"] == "1"
+    existing_memory_for_source(options.agentmemory_url, meta["id"], session[:path])
+  end
+  if existing_memory_id
+    append_state(options.state_path, {
+      "phase" => "ingest-summaries",
+      "sessionId" => meta["id"],
+      "status" => "remembered",
+      "memoryId" => existing_memory_id,
+      "reconciled" => true,
+      "project" => session[:project],
+      "cwd" => meta["cwd"],
+      "startedAt" => meta["timestamp"],
+      "source" => session[:path],
+      "rememberedAt" => now_iso
+    }.merge(state_fields))
+    puts "  memory=#{existing_memory_id} reconciled=true"
+    return existing_memory_id
+  end
+
+  append_state(options.state_path, {
+    "phase" => "ingest-summaries",
+    "sessionId" => meta["id"],
+    "status" => "pending",
+    "project" => session[:project],
+    "cwd" => meta["cwd"],
+    "startedAt" => meta["timestamp"],
+    "source" => session[:path],
+    "pendingAt" => now_iso
+  }.merge(state_fields))
+  memory = remember(options.agentmemory_url, session, summary)
+  append_state(options.state_path, {
+    "phase" => "ingest-summaries",
+    "sessionId" => meta["id"],
+    "status" => "remembered",
+    "memoryId" => memory["id"],
+    "project" => session[:project],
+    "cwd" => meta["cwd"],
+    "startedAt" => meta["timestamp"],
+    "source" => session[:path],
+    "rememberedAt" => now_iso
+  }.merge(state_fields))
+  puts "  memory=#{memory["id"]}"
+  memory["id"]
+rescue StandardError => e
+  append_ingest_failure(options, session, e, state_fields)
+  raise
+end
+
+def command_ingest(options)
+  single_schema = schema_path(options, "codex-session-summary.schema.json")
+  batch_schema = schema_path(options, "codex-session-summary-batch.schema.json")
+  selected = select_sessions(options).first(options.limit)
+  batches = plan_ingest_batches(selected, options).first(options.max_codex_calls)
+  runnable = batches.flatten
+  puts "command=ingest-summaries"
+  puts "state=#{options.state_path}"
+  puts "dry_run=#{options.dry_run}"
+  puts "codex_dry_run=#{options.codex_dry_run}"
+  puts "batch_size=#{options.batch_size}"
+  puts "sample_events=#{options.sample_events}"
+  puts "max_batch_prompt_chars=#{options.max_batch_prompt_chars}"
+  puts "batch_max_events=#{options.batch_max_events}"
+  puts "sleep_seconds=#{options.sleep_seconds}"
+  puts "selected=#{runnable.length}"
+  puts "batches=#{batches.length}"
+  batches.each_with_index do |batch, batch_idx|
+    batch_prompt_chars = if batch.length == 1
+      build_session_prompt(batch.first, options.max_prompt_chars).length
+    else
+      build_batch_session_prompt(batch, options).length
+    end
+    puts "batch[#{batch_idx + 1}/#{batches.length}] size=#{batch.length} events=#{batch.sum { |session| session_event_count(session) }} prompt_chars=#{batch_prompt_chars}"
+    batch.each_with_index do |session, idx|
+      meta = session[:meta]
+      sampled = session[:original_events] && session[:original_events] != session[:events].length ? " sampled=#{session[:events].length}" : ""
+      puts "[#{idx + 1}/#{batch.length}] #{meta["id"]} project=#{session[:project]} cwd=#{meta["cwd"]} events=#{session_event_count(session)}#{sampled} started=#{meta["timestamp"]} source=#{session[:path]}"
+    end
+    next if options.dry_run && !options.codex_dry_run
+
+    if batch.length == 1
+      ingest_one_session(batch.first, single_schema, options)
+      next
+    end
+
+    begin
+      prompt = build_batch_session_prompt(batch, options)
+      result = run_codex(prompt, batch_schema, options)
+      summaries = validate_batch_summary!(result["output"], batch)
+      if options.dry_run
+        puts "  batch output_hash=#{result["outputHash"]} summaries=#{summaries.length}"
+        summaries.each { |summary| puts "  source=#{summary["sourcePath"]} content_chars=#{summary["content"].length}" }
+        next
+      end
+
+      batch.zip(summaries).each do |session, summary|
+        ingest_one_session(session, batch_schema, options, result: result, summary: summary, batch: batch, batch_index: batch_idx + 1)
+      end
+    rescue StandardError => e
+      if options.batch_fallback_single && batch.length > 1
+        warn "batch failed; falling back to single-session ingest: #{e.message}"
+        batch.each { |session| ingest_one_session(session, single_schema, options) }
+      else
+        fields = {
+          "batch" => true,
+          "batchSize" => batch.length,
+          "batchIndex" => batch_idx + 1,
+          "batchSourcePaths" => batch.map { |session| session[:path] }
+        }
+        batch.each { |session| append_ingest_failure(options, session, e, fields) }
+        raise
+      end
+    end
+    if !options.dry_run && options.sleep_seconds.positive? && batch_idx < batches.length - 1
+      puts "sleeping #{options.sleep_seconds}s before next Codex batch"
+      sleep options.sleep_seconds
+    end
+  end
+end
+
+def append_reenrich_failure(options, session, error, fields = {})
+  row = session[:replay_row] || {}
+  meta = session[:meta]
+  append_state(options.state_path, {
+    "phase" => "re-enrich-ollama",
+    "sessionId" => meta["id"],
+    "status" => "failed",
+    "originalMemoryId" => row["memoryId"],
+    "project" => session[:project],
+    "cwd" => meta["cwd"],
+    "startedAt" => meta["timestamp"],
+    "source" => session[:path],
+    "error" => error.message,
+    "failedAt" => now_iso
+  }.merge(fields)) unless options.dry_run
+end
+
+def reenrich_one_session(session, schema, options, result: nil, summary: nil, batch: nil, batch_index: nil)
+  row = session[:replay_row] || {}
+  meta = session[:meta]
+  state_fields = {}
+  unless result && summary
+    prompt = build_session_prompt(session, options.max_prompt_chars)
+    result = run_codex(prompt, schema, options)
+    summary = validate_summary!(result["output"], session)
+  end
+  state_fields = ingest_result_fields(result, batch: batch, batch_index: batch_index)
+  if options.dry_run
+    puts "  codex output_hash=#{result["outputHash"]} content_chars=#{summary["content"].length}"
+    return nil
+  end
+
+  append_state(options.state_path, {
+    "phase" => "re-enrich-ollama",
+    "sessionId" => meta["id"],
+    "status" => "pending",
+    "originalMemoryId" => row["memoryId"],
+    "project" => session[:project],
+    "cwd" => meta["cwd"],
+    "startedAt" => meta["timestamp"],
+    "source" => session[:path],
+    "pendingAt" => now_iso
+  }.merge(state_fields))
+  memory = remember(
+    options.agentmemory_url,
+    session,
+    summary,
+    extra_concepts: [
+      "codex-reenriched",
+      "ollama-replacement",
+      "supersedes:#{row["memoryId"]}"
+    ],
+    extra_lines: [
+      "SupersedesMemory: #{row["memoryId"]}",
+      "ReenrichedFrom: replay-enrichment"
+    ]
+  )
+  append_state(options.state_path, {
+    "phase" => "re-enrich-ollama",
+    "sessionId" => meta["id"],
+    "status" => "remembered",
+    "memoryId" => memory["id"],
+    "originalMemoryId" => row["memoryId"],
+    "project" => session[:project],
+    "cwd" => meta["cwd"],
+    "startedAt" => meta["timestamp"],
+    "source" => session[:path],
+    "rememberedAt" => now_iso
+  }.merge(state_fields))
+  puts "  memory=#{memory["id"]} supersedes=#{row["memoryId"]}"
+  memory["id"]
+rescue StandardError => e
+  append_reenrich_failure(options, session, e, state_fields)
+  raise
+end
+
+def command_reenrich_ollama(options)
+  single_schema = schema_path(options, "codex-session-summary.schema.json")
+  batch_schema = schema_path(options, "codex-session-summary-batch.schema.json")
+  selected = select_reenrich_sessions(options).first(options.limit)
+  batches = plan_ingest_batches(selected, options).first(options.max_codex_calls)
+  runnable = batches.flatten
+  puts "command=re-enrich-ollama"
+  puts "state=#{options.state_path}"
+  puts "replay_state=#{options.replay_state_path}"
+  puts "dry_run=#{options.dry_run}"
+  puts "codex_dry_run=#{options.codex_dry_run}"
+  puts "batch_size=#{options.batch_size}"
+  puts "sample_events=#{options.sample_events}"
+  puts "max_batch_prompt_chars=#{options.max_batch_prompt_chars}"
+  puts "batch_max_events=#{options.batch_max_events}"
+  puts "sleep_seconds=#{options.sleep_seconds}"
+  puts "selected=#{runnable.length}"
+  puts "batches=#{batches.length}"
+  batches.each_with_index do |batch, batch_idx|
+    batch_prompt_chars = if batch.length == 1
+      build_session_prompt(batch.first, options.max_prompt_chars).length
+    else
+      build_batch_session_prompt(batch, options).length
+    end
+    puts "batch[#{batch_idx + 1}/#{batches.length}] size=#{batch.length} events=#{batch.sum { |session| session_event_count(session) }} prompt_chars=#{batch_prompt_chars}"
+    batch.each_with_index do |session, idx|
+      row = session[:replay_row] || {}
+      meta = session[:meta]
+      sampled = session[:original_events] && session[:original_events] != session[:events].length ? " sampled=#{session[:events].length}" : ""
+      puts "[#{idx + 1}/#{batch.length}] #{meta["id"]} original_memory=#{row["memoryId"]} project=#{session[:project]} cwd=#{meta["cwd"]} events=#{session_event_count(session)}#{sampled} started=#{meta["timestamp"]} source=#{session[:path]}"
+    end
+    next if options.dry_run && !options.codex_dry_run
+
+    if batch.length == 1
+      reenrich_one_session(batch.first, single_schema, options)
+      next
+    end
+
+    begin
+      prompt = build_batch_session_prompt(batch, options)
+      result = run_codex(prompt, batch_schema, options)
+      summaries = validate_batch_summary!(result["output"], batch)
+      if options.dry_run
+        puts "  batch output_hash=#{result["outputHash"]} summaries=#{summaries.length}"
+        summaries.each { |summary| puts "  source=#{summary["sourcePath"]} content_chars=#{summary["content"].length}" }
+        next
+      end
+
+      batch.zip(summaries).each do |session, summary|
+        reenrich_one_session(session, batch_schema, options, result: result, summary: summary, batch: batch, batch_index: batch_idx + 1)
+      end
+    rescue StandardError => e
+      if options.batch_fallback_single && batch.length > 1
+        warn "batch failed; falling back to single-session re-enrich: #{e.message}"
+        batch.each { |session| reenrich_one_session(session, single_schema, options) }
+      else
+        fields = {
+          "batch" => true,
+          "batchSize" => batch.length,
+          "batchIndex" => batch_idx + 1,
+          "batchSourcePaths" => batch.map { |session| session[:path] }
+        }
+        batch.each { |session| append_reenrich_failure(options, session, e, fields) }
+        raise
+      end
+    end
+    if !options.dry_run && options.sleep_seconds.positive? && batch_idx < batches.length - 1
+      puts "sleeping #{options.sleep_seconds}s before next Codex batch"
+      sleep options.sleep_seconds
+    end
+  end
+end
+
+def command_consolidate(options)
+  schema = schema_path(options, "codex-consolidation-delta.schema.json")
+  version = export_version(options.agentmemory_url)
+  memories = fetch_pipeline_memories(options)
+  puts "command=consolidate"
+  puts "state=#{options.state_path}"
+  puts "dry_run=#{options.dry_run}"
+  puts "selected_memories=#{memories.length}"
+  raise "no memories selected" if memories.empty?
+  return if options.dry_run && !options.codex_dry_run
+
+  prompt = build_consolidation_prompt(memories, version)
+  result = run_codex(prompt, schema, options)
+  export = validate_export_delta!(result["output"], "consolidate")
+  delta = canonicalize_semantic(export, version)
+  puts "semantic=#{delta["semanticMemories"].length}"
+  puts "procedural=#{delta["proceduralMemories"].length}"
+  puts "output_hash=#{result["outputHash"]}"
+  return if options.dry_run
+
+  response = import_delta(options.agentmemory_url, delta)
+  append_state(options.state_path, {
+    "phase" => "consolidate",
+    "status" => response["success"] == true ? "imported" : "failed",
+    "selectedMemoryIds" => memories.map { |memory| memory["id"] },
+    "semantic" => delta["semanticMemories"].length,
+    "procedural" => delta["proceduralMemories"].length,
+    "importResponse" => response,
+    "schema" => result["schema"],
+    "promptHash" => result["promptHash"],
+    "outputHash" => result["outputHash"],
+    "importedAt" => now_iso
+  })
+  puts "import_success=#{response["success"]}"
+end
+
+def command_graph(options)
+  schema = schema_path(options, "codex-graph-delta.schema.json")
+  version = export_version(options.agentmemory_url)
+  memories = fetch_pipeline_memories(options)
+  puts "command=graph"
+  puts "state=#{options.state_path}"
+  puts "dry_run=#{options.dry_run}"
+  puts "selected_memories=#{memories.length}"
+  raise "no memories selected" if memories.empty?
+  return if options.dry_run && !options.codex_dry_run
+
+  prompt = build_graph_prompt(memories, version)
+  result = run_codex(prompt, schema, options)
+  export = validate_export_delta!(result["output"], "graph")
+  delta = canonicalize_graph(export, version)
+  puts "graph_nodes=#{delta["graphNodes"].length}"
+  puts "graph_edges=#{delta["graphEdges"].length}"
+  puts "output_hash=#{result["outputHash"]}"
+  return if options.dry_run
+
+  response = import_delta(options.agentmemory_url, delta)
+  rebuild = options.snapshot_rebuild ? rebuild_graph_snapshot(options.agentmemory_url) : { "success" => true, "skipped" => true }
+  append_state(options.state_path, {
+    "phase" => "graph",
+    "status" => response["success"] == true && rebuild["success"] == true ? "imported" : "failed",
+    "selectedMemoryIds" => memories.map { |memory| memory["id"] },
+    "graphNodes" => delta["graphNodes"].length,
+    "graphEdges" => delta["graphEdges"].length,
+    "importResponse" => response,
+    "snapshotRebuild" => rebuild,
+    "schema" => result["schema"],
+    "promptHash" => result["promptHash"],
+    "outputHash" => result["outputHash"],
+    "importedAt" => now_iso
+  })
+  puts "import_success=#{response["success"]}"
+  puts "snapshot_success=#{rebuild["success"]}"
+  puts "snapshot_skipped=#{rebuild["skipped"] == true}"
+end
+
+def main(argv)
+  command = argv.shift
+  unless COMMANDS.include?(command)
+    usage
+    exit 2
+  end
+
+  options = parse_options(command, argv)
+  env_file = load_env_file(File.expand_path("~/.agentmemory/.env"))
+  UNSAFE_AGENTMEMORY_FLAGS.each do |key|
+    if env_file[key] == "true" && !unsafe_flag_allowed?(key, command)
+      raise "unsafe agentmemory flag enabled: #{key}=true"
+    end
+    if ENV[key] == "true" && !unsafe_flag_allowed?(key, command)
+      raise "unsafe live environment flag enabled: #{key}=true"
+    end
+  end
+  if env_file["OPENAI_BASE_URL"].to_s.include?("api.openai.com")
+    raise "unsafe agentmemory provider configured: OPENAI_BASE_URL=#{env_file["OPENAI_BASE_URL"]}"
+  end
+  raise "trusted cwd missing: #{options.trusted_cwd}" unless File.directory?(options.trusted_cwd)
+  raise "schema dir missing: #{options.schema_dir}" unless File.directory?(options.schema_dir)
+
+  case command
+  when "ingest-summaries"
+    command_ingest(options)
+  when "re-enrich-ollama"
+    command_reenrich_ollama(options)
+  when "consolidate"
+    command_consolidate(options)
+  when "graph"
+    command_graph(options)
+  end
+end
+
+main(ARGV)

--- a/src/config.ts
+++ b/src/config.ts
@@ -392,6 +392,10 @@ export function isAutoCompressEnabled(): boolean {
   return getMergedEnv()["AGENTMEMORY_AUTO_COMPRESS"] === "true";
 }
 
+export function isSummarizeOnStopEnabled(): boolean {
+  return getMergedEnv()["AGENTMEMORY_SUMMARIZE_ON_STOP"] === "true";
+}
+
 // Hook-level context injection into Claude Code's conversation is OFF by
 // default as of 0.8.10 (see #143). When disabled, pre-tool-use and
 // session-start hooks still POST observations for background capture, but

--- a/src/config.ts
+++ b/src/config.ts
@@ -332,6 +332,12 @@ export function isGraphExtractionEnabled(): boolean {
   return getMergedEnv()["GRAPH_EXTRACTION_ENABLED"] === "true";
 }
 
+export function isGraphReadEnabled(): boolean {
+  const env = getMergedEnv();
+  return env["GRAPH_READ_ENABLED"] === "true" ||
+    env["GRAPH_EXTRACTION_ENABLED"] === "true";
+}
+
 export function getGraphBatchSize(): number {
   return safeParseInt(getMergedEnv()["GRAPH_EXTRACTION_BATCH_SIZE"], 10);
 }

--- a/src/functions/export-import.ts
+++ b/src/functions/export-import.ts
@@ -30,6 +30,7 @@ import { StateKV } from "../state/kv.js";
 import { VERSION } from "../version.js";
 import { recordAudit } from "./audit.js";
 import { logger } from "../logger.js";
+import { upsertGraphDelta } from "./graph.js";
 
 export function registerExportImportFunction(sdk: ISdk, kv: StateKV): void {
   sdk.registerFunction("mem::export", 
@@ -321,6 +322,7 @@ export function registerExportImportFunction(sdk: ISdk, kv: StateKV): void {
         for (const e of await kv.list<{ id: string }>(KV.graphEdges).catch(() => [])) {
           await kv.delete(KV.graphEdges, e.id);
         }
+        await kv.delete(KV.graphSnapshot, "current").catch(() => undefined);
         for (const s of await kv.list<{ id: string }>(KV.semantic).catch(() => [])) {
           await kv.delete(KV.semantic, s.id);
         }
@@ -397,23 +399,14 @@ export function registerExportImportFunction(sdk: ISdk, kv: StateKV): void {
         stats.summaries++;
       }
 
-      if (importData.graphNodes) {
-        for (const node of importData.graphNodes) {
-          if (strategy === "skip") {
-            const existing = await kv.get(KV.graphNodes, node.id).catch(() => null);
-            if (existing) { stats.skipped++; continue; }
-          }
-          await kv.set(KV.graphNodes, node.id, node);
-        }
-      }
-      if (importData.graphEdges) {
-        for (const edge of importData.graphEdges) {
-          if (strategy === "skip") {
-            const existing = await kv.get(KV.graphEdges, edge.id).catch(() => null);
-            if (existing) { stats.skipped++; continue; }
-          }
-          await kv.set(KV.graphEdges, edge.id, edge);
-        }
+      if (importData.graphNodes || importData.graphEdges) {
+        const graphStats = await upsertGraphDelta(
+          kv,
+          importData.graphNodes ?? [],
+          importData.graphEdges ?? [],
+          strategy,
+        );
+        stats.skipped += graphStats.skipped;
       }
       if (importData.semanticMemories) {
         for (const sem of importData.semanticMemories) {

--- a/src/functions/graph.ts
+++ b/src/functions/graph.ts
@@ -15,6 +15,7 @@ import {
 } from "../prompts/graph-extraction.js";
 import { recordAudit } from "./audit.js";
 import { logger } from "../logger.js";
+import { isGraphExtractionEnabled } from "../config.js";
 
 // #753: keep the response payload below the iii state channel ceiling.
 // 500 nodes + their incident edges hold well under the limit on the
@@ -303,6 +304,127 @@ function mergeEdge(
   };
 }
 
+function mergeImportedNode(
+  existing: GraphNode,
+  incoming: GraphNode,
+  capturedAt: string,
+): GraphNode {
+  return {
+    ...existing,
+    properties: { ...existing.properties, ...incoming.properties },
+    sourceObservationIds: [
+      ...new Set([
+        ...existing.sourceObservationIds,
+        ...incoming.sourceObservationIds,
+      ]),
+    ],
+    updatedAt: capturedAt,
+  };
+}
+
+function mergeImportedEdge(existing: GraphEdge, incoming: GraphEdge): GraphEdge {
+  return {
+    ...existing,
+    weight: Math.max(existing.weight, incoming.weight),
+    sourceObservationIds: [
+      ...new Set([
+        ...existing.sourceObservationIds,
+        ...incoming.sourceObservationIds,
+      ]),
+    ],
+  };
+}
+
+export async function upsertGraphDelta(
+  kv: StateKV,
+  nodes: GraphNode[],
+  edges: GraphEdge[],
+  strategy: "merge" | "replace" | "skip" = "merge",
+): Promise<{ nodes: number; edges: number; skipped: number }> {
+  const snap = (await readSnapshot(kv)) ?? emptySnapshot();
+  const capturedAt = new Date().toISOString();
+  const changedEdges: GraphEdge[] = [];
+  let importedNodes = 0;
+  let importedEdges = 0;
+  let skipped = 0;
+
+  for (const node of nodes) {
+    const existing = await kv.get<GraphNode>(KV.graphNodes, node.id).catch(() => null);
+    if (strategy === "skip" && existing) {
+      skipped++;
+      continue;
+    }
+
+    const stored = existing ? mergeImportedNode(existing, node, capturedAt) : node;
+    await kv.set(KV.graphNodes, stored.id, stored);
+    await kv.set(KV.graphNameIndex, nameIndexKey(stored.type, stored.name), stored.id);
+
+    if (!existing) {
+      const degree = await kv.get<number>(KV.graphNodeDegree, stored.id) ?? 0;
+      await kv.set(KV.graphNodeDegree, stored.id, degree);
+      snap.stats.totalNodes += 1;
+      snap.stats.nodesByType[stored.type] =
+        (snap.stats.nodesByType[stored.type] ?? 0) + 1;
+      if (snap.topNodes.length < SNAPSHOT_TOP_NODES) {
+        snap.topNodes.push(stored);
+        snap.topDegrees[stored.id] = degree;
+      }
+    } else {
+      const topIdx = snap.topNodes.findIndex((n) => n.id === stored.id);
+      if (topIdx !== -1) snap.topNodes[topIdx] = stored;
+    }
+
+    importedNodes++;
+  }
+
+  for (const edge of edges) {
+    const sourceExists = await kv.get<GraphNode>(KV.graphNodes, edge.sourceNodeId).catch(() => null);
+    const targetExists = await kv.get<GraphNode>(KV.graphNodes, edge.targetNodeId).catch(() => null);
+    if (!sourceExists || !targetExists) {
+      skipped++;
+      continue;
+    }
+
+    const existing = await kv.get<GraphEdge>(KV.graphEdges, edge.id).catch(() => null);
+    if (strategy === "skip" && existing) {
+      skipped++;
+      continue;
+    }
+
+    const stored = existing ? mergeImportedEdge(existing, edge) : edge;
+    await kv.set(KV.graphEdges, stored.id, stored);
+    await kv.set(
+      KV.graphEdgeKey,
+      edgeIndexKey(stored.sourceNodeId, stored.targetNodeId, stored.type),
+      stored.id,
+    );
+
+    if (!existing) {
+      snap.stats.totalEdges += 1;
+      snap.stats.edgesByType[stored.type] =
+        (snap.stats.edgesByType[stored.type] ?? 0) + 1;
+      await applyDegreeDelta(kv, snap, stored.sourceNodeId, +1);
+      await applyDegreeDelta(kv, snap, stored.targetNodeId, +1);
+      changedEdges.push(stored);
+    } else {
+      const topIdx = snap.topEdges.findIndex((e) => e.id === stored.id);
+      if (topIdx !== -1) snap.topEdges[topIdx] = stored;
+    }
+
+    importedEdges++;
+  }
+
+  for (const edge of changedEdges) snapshotPushEdgeIfBothInTop(snap, edge);
+
+  if (importedNodes > 0 || importedEdges > 0) {
+    snap.updatedAt = capturedAt;
+    snap.dirty = false;
+    await kv.set(KV.graphSnapshot, SNAPSHOT_KEY, snap);
+  }
+
+  return { nodes: importedNodes, edges: importedEdges, skipped };
+}
+
 function resolvePagination(
   rawLimit: number | undefined,
   rawOffset: number | undefined,
@@ -457,6 +579,13 @@ export function registerGraphFunction(
 ): void {
   sdk.registerFunction("mem::graph-extract", 
     async (data: { observations: CompressedObservation[] }) => {
+      if (!isGraphExtractionEnabled()) {
+        return {
+          success: false,
+          error: "Knowledge graph extraction disabled; set GRAPH_EXTRACTION_ENABLED=true and restart to extract graph data.",
+        };
+      }
+
       if (!data.observations || data.observations.length === 0) {
         return { success: false, error: "No observations provided" };
       }

--- a/src/hooks/stop.ts
+++ b/src/hooks/stop.ts
@@ -11,6 +11,7 @@ function isSdkChildContext(payload: unknown): boolean {
 
 const REST_URL = process.env["AGENTMEMORY_URL"] || "http://localhost:3111";
 const SECRET = process.env["AGENTMEMORY_SECRET"] || "";
+const SUMMARIZE_ON_STOP = process.env["AGENTMEMORY_SUMMARIZE_ON_STOP"] === "true";
 
 function authHeaders(): Record<string, string> {
   const h: Record<string, string> = { "Content-Type": "application/json" };
@@ -39,12 +40,14 @@ async function main() {
 
   const sessionId = ((data.session_id || data.sessionId) as string) || "unknown";
 
-  fetch(`${REST_URL}/agentmemory/summarize`, {
-    method: "POST",
-    headers: authHeaders(),
-    body: JSON.stringify({ sessionId }),
-    signal: AbortSignal.timeout(120000),
-  }).catch(() => {});
+  if (SUMMARIZE_ON_STOP) {
+    fetch(`${REST_URL}/agentmemory/summarize`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ sessionId }),
+      signal: AbortSignal.timeout(120000),
+    }).catch(() => {});
+  }
 
   fetch(`${REST_URL}/agentmemory/session/end`, {
     method: "POST",

--- a/src/index.ts
+++ b/src/index.ts
@@ -266,10 +266,8 @@ async function main() {
     );
   }
 
-  if (isGraphExtractionEnabled()) {
-    registerGraphFunction(sdk, kv, provider);
-    bootLog(`Knowledge graph: extraction enabled`);
-  }
+  registerGraphFunction(sdk, kv, provider);
+  bootLog(`Knowledge graph: registered (GRAPH_EXTRACTION_ENABLED=${isGraphExtractionEnabled() ? "true" : "false"})`);
 
   registerConsolidationPipelineFunction(sdk, kv, provider);
   bootLog(`Consolidation pipeline: registered (CONSOLIDATION_ENABLED=${isConsolidationEnabled() ? "true" : "false"})`);

--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -15,6 +15,7 @@ import { MAX_FILES_UPPER_BOUND } from "../functions/replay.js";
 import { logger } from "../logger.js";
 import {
   isGraphExtractionEnabled,
+  isGraphReadEnabled,
   isConsolidationEnabled,
   isAutoCompressEnabled,
   isContextInjectionEnabled,
@@ -191,6 +192,17 @@ export function registerApiTriggers(
           needsLlm: true,
           description: "Extracts entities and relations from observations into a knowledge graph.",
           enableHow: "Set GRAPH_EXTRACTION_ENABLED=true and provide an LLM key, then restart.",
+          docsHref: "https://github.com/rohitg00/agentmemory#knowledge-graph",
+        },
+        {
+          key: "GRAPH_READ_ENABLED",
+          label: "Knowledge graph reads",
+          enabled: isGraphReadEnabled(),
+          default: false,
+          affects: ["Graph", "Dashboard"],
+          needsLlm: false,
+          description: "Exposes graph stats and query endpoints without enabling LLM-backed extraction.",
+          enableHow: "Set GRAPH_READ_ENABLED=true, then restart. GRAPH_EXTRACTION_ENABLED=true also enables graph reads for compatibility.",
           docsHref: "https://github.com/rohitg00/agentmemory#knowledge-graph",
         },
         {

--- a/src/triggers/events.ts
+++ b/src/triggers/events.ts
@@ -3,7 +3,7 @@ import type { CompressedObservation, HookPayload, Session } from "../types.js";
 import { KV, STREAM } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
 import { isReflectEnabled } from "../functions/slots.js";
-import { isGraphExtractionEnabled } from "../config.js";
+import { isGraphExtractionEnabled, isSummarizeOnStopEnabled } from "../config.js";
 import { logger } from "../logger.js";
 
 export function registerEventTriggers(sdk: ISdk, kv: StateKV): void {
@@ -45,7 +45,9 @@ export function registerEventTriggers(sdk: ISdk, kv: StateKV): void {
   });
 
   sdk.registerFunction("event::session::stopped", async (data: { sessionId: string }) => {
-    const summary = await sdk.trigger({ function_id: "mem::summarize", payload: data });
+    const summary = isSummarizeOnStopEnabled()
+      ? await sdk.trigger({ function_id: "mem::summarize", payload: data })
+      : { skipped: true, reason: "AGENTMEMORY_SUMMARIZE_ON_STOP is not true" };
     if (isReflectEnabled()) {
       try {
         sdk.trigger({

--- a/test/env-loader.test.ts
+++ b/test/env-loader.test.ts
@@ -28,6 +28,7 @@ describe("loadEnvFile", () => {
     delete process.env["AGENTMEMORY_DROP_STALE_INDEX"];
     delete process.env["CONSOLIDATION_ENABLED"];
     delete process.env["GRAPH_EXTRACTION_ENABLED"];
+    delete process.env["GRAPH_READ_ENABLED"];
     delete process.env["TOKEN"];
     delete process.env["HASHVAL"];
   });
@@ -88,5 +89,24 @@ describe("loadEnvFile", () => {
     writeEnv("AGENTMEMORY_DROP_STALE_INDEX=true");
     const cfg = await freshConfig();
     expect(cfg.isDropStaleIndexEnabled()).toBe(true);
+  });
+
+  it("allows graph reads while graph extraction stays disabled", async () => {
+    writeEnv(
+      [
+        "GRAPH_EXTRACTION_ENABLED=false",
+        "GRAPH_READ_ENABLED=true",
+      ].join("\n"),
+    );
+    const cfg = await freshConfig();
+    expect(cfg.isGraphExtractionEnabled()).toBe(false);
+    expect(cfg.isGraphReadEnabled()).toBe(true);
+  });
+
+  it("keeps graph read enabled when legacy graph extraction flag is enabled", async () => {
+    writeEnv("GRAPH_EXTRACTION_ENABLED=true");
+    const cfg = await freshConfig();
+    expect(cfg.isGraphExtractionEnabled()).toBe(true);
+    expect(cfg.isGraphReadEnabled()).toBe(true);
   });
 });

--- a/test/export-import.test.ts
+++ b/test/export-import.test.ts
@@ -5,12 +5,15 @@ vi.mock("../src/logger.js", () => ({
 }));
 
 import { registerExportImportFunction } from "../src/functions/export-import.js";
+import { registerGraphFunction } from "../src/functions/graph.js";
 import type {
   Session,
   CompressedObservation,
   Memory,
   SessionSummary,
   ExportData,
+  GraphNode,
+  GraphEdge,
 } from "../src/types.js";
 
 function mockKV() {
@@ -229,6 +232,71 @@ describe("Export/Import Functions", () => {
     )) as ExportData;
     expect(reExported.sessions.length).toBe(exported.sessions.length);
     expect(reExported.memories.length).toBe(exported.memories.length);
+  });
+
+  it("imported graph deltas update graph snapshot for immediate reads", async () => {
+    const freshKv = mockKV();
+    const freshSdk = mockSdk();
+    registerExportImportFunction(freshSdk as never, freshKv as never);
+    registerGraphFunction(freshSdk as never, freshKv as never, {
+      name: "test",
+      compress: vi.fn(),
+      summarize: vi.fn(),
+    } as never);
+
+    const graphNodes: GraphNode[] = [
+      {
+        id: "gn_codex_file",
+        type: "file",
+        name: "src/auth.ts",
+        properties: { path: "src/auth.ts" },
+        sourceObservationIds: ["obs_graph_1"],
+        createdAt: "2026-02-01T00:00:00Z",
+      },
+      {
+        id: "gn_codex_concept",
+        type: "concept",
+        name: "auth tokens",
+        properties: {},
+        sourceObservationIds: ["obs_graph_1"],
+        createdAt: "2026-02-01T00:00:00Z",
+      },
+    ];
+    const graphEdges: GraphEdge[] = [
+      {
+        id: "ge_codex_edge",
+        type: "related_to",
+        sourceNodeId: "gn_codex_file",
+        targetNodeId: "gn_codex_concept",
+        weight: 0.8,
+        sourceObservationIds: ["obs_graph_1"],
+        createdAt: "2026-02-01T00:00:00Z",
+      },
+    ];
+
+    const result = (await freshSdk.trigger("mem::import", {
+      strategy: "skip",
+      exportData: {
+        version: "0.9.27",
+        exportedAt: new Date().toISOString(),
+        sessions: [],
+        observations: {},
+        memories: [],
+        summaries: [],
+        graphNodes,
+        graphEdges,
+      },
+    })) as { success: boolean };
+    const stats = (await freshSdk.trigger("mem::graph-stats", {})) as {
+      totalNodes: number;
+      totalEdges: number;
+      fromSnapshot: boolean;
+    };
+
+    expect(result.success).toBe(true);
+    expect(stats.fromSnapshot).toBe(true);
+    expect(stats.totalNodes).toBe(2);
+    expect(stats.totalEdges).toBe(1);
   });
 
   it("import rejects unsupported version", async () => {

--- a/test/graph.test.ts
+++ b/test/graph.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
 vi.mock("../src/logger.js", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
@@ -63,6 +63,8 @@ const mockProvider = {
   summarize: vi.fn(),
 };
 
+const ORIGINAL_GRAPH_EXTRACTION_ENABLED = process.env["GRAPH_EXTRACTION_ENABLED"];
+
 const testObs: CompressedObservation = {
   id: "obs_1",
   sessionId: "ses_1",
@@ -81,10 +83,39 @@ describe("Graph Functions", () => {
   let kv: ReturnType<typeof mockKV>;
 
   beforeEach(() => {
+    process.env["GRAPH_EXTRACTION_ENABLED"] = "true";
     sdk = mockSdk();
     kv = mockKV();
     vi.clearAllMocks();
     registerGraphFunction(sdk as never, kv as never, mockProvider as never);
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_GRAPH_EXTRACTION_ENABLED === undefined) {
+      delete process.env["GRAPH_EXTRACTION_ENABLED"];
+    } else {
+      process.env["GRAPH_EXTRACTION_ENABLED"] = ORIGINAL_GRAPH_EXTRACTION_ENABLED;
+    }
+  });
+
+  it("keeps graph query available while graph extraction is disabled", async () => {
+    process.env["GRAPH_EXTRACTION_ENABLED"] = "false";
+
+    const extract = (await sdk.trigger("mem::graph-extract", {
+      observations: [testObs],
+    })) as { success: boolean; error?: string };
+    const stats = (await sdk.trigger("mem::graph-stats", {})) as {
+      totalNodes: number;
+      totalEdges: number;
+    };
+    const query = (await sdk.trigger("mem::graph-query", {})) as GraphQueryResult;
+
+    expect(extract.success).toBe(false);
+    expect(extract.error).toContain("Knowledge graph extraction disabled");
+    expect(mockProvider.compress).not.toHaveBeenCalled();
+    expect(stats.totalNodes).toBe(0);
+    expect(stats.totalEdges).toBe(0);
+    expect(query.nodes).toEqual([]);
   });
 
   it("graph-extract creates nodes and edges from XML response", async () => {

--- a/test/session-end-triggers-graph.test.ts
+++ b/test/session-end-triggers-graph.test.ts
@@ -35,6 +35,15 @@ describe("api::session::end → event::session::stopped (#666)", () => {
 // which returned 404 because the endpoint was never registered. Backfill
 // the knowledge graph from existing compressed observations across every
 // session in batches.
+describe("graph functions are registered for read-only graph access", () => {
+  const index = readFileSync("src/index.ts", "utf-8");
+
+  it("registers graph functions even when extraction is disabled", () => {
+    expect(index).not.toMatch(/if \(isGraphExtractionEnabled\(\)\) \{[\s\S]*?registerGraphFunction/);
+    expect(index).toMatch(/registerGraphFunction\(sdk, kv, provider\)/);
+  });
+});
+
 describe("api::graph-build endpoint (#666)", () => {
   const api = readFileSync("src/triggers/api.ts", "utf-8");
 


### PR DESCRIPTION
## Summary

Adds an offline Codex-backed batch path for agentmemory so expensive LLM work can be done outside the live hook/provider path.

- add `scripts/codex-memory-pipeline.rb` for session-summary ingestion, consolidation deltas, and graph deltas
- add JSON schemas for Codex structured outputs
- add graph-read support so imported graph data can remain queryable while live graph extraction is disabled
- pass graph snapshot rebuild request bodies through to the iii function so callers can use `{ "force": true }`
- make stop-time summarization opt-in with `AGENTMEMORY_SUMMARIZE_ON_STOP`
- make scheduled consolidate/graph phases no-op cleanly when no memories are selected

## Why

The local service should stay cheap and stable during normal agent sessions. Live hooks should capture deterministic observations, while higher-cost reasoning work runs in guarded batches through Codex and imports structured results back through agentmemory REST/import APIs.

This keeps these steady-state flags viable:

- `AGENTMEMORY_AUTO_COMPRESS=false`
- `AGENTMEMORY_INJECT_CONTEXT=false`
- `CONSOLIDATION_ENABLED=false`
- `GRAPH_EXTRACTION_ENABLED=false`
- `GRAPH_READ_ENABLED=true`

## Impact

- Codex can generate session summaries, semantic/procedural memory deltas, and graph deltas without calling the agentmemory LLM hot path.
- Graph query/read endpoints can be enabled independently of live extraction.
- Stop hooks no longer trigger summarization unless explicitly enabled.
- Empty scheduled pipeline runs can exit successfully instead of being reported as failures.

## Validation

- `git diff --cached --check`
- `mise exec node@20 -- env HOME=/home/dmartino/.cache/tmp/agentmemory-test-home TMPDIR=/home/dmartino/.cache/tmp XDG_CONFIG_HOME=/home/dmartino/.cache/tmp/agentmemory-test-home/.config npm test`
- `mise exec node@20 -- env HOME=/home/dmartino/.cache/tmp/agentmemory-test-home TMPDIR=/home/dmartino/.cache/tmp XDG_CONFIG_HOME=/home/dmartino/.cache/tmp/agentmemory-test-home/.config npm run build`

The default system Node 16 is too old for this repo's current build/test stack. Node 24 build also works, but the full test suite has one unrelated `fs.watch()` behavior difference in `test/fs-watcher.test.ts`; Node 20 LTS is green.
