### PR TITLE
fix(hooks): exit the SessionEnd hook within Claude Code's shutdown grace

### DIFF
--- a/plugin/scripts/session-end.mjs
+++ b/plugin/scripts/session-end.mjs
@@ -51,7 +51,7 @@ async function main() {
 		headers: authHeaders(),
 		signal: AbortSignal.timeout(3e4)
 	}).catch(() => {});
-	setTimeout(() => process.exit(0), 1500).unref();
+	setTimeout(() => process.exit(0), 500).unref();
 }
 main();
 

--- a/src/hooks/session-end.ts
+++ b/src/hooks/session-end.ts
@@ -63,7 +63,7 @@ async function main() {
     }).catch(() => {});
   }
 
-  setTimeout(() => process.exit(0), 1500).unref();
+  setTimeout(() => process.exit(0), 500).unref();
 }
 
 main();

--- a/test/session-end-exit-timing.test.ts
+++ b/test/session-end-exit-timing.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spawn } from "node:child_process";
+import { createServer, type Server } from "node:http";
+import { join } from "node:path";
+import { once } from "node:events";
+
+// Runs the BUILT hook artifact (what ships), not the TypeScript source. CI
+// builds before testing; locally run `npm run build` after editing
+// src/hooks/session-end.ts or this exercises stale code.
+const HOOK = join(
+  import.meta.dirname,
+  "..",
+  "plugin",
+  "scripts",
+  "session-end.mjs",
+);
+
+// A server that accepts the connection and reads the request but never sends a
+// response, so the hook's fire-and-forget `fetch` stays in flight. With the
+// request hanging, the only thing that ends the hook process is its deferred
+// `setTimeout(() => process.exit(0), N).unref()` — which lets us measure N.
+let blackHole: Server;
+let blackHoleUrl: string;
+
+beforeAll(async () => {
+  blackHole = createServer(() => {
+    // Intentionally never respond.
+  });
+  blackHole.listen(0, "127.0.0.1");
+  await once(blackHole, "listening");
+  const address = blackHole.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+  blackHoleUrl = `http://127.0.0.1:${port}`;
+});
+
+afterAll(async () => {
+  blackHole.close();
+  await once(blackHole, "close");
+});
+
+function runHook(
+  stdin: string,
+  env: Record<string, string>,
+): Promise<{ exitCode: number | null; tookMs: number }> {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const child = spawn(process.execPath, [HOOK], {
+      env: { PATH: process.env["PATH"] ?? "", ...env },
+      stdio: ["pipe", "ignore", "ignore"],
+    });
+    child.on("error", reject);
+    child.on("close", (exitCode) => {
+      resolve({ exitCode, tookMs: Date.now() - start });
+    });
+    child.stdin.write(stdin);
+    child.stdin.end();
+  });
+}
+
+describe("session-end hook exits within Claude Code's shutdown grace (#991)", () => {
+  it("exits well under the old 1500ms cap even when the memory server hangs", async () => {
+    const payload = JSON.stringify({ session_id: "ses_timing_test" });
+    const { exitCode, tookMs } = await runHook(payload, {
+      AGENTMEMORY_URL: blackHoleUrl,
+    });
+
+    expect(exitCode).toBe(0);
+    // Positive control: the hung request must actually hold the process open to
+    // the deferred-exit timer, otherwise the timing assertion is meaningless.
+    expect(tookMs).toBeGreaterThan(250);
+    // The deferred-exit timer must fire comfortably inside Claude Code's
+    // SessionEnd shutdown grace. The bound sits between the fixed 500ms timer
+    // (plus startup) and the old 1500ms cap that overran the grace, so the
+    // harness killed the hook and reported "Hook cancelled" (#991).
+    expect(tookMs).toBeLessThan(1400);
+  });
+});


### PR DESCRIPTION
## What

Fixes #991 — the SessionEnd hook printed "Hook cancelled" on exit.

## Root cause

`src/hooks/session-end.ts` deferred its exit with `setTimeout(() => process.exit(0), 1500).unref()`. The hook fires a fire-and-forget POST to the local memory server; while that request is in flight it keeps the process alive, so the process doesn't exit until the 1500ms timer fires. That overruns Claude Code's SessionEnd shutdown grace, so the harness kills the hook and reports "Hook cancelled".

The other seven lightweight hooks already use a 500ms cap; only `session-end` and `stop` were outliers at 1500ms.

## Fix

Lower the cap to 500ms (source + the committed `plugin/scripts/session-end.mjs` artifact). 500ms is still ample to flush the small POST to the local server, and keeps the hook comfortably inside the shutdown grace.

## Test

`test/session-end-exit-timing.test.ts` runs the built hook against a server that accepts the connection but never responds (so the request hangs and the deferred-exit timer is what ends the process), then asserts it exits well under the old 1500ms cap. Fails before this change (~1580ms), passes after (~580ms). Full suite: 1416 tests pass.

## Note: `stop.ts`

`src/hooks/stop.ts` has the identical 1500ms deferred exit and likely shows the same symptom. I kept this PR scoped to the reported SessionEnd issue, but happy to fix `stop` too (here or a follow-up) if you'd like — let me know if 1500ms was intentional there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced the delay before session shutdown completes, so the app exits sooner after the session ends.
* **Tests**
  * Added coverage to verify session-end shutdown timing when a request hangs, helping prevent regressions in exit behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->