### PR TITLE
fix(api): sort /memories newest-first before pagination

### DIFF
--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -1889,6 +1889,16 @@ export function registerApiTriggers(
           : undefined;
       const offset =
         Number.isInteger(parsedOffset) && parsedOffset >= 0 ? parsedOffset : 0;
+      // kv.list returns rows in insertion order (oldest first), so slicing the
+      // head served the OLDEST memories — the viewer then showed stale data once
+      // the corpus exceeded the limit (#990). Sort newest-first (createdAt desc,
+      // fallback updatedAt) before the slice, mirroring the viewer-side fix from
+      // #674/#701.
+      filtered.sort((a, b) => {
+        const aKey = a.createdAt || a.updatedAt || "";
+        const bKey = b.createdAt || b.updatedAt || "";
+        return bKey.localeCompare(aKey);
+      });
       const sliced =
         limit !== undefined ? filtered.slice(offset, offset + limit) : filtered;
 

--- a/test/memories-latest-sort-order.test.ts
+++ b/test/memories-latest-sort-order.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+
+// api::memories returned rows in KV-insertion order (oldest first), so
+// `?latest=true&limit=N` served the N OLDEST "latest" memories and the viewer
+// showed stale data once the corpus exceeded the limit (#990). The handler now
+// sorts newest-first (createdAt desc, fallback updatedAt) before it slices,
+// mirroring the viewer-side fix that already landed for the Memories tab
+// (#674/#701).
+//
+// Like the other api::memories tests in this repo, this asserts on the handler
+// source: the SDK-registered handler is not invoked in isolation here, so the
+// guard is that the sort exists, uses the agreed keys, and runs BEFORE the
+// slice (slicing an unsorted list is the bug).
+describe("api::memories sorts newest first before pagination (#990)", () => {
+  const api = readFileSync("src/triggers/api.ts", "utf-8");
+  const start = api.indexOf('registerFunction("api::memories"');
+  const end = api.indexOf('config: { api_path: "/agentmemory/memories"');
+  const handler = api.slice(start, end);
+
+  it("isolates the api::memories handler source", () => {
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+  });
+
+  it("sorts filtered memories before the offset/limit slice", () => {
+    const sortIdx = handler.search(/filtered\.sort\(/);
+    const sliceIdx = handler.search(/filtered\.slice\(offset/);
+    expect(sortIdx).toBeGreaterThan(-1);
+    expect(sliceIdx).toBeGreaterThan(-1);
+    // Slicing before sorting is the #990 bug — the sort must come first.
+    expect(sortIdx).toBeLessThan(sliceIdx);
+  });
+
+  it("sorts on createdAt desc with updatedAt fallback (matches the #701 viewer fix)", () => {
+    expect(handler).toMatch(/a\.createdAt \|\| a\.updatedAt/);
+    expect(handler).toMatch(/b\.createdAt \|\| b\.updatedAt/);
+    expect(handler).toMatch(/localeCompare/);
+  });
+});

--- a/test/memories-latest-sort-order.test.ts
+++ b/test/memories-latest-sort-order.test.ts
@@ -35,6 +35,10 @@ describe("api::memories sorts newest first before pagination (#990)", () => {
   it("sorts on createdAt desc with updatedAt fallback (matches the #701 viewer fix)", () => {
     expect(handler).toMatch(/a\.createdAt \|\| a\.updatedAt/);
     expect(handler).toMatch(/b\.createdAt \|\| b\.updatedAt/);
-    expect(handler).toMatch(/localeCompare/);
+    // Direction matters: newest-first requires the comparator to return
+    // bKey.localeCompare(aKey) (descending). A reversed comparator would still
+    // contain `localeCompare` and pass a bare match, so pin the argument order
+    // to guard against silently sorting oldest-first. (#990)
+    expect(handler).toMatch(/bKey\.localeCompare\(aKey\)/);
   });
 });


### PR DESCRIPTION
## What

Fixes #990. `GET /agentmemory/memories?latest=true&limit=N` returned the N *oldest* "latest" memories, so the viewer showed stale data once the corpus exceeded the limit.

## Root cause

The `api::memories` handler (`src/triggers/api.ts`) builds its list from `kv.list(KV.memories)` — insertion order, oldest first — filters by `isLatest`/`agentId`, then slices `offset..offset+limit`. There's no sort, so the slice takes the *head* (oldest).

## Fix

Sort the filtered list newest-first (`createdAt` desc, fallback `updatedAt`) before the slice, using the same key/`localeCompare` pattern as the merged viewer-side fix for the Memories tab (#674/#701) — making the server endpoint consistent with what the viewer already does client-side.

## Test

`test/memories-latest-sort-order.test.ts` asserts the handler sorts on the agreed keys and that the sort runs *before* the slice (slicing an unsorted list is the bug), matching the source-assertion style of the existing `api::memories` pagination tests. Full vitest suite passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the agent memory list so pagination now returns the most recent items first.
  * Added a stable recency sort using timestamp priority (newest `createdAt`, then `updatedAt`), with a deterministic tie-breaker.

* **Tests**
  * Added regression coverage to ensure the updated ordering is applied before offset/limit slicing and remains correct as the corpus grows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->