### PR TITLE
fix(session-end): remove .unref() so process force-exits after 1500ms

### DIFF
--- a/plugin/scripts/session-end.mjs
+++ b/plugin/scripts/session-end.mjs
@@ -51,7 +51,7 @@ async function main() {
 		headers: authHeaders(),
 		signal: AbortSignal.timeout(3e4)
 	}).catch(() => {});
-	setTimeout(() => process.exit(0), 1500).unref();
+	setTimeout(() => process.exit(0), 1500);
 }
 main();
 

--- a/src/hooks/session-end.ts
+++ b/src/hooks/session-end.ts
@@ -63,7 +63,11 @@ async function main() {
     }).catch(() => {});
   }
 
-  setTimeout(() => process.exit(0), 1500).unref();
+  // Force-exit after 1500ms regardless of in-flight fetches. Without this,
+  // .unref() makes the timer passive and pending fetch() calls keep the event
+  // loop alive until their AbortSignal timeouts fire (up to 120s), causing
+  // Claude Code to cancel the hook with "Hook cancelled".
+  setTimeout(() => process.exit(0), 1500);
 }
 
 main();


### PR DESCRIPTION
Fixes #1069.

## What

Remove `.unref()` from the `setTimeout` in `session-end.mjs` / `session-end.ts`.

## Why

The `session-end` hook fires fire-and-forget `fetch()` calls to the local daemon, then does:

```js
setTimeout(() => process.exit(0), 1500).unref();
```

`AGENTS.md` documents the intent: the process should force-exit after 1500ms so it does not block Claude Code's shutdown. But `.unref()` makes the timer passive — Node.js does not keep the event loop alive for an unref'd timer, but it also will not fire it while other handles (the pending `fetch()` calls) are keeping the loop alive.

The fetches use `AbortSignal.timeout()` values of 30s, 60s, and 120s. Those pending requests keep the event loop alive the entire time. Claude Code's hook deadline fires first and kills the process with:

```
SessionEnd hook [node "${CLAUDE_PLUGIN_ROOT}/scripts/session-end.mjs"] failed: Hook cancelled
```

This is intermittent because when the daemon responds fast the event loop drains before the deadline; when it is slow the race is lost.

## Fix

Remove `.unref()`. An active timer is the only handle that keeps the event loop alive after the fetches are dispatched, so the process exits after exactly 1500ms regardless of whether the fetches have settled. This matches the documented intent and the fire-and-forget pattern `AGENTS.md` prescribes.

```diff
- setTimeout(() => process.exit(0), 1500).unref();
+ setTimeout(() => process.exit(0), 1500);
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session-end handling so processes terminate reliably after the session ends.
  * Prevented lingering network requests from delaying shutdown beyond the expected timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->