### PR TITLE
fix: evicted observations leave ghost entries in search indexes

### DIFF
--- a/src/functions/evict.ts
+++ b/src/functions/evict.ts
@@ -10,6 +10,7 @@ import { KV } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
 import { recordAudit } from "./audit.js";
 import { deleteAccessLog } from "./access-tracker.js";
+import { getSearchIndex, vectorIndexRemove, flushIndexSave } from "./search.js";
 import { logger } from "../logger.js";
 
 interface EvictionConfig {
@@ -212,6 +213,8 @@ export function registerEvictFunction(sdk: ISdk, kv: StateKV): void {
                 });
                 continue;
               }
+              getSearchIndex().remove(o.id);
+              vectorIndexRemove(o.id);
               if (o.imageData) await decrementImageRef(kv, sdk, o.imageData);
               if (o.imageRef && o.imageRef !== o.imageData) await decrementImageRef(kv, sdk, o.imageRef);
               await recordAudit(kv, "delete", "mem::evict", [o.id], {
@@ -255,6 +258,8 @@ export function registerEvictFunction(sdk: ISdk, kv: StateKV): void {
                 });
                 continue;
               }
+              getSearchIndex().remove(o.id);
+              vectorIndexRemove(o.id);
               if (o.imageData) await decrementImageRef(kv, sdk, o.imageData);
               if (o.imageRef && o.imageRef !== o.imageData) await decrementImageRef(kv, sdk, o.imageRef);
               await recordAudit(kv, "delete", "mem::evict", [o.id], {
@@ -291,6 +296,8 @@ export function registerEvictFunction(sdk: ISdk, kv: StateKV): void {
                 });
                 continue;
               }
+              getSearchIndex().remove(mem.id);
+              vectorIndexRemove(mem.id);
               if (mem.imageRef) {
                 await decrementImageRef(kv, sdk, mem.imageRef);
               }
@@ -326,6 +333,8 @@ export function registerEvictFunction(sdk: ISdk, kv: StateKV): void {
                 });
                 continue;
               }
+              getSearchIndex().remove(mem.id);
+              vectorIndexRemove(mem.id);
               if (mem.imageRef) {
                 await decrementImageRef(kv, sdk, mem.imageRef);
               }
@@ -338,6 +347,10 @@ export function registerEvictFunction(sdk: ISdk, kv: StateKV): void {
             }
           }
         }
+      }
+
+      if (!dryRun) {
+        await flushIndexSave();
       }
 
       logger.info("Eviction complete", { stats });


### PR DESCRIPTION
Found a bug in the eviction logic — when observations are evicted from KV, they're never removed from the BM25 or vector indexes. This means searches return IDs for evicted entries, but the KV lookup in the second pass gets null, silently dropping results and under-filling search pages.

The forget and auto-forget code paths already handle this correctly (they call both \`getSearchIndex().remove()\` and \`vectorIndexRemove()\` alongside the KV delete). Applied the same pattern to eviction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory cleanup so deleted items are also removed from search and vector results.
  * Prevented stale or expired memories from continuing to appear in retrieval-based features.
  * Ensured index updates are saved after eviction, except during dry runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->