### PR TITLE
fix(hooks): skip capturing memory_* MCP tools and add capture config env vars

### DIFF
--- a/plugin/scripts/post-tool-failure.mjs
+++ b/plugin/scripts/post-tool-failure.mjs
@@ -1,6 +1,46 @@
 #!/usr/bin/env node
 import { execSync } from "node:child_process";
 import { basename } from "node:path";
+//#region src/hooks/_capture-filter.ts
+const DEFAULT_DENY_PATTERNS = [
+	"memory_*",
+	"toolsearch",
+	"listmcpresources",
+	"fetchmcpresource"
+];
+function parseEnvList(raw) {
+	if (!raw?.trim()) return void 0;
+	return raw.split(/[,\s]+/).map((part) => part.trim()).filter(Boolean);
+}
+function bareToolName(toolName) {
+	const trimmed = toolName.trim();
+	if (/^mcp__/i.test(trimmed)) {
+		const parts = trimmed.split("__");
+		if (parts.length >= 3) return parts[parts.length - 1];
+	}
+	return trimmed;
+}
+function normalizePattern(pattern) {
+	return pattern.trim().toLowerCase();
+}
+function matchesPattern(toolName, pattern) {
+	const bare = bareToolName(toolName).toLowerCase();
+	const pat = normalizePattern(pattern);
+	if (!pat.includes("*")) return bare === pat;
+	const escaped = pat.replace(/[.+?^${}()|[\]\\]/g, "\\$&");
+	const re = new RegExp(`^${escaped.replace(/\*/g, ".*")}$`);
+	return re.test(bare) || re.test(toolName.toLowerCase());
+}
+function matchesAny(toolName, patterns) {
+	return patterns.some((pattern) => matchesPattern(toolName, pattern));
+}
+function shouldCaptureTool(toolName) {
+	if (typeof toolName !== "string" || !toolName.trim()) return true;
+	const allow = parseEnvList(process.env["AGENTMEMORY_CAPTURE_ALLOW"]);
+	if (allow) return matchesAny(toolName, allow);
+	return !matchesAny(toolName, [...DEFAULT_DENY_PATTERNS, ...parseEnvList(process.env["AGENTMEMORY_CAPTURE_DENY"]) ?? []]);
+}
+//#endregion
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {
 	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
@@ -58,6 +98,7 @@ async function main() {
 	if (data.is_interrupt || data.isInterrupt) return;
 	const sessionId = data.session_id || data.sessionId || data.conversation_id || "unknown";
 	const toolName = data.tool_name ?? data.toolName;
+	if (!shouldCaptureTool(toolName)) return;
 	const toolInput = data.tool_input ?? data.toolArgs;
 	const error = data.error ?? data.errorMessage;
 	const cwd = hookCwd(data) || process.cwd();

--- a/plugin/scripts/post-tool-use.mjs
+++ b/plugin/scripts/post-tool-use.mjs
@@ -1,6 +1,52 @@
 #!/usr/bin/env node
 import { execSync } from "node:child_process";
 import { basename } from "node:path";
+//#region src/hooks/_capture-filter.ts
+const DEFAULT_DENY_PATTERNS = [
+	"memory_*",
+	"toolsearch",
+	"listmcpresources",
+	"fetchmcpresource"
+];
+function parseEnvList(raw) {
+	if (!raw?.trim()) return void 0;
+	return raw.split(/[,\s]+/).map((part) => part.trim()).filter(Boolean);
+}
+function bareToolName(toolName) {
+	const trimmed = toolName.trim();
+	if (/^mcp__/i.test(trimmed)) {
+		const parts = trimmed.split("__");
+		if (parts.length >= 3) return parts[parts.length - 1];
+	}
+	return trimmed;
+}
+function normalizePattern(pattern) {
+	return pattern.trim().toLowerCase();
+}
+function matchesPattern(toolName, pattern) {
+	const bare = bareToolName(toolName).toLowerCase();
+	const pat = normalizePattern(pattern);
+	if (!pat.includes("*")) return bare === pat;
+	const escaped = pat.replace(/[.+?^${}()|[\]\\]/g, "\\$&");
+	const re = new RegExp(`^${escaped.replace(/\*/g, ".*")}$`);
+	return re.test(bare) || re.test(toolName.toLowerCase());
+}
+function matchesAny(toolName, patterns) {
+	return patterns.some((pattern) => matchesPattern(toolName, pattern));
+}
+function shouldCaptureTool(toolName) {
+	if (typeof toolName !== "string" || !toolName.trim()) return true;
+	const allow = parseEnvList(process.env["AGENTMEMORY_CAPTURE_ALLOW"]);
+	if (allow) return matchesAny(toolName, allow);
+	return !matchesAny(toolName, [...DEFAULT_DENY_PATTERNS, ...parseEnvList(process.env["AGENTMEMORY_CAPTURE_DENY"]) ?? []]);
+}
+function captureOutputMax() {
+	const raw = process.env["AGENTMEMORY_CAPTURE_OUTPUT_MAX"];
+	if (!raw?.trim()) return 8e3;
+	const parsed = Number.parseInt(raw, 10);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : 8e3;
+}
+//#endregion
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {
 	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
@@ -57,9 +103,11 @@ async function main() {
 	if (isSdkChildContext(data)) return;
 	const sessionId = data.session_id || data.sessionId || data.conversation_id || "unknown";
 	const toolName = data.tool_name ?? data.toolName;
+	if (!shouldCaptureTool(toolName)) return;
 	const toolInput = data.tool_input ?? data.toolArgs;
 	const { imageData, cleanOutput } = extractImageData(toolOutput(data));
 	const cwd = hookCwd(data) || process.cwd();
+	const outputMax = captureOutputMax();
 	fetch(`${REST_URL}/agentmemory/observe`, {
 		method: "POST",
 		headers: authHeaders(),
@@ -72,7 +120,7 @@ async function main() {
 			data: {
 				tool_name: toolName,
 				tool_input: toolInput,
-				tool_output: truncate(cleanOutput, 8e3),
+				tool_output: truncate(cleanOutput, outputMax),
 				...imageData ? { image_data: imageData } : {}
 			}
 		}),

--- a/plugin/scripts/post-tool-use.mjs
+++ b/plugin/scripts/post-tool-use.mjs
@@ -46,6 +46,22 @@ function captureOutputMax() {
 	const parsed = Number.parseInt(raw, 10);
 	return Number.isFinite(parsed) && parsed > 0 ? parsed : 8e3;
 }
+/** Truncate so the result length is at most `max` (marker included). */
+function truncateCaptureOutput(value, max) {
+	if (typeof value === "string" && value.length > max) {
+		const suffix = "\n[...truncated]";
+		return max <= 15 ? suffix.slice(0, max) : value.slice(0, max - 15) + suffix;
+	}
+	if (typeof value === "object" && value !== null) {
+		const str = JSON.stringify(value);
+		if (str.length > max) {
+			const suffix = "...[truncated]";
+			return max <= 14 ? suffix.slice(0, max) : str.slice(0, max - 14) + suffix;
+		}
+		return value;
+	}
+	return value;
+}
 //#endregion
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {
@@ -120,7 +136,7 @@ async function main() {
 			data: {
 				tool_name: toolName,
 				tool_input: toolInput,
-				tool_output: truncate(cleanOutput, outputMax),
+				tool_output: truncateCaptureOutput(cleanOutput, outputMax),
 				...imageData ? { image_data: imageData } : {}
 			}
 		}),
@@ -164,17 +180,6 @@ function extractImageData(output) {
 		cleanOutput: output
 	};
 }
-function truncate(value, max) {
-	if (typeof value === "string" && value.length > max) return value.slice(0, max) + "\n[...truncated]";
-	if (typeof value === "object" && value !== null) {
-		const str = JSON.stringify(value);
-		if (str.length > max) return str.slice(0, max) + "...[truncated]";
-		return value;
-	}
-	return value;
-}
 main().catch(() => process.exit(0));
 //#endregion
 export {};
-
-//# sourceMappingURL=post-tool-use.mjs.map

--- a/plugin/scripts/pre-compact.mjs
+++ b/plugin/scripts/pre-compact.mjs
@@ -1,6 +1,15 @@
 #!/usr/bin/env node
 import { execSync } from "node:child_process";
 import { basename } from "node:path";
+//#region src/hooks/_capture-filter.ts
+function preCompactBudget() {
+	const raw = process.env["AGENTMEMORY_PRE_COMPACT_BUDGET"];
+	if (raw?.trim() === "0") return 0;
+	if (!raw?.trim()) return 1500;
+	const parsed = Number.parseInt(raw, 10);
+	return Number.isFinite(parsed) && parsed >= 0 ? parsed : 1500;
+}
+//#endregion
 //#region src/hooks/_project.ts
 function resolveProject(cwd) {
 	const explicit = process.env["AGENTMEMORY_PROJECT_NAME"];
@@ -65,6 +74,8 @@ async function main() {
 			signal: AbortSignal.timeout(5e3)
 		});
 	} catch {}
+	const budget = preCompactBudget();
+	if (budget === 0) return;
 	try {
 		const res = await fetch(`${REST_URL}/agentmemory/context`, {
 			method: "POST",
@@ -72,7 +83,7 @@ async function main() {
 			body: JSON.stringify({
 				sessionId,
 				project,
-				budget: 1500
+				budget
 			}),
 			signal: AbortSignal.timeout(5e3)
 		});

--- a/src/hooks/_capture-filter.ts
+++ b/src/hooks/_capture-filter.ts
@@ -1,0 +1,68 @@
+const DEFAULT_DENY_PATTERNS = [
+  "memory_*",
+  "toolsearch",
+  "listmcpresources",
+  "fetchmcpresource",
+];
+
+function parseEnvList(raw: string | undefined): string[] | undefined {
+  if (!raw?.trim()) return undefined;
+  return raw
+    .split(/[,\s]+/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+export function bareToolName(toolName: string): string {
+  const trimmed = toolName.trim();
+  if (/^mcp__/i.test(trimmed)) {
+    const parts = trimmed.split("__");
+    if (parts.length >= 3) return parts[parts.length - 1]!;
+  }
+  return trimmed;
+}
+
+function normalizePattern(pattern: string): string {
+  return pattern.trim().toLowerCase();
+}
+
+function matchesPattern(toolName: string, pattern: string): boolean {
+  const bare = bareToolName(toolName).toLowerCase();
+  const pat = normalizePattern(pattern);
+  if (!pat.includes("*")) return bare === pat;
+  const escaped = pat.replace(/[.+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`^${escaped.replace(/\*/g, ".*")}$`);
+  return re.test(bare) || re.test(toolName.toLowerCase());
+}
+
+function matchesAny(toolName: string, patterns: string[]): boolean {
+  return patterns.some((pattern) => matchesPattern(toolName, pattern));
+}
+
+export function shouldCaptureTool(toolName: unknown): boolean {
+  if (typeof toolName !== "string" || !toolName.trim()) return true;
+
+  const allow = parseEnvList(process.env["AGENTMEMORY_CAPTURE_ALLOW"]);
+  if (allow) return matchesAny(toolName, allow);
+
+  const deny = [
+    ...DEFAULT_DENY_PATTERNS,
+    ...(parseEnvList(process.env["AGENTMEMORY_CAPTURE_DENY"]) ?? []),
+  ];
+  return !matchesAny(toolName, deny);
+}
+
+export function captureOutputMax(): number {
+  const raw = process.env["AGENTMEMORY_CAPTURE_OUTPUT_MAX"];
+  if (!raw?.trim()) return 8000;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 8000;
+}
+
+export function preCompactBudget(): number {
+  const raw = process.env["AGENTMEMORY_PRE_COMPACT_BUDGET"];
+  if (raw?.trim() === "0") return 0;
+  if (!raw?.trim()) return 1500;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 1500;
+}

--- a/src/hooks/_capture-filter.ts
+++ b/src/hooks/_capture-filter.ts
@@ -59,6 +59,27 @@ export function captureOutputMax(): number {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : 8000;
 }
 
+/** Truncate so the result length is at most `max` (marker included). */
+export function truncateCaptureOutput(value: unknown, max: number): unknown {
+  if (typeof value === "string" && value.length > max) {
+    const suffix = "\n[...truncated]";
+    return max <= suffix.length
+      ? suffix.slice(0, max)
+      : value.slice(0, max - suffix.length) + suffix;
+  }
+  if (typeof value === "object" && value !== null) {
+    const str = JSON.stringify(value);
+    if (str.length > max) {
+      const suffix = "...[truncated]";
+      return max <= suffix.length
+        ? suffix.slice(0, max)
+        : str.slice(0, max - suffix.length) + suffix;
+    }
+    return value;
+  }
+  return value;
+}
+
 export function preCompactBudget(): number {
   const raw = process.env["AGENTMEMORY_PRE_COMPACT_BUDGET"];
   if (raw?.trim() === "0") return 0;

--- a/src/hooks/post-tool-failure.ts
+++ b/src/hooks/post-tool-failure.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { shouldCaptureTool } from "./_capture-filter.js";
 import { resolveProject, hookCwd } from "./_project.js";
 
 function isSdkChildContext(payload: unknown): boolean {
@@ -35,6 +36,8 @@ async function main() {
 
   const sessionId = ((data.session_id || data.sessionId || data.conversation_id) as string) || "unknown";
   const toolName = data.tool_name ?? data.toolName;
+  if (!shouldCaptureTool(toolName)) return;
+
   const toolInput = data.tool_input ?? data.toolArgs;
   const error = data.error ?? data.errorMessage;
 

--- a/src/hooks/post-tool-use.ts
+++ b/src/hooks/post-tool-use.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { captureOutputMax, shouldCaptureTool } from "./_capture-filter.js";
 import { resolveProject, hookCwd } from "./_project.js";
 
 function isSdkChildContext(payload: unknown): boolean {
@@ -34,10 +35,13 @@ async function main() {
 
   const sessionId = ((data.session_id || data.sessionId || data.conversation_id) as string) || "unknown";
   const toolName = data.tool_name ?? data.toolName;
+  if (!shouldCaptureTool(toolName)) return;
+
   const toolInput = data.tool_input ?? data.toolArgs;
 
   const { imageData, cleanOutput } = extractImageData(toolOutput(data));
   const cwd = hookCwd(data) || process.cwd();
+  const outputMax = captureOutputMax();
 
   fetch(`${REST_URL}/agentmemory/observe`, {
     method: "POST",
@@ -51,7 +55,7 @@ async function main() {
       data: {
         tool_name: toolName,
         tool_input: toolInput,
-        tool_output: truncate(cleanOutput, 8000),
+        tool_output: truncate(cleanOutput, outputMax),
         ...(imageData ? { image_data: imageData } : {}),
       },
     }),

--- a/src/hooks/post-tool-use.ts
+++ b/src/hooks/post-tool-use.ts
@@ -1,5 +1,9 @@
 #!/usr/bin/env node
-import { captureOutputMax, shouldCaptureTool } from "./_capture-filter.js";
+import {
+  captureOutputMax,
+  shouldCaptureTool,
+  truncateCaptureOutput,
+} from "./_capture-filter.js";
 import { resolveProject, hookCwd } from "./_project.js";
 
 function isSdkChildContext(payload: unknown): boolean {
@@ -55,7 +59,7 @@ async function main() {
       data: {
         tool_name: toolName,
         tool_input: toolInput,
-        tool_output: truncate(cleanOutput, outputMax),
+        tool_output: truncateCaptureOutput(cleanOutput, outputMax),
         ...(imageData ? { image_data: imageData } : {}),
       },
     }),
@@ -106,18 +110,6 @@ function extractImageData(output: unknown): { imageData: string | undefined; cle
   }
 
   return { imageData: undefined, cleanOutput: output };
-}
-
-function truncate(value: unknown, max: number): unknown {
-  if (typeof value === "string" && value.length > max) {
-    return value.slice(0, max) + "\n[...truncated]";
-  }
-  if (typeof value === "object" && value !== null) {
-    const str = JSON.stringify(value);
-    if (str.length > max) return str.slice(0, max) + "...[truncated]";
-    return value;
-  }
-  return value;
 }
 
 main().catch(() => process.exit(0));

--- a/src/hooks/pre-compact.ts
+++ b/src/hooks/pre-compact.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { preCompactBudget } from "./_capture-filter.js";
 import { resolveProject, hookCwd } from "./_project.js";
 
 function isSdkChildContext(payload: unknown): boolean {
@@ -48,11 +49,14 @@ async function main() {
     }
   }
 
+  const budget = preCompactBudget();
+  if (budget === 0) return;
+
   try {
     const res = await fetch(`${REST_URL}/agentmemory/context`, {
       method: "POST",
       headers: authHeaders(),
-      body: JSON.stringify({ sessionId, project, budget: 1500 }),
+      body: JSON.stringify({ sessionId, project, budget }),
       signal: AbortSignal.timeout(5000),
     });
 

--- a/test/capture-filter.test.ts
+++ b/test/capture-filter.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  bareToolName,
+  captureOutputMax,
+  preCompactBudget,
+  shouldCaptureTool,
+} from "../src/hooks/_capture-filter.js";
+
+describe("bareToolName", () => {
+  it("returns plain tool names unchanged", () => {
+    expect(bareToolName("Bash")).toBe("Bash");
+    expect(bareToolName("memory_recall")).toBe("memory_recall");
+  });
+
+  it("strips Claude Code MCP prefixes", () => {
+    expect(bareToolName("mcp__agentmemory__memory_smart_search")).toBe(
+      "memory_smart_search",
+    );
+  });
+});
+
+describe("shouldCaptureTool (#993)", () => {
+  const envKeys = [
+    "AGENTMEMORY_CAPTURE_ALLOW",
+    "AGENTMEMORY_CAPTURE_DENY",
+  ] as const;
+  const original: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of envKeys) {
+      original[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of envKeys) {
+      if (original[key] === undefined) delete process.env[key];
+      else process.env[key] = original[key];
+    }
+  });
+
+  it("captures normal agent tools by default", () => {
+    expect(shouldCaptureTool("Bash")).toBe(true);
+    expect(shouldCaptureTool("Edit")).toBe(true);
+    expect(shouldCaptureTool("Agent")).toBe(true);
+  });
+
+  it("skips agentmemory memory_* MCP tools by default", () => {
+    expect(shouldCaptureTool("memory_recall")).toBe(false);
+    expect(shouldCaptureTool("memory_smart_search")).toBe(false);
+    expect(shouldCaptureTool("mcp__agentmemory__memory_recall")).toBe(false);
+  });
+
+  it("skips plumbing tools by default", () => {
+    expect(shouldCaptureTool("ToolSearch")).toBe(false);
+    expect(shouldCaptureTool("ListMcpResources")).toBe(false);
+  });
+
+  it("honors AGENTMEMORY_CAPTURE_DENY", () => {
+    process.env.AGENTMEMORY_CAPTURE_DENY = "Grep, Glob";
+    expect(shouldCaptureTool("Grep")).toBe(false);
+    expect(shouldCaptureTool("Bash")).toBe(true);
+  });
+
+  it("honors AGENTMEMORY_CAPTURE_ALLOW over defaults", () => {
+    process.env.AGENTMEMORY_CAPTURE_ALLOW = "memory_recall, Bash";
+    expect(shouldCaptureTool("memory_recall")).toBe(true);
+    expect(shouldCaptureTool("memory_smart_search")).toBe(false);
+    expect(shouldCaptureTool("Bash")).toBe(true);
+    expect(shouldCaptureTool("Edit")).toBe(false);
+  });
+});
+
+describe("captureOutputMax", () => {
+  const key = "AGENTMEMORY_CAPTURE_OUTPUT_MAX";
+  const original = process.env[key];
+
+  afterEach(() => {
+    if (original === undefined) delete process.env[key];
+    else process.env[key] = original;
+  });
+
+  it("defaults to 8000", () => {
+    delete process.env[key];
+    expect(captureOutputMax()).toBe(8000);
+  });
+
+  it("reads a positive override", () => {
+    process.env[key] = "4096";
+    expect(captureOutputMax()).toBe(4096);
+  });
+});
+
+describe("preCompactBudget", () => {
+  const key = "AGENTMEMORY_PRE_COMPACT_BUDGET";
+  const original = process.env[key];
+
+  afterEach(() => {
+    if (original === undefined) delete process.env[key];
+    else process.env[key] = original;
+  });
+
+  it("defaults to 1500", () => {
+    delete process.env[key];
+    expect(preCompactBudget()).toBe(1500);
+  });
+
+  it("allows disabling injection with 0", () => {
+    process.env[key] = "0";
+    expect(preCompactBudget()).toBe(0);
+  });
+});

--- a/test/capture-filter.test.ts
+++ b/test/capture-filter.test.ts
@@ -4,6 +4,7 @@ import {
   captureOutputMax,
   preCompactBudget,
   shouldCaptureTool,
+  truncateCaptureOutput,
 } from "../src/hooks/_capture-filter.js";
 
 describe("bareToolName", () => {
@@ -89,6 +90,32 @@ describe("captureOutputMax", () => {
   it("reads a positive override", () => {
     process.env[key] = "4096";
     expect(captureOutputMax()).toBe(4096);
+  });
+});
+
+describe("truncateCaptureOutput", () => {
+  it("leaves short strings alone", () => {
+    expect(truncateCaptureOutput("hello", 20)).toBe("hello");
+  });
+
+  it("keeps truncated string length within max", () => {
+    const out = truncateCaptureOutput("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 20);
+    expect(typeof out).toBe("string");
+    expect((out as string).length).toBe(20);
+    expect(out).toBe("ABCDE\n[...truncated]");
+  });
+
+  it("handles max smaller than the marker", () => {
+    expect(truncateCaptureOutput("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 5)).toBe(
+      "\n[...",
+    );
+  });
+
+  it("keeps truncated JSON length within max", () => {
+    const out = truncateCaptureOutput({ a: "x".repeat(50) }, 30);
+    expect(typeof out).toBe("string");
+    expect((out as string).length).toBe(30);
+    expect(out).toMatch(/\.\.\.\[truncated\]$/);
   });
 });
 

--- a/test/post-tool-use-capture.test.ts
+++ b/test/post-tool-use-capture.test.ts
@@ -29,9 +29,11 @@ describe("post-tool-use hook — capture filter (#993)", () => {
   let server: Server;
   let observeCalls = 0;
   let port = 0;
+  let onObserve: (() => void) | undefined;
 
   afterEach(async () => {
     observeCalls = 0;
+    onObserve = undefined;
     if (server) {
       await new Promise<void>((resolve, reject) => {
         server.close((err) => (err ? reject(err) : resolve()));
@@ -39,10 +41,26 @@ describe("post-tool-use hook — capture filter (#993)", () => {
     }
   });
 
+  async function assertNoObserveAfterHook(
+    hook: Promise<{ exitCode: number | null }>,
+    { settleMs = 300 } = {},
+  ): Promise<{ exitCode: number | null }> {
+    const result = await hook;
+    const deadline = Date.now() + settleMs;
+    while (Date.now() < deadline) {
+      if (observeCalls !== 0) {
+        throw new Error(`unexpected observe call(s): ${observeCalls}`);
+      }
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    return result;
+  }
+
   async function startServer() {
     server = createServer((req, res) => {
       if (req.method === "POST" && req.url === "/agentmemory/observe") {
         observeCalls += 1;
+        onObserve?.();
       }
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end("{}");
@@ -64,10 +82,11 @@ describe("post-tool-use hook — capture filter (#993)", () => {
       tool_input: { query: "hooks" },
       tool_output: "results",
     });
-    const result = await runHook("post-tool-use.mjs", payload, {
-      AGENTMEMORY_URL: `http://127.0.0.1:${port}`,
-    });
-    await new Promise((r) => setTimeout(r, 600));
+    const result = await assertNoObserveAfterHook(
+      runHook("post-tool-use.mjs", payload, {
+        AGENTMEMORY_URL: `http://127.0.0.1:${port}`,
+      }),
+    );
     expect(result.exitCode).toBe(0);
     expect(observeCalls).toBe(0);
   });
@@ -80,10 +99,20 @@ describe("post-tool-use hook — capture filter (#993)", () => {
       tool_input: { command: "ls" },
       tool_output: "ok",
     });
+    const observeSeen = new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error("observe request never arrived")),
+        2000,
+      );
+      onObserve = () => {
+        clearTimeout(timer);
+        resolve();
+      };
+    });
     const result = await runHook("post-tool-use.mjs", payload, {
       AGENTMEMORY_URL: `http://127.0.0.1:${port}`,
     });
-    await new Promise((r) => setTimeout(r, 600));
+    await observeSeen;
     expect(result.exitCode).toBe(0);
     expect(observeCalls).toBe(1);
   });

--- a/test/post-tool-use-capture.test.ts
+++ b/test/post-tool-use-capture.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { spawn } from "node:child_process";
+import { createServer, type Server } from "node:http";
+import { join } from "node:path";
+
+const HOOKS_DIR = join(import.meta.dirname, "..", "plugin", "scripts");
+
+function runHook(
+  scriptName: string,
+  stdin: string,
+  env: Record<string, string>,
+): Promise<{ exitCode: number | null }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [join(HOOKS_DIR, scriptName)], {
+      env: {
+        PATH: process.env["PATH"] ?? "",
+        ...env,
+      },
+      stdio: ["pipe", "ignore", "ignore"],
+    });
+    child.on("error", reject);
+    child.on("close", (exitCode) => resolve({ exitCode }));
+    child.stdin.write(stdin);
+    child.stdin.end();
+  });
+}
+
+describe("post-tool-use hook — capture filter (#993)", () => {
+  let server: Server;
+  let observeCalls = 0;
+  let port = 0;
+
+  afterEach(async () => {
+    observeCalls = 0;
+    if (server) {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    }
+  });
+
+  async function startServer() {
+    server = createServer((req, res) => {
+      if (req.method === "POST" && req.url === "/agentmemory/observe") {
+        observeCalls += 1;
+      }
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end("{}");
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => {
+        const addr = server.address();
+        if (addr && typeof addr === "object") port = addr.port;
+        resolve();
+      });
+    });
+  }
+
+  it("does not observe memory_* MCP tools", async () => {
+    await startServer();
+    const payload = JSON.stringify({
+      session_id: "ses_test",
+      tool_name: "mcp__agentmemory__memory_smart_search",
+      tool_input: { query: "hooks" },
+      tool_output: "results",
+    });
+    const result = await runHook("post-tool-use.mjs", payload, {
+      AGENTMEMORY_URL: `http://127.0.0.1:${port}`,
+    });
+    await new Promise((r) => setTimeout(r, 600));
+    expect(result.exitCode).toBe(0);
+    expect(observeCalls).toBe(0);
+  });
+
+  it("still observes normal tools", async () => {
+    await startServer();
+    const payload = JSON.stringify({
+      session_id: "ses_test",
+      tool_name: "Bash",
+      tool_input: { command: "ls" },
+      tool_output: "ok",
+    });
+    const result = await runHook("post-tool-use.mjs", payload, {
+      AGENTMEMORY_URL: `http://127.0.0.1:${port}`,
+    });
+    await new Promise((r) => setTimeout(r, 600));
+    expect(result.exitCode).toBe(0);
+    expect(observeCalls).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #993.

- **Bug fix:** `post-tool-use` and `post-tool-failure` now skip agentmemory's own MCP tools (`memory_*`, plus plumbing like `ToolSearch`) so recall/search calls are not written back into the observation store.
- **Config knobs:** new env vars for capture filtering and limits:
  - `AGENTMEMORY_CAPTURE_DENY` — extra comma/whitespace-separated deny patterns (default deny includes `memory_*` and plumbing tools even when unset)
  - `AGENTMEMORY_CAPTURE_ALLOW` — if set, only listed tools are captured (overrides deny defaults)
  - `AGENTMEMORY_CAPTURE_OUTPUT_MAX` — per-observation output cap (default `8000`)
  - `AGENTMEMORY_PRE_COMPACT_BUDGET` — `/agentmemory/context` budget on `/compact` (default `1500`; `0` disables injection)

## Test plan

- [x] `vitest run test/capture-filter.test.ts test/post-tool-use-capture.test.ts`
- [x] `memory_*` MCP tool names are skipped by default (including `mcp__agentmemory__*` prefixed forms)
- [x] normal tools (`Bash`, `Edit`, etc.) still captured
- [x] hook integration test confirms no `/observe` POST for filtered tools

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable allow/deny filtering to control which tool events are recorded.
  * Added configurable limits for captured tool-output size, with safe truncation.
  * Added runtime control for the pre-compaction context budget, including an option to disable context requests.

* **Bug Fixes**
  * Prevented excluded tool events from generating observation requests.
  * Ensured captured output stays within the configured size limit.

* **Tests**
  * Added coverage for filtering, output limits, and pre-compaction budget settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->