### PR TITLE
fix: scope GET /agentmemory/memories by the project query param (#918)

### DIFF
--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -1848,6 +1848,13 @@ export function registerApiTriggers(
       const filterAgentId = wildcardAgent
         ? undefined
         : explicitAgentId ?? (isAgentScopeIsolated() ? getAgentId() : undefined);
+      // project filter. Scopes the list (and ?count=true totals) to a
+      // single project the same way agentId does, consistent with the
+      // project scoping POST /agentmemory/search already applies.
+      const projectFilter =
+        typeof req.query_params?.["project"] === "string"
+          ? req.query_params["project"].trim()
+          : undefined;
       let filtered = latest ? memories.filter((m) => m.isLatest) : memories;
       if (filterAgentId) {
         filtered = filtered.filter(
@@ -1855,6 +1862,9 @@ export function registerApiTriggers(
             m.agentId === filterAgentId ||
             (includeOrphans && m.agentId === undefined),
         );
+      }
+      if (projectFilter) {
+        filtered = filtered.filter((m) => m.project === projectFilter);
       }
 
       // viewer + `agentmemory status` were hitting this endpoint to

--- a/test/memories-project-filter.test.ts
+++ b/test/memories-project-filter.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { registerApiTriggers } from "../src/triggers/api.js";
+import { KV } from "../src/state/schema.js";
+import { mockSdk, mockKV } from "./helpers/mocks.js";
+import type { Memory } from "../src/types.js";
+
+// #918: GET /agentmemory/memories must honor the `project` query param.
+// Reproduces the issue fixture: 9 memories across `witto` (5) and
+// `_shared` (4). The list (and ?count=true totals) must scope to the
+// requested project, matching POST /agentmemory/search semantics.
+describe("api::memories project filter (#918)", () => {
+  function makeMemory(id: string, project: string): Memory {
+    return {
+      id,
+      createdAt: "2026-06-01T00:00:00.000Z",
+      updatedAt: "2026-06-01T00:00:00.000Z",
+      type: "fact",
+      title: id,
+      content: `content for ${id}`,
+      concepts: [],
+      files: [],
+      sessionIds: [],
+      strength: 1,
+      version: 1,
+      isLatest: true,
+      project,
+    };
+  }
+
+  let sdk: ReturnType<typeof mockSdk>;
+  let kv: ReturnType<typeof mockKV>;
+
+  beforeEach(async () => {
+    sdk = mockSdk();
+    kv = mockKV();
+    const memories = [
+      ...Array.from({ length: 5 }, (_, i) => makeMemory(`witto-${i}`, "witto")),
+      ...Array.from({ length: 4 }, (_, i) =>
+        makeMemory(`shared-${i}`, "_shared"),
+      ),
+    ];
+    for (const m of memories) await kv.set(KV.memories, m.id, m);
+    // no secret → checkAuth is a no-op, mirroring an open self-hosted install
+    registerApiTriggers(sdk as never, kv as never);
+  });
+
+  async function list(query: Record<string, string>) {
+    return (await sdk.trigger("api::memories", { query_params: query })) as {
+      status_code: number;
+      body: { memories: Memory[]; total: number };
+    };
+  }
+
+  it("with no project param, returns all 9 (back-compat)", async () => {
+    const res = await list({});
+    expect(res.status_code).toBe(200);
+    expect(res.body.memories).toHaveLength(9);
+    expect(res.body.total).toBe(9);
+  });
+
+  it("?project=witto returns only the 5 witto memories", async () => {
+    const res = await list({ project: "witto" });
+    expect(res.body.memories).toHaveLength(5);
+    expect([...new Set(res.body.memories.map((m) => m.project))]).toEqual([
+      "witto",
+    ]);
+    expect(res.body.total).toBe(5);
+  });
+
+  it("?project=nonexistent-xyz returns 0 (not the whole corpus)", async () => {
+    const res = await list({ project: "nonexistent-xyz" });
+    expect(res.body.memories).toHaveLength(0);
+    expect(res.body.total).toBe(0);
+  });
+
+  it("?count=true totals respect the project scope", async () => {
+    const res = (await sdk.trigger("api::memories", {
+      query_params: { count: "true", project: "_shared" },
+    })) as { body: { total: number; latestCount: number } };
+    expect(res.body.total).toBe(4);
+    expect(res.body.latestCount).toBe(4);
+  });
+
+  it("blank/whitespace project param is ignored (returns all)", async () => {
+    const res = await list({ project: "   " });
+    expect(res.body.memories).toHaveLength(9);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #918. `GET /agentmemory/memories` advertised no project filter, so on multi-project installs it returned the **entire** corpus regardless of `?project=` and clients had to over-fetch and filter client-side.

This honors `project` the same way the existing `agentId` filter works:
- Reads + trims the `project` query param.
- Filters the list payload by exact `m.project === project`.
- Applies the same scope to the `?count=true` totals (they reuse the same `filtered` array), so counts match the list scope — consistent with `POST /agentmemory/search`.
- Blank/whitespace `project` is ignored (returns all), preserving back-compat with the no-param behavior.

## Behavior

| Request | Before | After |
| --- | --- | --- |
| (no param) | all memories | all memories (unchanged) |
| `?project=witto` | all memories | only `witto` |
| `?project=nonexistent-xyz` | all memories | `0` |
| `?count=true&project=foo` | unscoped totals | totals scoped to `foo` |

## Test plan

- [x] New behavioral test `test/memories-project-filter.test.ts` drives the real `api::memories` handler with the issue's fixture (9 memories across `witto`/`_shared`), covering project match, nonexistent project, `?count=true` scoping, and blank-param back-compat. Mirrors the existing `cross-project-isolation.test.ts` / `remember-project-scope.test.ts` pattern.
- [x] Confirmed the new test fails on the unpatched handler (returns all 9) and passes with the fix.
- [x] Full suite green: `npm test` → 1420 passing.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for filtering memories by project in the memories API.
  * Results, totals, and paginated counts now reflect the selected project.
* **Bug Fixes**
  * Blank or whitespace-only project filters are ignored, preserving the full result set.
  * Requests for non-matching projects now correctly return no memories and a total of zero.
* **Tests**
  * Added coverage for project-scoped memory queries, including count handling and empty-result cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->