### PR TITLE
fix: skip summarize for noop provider behind resilient wrapper (#996)

### DIFF
--- a/src/functions/summarize.ts
+++ b/src/functions/summarize.ts
@@ -260,7 +260,11 @@ export function registerSummarizeFunction(
         return { success: false, error: "no_observations" };
       }
 
-      if (provider.name === "noop") {
+      // #996: check isNoop, not name — the provider handed in here is
+      // always wrapped (name `resilient(noop)`), so a name check never
+      // fires and the noop path fell through to empty_provider_response,
+      // recording a false failure in metrics on every invocation.
+      if (provider.isNoop) {
         logger.info("Summarize skipped — no LLM provider configured", {
           sessionId,
         });

--- a/src/providers/fallback-chain.ts
+++ b/src/providers/fallback-chain.ts
@@ -2,9 +2,11 @@ import type { MemoryProvider } from "../types.js";
 
 export class FallbackChainProvider implements MemoryProvider {
   name: string;
+  isNoop: boolean;
 
   constructor(private providers: MemoryProvider[]) {
     this.name = `fallback(${providers.map((p) => p.name).join(" -> ")})`;
+    this.isNoop = providers.every((p) => p.isNoop === true);
   }
 
   async compress(systemPrompt: string, userPrompt: string): Promise<string> {

--- a/src/providers/noop.ts
+++ b/src/providers/noop.ts
@@ -9,6 +9,7 @@ import type { MemoryProvider } from "../types.js";
  */
 export class NoopProvider implements MemoryProvider {
   name = "noop";
+  isNoop = true;
 
   async compress(): Promise<string> {
     return "";

--- a/src/providers/resilient.ts
+++ b/src/providers/resilient.ts
@@ -4,9 +4,11 @@ import { CircuitBreaker } from "./circuit-breaker.js";
 export class ResilientProvider implements MemoryProvider {
   private breaker = new CircuitBreaker();
   name: string;
+  isNoop: boolean;
 
   constructor(private inner: MemoryProvider) {
     this.name = `resilient(${inner.name})`;
+    this.isNoop = inner.isNoop === true;
   }
 
   private async call(fn: () => Promise<string>): Promise<string> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -151,6 +151,13 @@ export type ProviderType = "agent-sdk" | "anthropic" | "gemini" | "openrouter" |
 
 export interface MemoryProvider {
   name: string;
+  /**
+   * True when the provider performs no LLM work (zero-LLM mode). Wrapper
+   * providers (resilient, fallback chain) must propagate this from their
+   * inner provider(s) so callers can skip LLM-gated work without relying
+   * on `name`, which wrappers decorate (e.g. `resilient(noop)`).
+   */
+  isNoop?: boolean;
   compress(systemPrompt: string, userPrompt: string): Promise<string>;
   summarize(systemPrompt: string, userPrompt: string): Promise<string>;
   describeImage?(imageData: string, mimeType: string, prompt: string): Promise<string>;

--- a/test/zero-llm-summarize-metrics.test.ts
+++ b/test/zero-llm-summarize-metrics.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../src/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("../src/state/schema.js", () => ({
+  KV: {
+    sessions: "sessions",
+    summaries: "summaries",
+    observations: (sessionId: string) => `obs:${sessionId}`,
+    audit: "audit",
+  },
+}));
+
+vi.mock("../src/eval/schemas.js", () => ({
+  SummaryOutputSchema: {},
+}));
+
+vi.mock("../src/eval/validator.js", () => ({
+  validateOutput: () => ({ valid: true, result: { errors: [] } }),
+}));
+
+vi.mock("../src/eval/quality.js", () => ({
+  scoreSummary: () => 100,
+}));
+
+vi.mock("../src/functions/audit.js", () => ({
+  safeAudit: vi.fn(),
+}));
+
+import { registerSummarizeFunction } from "../src/functions/summarize.js";
+import { NoopProvider } from "../src/providers/noop.js";
+import { ResilientProvider } from "../src/providers/resilient.js";
+import { FallbackChainProvider } from "../src/providers/fallback-chain.js";
+import type {
+  CompressedObservation,
+  Session,
+  MemoryProvider,
+} from "../src/types.js";
+
+function mockKV() {
+  const store = new Map<string, Map<string, unknown>>();
+  return {
+    store,
+    get: async <T>(scope: string, key: string): Promise<T | null> =>
+      (store.get(scope)?.get(key) as T) ?? null,
+    set: async <T>(scope: string, key: string, data: T): Promise<T> => {
+      if (!store.has(scope)) store.set(scope, new Map());
+      store.get(scope)!.set(key, data);
+      return data;
+    },
+    delete: async (scope: string, key: string): Promise<void> => {
+      store.get(scope)?.delete(key);
+    },
+    list: async <T>(scope: string): Promise<T[]> => {
+      const entries = store.get(scope);
+      return entries ? (Array.from(entries.values()) as T[]) : [];
+    },
+  };
+}
+
+function mockSdk() {
+  const functions = new Map<string, Function>();
+  return {
+    functions,
+    registerFunction: (id: string, handler: Function) => {
+      functions.set(id, handler);
+    },
+    registerTrigger: () => {},
+    trigger: async () => ({}),
+  };
+}
+
+function mockMetricsStore() {
+  return { record: vi.fn(async () => {}) };
+}
+
+function makeObs(i: number, sessionId: string): CompressedObservation {
+  return {
+    id: `obs_${i}`,
+    sessionId,
+    timestamp: new Date().toISOString(),
+    type: "conversation",
+    title: `obs ${i}`,
+    facts: [`fact ${i}`],
+    narrative: `narrative for obs ${i}`,
+    concepts: [],
+    files: [`src/file_${i}.ts`],
+    importance: 5,
+  };
+}
+
+function makeRealProvider(response: string): MemoryProvider {
+  return {
+    name: "test",
+    compress: async () => "",
+    summarize: async () => response,
+  };
+}
+
+const SUMMARY_XML = `<summary>
+<title>Real summary</title>
+<narrative>narrative</narrative>
+<decisions><decision>decision A</decision></decisions>
+<files><file>src/a.ts</file></files>
+<concepts><concept>concept-a</concept></concepts>
+</summary>`;
+
+async function setupHandler(opts: {
+  sessionId: string;
+  obsCount: number;
+  provider: MemoryProvider;
+}) {
+  const sdk = mockSdk();
+  const kv = mockKV();
+  const metricsStore = mockMetricsStore();
+  const session: Session = {
+    id: opts.sessionId,
+    project: "test-project",
+    cwd: "/tmp",
+    startedAt: new Date().toISOString(),
+    status: "completed",
+    observationCount: opts.obsCount,
+  };
+  await kv.set("sessions", opts.sessionId, session);
+  for (let i = 0; i < opts.obsCount; i++) {
+    const o = makeObs(i, opts.sessionId);
+    await kv.set(`obs:${opts.sessionId}`, o.id, o);
+  }
+  registerSummarizeFunction(
+    sdk as any,
+    kv as any,
+    opts.provider,
+    metricsStore as any,
+  );
+  const handler = sdk.functions.get("mem::summarize")!;
+  return { handler, kv, metricsStore };
+}
+
+describe("zero-LLM mode: summarize skip must not record metrics (#996)", () => {
+  it("skips with no_provider when the noop provider is wrapped in ResilientProvider", async () => {
+    const { handler, metricsStore } = await setupHandler({
+      sessionId: "ses_noop",
+      obsCount: 3,
+      provider: new ResilientProvider(new NoopProvider()),
+    });
+
+    const result: any = await handler({ sessionId: "ses_noop" });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("no_provider");
+    expect(metricsStore.record).not.toHaveBeenCalled();
+  });
+
+  it("skips when the noop provider sits behind resilient(fallback(...)) and every chain member is noop", async () => {
+    const { handler, metricsStore } = await setupHandler({
+      sessionId: "ses_chain",
+      obsCount: 3,
+      provider: new ResilientProvider(
+        new FallbackChainProvider([new NoopProvider()]),
+      ),
+    });
+
+    const result: any = await handler({ sessionId: "ses_chain" });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("no_provider");
+    expect(metricsStore.record).not.toHaveBeenCalled();
+  });
+
+  it("does not skip a real provider behind ResilientProvider", async () => {
+    const { handler, metricsStore } = await setupHandler({
+      sessionId: "ses_real",
+      obsCount: 3,
+      provider: new ResilientProvider(makeRealProvider(SUMMARY_XML)),
+    });
+
+    const result: any = await handler({ sessionId: "ses_real" });
+
+    expect(result.success).toBe(true);
+    expect(metricsStore.record).toHaveBeenCalledWith(
+      "mem::summarize",
+      expect.any(Number),
+      true,
+      expect.any(Number),
+    );
+  });
+
+  it("does not skip a fallback chain that contains a real provider", async () => {
+    const { handler, metricsStore } = await setupHandler({
+      sessionId: "ses_mixed",
+      obsCount: 3,
+      provider: new ResilientProvider(
+        new FallbackChainProvider([
+          makeRealProvider(SUMMARY_XML),
+          new NoopProvider(),
+        ]),
+      ),
+    });
+
+    const result: any = await handler({ sessionId: "ses_mixed" });
+
+    expect(result.success).toBe(true);
+    expect(metricsStore.record).toHaveBeenCalledWith(
+      "mem::summarize",
+      expect.any(Number),
+      true,
+      expect.any(Number),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

In zero-LLM mode `mem::summarize` records a failure in the health metrics on every invocation, so `functionMetrics` for `mem::summarize` shows an ever-growing `failureCount` (observed 1419 -> 1429 within minutes) even though skipping is the correct behavior without an LLM.

One correction to the diagnosis in the issue. The `no_provider` early return itself records nothing, so it is not the skip being tallied. The real problem is that the skip guard never fires at all. `createProvider` always wraps the base provider in `ResilientProvider`, whose name is `resilient(noop)`, so the guard `if (provider.name === "noop")` in `registerSummarizeFunction` is dead code. Execution falls through to `NoopProvider.summarize()`, which returns an empty string, and the `empty_provider_response` branch then calls `metricsStore.record("mem::summarize", latencyMs, false)`. That happens twice per Claude Code turn (the Stop hook posts both `/agentmemory/summarize` and `/agentmemory/session/end`), which matches the observed growth rate.

## Fix

- Add an optional `isNoop` flag to `MemoryProvider` and set it on `NoopProvider`.
- Propagate the flag through the wrappers. `ResilientProvider` mirrors its inner provider, and `FallbackChainProvider` is noop only when every chain member is.
- Guard the summarize skip on `provider.isNoop` instead of the name. The skip returns `no_provider` before any metrics call, so zero-LLM invocations stay metrics-silent.

No new "skipped" metrics outcome is needed. Once the guard fires, the skip path records nothing, which keeps `failureCount` reserved for genuine failures.

## Testing

- New `test/zero-llm-summarize-metrics.test.ts` covers four cases: `resilient(noop)` skips with `no_provider` and never touches the metrics store, `resilient(fallback(noop))` does the same, and a real provider (bare or in a chain) is not skipped and still records success metrics. The first two fail on main (they get `empty_provider_response` and a recorded failure) and pass with the fix.
- Full `npm test` passes (1414 tests; the only local exceptions were 5 `hook-project` tests that assert on the checkout directory name and fail in any git worktree, unrelated to this change). `npm run build` and `npm run skills:check` also pass.

Fixes #996

## Notes for reviewers

- `isNoop` is optional with strict `=== true` checks in the wrappers, so a provider that never sets it can only fail toward "not noop" (real work still happens). Making it a required member was considered and skipped to keep the diff minimal; happy to change if you prefer the compiler-enforced version.
- Adjacent gap, not touched here: the viewer's Summarize button shows "Done" without inspecting the result, so in zero-LLM mode a user gets "Done" with no summary. Pre-existing behavior; worth a small follow-up if you want the button to surface the `no_provider` reason.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting “no LLM” provider chains more reliably, including wrapped and fallback provider setups.
  * Summarize requests now correctly skip LLM-dependent work when the active provider is effectively noop.

* **Bug Fixes**
  * Fixed cases where provider detection could incorrectly treat wrapped noop providers as real providers.
  * Prevented metric recording when summarize cannot run due to a noop-only provider chain.

* **Tests**
  * Added coverage for zero-LLM behavior across direct, wrapped, and fallback provider combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->