### PR TITLE
fix(replay): surface compressed observation content in replay detail

### DIFF
--- a/src/functions/replay.ts
+++ b/src/functions/replay.ts
@@ -46,16 +46,35 @@ async function isSymlink(path: string): Promise<boolean> {
   }
 }
 
-function rawFromCompressed(obs: CompressedObservation): RawObservation {
+/**
+ * 将压缩后的 observation 还原为 RawObservation 结构，供 replay/timeline 使用。
+ *
+ * 背景：运行时（含 live capture 和 jsonl-import 路径）会将所有 observation 压缩，
+ * 压缩后只保留 title/subtitle/narrative/facts/type 等字段，丢弃原始的
+ * toolName/toolInput/toolOutput 等工具字段。
+ *
+ * 旧版 shim 对所有类型一律返回 hookType:"post_tool_use" 并将工具字段全部置为
+ * undefined，导致 projectTimeline → renderReplayDetail 收到的事件没有任何可展示
+ * 的内容（detail 面板空白）。
+ *
+ * 修复：根据 obs.type 分支处理——
+ *   - "conversation"：映射为对话事件（hookType:"prompt_submit"），内容取 narrative。
+ *   - 其他（command_run / file_read / …）：映射为工具调用事件
+ *     （hookType:"post_tool_use"），工具名取 title、输入取 subtitle、输出取 narrative。
+ *
+ * 纯函数，无 I/O 副作用——导出供单元测试直接验证。
+ */
+export function rawFromCompressed(obs: CompressedObservation): RawObservation {
+  const isConversation = obs.type === "conversation";
   return {
     id: obs.id,
     sessionId: obs.sessionId,
     timestamp: obs.timestamp,
-    hookType: "post_tool_use",
-    toolName: undefined,
-    toolInput: undefined,
-    toolOutput: undefined,
-    userPrompt: obs.type === "conversation" ? obs.narrative : undefined,
+    hookType: isConversation ? "prompt_submit" : "post_tool_use",
+    toolName: isConversation ? undefined : obs.title,
+    toolInput: isConversation ? undefined : obs.subtitle,
+    toolOutput: isConversation ? undefined : obs.narrative,
+    userPrompt: isConversation ? obs.narrative : undefined,
     assistantResponse: undefined,
     raw: { title: obs.title, narrative: obs.narrative, facts: obs.facts },
   };

--- a/test/replay.test.ts
+++ b/test/replay.test.ts
@@ -3,6 +3,8 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { parseJsonlText } from "../src/replay/jsonl-parser.js";
 import { projectTimeline } from "../src/replay/timeline.js";
+import { rawFromCompressed } from "../src/functions/replay.js";
+import type { CompressedObservation } from "../src/types.js";
 
 const fx = (name: string) =>
   readFileSync(join(__dirname, "fixtures/jsonl", name), "utf-8");
@@ -140,6 +142,126 @@ describe("projectTimeline", () => {
     });
     const out = parseJsonlText(text);
     expect(out.startedAt).toBe(out.endedAt);
+  });
+});
+
+// 基础工厂：生成最小合法的 CompressedObservation，允许按需覆盖字段。
+function makeCompressed(
+  overrides: Partial<CompressedObservation> & { type: CompressedObservation["type"] },
+): CompressedObservation {
+  return {
+    id: "obs-test-1",
+    sessionId: "sess-test",
+    timestamp: "2026-04-17T10:00:00.000Z",
+    title: "default-title",
+    narrative: "default narrative",
+    facts: [],
+    concepts: [],
+    files: [],
+    importance: 0.5,
+    ...overrides,
+  };
+}
+
+describe("rawFromCompressed", () => {
+  /**
+   * 回归测试：压缩->重建 shim 在工具类事件上必须保留可展示内容。
+   *
+   * 旧版 shim 将所有 CompressedObservation 一律映射为 hookType:"post_tool_use"
+   * 但 toolName/toolInput/toolOutput 全部为 undefined，replay detail 面板因此
+   * 一片空白。修复后工具类 obs 的 title/subtitle/narrative 应分别流向对应字段。
+   */
+  it("工具类 observation（command_run）应映射为 post_tool_use，并保留工具内容", () => {
+    const obs = makeCompressed({
+      type: "command_run",
+      title: "Bash",
+      subtitle: "ls -la",
+      narrative: "README.md\nsrc\n",
+      facts: ["ran ls"],
+    });
+
+    const raw = rawFromCompressed(obs);
+
+    expect(raw.hookType).toBe("post_tool_use");
+    expect(raw.toolName).toBe("Bash");
+    expect(raw.toolInput).toBe("ls -la");
+    expect(raw.toolOutput).toBe("README.md\nsrc\n");
+    expect(raw.userPrompt).toBeUndefined();
+    expect(raw.assistantResponse).toBeUndefined();
+  });
+
+  it("对话类 observation（conversation）应映射为 prompt_submit，内容取 narrative", () => {
+    const obs = makeCompressed({
+      type: "conversation",
+      title: "User message",
+      narrative: "Fix the login bug",
+      facts: [],
+    });
+
+    const raw = rawFromCompressed(obs);
+
+    expect(raw.hookType).toBe("prompt_submit");
+    expect(raw.userPrompt).toBe("Fix the login bug");
+    expect(raw.toolName).toBeUndefined();
+    expect(raw.toolInput).toBeUndefined();
+    expect(raw.toolOutput).toBeUndefined();
+    expect(raw.assistantResponse).toBeUndefined();
+  });
+
+  it("工具类 observation 在 subtitle 缺失时 toolInput 应为 undefined（不报错）", () => {
+    // subtitle 是 CompressedObservation 的可选字段；旧数据可能没有该字段。
+    const obs = makeCompressed({
+      type: "file_read",
+      title: "Read",
+      // subtitle 故意省略
+      narrative: "file content here",
+      facts: [],
+    });
+
+    const raw = rawFromCompressed(obs);
+
+    expect(raw.hookType).toBe("post_tool_use");
+    expect(raw.toolName).toBe("Read");
+    expect(raw.toolInput).toBeUndefined();
+    expect(raw.toolOutput).toBe("file content here");
+  });
+
+  it("rawFromCompressed 的输出经 projectTimeline 后 detail 字段可在事件中取到", () => {
+    // 端到端验证：压缩 obs → rawFromCompressed → projectTimeline → TimelineEvent
+    // 工具类事件的 toolName/toolInput/toolOutput 必须出现在最终的 timeline 事件里。
+    const toolObs = rawFromCompressed(
+      makeCompressed({
+        type: "command_run",
+        title: "Bash",
+        subtitle: "echo hello",
+        narrative: "hello",
+        facts: [],
+      }),
+    );
+    const convObs = rawFromCompressed(
+      makeCompressed({
+        id: "obs-test-2",
+        type: "conversation",
+        title: "User message",
+        narrative: "What files are here?",
+        facts: [],
+        timestamp: "2026-04-17T10:00:01.000Z",
+      }),
+    );
+
+    const tl = projectTimeline([toolObs, convObs]);
+
+    // 工具结果事件
+    const toolEvent = tl.events.find((e) => e.kind === "tool_result");
+    expect(toolEvent).toBeDefined();
+    expect(toolEvent?.toolName).toBe("Bash");
+    expect(toolEvent?.toolInput).toBe("echo hello");
+    expect(toolEvent?.toolOutput).toBe("hello");
+
+    // 对话（prompt）事件
+    const promptEvent = tl.events.find((e) => e.kind === "prompt");
+    expect(promptEvent).toBeDefined();
+    expect(promptEvent?.body).toBe("What files are here?");
   });
 });
 


### PR DESCRIPTION
## Problem

The Replay tab in the viewer steps through session events correctly, but the detail panel is empty for every event — only a label and timestamp are shown.

## Root Cause

`rawFromCompressed()` in `src/functions/replay.ts` was the compatibility shim between the compressed storage format and the `RawObservation` shape expected by `projectTimeline`. It had two bugs:

1. **Wrong `hookType` for all events** — hardcoded `"post_tool_use"` regardless of observation type, so conversation events never rendered as prompts.
2. **Tool fields discarded** — `toolName`, `toolInput`, and `toolOutput` were all `undefined`. The compressed format *does* retain this data under different field names (`title` = tool name, `subtitle` = raw input, `narrative` = combined output), but the shim never mapped them.

Since the runtime compresses every observation (both live-capture and jsonl-import paths), every replay session was affected.

## Fix

Branch on `obs.type` in `rawFromCompressed`:

- `"conversation"` → `hookType: "prompt_submit"`, `userPrompt ← narrative`
- everything else (command_run, file_read, …) → `hookType: "post_tool_use"`, `toolName ← title`, `toolInput ← subtitle`, `toolOutput ← narrative`

`assistantResponse` stays `undefined` — the compression pass doesn't preserve a separate assistant-response field.

The function is also exported (it was previously unexported) so it can be directly unit-tested. Precedent: `src/cli/doctor-diagnostics.ts` does the same for its pure helpers.

## Tests

Four new test cases added to `test/replay.test.ts` in the new `rawFromCompressed` describe block:

| Test | Verifies |
|------|----------|
| `command_run` with subtitle | `hookType`, `toolName`, `toolInput`, `toolOutput` all populated |
| `conversation` | `hookType:"prompt_submit"`, `userPrompt` populated, tool fields undefined |
| tool obs with no `subtitle` | gracefully maps `toolInput` to `undefined` without throwing |
| end-to-end via `projectTimeline` | `TimelineEvent` carries `toolName`/`toolInput`/`toolOutput`/`body` |

```
Test Files  1 passed (1)
     Tests  17 passed (17)   ← 13 original + 4 new
  Duration  235ms
```

TypeScript typecheck (`npx tsc --noEmit`): zero errors in changed files (pre-existing errors in unrelated files are unchanged).

## Checklist

- [x] Reproduces the bug (empty detail panel for every event)
- [x] All 17 replay tests pass
- [x] No new TypeScript errors introduced
- [x] Comments explain the why (compression-drops-raw regression context)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Timeline and replay views now show the correct details for conversation and tool events.
  * Prompt submissions and tool runs are mapped to the right display fields, so event content is no longer missing.
  * Optional event details are handled more gracefully, avoiding blank or incomplete timeline entries.

* **Tests**
  * Added coverage for replay-to-timeline conversion to verify the expected event content appears end to end.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->