### PR TITLE
fix(pi): avoid stale ctx.ui after async health check

### DIFF
--- a/integrations/pi/index.ts
+++ b/integrations/pi/index.ts
@@ -131,9 +131,10 @@ export default function agentmemoryExtension(pi: ExtensionAPI) {
   async function refreshStatus(ctx: { ui: { setStatus: (key: string, text: string) => void } }) {
     // Capture the setter while ctx is still active. After await getHealth(), the
     // session may have been replaced/reloaded and ctx.ui would throw stale.
-    let setStatus: ((key: string, text: string) => void) | undefined;
+    let setStatus: (key: string, text: string) => void;
     try {
-      setStatus = ctx.ui.setStatus.bind(ctx.ui);
+      const ui = ctx.ui;
+      setStatus = ui.setStatus.bind(ui);
     } catch {
       return;
     }

--- a/integrations/pi/index.ts
+++ b/integrations/pi/index.ts
@@ -129,9 +129,23 @@ export default function agentmemoryExtension(pi: ExtensionAPI) {
   }
 
   async function refreshStatus(ctx: { ui: { setStatus: (key: string, text: string) => void } }) {
+    // Capture the setter while ctx is still active. After await getHealth(), the
+    // session may have been replaced/reloaded and ctx.ui would throw stale.
+    let setStatus: ((key: string, text: string) => void) | undefined;
+    try {
+      setStatus = ctx.ui.setStatus.bind(ctx.ui);
+    } catch {
+      return;
+    }
+
     const health = await getHealth();
     lastHealthOk = !!health && (health.status === "healthy" || health.health?.status === "healthy");
-    ctx.ui.setStatus("agentmemory", lastHealthOk ? "🧠 agentmemory" : "🧠 agentmemory off");
+
+    try {
+      setStatus("agentmemory", lastHealthOk ? "🧠 agentmemory" : "🧠 agentmemory off");
+    } catch {
+      // UI may already be gone after session replacement; status is best-effort.
+    }
   }
 
   pi.registerCommand("agentmemory-status", {


### PR DESCRIPTION
## Summary

Fixes a race in the official pi extension where `refreshStatus()` awaits `getHealth()` and then accesses `ctx.ui.setStatus`. If the pi session is replaced/reloaded during that await, pi invalidates the extension context and `assertActive()` throws:

`This extension ctx is stale after session replacement or reload`

This surfaces as a noisy extension error and can skip memory-recall injection for that turn.

Fixes #1035

## Change

In `integrations/pi/index.ts` `refreshStatus`:

1. Bind `ctx.ui.setStatus` **before** the await (while ctx is still active).
2. After the health check, call the bound setter.
3. Wrap the post-await UI update in try/catch so status is best-effort.

No behavior change for the healthy path; only avoids throwing when the session is already gone.

## Test plan

- [x] Compared against current `main` `integrations/pi/index.ts`
- [x] Deployed patched file to three local pi installs; after `/reload`, stale-ctx error no longer reproduces on normal prompts
- [ ] Reviewer: run pi with extension installed, trigger prompt while health endpoint is slow, then `/reload`/`/new` during await — should not throw stale ctx
- [ ] Reviewer: healthy server still shows footer status `🧠 agentmemory`

## Notes

- `agentmemory connect pi` currently documents manual copy of these files; published npm package does not ship `integrations/` in `files`.
- Minimal fix only; does not add health-request timeout (optional follow-up).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved refresh status handling to prevent failures when the app UI is replaced or temporarily unavailable.
  * Status updates are now applied more safely during health checks, ensuring the refresh flow continues smoothly even if the UI reference becomes stale.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->