### PR TITLE
Add wire support for IBM Bob

### DIFF
--- a/INSTALL_FOR_AGENTS.md
+++ b/INSTALL_FOR_AGENTS.md
@@ -76,7 +76,7 @@ agentmemory connect <agent>
 
 `connect` merges agentmemory into that agent's MCP config and preserves any existing servers. Supported agent names:
 
-`claude-code`, `copilot-cli`, `codex`, `cursor`, `gemini-cli`, `opencode`, `cline`, `continue`, `droid`, `hermes`, `openclaw`, `openhuman`, `pi`, `qwen`, `warp`, `zed`, `antigravity`, `kiro`.
+`claude-code`, `copilot-cli`, `codex`, `cursor`, `gemini-cli`, `opencode`, `cline`, `continue`, `droid`, `hermes`, `openclaw`, `openhuman`, `pi`, `qwen`, `warp`, `zed`, `antigravity`, `kiro`, `bob`.
 
 If you cannot tell which agent you are, default to `claude-code`. After wiring, restart the agent or run its MCP reload command (for example `/mcp` in Claude Code) so it picks up the server.
 

--- a/src/cli/connect/bob.ts
+++ b/src/cli/connect/bob.ts
@@ -1,0 +1,13 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { createJsonMcpAdapter } from "./json-mcp-adapter.js";
+
+export const adapter = createJsonMcpAdapter({
+  name: "bob",
+  displayName: "IBM Bob",
+  detectDir: join(homedir(), ".bob"),
+  configPath: join(homedir(), ".bob", "settings", "mcp.json"),
+  docs: "https://github.com/rohitg00/agentmemory#bob",
+  protocolNote:
+    "→ Using MCP. Runs the agentmemory server at localhost:3111.",
+});

--- a/src/cli/connect/index.ts
+++ b/src/cli/connect/index.ts
@@ -3,6 +3,7 @@ import * as p from "@clack/prompts";
 import pc from "picocolors";
 import type { ConnectAdapter, ConnectOptions, ConnectResult } from "./types.js";
 import { adapter as antigravity } from "./antigravity.js";
+import { adapter as bob } from "./bob.js";
 import { adapter as claudeCode } from "./claude-code.js";
 import { adapter as cline } from "./cline.js";
 import { adapter as copilotCli } from "./copilot-cli.js";
@@ -35,6 +36,7 @@ export const ADAPTERS: readonly ConnectAdapter[] = [
   continueDev,
   zed,
   droid,
+  bob,
   opencode,
   openclaw,
   hermes,


### PR DESCRIPTION
Add wire support for IBM Bob

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for connecting the CLI with Bob as a supported agent.
  * Bob is now included in agent detection and selection flows.
* **Documentation**
  * Updated the setup guide to list Bob in the supported agent names for connection setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->