### PR TITLE
fix: noop provider check handles ResilientProvider wrapper (#1020)

### DIFF
--- a/src/functions/summarize.ts
+++ b/src/functions/summarize.ts
@@ -260,7 +260,7 @@ export function registerSummarizeFunction(
         return { success: false, error: "no_observations" };
       }
 
-      if (provider.name === "noop") {
+      if (provider.name === "noop" || provider.name === "resilient(noop)") {
         logger.info("Summarize skipped — no LLM provider configured", {
           sessionId,
         });


### PR DESCRIPTION
## Problem

In zero-LLM mode (no API key configured), `mem::summarize` is supposed to short-circuit via `provider.name === "noop"`. But every provider is wrapped in `ResilientProvider` before reaching the summarize function, and `ResilientProvider` renames it to `"resilient(noop)"` in its constructor. The literal string `"noop"` never matches, so the clean no-op skip is unreachable dead code.

Zero-LLM installs get misleading `empty_provider_response` / `too_many_chunks_skipped` errors instead of the intended `no_provider` skip, and failure counters climb into the hundreds.

## Fix

Check both the unwrapped and wrapped names:

```typescript
if (provider.name === "noop" || provider.name === "resilient(noop)") {
```

One-line fix in `src/functions/summarize.ts`. No new dependencies, no API changes.

Closes #1020

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved summarization behavior when no AI provider is configured, including an additional fallback case.
  * Prevents the app from attempting summarization in more no-provider scenarios, making the experience more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->