### PR TITLE
docs(hermes): enable copied provider plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,7 +602,7 @@ mcp_servers:
 memory:
   provider: agentmemory
 
-Verify with `curl http://localhost:3111/agentmemory/health`. Open http://localhost:3113 for the real-time viewer. For deeper 6-hook memory provider integration (pre-LLM context injection, turn capture, MEMORY.md mirroring, system prompt block), copy integrations/hermes from the agentmemory repo to ~/.hermes/plugins/agentmemory.
+Verify with `curl http://localhost:3111/agentmemory/health`. Open http://localhost:3113 for the real-time viewer. For deeper 6-hook memory provider integration (pre-LLM context injection, turn capture, MEMORY.md mirroring, system prompt block), copy integrations/hermes from the agentmemory repo to ~/.hermes/plugins/agentmemory, then run `hermes plugins enable agentmemory --no-allow-tool-override`. The hooks take effect on the next session.
 ```
 
 Full guide: [`integrations/hermes/`](integrations/hermes/)

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -49,7 +49,9 @@ If I want deeper integration — pre-LLM context injection, turn-level
 capture, memory-write mirroring to MEMORY.md, and system prompt block
 injection — copy `integrations/hermes` from the agentmemory repo to
 `~/.hermes/plugins/agentmemory` instead. That gives me the
-6-hook memory provider plugin on top of the MCP server.
+6-hook memory provider plugin on top of the MCP server. After copying
+it, run `hermes plugins enable agentmemory --no-allow-tool-override`;
+the hooks take effect on the next session.
 ```
 
 That's it. Hermes handles the rest.
@@ -82,7 +84,11 @@ Copy this folder to your Hermes plugins directory:
 
 ```bash
 cp -r integrations/hermes ~/.hermes/plugins/agentmemory
+hermes plugins enable agentmemory --no-allow-tool-override
 ```
+
+Hermes user plugins are opt-in. Copying the directory alone leaves the
+plugin installed but disabled, so its lifecycle hooks will not load.
 
 Start the agentmemory server:
 


### PR DESCRIPTION
## What changed

- add the required `hermes plugins enable agentmemory --no-allow-tool-override` step to the root Hermes install prompt
- add the same command to the dedicated Hermes integration guide
- explain that copied Hermes user plugins are opt-in and their hooks load on the next session

## Why

Copying `integrations/hermes` to `~/.hermes/plugins/agentmemory` installs the provider files, but current Hermes versions leave user plugins disabled until they are explicitly enabled. The existing guide says that copying the directory is enough, which can leave all six lifecycle hooks inactive while the MCP server continues to work and masks the missing integration.

`--no-allow-tool-override` is sufficient because this provider does not need to replace Hermes built-in tools.

## User impact

Following either documented install path now results in an enabled AgentMemory provider instead of an installed-but-disabled plugin.

## Validation

- `git diff --check`
- reviewed the rendered Markdown structure and command placement
- scanned the complete diff for credentials, tokens, API keys, and private paths
