### PR TITLE
fix: resolve OpenRouter embedding dimensions from model table + env override

### DIFF
--- a/src/providers/embedding/openrouter.ts
+++ b/src/providers/embedding/openrouter.ts
@@ -4,9 +4,43 @@ import { fetchWithTimeout } from "../_fetch.js";
 
 const API_URL = "https://openrouter.ai/api/v1/embeddings";
 
+const DEFAULT_MODEL = "openai/text-embedding-3-small";
+
+/**
+ * Known embedding model dimensions accessible via OpenRouter.
+ * Extend as new models are added. Override in any case via
+ * OPENROUTER_EMBEDDING_DIMENSIONS for models not listed here.
+ */
+const MODEL_DIMENSIONS: Record<string, number> = {
+  "openai/text-embedding-3-small": 1536,
+  "openai/text-embedding-3-large": 3072,
+  "openai/text-embedding-ada-002": 1536,
+  "qwen/qwen3-embedding-8b": 4096,
+  "google/gemini-embedding-001": 3072,
+  "cohere/embed-multilingual-v3.0": 1024,
+  "cohere/embed-english-v3.0": 1024,
+  "cohere/embed-multilingual-light-v3.0": 384,
+  "cohere/embed-english-light-v3.0": 384,
+};
+
+const DEFAULT_DIMENSIONS = MODEL_DIMENSIONS[DEFAULT_MODEL] ?? 1536;
+
+function resolveDimensions(model: string, override: string | undefined): number {
+  if (override !== undefined && override.trim().length > 0) {
+    const parsed = parseInt(override, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      throw new Error(
+        `OPENROUTER_EMBEDDING_DIMENSIONS must be a positive integer, got: ${override}`,
+      );
+    }
+    return parsed;
+  }
+  return MODEL_DIMENSIONS[model] ?? DEFAULT_DIMENSIONS;
+}
+
 export class OpenRouterEmbeddingProvider implements EmbeddingProvider {
   readonly name = "openrouter";
-  readonly dimensions = 1536;
+  readonly dimensions: number;
   private apiKey: string;
   private model: string;
 
@@ -15,7 +49,11 @@ export class OpenRouterEmbeddingProvider implements EmbeddingProvider {
     if (!this.apiKey) throw new Error("OPENROUTER_API_KEY is required");
     this.model =
       getEnvVar("OPENROUTER_EMBEDDING_MODEL") ||
-      "openai/text-embedding-3-small";
+      DEFAULT_MODEL;
+    this.dimensions = resolveDimensions(
+      this.model,
+      getEnvVar("OPENROUTER_EMBEDDING_DIMENSIONS"),
+    );
   }
 
   async embed(text: string): Promise<Float32Array> {

--- a/src/providers/embedding/openrouter.ts
+++ b/src/providers/embedding/openrouter.ts
@@ -27,13 +27,18 @@ const DEFAULT_DIMENSIONS = MODEL_DIMENSIONS[DEFAULT_MODEL] ?? 1536;
 
 function resolveDimensions(model: string, override: string | undefined): number {
   if (override !== undefined && override.trim().length > 0) {
-    const parsed = parseInt(override, 10);
-    if (!Number.isFinite(parsed) || parsed <= 0) {
+    const parsed = Number(override.trim());
+    if (!Number.isFinite(parsed) || parsed <= 0 || !Number.isInteger(parsed)) {
       throw new Error(
         `OPENROUTER_EMBEDDING_DIMENSIONS must be a positive integer, got: ${override}`,
       );
     }
     return parsed;
+  }
+  if (!(model in MODEL_DIMENSIONS)) {
+    console.warn(
+      `[agentmemory] Unknown embedding model "${model}" not in MODEL_DIMENSIONS; using default dimensions (${DEFAULT_DIMENSIONS}). Set OPENROUTER_EMBEDDING_DIMENSIONS to override.`,
+    );
   }
   return MODEL_DIMENSIONS[model] ?? DEFAULT_DIMENSIONS;
 }

--- a/test/openrouter-embedding.test.ts
+++ b/test/openrouter-embedding.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { OpenRouterEmbeddingProvider } from "../src/providers/embedding/openrouter.js";
+
+describe("OpenRouterEmbeddingProvider", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env["OPENROUTER_API_KEY"];
+    delete process.env["OPENROUTER_EMBEDDING_MODEL"];
+    delete process.env["OPENROUTER_EMBEDDING_DIMENSIONS"];
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("defaults to 1536 dimensions for the default model", () => {
+    const provider = new OpenRouterEmbeddingProvider("test-key");
+    expect(provider.name).toBe("openrouter");
+    expect(provider.dimensions).toBe(1536);
+  });
+
+  it("throws when no API key is provided", () => {
+    expect(() => new OpenRouterEmbeddingProvider()).toThrow(
+      /OPENROUTER_API_KEY is required/,
+    );
+  });
+
+  it("derives dimensions from the known-models table", () => {
+    process.env["OPENROUTER_EMBEDDING_MODEL"] = "qwen/qwen3-embedding-8b";
+    const qwen = new OpenRouterEmbeddingProvider("test-key");
+    expect(qwen.dimensions).toBe(4096);
+
+    process.env["OPENROUTER_EMBEDDING_MODEL"] = "openai/text-embedding-3-large";
+    const large = new OpenRouterEmbeddingProvider("test-key");
+    expect(large.dimensions).toBe(3072);
+
+    process.env["OPENROUTER_EMBEDDING_MODEL"] = "cohere/embed-multilingual-v3.0";
+    const cohere = new OpenRouterEmbeddingProvider("test-key");
+    expect(cohere.dimensions).toBe(1024);
+  });
+
+  it("OPENROUTER_EMBEDDING_DIMENSIONS overrides model-derived dimensions", () => {
+    process.env["OPENROUTER_EMBEDDING_MODEL"] = "openai/text-embedding-3-large";
+    process.env["OPENROUTER_EMBEDDING_DIMENSIONS"] = "768";
+    const provider = new OpenRouterEmbeddingProvider("test-key");
+    expect(provider.dimensions).toBe(768);
+  });
+
+  it("falls back to 1536 for unknown models", () => {
+    process.env["OPENROUTER_EMBEDDING_MODEL"] = "unknown/custom-model";
+    const provider = new OpenRouterEmbeddingProvider("test-key");
+    expect(provider.dimensions).toBe(1536);
+  });
+
+  it("rejects invalid OPENROUTER_EMBEDDING_DIMENSIONS values", () => {
+    process.env["OPENROUTER_EMBEDDING_DIMENSIONS"] = "not-a-number";
+    expect(() => new OpenRouterEmbeddingProvider("test-key")).toThrow(
+      /OPENROUTER_EMBEDDING_DIMENSIONS must be a positive integer/,
+    );
+
+    process.env["OPENROUTER_EMBEDDING_DIMENSIONS"] = "-5";
+    expect(() => new OpenRouterEmbeddingProvider("test-key")).toThrow(
+      /OPENROUTER_EMBEDDING_DIMENSIONS must be a positive integer/,
+    );
+
+    process.env["OPENROUTER_EMBEDDING_DIMENSIONS"] = "0";
+    expect(() => new OpenRouterEmbeddingProvider("test-key")).toThrow(
+      /OPENROUTER_EMBEDDING_DIMENSIONS must be a positive integer/,
+    );
+  });
+
+  it("sends correct model in the request body", async () => {
+    process.env["OPENROUTER_EMBEDDING_MODEL"] = "qwen/qwen3-embedding-8b";
+    const provider = new OpenRouterEmbeddingProvider("test-key");
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({ data: [{ embedding: Array(4096).fill(0.1) }] }),
+        { status: 200 },
+      ),
+    );
+
+    await provider.embed("hello");
+    const body = JSON.parse(
+      (fetchSpy.mock.calls[0][1] as RequestInit).body as string,
+    );
+    expect(body.model).toBe("qwen/qwen3-embedding-8b");
+
+    fetchSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

`OpenRouterEmbeddingProvider` hardcoded `dimensions = 1536` regardless of the configured model. Models with different native dimensions (e.g. `qwen/qwen3-embedding-8b` at 4096) produced vectors silently rejected by the index, causing semantic recall to return 0 hits with no logged error.

## Changes

**`src/providers/embedding/openrouter.ts`**:
- Add `MODEL_DIMENSIONS` table for known OpenRouter-accessible embedding models, following the pattern established by `OpenAIEmbeddingProvider`
- Support `OPENROUTER_EMBEDDING_DIMENSIONS` env var override for custom/unlisted models
- Extract `resolveDimensions()` helper (same shape as the OpenAI provider)
- Default behavior unchanged: `openai/text-embedding-3-small` still resolves to 1536

**`test/openrouter-embedding.test.ts`** (new):
- Default dimensions (1536)
- Model-derived dimensions (qwen3-embedding-8b → 4096, text-embedding-3-large → 3072)
- Env override takes precedence
- Unknown model fallback (1536)
- Invalid override rejection
- Correct model in request body

## How it works

1. Check `OPENROUTER_EMBEDDING_DIMENSIONS` env var — if set, use it (explicit override always wins)
2. Look up the configured model in the `MODEL_DIMENSIONS` table
3. Fall back to 1536 (default model dimensions) for unknown models

The existing `withDimensionGuard` wrapper (applied in `createEmbeddingProvider`) will catch any remaining mismatches at runtime.

Fixes #1002

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Embedding settings now adapt to the selected OpenRouter model, with support for a custom dimension override.
* **Bug Fixes**
  * Added validation for embedding dimension values to prevent invalid configuration.
  * Unknown models now safely fall back to a standard default dimension.
* **Tests**
  * Added coverage for model-based dimensions, environment overrides, missing API keys, invalid values, and request payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->