### PR TITLE
Fix opencode session project path tracking in agentmemory capture plugin

### DIFF
--- a/plugin/opencode/agentmemory-capture.ts
+++ b/plugin/opencode/agentmemory-capture.ts
@@ -47,11 +47,12 @@ async function observe(
   hookType: string,
   data: Record<string, unknown>,
 ): Promise<void> {
+  const project = sessionProjects.get(sessionId) || projectPath;
   await post("/observe", {
     hookType,
     sessionId,
-    project: projectPath,
-    cwd: projectPath,
+    project,
+    cwd: project,
     timestamp: new Date().toISOString(),
     data,
   });
@@ -60,6 +61,7 @@ async function observe(
 let activeSessionId: string | null = null;
 let pendingConfig: Record<string, unknown> | null = null;
 let projectPath: string | null = null;
+const sessionProjects = new Map<string, string>();
 const stashedFiles = new Map<string, Set<string>>();
 const seenSubtaskIds = new Map<string, Set<string>>();
 const seenToolCallIds = new Map<string, Set<string>>();
@@ -93,6 +95,13 @@ function pruneSessionMaps(sid: string): void {
   stashedFiles.delete(sid);
   seenSubtaskIds.delete(sid);
   seenToolCallIds.delete(sid);
+  sessionProjects.delete(sid);
+}
+
+async function updateSessionProject(sessionId: string, cwd: unknown): Promise<void> {
+  if (typeof cwd !== "string" || cwd.length === 0) return;
+  if (sessionProjects.get(sessionId) === cwd) return;
+  sessionProjects.set(sessionId, cwd);
 }
 
 function safeSlice(v: unknown, max: number): string {
@@ -168,7 +177,8 @@ function extractErrorMessage(err: unknown): string {
 }
 
 export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
-  projectPath = ctx.worktree || ctx.project?.id || process.cwd();
+  const currentDirectory = (ctx as any).directory || process.cwd();
+  projectPath = process.env.AGENTMEMORY_PROJECT || currentDirectory || ctx.project?.id || ctx.worktree || process.cwd();
 
   return {
     event: async ({ event }) => {
@@ -180,6 +190,11 @@ export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
         const info = props.info as Record<string, unknown> | undefined;
         activeSessionId = (info?.id as string) || props.sessionID || null;
         if (!activeSessionId) return;
+        const sessionProject = process.env.AGENTMEMORY_PROJECT
+          || (typeof info?.directory === "string" && info.directory.length > 0 ? info.directory : "")
+          || projectPath
+          || process.cwd();
+        sessionProjects.set(activeSessionId, sessionProject);
         stashedFiles.set(activeSessionId, new Set());
         seenSubtaskIds.delete(activeSessionId);
         seenToolCallIds.delete(activeSessionId);
@@ -190,11 +205,11 @@ export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
         const sessionId = activeSessionId;
         const startResult = await postJson("/session/start", {
           sessionId,
-          title: info?.title ?? null,
+          title: info?.title ?? sessionProject,
           parentID: info?.parentID ?? null,
           version: info?.version ?? null,
-          project: projectPath,
-          cwd: projectPath,
+          project: sessionProject,
+          cwd: sessionProject,
         });
         // cache the context returned at session/start so the
         // chat.system.transform hook injects it without a second fetch.
@@ -239,6 +254,9 @@ export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
         const info = props.info as Record<string, unknown> | undefined;
         const sid = (info?.id as string) || props.sessionID || activeSessionId;
         if (!sid) return;
+        if (typeof info?.directory === "string" && info.directory.length > 0) {
+          sessionProjects.set(sid, process.env.AGENTMEMORY_PROJECT || info.directory);
+        }
         await observe(sid, "session_updated", {
           title: info?.title ?? null,
           parentID: info?.parentID ?? null,
@@ -299,6 +317,10 @@ export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
         if (info.role === "assistant") {
           const sid = props.sessionID || (info.sessionID as string) || activeSessionId;
           if (!sid) return;
+          const cwd = (info as any).path?.cwd;
+          if (typeof cwd === "string" && cwd.length > 0) {
+            sessionProjects.set(sid, process.env.AGENTMEMORY_PROJECT || cwd);
+          }
           const tokens = info.tokens as Record<string, unknown> | undefined;
           const error = info.error ? extractErrorMessage(info.error) : null;
           await observe(sid, "assistant_message", {
@@ -577,6 +599,11 @@ export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
         cost_1k_input: input.model.cost?.input ?? 0,
         cost_1k_output: input.model.cost?.output ?? 0,
       });
+    },
+
+    // ── shell.env ──
+    "shell.env": async (input) => {
+      if (input.sessionID) await updateSessionProject(input.sessionID, input.cwd);
     },
 
     // ── tool.execute.before ──

--- a/plugin/opencode/agentmemory-capture.ts
+++ b/plugin/opencode/agentmemory-capture.ts
@@ -639,7 +639,7 @@ export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
         if (typeof ctx !== "string" || ctx.length === 0) {
           const result = await postJson("/context", {
             sessionId: sid,
-            project: projectPath,
+            project: sessionProjects.get(sid) || projectPath,
           });
           ctx = (result as any)?.context;
         } else {
@@ -677,7 +677,7 @@ export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
 
       const result = await postJson("/context", {
         sessionId: sid,
-        project: projectPath,
+        project: sessionProjects.get(sid) || projectPath,
       });
       const ctx = (result as any)?.context;
       if (typeof ctx === "string" && ctx.length > 0) {


### PR DESCRIPTION
Problem agentmemory-capture.ts currently uses the plugin-level path:
```
ctx.worktree || ctx.project?.id || process.cwd()
```
as the project/cwd for all sessions.

In opencode desktop/server setups, that value can point to the server/worktree path instead of the actual active session directory. After switching projects, new sessions can be incorrectly assigned to the previous project scope, causing the dashboard to show the wrong session path.

Key Fix Track project paths per session:
```
const sessionProjects = new Map<string, string>();
```
Update observe() to prefer the current session’s project path instead of the global plugin path:
```
const project = sessionProjects.get(sessionId) || projectPath;
```
On session.created, read the real session directory from opencode session metadata:
```
const sessionProject = process.env.AGENTMEMORY_PROJECT
  || info.directory
  || projectPath
  || process.cwd();
```
Use that value when starting the agentmemory session:

```
project: sessionProject,
cwd: sessionProject,
```

Also keep the session project path in sync from session.updated, assistant message path.cwd, and shell.env to avoid path drift during the session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session activity now tracks a session-specific workspace path, improving accuracy for `/observe`, session start details, and system context injection.
  * Added environment-based workspace override and improved detection of the current working directory for new sessions.

* **Bug Fixes**
  * Session workspace updates now respond to changes from session updates, assistant message updates, and shell environment changes.
  * Invalid or redundant workspace updates are ignored, and session tracking data is cleaned up when sessions end.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->