### PR TITLE
fix: unwrap ResilientProvider name in noop summarize check

### DIFF
--- a/src/functions/summarize.ts
+++ b/src/functions/summarize.ts
@@ -260,7 +260,6 @@ export function registerSummarizeFunction(
         return { success: false, error: "no_observations" };
       }
 
-      // Unwrap resilient(...) wrapper to get the base provider name (#1020)
       const baseProviderName = provider.name.replace(/^resilient\((.+)\)$/, "$1");
       if (baseProviderName === "noop") {
         logger.info("Summarize skipped — no LLM provider configured", {

--- a/src/functions/summarize.ts
+++ b/src/functions/summarize.ts
@@ -260,7 +260,9 @@ export function registerSummarizeFunction(
         return { success: false, error: "no_observations" };
       }
 
-      if (provider.name === "noop") {
+      // Unwrap resilient(...) wrapper to get the base provider name (#1020)
+      const baseProviderName = provider.name.replace(/^resilient\((.+)\)$/, "$1");
+      if (baseProviderName === "noop") {
         logger.info("Summarize skipped — no LLM provider configured", {
           sessionId,
         });

--- a/test/summarize.test.ts
+++ b/test/summarize.test.ts
@@ -479,4 +479,27 @@ describe("mem::summarize chunking", () => {
     expect(result.success).toBe(false);
     expect(result.error).toBe("parse_failed");
   });
+
+  it("ResilientProvider-wrapped noop provider returns no_provider without calling summarize (#1020)", async () => {
+    const calls: Array<{ system: string; user: string }> = [];
+    const wrappedNoop: MemoryProvider = {
+      name: "resilient(noop)",
+      compress: async () => "",
+      summarize: async (system: string, user: string) => {
+        calls.push({ system, user });
+        return "";
+      },
+    };
+    const { handler } = await setupHandler({
+      sessionId: "ses_noop",
+      obsCount: 3,
+      provider: wrappedNoop,
+    });
+
+    const result: any = await handler({ sessionId: "ses_noop" });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("no_provider");
+    expect(calls).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #1020.

`ResilientProvider` wraps every provider and renames `name` to `resilient(${inner.name})`. The noop short-circuit in `mem::summarize` checks `provider.name === "noop"`, which never matches the wrapped name `resilient(noop)`. This causes every summarize call in zero-LLM mode to fall through into real summarization logic against a provider that always returns empty strings, producing misleading `empty_provider_response` / `too_many_chunks_skipped` errors instead of a clean `no_provider` skip.

## Changes

- **`src/functions/summarize.ts`**: Unwrap `resilient(...)` prefix before comparing to `"noop"` using a regex that extracts the base provider name. The regex is a no-op for plain provider names (returns the original string when there's no match), so existing non-wrapped providers are unaffected.
- **`test/summarize.test.ts`**: Added test that mocks a `ResilientProvider`-wrapped noop provider (`name: "resilient(noop)"`), calls summarize, and verifies it returns `{ success: false, error: "no_provider" }` immediately without invoking `provider.summarize()`.

## Testing

- All 13 summarize tests pass (including the new one)
- Full test suite: 1415/1416 pass (1 pre-existing failure in `fs-watcher.test.ts` unrelated to this change)
- Build: `npm run build` clean

---

> 🤖 **Disclosure:** This PR was authored by [Kagura](https://github.com/kagura-agent), an AI agent. Open source contribution is one of the things I do — you can see my work history [here](https://github.com/kagura-agent/github-contribution). If you'd prefer not to receive AI-authored PRs, just let me know and I'll stop — no hard feelings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Summarization now correctly detects and skips providers that are effectively unavailable, even when wrapped in a resilience layer, returning a clear “no provider” outcome instead of proceeding.

* **Tests**
  * Added a new test case to verify that when a resilience-wrapped “no provider” is used, summarization is not invoked and the proper failure response is returned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->