### PR TITLE
feat: forward agentId on remember + Hermes multi-profile project tagging

### DIFF
--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -106,8 +106,26 @@ The plugin auto-detects the running server and hooks into the Hermes agent loop.
 | `AGENTMEMORY_URL` | `http://localhost:3111` | agentmemory server URL |
 | `AGENTMEMORY_SECRET` | (none) | Auth token for protected instances |
 | `AGENTMEMORY_REQUIRE_HTTPS` | (off) | When set to `1`, refuse to send the bearer token over plaintext HTTP to a non-loopback host. Sends only when `AGENTMEMORY_URL` is `https://...` or points at `localhost`/`127.0.0.1`/`::1`. With this off, the plugin warns once on stderr but still sends. |
+| `AGENTMEMORY_PROJECT` | (auto) | Force a project slug on writes |
+| `AGENTMEMORY_AGENT_ID` | (auto = Hermes profile) | Force `agentId` on writes |
+| `AGENTMEMORY_WORK_ROOTS` | auto-detect | Colon-separated work roots for repo slugs (authoritative if set). Auto: existing `~/code`, `~/projects`, `~/src`, `~/work`, `~/Developer`, `~/Repos` |
+| `AGENTMEMORY_WORKDIR` | (none) | Optional workdir hint for repo detection |
+| `TERMINAL_CWD` | (Hermes) | Also used as a workdir candidate |
 
 The plugin reads `~/.agentmemory/.env` (or `$XDG_CONFIG_HOME/agentmemory/.env`) at import time and populates any missing values into the process environment via `os.environ.setdefault`. Anything you set in the shell takes precedence; the file is only used to fill gaps. This means `hermes memory status` reports the plugin as available even when the agentmemory service is launched by systemd or another process manager that loads `~/.agentmemory/.env` directly without exporting it to the Hermes CLI shell (#250).
+
+## Multi-profile / project tagging
+
+One agentmemory daemon can serve multiple Hermes profiles (**shared** scope). This plugin tags writes:
+
+| Field | Value |
+|-------|--------|
+| `agentId` | Hermes profile (`agent_identity` / `…/profiles/<name>`) |
+| `project` | Explicit `memory_save` arg → `AGENTMEMORY_PROJECT` → first path segment under a work root (`~/code/<repo>/…`) → profile slug |
+
+Slugs are sanitized (`a-z0-9-`, `_`→`-`). Filesystem paths are never stored as `project`. Search/prefetch stay **unfiltered** so profiles still share host-wide memory; context/lessons use `project` for ranking boosts.
+
+See `scoping.py` and run `python3 tests/test_scoping.py -v` from this directory.
 
 ## What Hermes gets
 

--- a/integrations/hermes/__init__.py
+++ b/integrations/hermes/__init__.py
@@ -94,6 +94,7 @@ _plaintext_bearer_warned = False
 # unreadable, malformed) — the plugin falls back to its existing default
 # (http://localhost:3111) and Hermes status reflects that.
 def _preload_agentmemory_dotenv() -> None:
+    """Load AGENTMEMORY_* (and daemon .env keys) into os.environ via setdefault."""
     candidates: list[Path] = []
     # Hermes profile sessions often skew HOME to profiles/<name>/home while the
     # daemon keeps secrets at the real user home (~/.agentmemory/.env). Also try
@@ -165,6 +166,7 @@ _preload_agentmemory_dotenv()
 
 
 def _validate_url(base: str) -> bool:
+    """True if base is a parseable http(s) URL with a hostname."""
     if not base:
         return False
     try:
@@ -179,6 +181,7 @@ def _validate_url(base: str) -> bool:
 
 
 def _uses_plaintext_bearer_auth(base: str, secret: str = "") -> bool:
+    """True when a non-empty secret would be sent over non-loopback HTTP."""
     if not secret:
         return False
     parsed = urlparse(base)
@@ -186,10 +189,12 @@ def _uses_plaintext_bearer_auth(base: str, secret: str = "") -> bool:
 
 
 def _plaintext_bearer_auth_message(base: str) -> str:
+    """Human-readable warning/error for bearer auth over plaintext HTTP."""
     return f"agentmemory: AGENTMEMORY_SECRET is configured for plaintext HTTP to {base}. Bearer tokens and memory payloads can be observed on the network; use HTTPS or an SSH tunnel."
 
 
 def _warn_plaintext_bearer_auth(message: str) -> None:
+    """Emit a one-line plaintext-auth warning to stderr."""
     print(message, file=sys.stderr)
 
 
@@ -198,6 +203,7 @@ def _check_plaintext_bearer_guard(
     secret: str = "",
     warn: Callable[[str], None] | None = None,
 ) -> None:
+    """Warn once (or raise if AGENTMEMORY_REQUIRE_HTTPS=1) for plaintext bearer auth."""
     global _plaintext_bearer_warned
     if not _uses_plaintext_bearer_auth(base, secret):
         return
@@ -210,6 +216,7 @@ def _check_plaintext_bearer_guard(
 
 
 def _reset_plaintext_bearer_guard_for_tests() -> None:
+    """Clear the once-only plaintext warning latch (tests only)."""
     global _plaintext_bearer_warned
     _plaintext_bearer_warned = False
 
@@ -227,6 +234,7 @@ def _resolve_agentmemory_secret(explicit: str = "") -> str:
 
 
 def _api(base: str, path: str, body: dict | None = None, method: str = "POST", secret: str = "") -> dict | None:
+    """POST/GET JSON against `{base}/agentmemory/{path}`; None on transport/auth failure."""
     if not _validate_url(base):
         _debug_log(f"_api invalid base={base!r} path={path}")
         return None
@@ -305,14 +313,17 @@ def _debug_log(msg: str) -> None:
 
 
 def _api_bg(base: str, path: str, body: dict | None = None) -> None:
+    """Fire-and-forget daemon API call on a background thread."""
     t = threading.Thread(target=_api, args=(base, path, body), daemon=True)
     t.start()
 
 
 class AgentMemoryProvider(MemoryProvider):
+    """Hermes MemoryProvider that tags writes with stable project/agentId slugs."""
 
     @property
     def name(self) -> str:
+        """Provider id registered with Hermes (`agentmemory`)."""
         return "agentmemory"
 
     def is_available(self) -> bool:
@@ -640,4 +651,5 @@ class AgentMemoryProvider(MemoryProvider):
 
 
 def register(ctx: Any) -> None:
+    """Hermes plugin entrypoint: register AgentMemoryProvider on the host context."""
     ctx.register_memory_provider(AgentMemoryProvider())

--- a/integrations/hermes/__init__.py
+++ b/integrations/hermes/__init__.py
@@ -5,6 +5,8 @@ Drop this folder into ~/.hermes/plugins/agentmemory/
 or install via: hermes plugin install agentmemory
 
 Requires agentmemory server running: npx @agentmemory/agentmemory
+
+Project / agentId tagging: see scoping.py and README (multi-profile section).
 """
 
 from __future__ import annotations
@@ -49,6 +51,28 @@ except ImportError:
         def shutdown(self, **kwargs: Any) -> None: pass
 
 
+# Prefer package-relative import when shipped as a package; fall back to the
+# sibling module path used by `cp -r integrations/hermes …/plugins/agentmemory`
+# and by tests that load __init__.py via importlib from a file path.
+try:
+    from .scoping import (  # type: ignore
+        load_work_roots,
+        pick_workdir,
+        resolve_agent_id,
+        resolve_project,
+    )
+except ImportError:  # pragma: no cover - exercised via file-path import tests
+    _here = Path(__file__).resolve().parent
+    if str(_here) not in sys.path:
+        sys.path.insert(0, str(_here))
+    from scoping import (  # type: ignore
+        load_work_roots,
+        pick_workdir,
+        resolve_agent_id,
+        resolve_project,
+    )
+
+
 DEFAULT_BASE_URL = "http://localhost:3111"
 TIMEOUT = 5
 LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1"}
@@ -69,12 +93,41 @@ _plaintext_bearer_warned = False
 # (http://localhost:3111) and Hermes status reflects that.
 def _preload_agentmemory_dotenv() -> None:
     candidates: list[Path] = []
-    home = os.environ.get("HOME")
-    if home:
-        candidates.append(Path(home) / ".agentmemory" / ".env")
+    # Hermes profile sessions often skew HOME to profiles/<name>/home while the
+    # daemon keeps secrets at the real user home (~/.agentmemory/.env). Also try
+    # HERMES_REAL_HOME and the passwd home so plugin tools don't 401 silently.
+    # Profile Hermes .env (HERMES_HOME/.env) often holds AGENTMEMORY_URL/SECRET
+    # even when the slash_worker process env strips *SECRET* values.
+    for key in ("HERMES_REAL_HOME", "HOME", "HERMES_HOME"):
+        val = os.environ.get(key)
+        if not val:
+            continue
+        root = Path(val)
+        if key == "HERMES_HOME":
+            candidates.append(root / ".env")
+        else:
+            candidates.append(root / ".agentmemory" / ".env")
+    try:
+        import pwd
+
+        pw_home = pwd.getpwuid(os.getuid()).pw_dir
+        if pw_home:
+            candidates.append(Path(pw_home) / ".agentmemory" / ".env")
+    except Exception:
+        pass
     xdg_config = os.environ.get("XDG_CONFIG_HOME")
     if xdg_config:
         candidates.append(Path(xdg_config) / "agentmemory" / ".env")
+    # de-dupe while preserving order
+    seen: set[str] = set()
+    uniq: list[Path] = []
+    for path in candidates:
+        key = str(path)
+        if key in seen:
+            continue
+        seen.add(key)
+        uniq.append(path)
+    candidates = uniq
     for path in candidates:
         try:
             if not path.is_file():
@@ -86,8 +139,18 @@ def _preload_agentmemory_dotenv() -> None:
                 key, _, value = line.partition("=")
                 key = key.strip()
                 value = value.strip().strip('"').strip("'")
-                if key:
-                    os.environ.setdefault(key, value)
+                if not key or not value:
+                    continue
+                # Only pull agentmemory-related keys from Hermes profile .env so
+                # we never stomp unrelated shell credentials from that file.
+                if path.name == ".env" and "agentmemory" not in path.parts:
+                    if not key.startswith("AGENTMEMORY_"):
+                        continue
+                existing = os.environ.get(key)
+                # setdefault alone is wrong if Hermes exported AGENTMEMORY_SECRET=""
+                # after filtering — empty must be treated as missing.
+                if existing is None or existing == "":
+                    os.environ[key] = value
         except (OSError, UnicodeDecodeError):
             continue
     # Guarantee AGENTMEMORY_URL is set so `hermes memory status` never
@@ -150,12 +213,27 @@ def _reset_plaintext_bearer_guard_for_tests() -> None:
     _plaintext_bearer_warned = False
 
 
+def _resolve_agentmemory_secret(explicit: str = "") -> str:
+    """Return bearer secret: explicit arg, env, or real-home dotenv (HOME may be skewed)."""
+    if explicit:
+        return explicit
+    env_secret = os.environ.get("AGENTMEMORY_SECRET", "")
+    if env_secret:
+        return env_secret
+    # Last resort: read daemon dotenv without relying on skewed HOME.
+    _preload_agentmemory_dotenv()
+    return os.environ.get("AGENTMEMORY_SECRET", "")
+
+
 def _api(base: str, path: str, body: dict | None = None, method: str = "POST", secret: str = "") -> dict | None:
     if not _validate_url(base):
+        _debug_log(f"_api invalid base={base!r} path={path}")
         return None
+    # Normalize trailing slash so we never hit //agentmemory/
+    base = (base or DEFAULT_BASE_URL).rstrip("/")
     url = f"{base}/agentmemory/{path}"
     headers = {"Content-Type": "application/json"}
-    auth = secret or os.environ.get("AGENTMEMORY_SECRET", "")
+    auth = _resolve_agentmemory_secret(secret)
     _check_plaintext_bearer_guard(base, auth)
     if auth:
         headers["Authorization"] = f"Bearer {auth}"
@@ -165,8 +243,25 @@ def _api(base: str, path: str, body: dict | None = None, method: str = "POST", s
     try:
         with urlopen(req, timeout=TIMEOUT) as resp:
             return json.loads(resp.read().decode())
-    except (URLError, TimeoutError, json.JSONDecodeError):
+    except Exception as exc:  # noqa: BLE001 — surface class for silent 401/None diagnosis
+        # HTTPError is a URLError subclass; include status without body secrets.
+        status = getattr(exc, "code", None)
+        _debug_log(
+            f"_api fail path={path} status={status} err={type(exc).__name__}: {exc} "
+            f"auth_set={bool(auth)} base={base} home={os.environ.get('HOME')!r} "
+            f"real_home={os.environ.get('HERMES_REAL_HOME')!r}"
+        )
         return None
+
+
+def _debug_log(msg: str) -> None:
+    """Best-effort local diagnose log (no secrets)."""
+    try:
+        log_path = Path("/tmp/agentmemory_plugin_debug.log")
+        with log_path.open("a", encoding="utf-8") as fh:
+            fh.write(f"{time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())} {msg}\n")
+    except OSError:
+        pass
 
 
 def _api_bg(base: str, path: str, body: dict | None = None) -> None:
@@ -185,18 +280,77 @@ class AgentMemoryProvider(MemoryProvider):
         base = os.environ.get("AGENTMEMORY_URL", DEFAULT_BASE_URL)
         return _validate_url(base)
 
+    def _ensure_scope_defaults(self) -> None:
+        """Idempotent defaults if initialize was skipped (tests / odd hosts)."""
+        if not getattr(self, "_base", None):
+            self._base = os.environ.get("AGENTMEMORY_URL", DEFAULT_BASE_URL)
+        if not getattr(self, "_session_id", None):
+            self._session_id = ""
+        if not hasattr(self, "_agent_id") or not hasattr(self, "_project"):
+            self._hermes_home = getattr(self, "_hermes_home", None) or os.environ.get(
+                "HERMES_HOME"
+            )
+            self._agent_identity = getattr(self, "_agent_identity", None)
+            self._cwd = getattr(self, "_cwd", None)
+            self._agent_id = resolve_agent_id(
+                agent_identity=self._agent_identity,
+                hermes_home=self._hermes_home,
+                env_agent_id=os.environ.get("AGENTMEMORY_AGENT_ID"),
+            )
+            self._project = resolve_project(
+                workdir=self._cwd,
+                agent_identity=self._agent_identity,
+                hermes_home=self._hermes_home,
+                env_project=os.environ.get("AGENTMEMORY_PROJECT"),
+                env_agent_id=os.environ.get("AGENTMEMORY_AGENT_ID"),
+            )
+
+    def _resolve_project(self, explicit: str | None = None) -> str:
+        self._ensure_scope_defaults()
+        return resolve_project(
+            explicit=explicit,
+            workdir=getattr(self, "_cwd", None),
+            agent_identity=getattr(self, "_agent_identity", None),
+            hermes_home=getattr(self, "_hermes_home", None),
+            env_project=os.environ.get("AGENTMEMORY_PROJECT"),
+            env_agent_id=os.environ.get("AGENTMEMORY_AGENT_ID"),
+        )
+
     def initialize(self, session_id: str, **kwargs: Any) -> None:
         self._base = os.environ.get("AGENTMEMORY_URL", DEFAULT_BASE_URL)
         self._session_id = session_id
-        self._project = kwargs.get("cwd", os.getcwd())
+        self._hermes_home = kwargs.get("hermes_home") or os.environ.get("HERMES_HOME")
+        self._agent_identity = kwargs.get("agent_identity")
+        self._cwd = pick_workdir(kwargs_cwd=kwargs.get("cwd"))
+        self._agent_id = resolve_agent_id(
+            agent_identity=self._agent_identity,
+            hermes_home=self._hermes_home,
+            env_agent_id=os.environ.get("AGENTMEMORY_AGENT_ID"),
+        )
+        self._project = resolve_project(
+            workdir=self._cwd,
+            agent_identity=self._agent_identity,
+            hermes_home=self._hermes_home,
+            env_project=os.environ.get("AGENTMEMORY_PROJECT"),
+            env_agent_id=os.environ.get("AGENTMEMORY_AGENT_ID"),
+        )
+        roots = load_work_roots()
+        _debug_log(
+            f"scope init session={session_id!r} agentId={self._agent_id!r} "
+            f"project={self._project!r} cwd={self._cwd!r} work_roots={len(roots)} "
+            f"identity={self._agent_identity!r} hermes_home={self._hermes_home!r}"
+        )
         if os.environ.get("AGENTMEMORY_REQUIRE_HTTPS") == "1":
             _check_plaintext_bearer_guard(self._base, os.environ.get("AGENTMEMORY_SECRET", ""))
 
-        _api(self._base, "session/start", {
+        body: dict[str, Any] = {
             "sessionId": session_id,
             "project": self._project,
-            "cwd": self._project,
-        })
+            "agentId": self._agent_id,
+        }
+        if self._cwd:
+            body["cwd"] = self._cwd
+        _api(self._base, "session/start", body)
 
     def get_config_schema(self) -> list[dict]:
         return [
@@ -220,6 +374,7 @@ class AgentMemoryProvider(MemoryProvider):
         config_path.write_text(json.dumps(values, indent=2))
 
     def system_prompt_block(self) -> str:
+        self._ensure_scope_defaults()
         result = _api(self._base, "context", {
             "sessionId": self._session_id,
             "project": self._project,
@@ -229,6 +384,7 @@ class AgentMemoryProvider(MemoryProvider):
         return ""
 
     def prefetch(self, query: str, **kwargs: Any) -> str:
+        # Shared-scope: do not hard-filter smart-search by project (v1).
         result = _api(self._base, "smart-search", {
             "query": query,
             "limit": 5,
@@ -274,6 +430,13 @@ class AgentMemoryProvider(MemoryProvider):
                             "enum": ["pattern", "preference", "architecture", "bug", "workflow", "fact"],
                             "description": "Memory type",
                         },
+                        "project": {
+                            "type": "string",
+                            "description": (
+                                "Optional stable project slug (a-z0-9-). "
+                                "Default: auto from repo under work roots or Hermes profile."
+                            ),
+                        },
                     },
                     "required": ["content"],
                 },
@@ -298,6 +461,8 @@ class AgentMemoryProvider(MemoryProvider):
         # content with a 400 on the next request, so always serialize to a
         # JSON string here — matches what agentmemory's main MCP server does
         # in src/mcp/standalone.ts (`{ type: "text", text: JSON.stringify(...) }`).
+        self._ensure_scope_defaults()
+
         if name == "memory_recall":
             result = _api(self._base, "search", {
                 "query": args["query"],
@@ -318,11 +483,31 @@ class AgentMemoryProvider(MemoryProvider):
             return json.dumps({"results": items})
 
         if name == "memory_save":
+            # Re-resolve base/secret at call time — worker env may gain
+            # HERMES_* late, and SECRET is often absent from process env.
+            self._base = os.environ.get("AGENTMEMORY_URL", getattr(self, "_base", DEFAULT_BASE_URL))
+            project = self._resolve_project(args.get("project"))
+            agent_id = getattr(self, "_agent_id", None) or resolve_agent_id(
+                agent_identity=getattr(self, "_agent_identity", None),
+                hermes_home=getattr(self, "_hermes_home", None),
+                env_agent_id=os.environ.get("AGENTMEMORY_AGENT_ID"),
+            )
+            _debug_log(
+                f"memory_save agentId={agent_id!r} project={project!r} "
+                f"explicit={args.get('project')!r}"
+            )
             result = _api(self._base, "remember", {
                 "content": args["content"],
                 "type": args.get("type", "fact"),
+                "project": project,
+                "agentId": agent_id,
             })
-            return json.dumps(result or {"success": False})
+            if result:
+                return json.dumps(result)
+            return json.dumps({
+                "success": False,
+                "error": "agentmemory remember failed (auth/network); see /tmp/agentmemory_plugin_debug.log",
+            })
 
         if name == "memory_search":
             result = _api(self._base, "smart-search", {
@@ -344,25 +529,31 @@ class AgentMemoryProvider(MemoryProvider):
         return json.dumps({"error": f"Unknown tool: {name}"})
 
     def sync_turn(self, user: str, assistant: str, **kwargs: Any) -> None:
-        _api_bg(self._base, "observe", {
+        self._ensure_scope_defaults()
+        # api::observe requires hookType, sessionId, project, cwd, timestamp (all strings).
+        cwd = self._cwd or self._hermes_home or self._project or "."
+        body: dict[str, Any] = {
             "hookType": "post_tool_use",
             "sessionId": kwargs.get("session_id", self._session_id),
             "project": self._project,
-            "cwd": self._project,
+            "cwd": cwd,
+            "agentId": self._agent_id,
             "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
             "data": {
                 "tool_name": "conversation",
                 "tool_input": user[:500],
                 "tool_output": assistant[:2000],
             },
-        })
+        }
+        _api_bg(self._base, "observe", body)
 
     def on_session_end(self, messages: list, **kwargs: Any) -> None:
         _api(self._base, "session/end", {
-            "sessionId": kwargs.get("session_id", self._session_id),
+            "sessionId": kwargs.get("session_id", getattr(self, "_session_id", "")),
         })
 
     def on_pre_compress(self, messages: list, **kwargs: Any) -> None:
+        self._ensure_scope_defaults()
         result = _api(self._base, "context", {
             "sessionId": kwargs.get("session_id", self._session_id),
             "project": self._project,
@@ -375,9 +566,12 @@ class AgentMemoryProvider(MemoryProvider):
 
     def on_memory_write(self, action: str, target: str, content: str, **kwargs: Any) -> None:
         if action in ("add", "update") and content:
+            self._ensure_scope_defaults()
             _api_bg(self._base, "remember", {
                 "content": content,
                 "type": "fact",
+                "project": self._project,
+                "agentId": self._agent_id,
             })
 
     def shutdown(self, **kwargs: Any) -> None:

--- a/integrations/hermes/__init__.py
+++ b/integrations/hermes/__init__.py
@@ -140,7 +140,11 @@ def _preload_agentmemory_dotenv() -> None:
                     continue
                 # Only pull agentmemory-related keys from Hermes profile .env so
                 # we never stomp unrelated shell credentials from that file.
-                if path.name == ".env" and "agentmemory" not in path.parts:
+                # Exempt both ~/.agentmemory/.env and XDG …/agentmemory/.env
+                # (substring on path components — bare equality misses the dotdir).
+                if path.name == ".env" and not any(
+                    "agentmemory" in part for part in path.parts
+                ):
                     if not key.startswith("AGENTMEMORY_"):
                         continue
                 existing = os.environ.get(key)
@@ -266,7 +270,19 @@ def _debug_log_path() -> Path:
     # Last resort: uid-scoped name under the process temp dir (not a shared fixed path).
     import tempfile
 
-    return Path(tempfile.gettempdir()) / f"agentmemory_plugin_debug-{os.getuid()}.log"
+    getuid = getattr(os, "getuid", None)
+    uid = getuid() if callable(getuid) else None
+    if uid is not None:
+        return Path(tempfile.gettempdir()) / f"agentmemory_plugin_debug-{uid}.log"
+    # Windows / platforms without getuid: stable non-colliding name via username.
+    try:
+        import getpass
+
+        user = getpass.getuser() or "user"
+    except Exception:  # noqa: BLE001 — best-effort identity only
+        user = "user"
+    safe = "".join(c if c.isalnum() or c in "-_" else "_" for c in str(user))[:64]
+    return Path(tempfile.gettempdir()) / f"agentmemory_plugin_debug-{safe or 'user'}.log"
 
 
 def _debug_log(msg: str) -> None:

--- a/integrations/hermes/__init__.py
+++ b/integrations/hermes/__init__.py
@@ -58,6 +58,7 @@ try:
     from .scoping import (  # type: ignore
         load_work_roots,
         pick_workdir,
+        pwd_home,
         resolve_agent_id,
         resolve_project,
     )
@@ -68,6 +69,7 @@ except ImportError:  # pragma: no cover - exercised via file-path import tests
     from scoping import (  # type: ignore
         load_work_roots,
         pick_workdir,
+        pwd_home,
         resolve_agent_id,
         resolve_project,
     )
@@ -107,14 +109,9 @@ def _preload_agentmemory_dotenv() -> None:
             candidates.append(root / ".env")
         else:
             candidates.append(root / ".agentmemory" / ".env")
-    try:
-        import pwd
-
-        pw_home = pwd.getpwuid(os.getuid()).pw_dir
-        if pw_home:
-            candidates.append(Path(pw_home) / ".agentmemory" / ".env")
-    except Exception:
-        pass
+    pw_home = pwd_home()
+    if pw_home:
+        candidates.append(Path(pw_home) / ".agentmemory" / ".env")
     xdg_config = os.environ.get("XDG_CONFIG_HOME")
     if xdg_config:
         candidates.append(Path(xdg_config) / "agentmemory" / ".env")
@@ -254,11 +251,38 @@ def _api(base: str, path: str, body: dict | None = None, method: str = "POST", s
         return None
 
 
+def _debug_log_path() -> Path:
+    """Per-user private path for plugin diagnostics (never a fixed world /tmp name)."""
+    hermes_home = os.environ.get("HERMES_HOME")
+    if hermes_home:
+        return Path(hermes_home) / "agentmemory_plugin_debug.log"
+    for key in ("HERMES_REAL_HOME", "HOME"):
+        val = os.environ.get(key)
+        if val:
+            return Path(val) / ".agentmemory" / "plugin_debug.log"
+    pw = pwd_home()
+    if pw:
+        return Path(pw) / ".agentmemory" / "plugin_debug.log"
+    # Last resort: uid-scoped name under the process temp dir (not a shared fixed path).
+    import tempfile
+
+    return Path(tempfile.gettempdir()) / f"agentmemory_plugin_debug-{os.getuid()}.log"
+
+
 def _debug_log(msg: str) -> None:
-    """Best-effort local diagnose log (no secrets)."""
+    """Best-effort local diagnose log (no secrets).
+
+    Writes under HERMES_HOME or ~/.agentmemory with O_NOFOLLOW when available
+    so a pre-created symlink in a shared temp dir cannot redirect the write.
+    """
     try:
-        log_path = Path("/tmp/agentmemory_plugin_debug.log")
-        with log_path.open("a", encoding="utf-8") as fh:
+        log_path = _debug_log_path()
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        flags = os.O_WRONLY | os.O_APPEND | os.O_CREAT
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(str(log_path), flags, 0o600)
+        with os.fdopen(fd, "a", encoding="utf-8") as fh:
             fh.write(f"{time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())} {msg}\n")
     except OSError:
         pass
@@ -276,6 +300,7 @@ class AgentMemoryProvider(MemoryProvider):
         return "agentmemory"
 
     def is_available(self) -> bool:
+        """True when AGENTMEMORY_URL is a valid http(s) base (no network I/O)."""
         # Hermes contract: no network calls in is_available.
         base = os.environ.get("AGENTMEMORY_URL", DEFAULT_BASE_URL)
         return _validate_url(base)
@@ -306,6 +331,7 @@ class AgentMemoryProvider(MemoryProvider):
             )
 
     def _resolve_project(self, explicit: str | None = None) -> str:
+        """Resolve project slug for this write (explicit arg wins over env/workdir)."""
         self._ensure_scope_defaults()
         return resolve_project(
             explicit=explicit,
@@ -317,6 +343,7 @@ class AgentMemoryProvider(MemoryProvider):
         )
 
     def initialize(self, session_id: str, **kwargs: Any) -> None:
+        """Bind session scope (project/agentId) and start a daemon session."""
         self._base = os.environ.get("AGENTMEMORY_URL", DEFAULT_BASE_URL)
         self._session_id = session_id
         self._hermes_home = kwargs.get("hermes_home") or os.environ.get("HERMES_HOME")
@@ -353,6 +380,7 @@ class AgentMemoryProvider(MemoryProvider):
         _api(self._base, "session/start", body)
 
     def get_config_schema(self) -> list[dict]:
+        """Hermes plugin config UI schema (URL + optional secret)."""
         return [
             {
                 "key": "url",
@@ -370,10 +398,12 @@ class AgentMemoryProvider(MemoryProvider):
         ]
 
     def save_config(self, values: dict, hermes_home: str) -> None:
+        """Persist plugin config JSON under the active Hermes home."""
         config_path = Path(hermes_home) / "agentmemory.json"
         config_path.write_text(json.dumps(values, indent=2))
 
     def system_prompt_block(self) -> str:
+        """Return daemon context block for system-prompt injection, if any."""
         self._ensure_scope_defaults()
         result = _api(self._base, "context", {
             "sessionId": self._session_id,
@@ -384,6 +414,8 @@ class AgentMemoryProvider(MemoryProvider):
         return ""
 
     def prefetch(self, query: str, **kwargs: Any) -> str:
+        """Sync smart-search prefetch for the current turn (shared-scope, no project filter)."""
+        self._ensure_scope_defaults()
         # Shared-scope: do not hard-filter smart-search by project (v1).
         result = _api(self._base, "smart-search", {
             "query": query,
@@ -402,9 +434,12 @@ class AgentMemoryProvider(MemoryProvider):
         return "\n".join(lines) if lines else ""
 
     def queue_prefetch(self, query: str, **kwargs: Any) -> None:
+        """Background smart-search prefetch (fire-and-forget)."""
+        self._ensure_scope_defaults()
         _api_bg(self._base, "smart-search", {"query": query, "limit": 3})
 
     def get_tool_schemas(self) -> list[dict]:
+        """OpenAI-style tool schemas Hermes exposes for memory_* tools."""
         return [
             {
                 "name": "memory_recall",
@@ -456,6 +491,7 @@ class AgentMemoryProvider(MemoryProvider):
         ]
 
     def handle_tool_call(self, name: str, args: dict) -> str:
+        """Dispatch memory_* tools; always return a JSON string for protocol safety."""
         # Hermes stores the return value as the tool result `content` in the
         # session history. Anthropic-protocol providers reject non-string
         # content with a 400 on the next request, so always serialize to a
@@ -506,7 +542,10 @@ class AgentMemoryProvider(MemoryProvider):
                 return json.dumps(result)
             return json.dumps({
                 "success": False,
-                "error": "agentmemory remember failed (auth/network); see /tmp/agentmemory_plugin_debug.log",
+                "error": (
+                    "agentmemory remember failed (auth/network); "
+                    f"see {_debug_log_path()}"
+                ),
             })
 
         if name == "memory_search":
@@ -529,6 +568,7 @@ class AgentMemoryProvider(MemoryProvider):
         return json.dumps({"error": f"Unknown tool: {name}"})
 
     def sync_turn(self, user: str, assistant: str, **kwargs: Any) -> None:
+        """Background-observe a completed user/assistant turn with scope tags."""
         self._ensure_scope_defaults()
         # api::observe requires hookType, sessionId, project, cwd, timestamp (all strings).
         cwd = self._cwd or self._hermes_home or self._project or "."
@@ -548,11 +588,14 @@ class AgentMemoryProvider(MemoryProvider):
         _api_bg(self._base, "observe", body)
 
     def on_session_end(self, messages: list, **kwargs: Any) -> None:
+        """Notify the daemon that the Hermes session is ending."""
+        self._ensure_scope_defaults()
         _api(self._base, "session/end", {
             "sessionId": kwargs.get("session_id", getattr(self, "_session_id", "")),
         })
 
     def on_pre_compress(self, messages: list, **kwargs: Any) -> None:
+        """Inject agentmemory context before context compression when available."""
         self._ensure_scope_defaults()
         result = _api(self._base, "context", {
             "sessionId": kwargs.get("session_id", self._session_id),
@@ -565,6 +608,7 @@ class AgentMemoryProvider(MemoryProvider):
             })
 
     def on_memory_write(self, action: str, target: str, content: str, **kwargs: Any) -> None:
+        """Mirror Hermes native memory writes into agentmemory with project/agentId."""
         if action in ("add", "update") and content:
             self._ensure_scope_defaults()
             _api_bg(self._base, "remember", {
@@ -575,6 +619,7 @@ class AgentMemoryProvider(MemoryProvider):
             })
 
     def shutdown(self, **kwargs: Any) -> None:
+        """No-op teardown hook (Hermes lifecycle)."""
         pass
 
 

--- a/integrations/hermes/scoping.py
+++ b/integrations/hermes/scoping.py
@@ -1,0 +1,291 @@
+"""Deterministic agentId / project slug resolution for the Hermes agentmemory plugin.
+
+Pure helpers — no Hermes imports, no network. Safe to unit-test and to upstream
+into rohitg00/agentmemory integrations/hermes.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import Sequence
+
+_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
+
+# Candidate work roots when AGENTMEMORY_WORK_ROOTS is unset. Included only if
+# the path exists as a directory after expanduser/resolve.
+_AUTO_WORK_ROOT_NAMES = (
+    "code",
+    "projects",
+    "src",
+    "work",
+    "Developer",  # common macOS layout
+    "Repos",
+)
+
+
+def sanitize_slug(value: str | None) -> str | None:
+    """Normalize and validate a project/agentId slug.
+
+    - lower/strip
+    - reject path-like values (/, \\, . , ..)
+    - map _ → - then collapse repeated hyphens
+    - accept only ^[a-z0-9][a-z0-9-]{0,63}$
+    """
+    if value is None or not isinstance(value, str):
+        return None
+    s = value.strip().lower()
+    if not s or s in {".", ".."}:
+        return None
+    if "/" in s or "\\" in s or "\x00" in s:
+        return None
+    s = s.replace("_", "-")
+    while "--" in s:
+        s = s.replace("--", "-")
+    s = s.strip("-")
+    if not s or not _SLUG_RE.match(s):
+        return None
+    return s
+
+
+def profile_from_hermes_home(hermes_home: str | None) -> str | None:
+    """Extract .../profiles/<name> segment as a slug, if present."""
+    if not hermes_home or not isinstance(hermes_home, str):
+        return None
+    try:
+        parts = Path(hermes_home).expanduser().resolve().parts
+    except (OSError, RuntimeError):
+        try:
+            parts = Path(hermes_home).expanduser().parts
+        except (OSError, RuntimeError):
+            return None
+    if "profiles" not in parts:
+        return None
+    i = parts.index("profiles")
+    if i + 1 >= len(parts):
+        return None
+    return sanitize_slug(parts[i + 1])
+
+
+def _resolve_existing_dir(raw: str) -> Path | None:
+    try:
+        p = Path(raw).expanduser().resolve()
+    except (OSError, RuntimeError):
+        return None
+    if p.is_dir():
+        return p
+    return None
+
+
+def _candidate_homes(
+    env: dict[str, str] | None = None,
+    *,
+    home: str | Path | None = None,
+) -> list[Path]:
+    """Homes to scan for auto work roots.
+
+    Hermes profile sessions often set HOME to profiles/<name>/home while the
+    real user home (with ~/code) lives elsewhere — mirror dotenv preload.
+    """
+    e = env if env is not None else os.environ
+    out: list[Path] = []
+    seen: set[str] = set()
+
+    def add(raw: str | Path | None) -> None:
+        if raw is None:
+            return
+        try:
+            p = Path(raw).expanduser()
+            p = p.resolve()
+        except (OSError, RuntimeError):
+            try:
+                p = Path(str(raw)).expanduser()
+            except (OSError, RuntimeError):
+                return
+        key = str(p)
+        if key in seen:
+            return
+        seen.add(key)
+        out.append(p)
+
+    if home is not None:
+        add(home)
+    add(e.get("HERMES_REAL_HOME"))
+    add(e.get("HOME"))
+    try:
+        import pwd
+
+        add(pwd.getpwuid(os.getuid()).pw_dir)
+    except Exception:
+        pass
+    try:
+        add(Path.home())
+    except (OSError, RuntimeError):
+        pass
+    return out
+
+
+def load_work_roots(
+    env: dict[str, str] | None = None,
+    *,
+    home: str | Path | None = None,
+) -> tuple[Path, ...]:
+    """Return trusted work roots for repo-slug detection.
+
+    If AGENTMEMORY_WORK_ROOTS is set (colon-separated on Unix), that list is
+    **authoritative** (only existing dirs kept). Otherwise auto-detect common
+    directories under real user home(s) that exist.
+    """
+    e = env if env is not None else os.environ
+    explicit = (e.get("AGENTMEMORY_WORK_ROOTS") or "").strip()
+    if explicit:
+        roots: list[Path] = []
+        seen: set[str] = set()
+        for seg in explicit.split(":"):
+            seg = seg.strip()
+            if not seg:
+                continue
+            p = _resolve_existing_dir(seg)
+            if p is None:
+                continue
+            key = str(p)
+            if key in seen:
+                continue
+            seen.add(key)
+            roots.append(p)
+        return tuple(roots)
+
+    roots = []
+    seen_r: set[str] = set()
+    for home_p in _candidate_homes(e, home=home):
+        for name in _AUTO_WORK_ROOT_NAMES:
+            p = _resolve_existing_dir(str(home_p / name))
+            if p is None:
+                continue
+            key = str(p)
+            if key in seen_r:
+                continue
+            seen_r.add(key)
+            roots.append(p)
+    return tuple(roots)
+
+
+def repo_slug_from_workdir(
+    workdir: str | None,
+    work_roots: Sequence[Path] | None = None,
+    *,
+    env: dict[str, str] | None = None,
+    home: str | Path | None = None,
+) -> str | None:
+    """If workdir is under <root>/<repo>/..., return sanitized <repo>.
+
+    If workdir equals a work root exactly, return None (not project=code).
+    """
+    if not workdir:
+        return None
+    roots = list(work_roots) if work_roots is not None else list(
+        load_work_roots(env=env, home=home)
+    )
+    if not roots:
+        return None
+    try:
+        wd = Path(workdir).expanduser().resolve()
+    except (OSError, RuntimeError):
+        return None
+
+    roots_sorted = sorted(roots, key=lambda p: len(str(p)), reverse=True)
+    for root in roots_sorted:
+        try:
+            rel = wd.relative_to(root)
+        except ValueError:
+            continue
+        if rel == Path(".") or not rel.parts:
+            return None
+        return sanitize_slug(rel.parts[0])
+    return None
+
+
+def pick_workdir(
+    *,
+    kwargs_cwd: str | None = None,
+    env: dict[str, str] | None = None,
+    work_roots: Sequence[Path] | None = None,
+    home: str | Path | None = None,
+    getcwd: str | None = None,
+) -> str | None:
+    """Choose a filesystem workdir for repo detection (not necessarily project slug)."""
+    e = env if env is not None else os.environ
+    roots = list(work_roots) if work_roots is not None else list(
+        load_work_roots(env=e, home=home)
+    )
+
+    for c in (kwargs_cwd, e.get("TERMINAL_CWD"), e.get("AGENTMEMORY_WORKDIR")):
+        if c and str(c).strip():
+            return str(c).strip()
+
+    gc = getcwd
+    if gc is None:
+        try:
+            gc = os.getcwd()
+        except OSError:
+            gc = None
+    if not gc:
+        return None
+
+    if repo_slug_from_workdir(gc, work_roots=roots, env=e, home=home) is not None:
+        return gc
+    try:
+        gcp = Path(gc).expanduser().resolve()
+        for root in roots:
+            if gcp == root:
+                return gc
+    except (OSError, RuntimeError):
+        pass
+    return None
+
+
+def resolve_agent_id(
+    *,
+    agent_identity: str | None = None,
+    hermes_home: str | None = None,
+    env_agent_id: str | None = None,
+) -> str:
+    """Hermes profile name as agentId; default 'default'."""
+    for cand in (env_agent_id, agent_identity):
+        s = sanitize_slug(cand)
+        if s:
+            return s
+    p = profile_from_hermes_home(hermes_home)
+    if p:
+        return p
+    return "default"
+
+
+def resolve_project(
+    *,
+    explicit: str | None = None,
+    workdir: str | None = None,
+    agent_identity: str | None = None,
+    hermes_home: str | None = None,
+    env_project: str | None = None,
+    env_agent_id: str | None = None,
+    work_roots: Sequence[Path] | None = None,
+    env: dict[str, str] | None = None,
+    home: str | Path | None = None,
+) -> str:
+    """explicit → env project → repo under work roots → profile agentId."""
+    for cand in (explicit, env_project):
+        s = sanitize_slug(cand)
+        if s:
+            return s
+    repo = repo_slug_from_workdir(
+        workdir, work_roots=work_roots, env=env, home=home
+    )
+    if repo:
+        return repo
+    return resolve_agent_id(
+        agent_identity=agent_identity,
+        hermes_home=hermes_home,
+        env_agent_id=env_agent_id,
+    )

--- a/integrations/hermes/scoping.py
+++ b/integrations/hermes/scoping.py
@@ -25,6 +25,23 @@ _AUTO_WORK_ROOT_NAMES = (
 )
 
 
+def pwd_home() -> str | None:
+    """Passwd home for the current uid, or None if unavailable.
+
+    Narrow exceptions: missing ``pwd`` (non-Unix), unknown uid, or broken
+    pwd entry attributes — not a blanket ``Exception``.
+    """
+    try:
+        import pwd
+
+        home = pwd.getpwuid(os.getuid()).pw_dir
+    except (ImportError, KeyError, AttributeError, OSError, TypeError):
+        return None
+    if isinstance(home, str) and home.strip():
+        return home
+    return None
+
+
 def sanitize_slug(value: str | None) -> str | None:
     """Normalize and validate a project/agentId slug.
 
@@ -113,12 +130,7 @@ def _candidate_homes(
         add(home)
     add(e.get("HERMES_REAL_HOME"))
     add(e.get("HOME"))
-    try:
-        import pwd
-
-        add(pwd.getpwuid(os.getuid()).pw_dir)
-    except Exception:
-        pass
+    add(pwd_home())
     try:
         add(Path.home())
     except (OSError, RuntimeError):

--- a/integrations/hermes/scoping.py
+++ b/integrations/hermes/scoping.py
@@ -86,6 +86,7 @@ def profile_from_hermes_home(hermes_home: str | None) -> str | None:
 
 
 def _resolve_existing_dir(raw: str) -> Path | None:
+    """Expand/resolve raw path and return it only if it is an existing directory."""
     try:
         p = Path(raw).expanduser().resolve()
     except (OSError, RuntimeError):

--- a/integrations/hermes/tests/test_scoping.py
+++ b/integrations/hermes/tests/test_scoping.py
@@ -1,0 +1,207 @@
+"""Unit tests for agentmemory Hermes plugin scoping helpers (stdlib unittest)."""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scoping import (
+    load_work_roots,
+    pick_workdir,
+    profile_from_hermes_home,
+    repo_slug_from_workdir,
+    resolve_agent_id,
+    resolve_project,
+    sanitize_slug,
+)
+
+
+class TestSanitizeSlug(unittest.TestCase):
+    def test_basic(self):
+        self.assertEqual(sanitize_slug("Software-Engineer"), "software-engineer")
+
+    def test_underscore_to_hyphen(self):
+        self.assertEqual(sanitize_slug("trade_house"), "trade-house")
+
+    def test_collapse_hyphens(self):
+        self.assertEqual(sanitize_slug("a__b"), "a-b")
+
+    def test_reject_path(self):
+        self.assertIsNone(sanitize_slug("/evil/path"))
+        self.assertIsNone(sanitize_slug("foo/bar"))
+
+    def test_reject_junk(self):
+        self.assertIsNone(sanitize_slug("BAD slug!!"))
+        self.assertIsNone(sanitize_slug(""))
+        self.assertIsNone(sanitize_slug(None))
+        self.assertIsNone(sanitize_slug("."))
+
+    def test_host(self):
+        self.assertEqual(sanitize_slug("host"), "host")
+
+
+class TestProfileAndRoots(unittest.TestCase):
+    def test_profile_segment(self):
+        with tempfile.TemporaryDirectory() as td:
+            hh = Path(td) / "profiles" / "server-manager"
+            hh.mkdir(parents=True)
+            self.assertEqual(profile_from_hermes_home(str(hh)), "server-manager")
+
+    def test_auto_detect_code(self):
+        with tempfile.TemporaryDirectory() as td:
+            home = Path(td)
+            code = home / "code"
+            code.mkdir()
+            roots = load_work_roots(env={}, home=home)
+            self.assertIn(code.resolve(), roots)
+
+    def test_auto_detect_via_real_home_env(self):
+        """Skewed HOME still finds ~/code under HERMES_REAL_HOME."""
+        with tempfile.TemporaryDirectory() as td:
+            real = Path(td) / "real"
+            skewed = Path(td) / "skewed"
+            real.mkdir()
+            skewed.mkdir()
+            code = real / "code"
+            code.mkdir()
+            roots = load_work_roots(
+                env={"HOME": str(skewed), "HERMES_REAL_HOME": str(real)},
+                home=None,
+            )
+            self.assertIn(code.resolve(), roots)
+
+    def test_env_roots_authoritative(self):
+        with tempfile.TemporaryDirectory() as td:
+            home = Path(td)
+            code = home / "code"
+            code.mkdir()
+            other = home / "other"
+            other.mkdir()
+            (other / "r1").mkdir()
+            roots = load_work_roots(
+                env={"AGENTMEMORY_WORK_ROOTS": str(other)},
+                home=home,
+            )
+            self.assertEqual(roots, (other.resolve(),))
+            self.assertEqual(
+                repo_slug_from_workdir(str(other / "r1"), work_roots=roots),
+                "r1",
+            )
+            self.assertIsNone(
+                repo_slug_from_workdir(str(code / "foo"), work_roots=roots)
+            )
+
+    def test_repo_under_code(self):
+        with tempfile.TemporaryDirectory() as td:
+            code = Path(td) / "code"
+            repo = code / "trade-house" / "app"
+            repo.mkdir(parents=True)
+            roots = (code.resolve(),)
+            self.assertEqual(
+                repo_slug_from_workdir(str(repo), work_roots=roots),
+                "trade-house",
+            )
+
+    def test_exact_work_root_no_repo(self):
+        with tempfile.TemporaryDirectory() as td:
+            code = Path(td) / "code"
+            code.mkdir()
+            roots = (code.resolve(),)
+            self.assertIsNone(repo_slug_from_workdir(str(code), work_roots=roots))
+
+
+class TestResolve(unittest.TestCase):
+    def test_profile_when_workdir_is_code_root(self):
+        with tempfile.TemporaryDirectory() as td:
+            home = Path(td)
+            code = home / "code"
+            code.mkdir()
+            hh = home / "profiles" / "software-engineer"
+            hh.mkdir(parents=True)
+            roots = (code.resolve(),)
+            self.assertEqual(
+                resolve_project(
+                    workdir=str(code),
+                    agent_identity="software-engineer",
+                    hermes_home=str(hh),
+                    work_roots=roots,
+                ),
+                "software-engineer",
+            )
+            self.assertEqual(
+                resolve_agent_id(
+                    agent_identity="software-engineer", hermes_home=str(hh)
+                ),
+                "software-engineer",
+            )
+
+    def test_repo_wins(self):
+        with tempfile.TemporaryDirectory() as td:
+            code = Path(td) / "code"
+            repo = code / "trade-house"
+            repo.mkdir(parents=True)
+            roots = (code.resolve(),)
+            self.assertEqual(
+                resolve_project(
+                    workdir=str(repo),
+                    agent_identity="software-engineer",
+                    work_roots=roots,
+                ),
+                "trade-house",
+            )
+
+    def test_explicit_host(self):
+        self.assertEqual(
+            resolve_project(explicit="host", agent_identity="software-engineer"),
+            "host",
+        )
+
+    def test_explicit_path_falls_back(self):
+        self.assertEqual(
+            resolve_project(
+                explicit="/evil/path", agent_identity="software-engineer"
+            ),
+            "software-engineer",
+        )
+
+    def test_hermes_home_only(self):
+        with tempfile.TemporaryDirectory() as td:
+            hh = Path(td) / "profiles" / "server-manager"
+            hh.mkdir(parents=True)
+            self.assertEqual(resolve_agent_id(hermes_home=str(hh)), "server-manager")
+            self.assertEqual(resolve_project(hermes_home=str(hh)), "server-manager")
+
+    def test_default(self):
+        self.assertEqual(resolve_agent_id(), "default")
+        self.assertEqual(resolve_project(), "default")
+
+    def test_pick_workdir_prefers_terminal_cwd(self):
+        with tempfile.TemporaryDirectory() as td:
+            code = Path(td) / "code"
+            code.mkdir()
+            wd = pick_workdir(
+                kwargs_cwd=None,
+                env={"TERMINAL_CWD": str(code / "x")},
+                work_roots=(code.resolve(),),
+                getcwd=str(td),
+            )
+            self.assertEqual(wd, str(code / "x"))
+
+    def test_pick_workdir_ignores_home_getcwd(self):
+        with tempfile.TemporaryDirectory() as td:
+            code = Path(td) / "code"
+            code.mkdir()
+            wd = pick_workdir(
+                env={},
+                work_roots=(code.resolve(),),
+                getcwd=str(td),
+            )
+            self.assertIsNone(wd)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/integrations/hermes/tests/test_scoping.py
+++ b/integrations/hermes/tests/test_scoping.py
@@ -13,6 +13,7 @@ from scoping import (
     load_work_roots,
     pick_workdir,
     profile_from_hermes_home,
+    pwd_home,
     repo_slug_from_workdir,
     resolve_agent_id,
     resolve_project,
@@ -201,6 +202,12 @@ class TestResolve(unittest.TestCase):
                 getcwd=str(td),
             )
             self.assertIsNone(wd)
+
+
+class TestPwdHome(unittest.TestCase):
+    def test_pwd_home_returns_str_or_none(self):
+        home = pwd_home()
+        self.assertTrue(home is None or (isinstance(home, str) and home.strip()))
 
 
 if __name__ == "__main__":

--- a/src/config.ts
+++ b/src/config.ts
@@ -287,6 +287,45 @@ export function loadTeamConfig(): TeamConfig | null {
 // Filtering is gated by AGENTMEMORY_AGENT_SCOPE:
 //   "shared"   (default) — tag everything, do not filter recall paths
 //   "isolated"           — tag everything AND filter recall paths
+
+/** Max length for agentId values accepted at write/session boundaries. */
+export const AGENT_ID_MAX_LEN = 128;
+
+/**
+ * Normalize an optional agentId from env/request/tool args.
+ * Returns undefined when absent, non-string, or blank after trim.
+ * Valid values are trimmed and capped at maxLen (default 128).
+ */
+export function sanitizeAgentId(
+  value: unknown,
+  maxLen: number = AGENT_ID_MAX_LEN,
+): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  return trimmed.length > maxLen ? trimmed.slice(0, maxLen) : trimmed;
+}
+
+/**
+ * Parse an optional agentId field when the key may be present.
+ * - undefined/null → ok, value undefined (field omitted)
+ * - present but blank/non-string → error (callers return 400 / throw)
+ * - present valid string → ok, trimmed+capped value
+ */
+export function parseOptionalAgentIdField(
+  value: unknown,
+  maxLen: number = AGENT_ID_MAX_LEN,
+): { ok: true; value: string | undefined } | { ok: false; error: string } {
+  if (value === undefined || value === null) {
+    return { ok: true, value: undefined };
+  }
+  const sanitized = sanitizeAgentId(value, maxLen);
+  if (sanitized === undefined) {
+    return { ok: false, error: "agentId must be a non-empty string" };
+  }
+  return { ok: true, value: sanitized };
+}
+
 export function loadAgentScope(): {
   agentId: string;
   mode: "shared" | "isolated";
@@ -294,7 +333,7 @@ export function loadAgentScope(): {
   const env = getMergedEnv();
   const raw = env["AGENT_ID"];
   if (!raw) return null;
-  const agentId = raw.trim().slice(0, 128);
+  const agentId = sanitizeAgentId(raw);
   if (!agentId) return null;
   const mode = env["AGENTMEMORY_AGENT_SCOPE"] === "isolated"
     ? "isolated"

--- a/src/functions/remember.ts
+++ b/src/functions/remember.ts
@@ -7,7 +7,7 @@ import { memoryToObservation } from "../state/memory-utils.js";
 import { deleteAccessLog } from "./access-tracker.js";
 import { recordAudit } from "./audit.js";
 import { getSearchIndex, vectorIndexAddGuarded, vectorIndexRemove, flushIndexSave } from "./search.js";
-import { getAgentId } from "../config.js";
+import { getAgentId, sanitizeAgentId } from "../config.js";
 import { logger } from "../logger.js";
 
 export function registerRememberFunction(sdk: ISdk, kv: StateKV): void {
@@ -90,10 +90,7 @@ export function registerRememberFunction(sdk: ISdk, kv: StateKV): void {
         // filter by agent. Request body wins (multi-agent runtimes
         // explicitly tagging at write time), env AGENT_ID fallback,
         // none → memory is unscoped (legacy behavior).
-        const callAgentId =
-          typeof data.agentId === "string" && data.agentId.trim().length > 0
-            ? data.agentId.trim().slice(0, 128)
-            : getAgentId();
+        const callAgentId = sanitizeAgentId(data.agentId) ?? getAgentId();
 
         const memory: Memory = {
           id: generateId("mem"),

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -187,12 +187,18 @@ export function registerMcpEndpoints(
                 ? args.project.trim()
                 : undefined;
 
+            const agentId =
+              typeof args.agentId === "string" && args.agentId.trim().length > 0
+                ? args.agentId.trim().slice(0, 128)
+                : undefined;
+
             const result = await sdk.trigger({ function_id: "mem::remember", payload: {
               content: args.content,
               type,
               concepts,
               files,
               ...(project !== undefined && { project }),
+              ...(agentId !== undefined && { agentId }),
             } });
             return {
               status_code: 200,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -10,7 +10,7 @@ import type {
 } from "../types.js";
 import { getVisibleTools } from "./tools-registry.js";
 import { timingSafeCompare } from "../auth.js";
-import { getAgentId, isAgentScopeIsolated } from "../config.js";
+import { getAgentId, isAgentScopeIsolated, parseOptionalAgentIdField } from "../config.js";
 
 type McpResponse = {
   status_code: number;
@@ -187,10 +187,14 @@ export function registerMcpEndpoints(
                 ? args.project.trim()
                 : undefined;
 
-            const agentId =
-              typeof args.agentId === "string" && args.agentId.trim().length > 0
-                ? args.agentId.trim().slice(0, 128)
-                : undefined;
+            const agentIdField = parseOptionalAgentIdField(args.agentId);
+            if (!agentIdField.ok) {
+              return {
+                status_code: 400,
+                body: { error: agentIdField.error },
+              };
+            }
+            const agentId = agentIdField.value;
 
             const result = await sdk.trigger({ function_id: "mem::remember", payload: {
               content: args.content,

--- a/src/mcp/standalone.ts
+++ b/src/mcp/standalone.ts
@@ -99,6 +99,8 @@ interface Validated {
   type?: string;
   concepts?: string[];
   files?: string[];
+  project?: string;
+  agentId?: string;
   query?: string;
   limit?: number;
   format?: string;
@@ -122,6 +124,14 @@ function validate(toolName: string, args: Record<string, unknown>): Validated {
       v.type = (args["type"] as string) || "fact";
       v.concepts = normalizeList(args["concepts"]);
       v.files = normalizeList(args["files"]);
+      const project = args["project"];
+      if (typeof project === "string" && project.trim()) {
+        v.project = project.trim();
+      }
+      const agentId = args["agentId"];
+      if (typeof agentId === "string" && agentId.trim()) {
+        v.agentId = agentId.trim().slice(0, 128);
+      }
       return v;
     }
     case "memory_recall":
@@ -180,6 +190,8 @@ async function handleProxy(
           type: v.type,
           concepts: v.concepts,
           files: v.files,
+          ...(v.project !== undefined && { project: v.project }),
+          ...(v.agentId !== undefined && { agentId: v.agentId }),
         }),
       });
       return textResponse(result);

--- a/src/mcp/standalone.ts
+++ b/src/mcp/standalone.ts
@@ -3,7 +3,7 @@
 import { InMemoryKV } from "./in-memory-kv.js";
 import { createStdioTransport } from "./transport.js";
 import { getAllTools } from "./tools-registry.js";
-import { getStandalonePersistPath } from "../config.js";
+import { getStandalonePersistPath, parseOptionalAgentIdField } from "../config.js";
 import { VERSION } from "../version.js";
 import { generateId } from "../state/schema.js";
 import {
@@ -125,12 +125,18 @@ function validate(toolName: string, args: Record<string, unknown>): Validated {
       v.concepts = normalizeList(args["concepts"]);
       v.files = normalizeList(args["files"]);
       const project = args["project"];
-      if (typeof project === "string" && project.trim()) {
+      if (project !== undefined && project !== null) {
+        if (typeof project !== "string" || !project.trim()) {
+          throw new Error("project must be a non-empty string");
+        }
         v.project = project.trim();
       }
-      const agentId = args["agentId"];
-      if (typeof agentId === "string" && agentId.trim()) {
-        v.agentId = agentId.trim().slice(0, 128);
+      const agentIdField = parseOptionalAgentIdField(args["agentId"]);
+      if (!agentIdField.ok) {
+        throw new Error(agentIdField.error);
+      }
+      if (agentIdField.value !== undefined) {
+        v.agentId = agentIdField.value;
       }
       return v;
     }
@@ -270,9 +276,12 @@ async function handleLocal(
         version: 1,
         isLatest: true,
         sessionIds: [],
+        ...(v.project !== undefined && { project: v.project }),
+        ...(v.agentId !== undefined && { agentId: v.agentId }),
       });
       kvInstance.persist();
-      return textResponse({ saved: id });
+      const saved = await kvInstance.get("mem:memories", id);
+      return textResponse({ saved: id, memory: saved });
     }
 
     case "memory_recall":

--- a/src/mcp/tools-registry.ts
+++ b/src/mcp/tools-registry.ts
@@ -83,6 +83,12 @@ export const CORE_TOOLS: McpToolDef[] = [
             "started. Do not use filesystem paths or ad-hoc display names — those " +
             "change across machines and will silently break project scoping.",
         },
+        agentId: {
+          type: "string",
+          description:
+            "Optional agent/role id that wrote this memory (e.g. Hermes profile name). " +
+            "Used for multi-agent provenance; pair with AGENTMEMORY_AGENT_SCOPE when isolating.",
+        },
       },
       required: ["content"],
     },

--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -22,6 +22,8 @@ import {
   detectLlmProviderKind,
   getAgentId,
   isAgentScopeIsolated,
+  parseOptionalAgentIdField,
+  sanitizeAgentId,
 } from "../config.js";
 
 type Response = {
@@ -602,10 +604,7 @@ export function registerApiTriggers(
       // allow session/start to override AGENT_ID from request body
       // (multi-agent runtimes that route many roles through one server
       // process). Falls back to the AGENT_ID env on the server.
-      const requestAgentId =
-        typeof body.agentId === "string" && body.agentId.trim().length > 0
-          ? body.agentId.trim().slice(0, 128)
-          : undefined;
+      const requestAgentId = sanitizeAgentId(body.agentId);
       const agentId = requestAgentId ?? getAgentId();
       const session: Session = {
         id: sessionId,
@@ -1009,11 +1008,9 @@ export function registerApiTriggers(
       ) {
         return { status_code: 400, body: { error: "project must be a non-empty string" } };
       }
-      if (
-        req.body.agentId !== undefined &&
-        (typeof req.body.agentId !== "string" || !req.body.agentId.trim())
-      ) {
-        return { status_code: 400, body: { error: "agentId must be a non-empty string" } };
+      const agentIdField = parseOptionalAgentIdField(req.body.agentId);
+      if (!agentIdField.ok) {
+        return { status_code: 400, body: { error: agentIdField.error } };
       }
       const result = await sdk.trigger({
         function_id: "mem::remember",
@@ -1025,7 +1022,7 @@ export function registerApiTriggers(
           ...(req.body.ttlDays !== undefined && { ttlDays: req.body.ttlDays }),
           ...(req.body.sourceObservationIds !== undefined && { sourceObservationIds: req.body.sourceObservationIds }),
           ...(req.body.project !== undefined && { project: req.body.project }),
-          ...(req.body.agentId !== undefined && { agentId: req.body.agentId.trim().slice(0, 128) }),
+          ...(agentIdField.value !== undefined && { agentId: agentIdField.value }),
         },
       });
       return { status_code: 201, body: result };

--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -23,7 +23,6 @@ import {
   getAgentId,
   isAgentScopeIsolated,
   parseOptionalAgentIdField,
-  sanitizeAgentId,
 } from "../config.js";
 
 type Response = {
@@ -604,8 +603,12 @@ export function registerApiTriggers(
       // allow session/start to override AGENT_ID from request body
       // (multi-agent runtimes that route many roles through one server
       // process). Falls back to the AGENT_ID env on the server.
-      const requestAgentId = sanitizeAgentId(body.agentId);
-      const agentId = requestAgentId ?? getAgentId();
+      // Malformed/blank body.agentId → 400 (same contract as api::remember).
+      const agentIdField = parseOptionalAgentIdField(body.agentId);
+      if (!agentIdField.ok) {
+        return { status_code: 400, body: { error: agentIdField.error } };
+      }
+      const agentId = agentIdField.value ?? getAgentId();
       const session: Session = {
         id: sessionId,
         project,

--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -603,7 +603,6 @@ export function registerApiTriggers(
       // allow session/start to override AGENT_ID from request body
       // (multi-agent runtimes that route many roles through one server
       // process). Falls back to the AGENT_ID env on the server.
-      // Malformed/blank body.agentId → 400 (same contract as api::remember).
       const agentIdField = parseOptionalAgentIdField(body.agentId);
       if (!agentIdField.ok) {
         return { status_code: 400, body: { error: agentIdField.error } };

--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -991,6 +991,7 @@ export function registerApiTriggers(
         ttlDays?: number;
         sourceObservationIds?: string[];
         project?: string;
+        agentId?: string;
       }>,
     ): Promise<Response> => {
       const authErr = checkAuth(req, secret);
@@ -1008,6 +1009,12 @@ export function registerApiTriggers(
       ) {
         return { status_code: 400, body: { error: "project must be a non-empty string" } };
       }
+      if (
+        req.body.agentId !== undefined &&
+        (typeof req.body.agentId !== "string" || !req.body.agentId.trim())
+      ) {
+        return { status_code: 400, body: { error: "agentId must be a non-empty string" } };
+      }
       const result = await sdk.trigger({
         function_id: "mem::remember",
         payload: {
@@ -1018,6 +1025,7 @@ export function registerApiTriggers(
           ...(req.body.ttlDays !== undefined && { ttlDays: req.body.ttlDays }),
           ...(req.body.sourceObservationIds !== undefined && { sourceObservationIds: req.body.sourceObservationIds }),
           ...(req.body.project !== undefined && { project: req.body.project }),
+          ...(req.body.agentId !== undefined && { agentId: req.body.agentId.trim().slice(0, 128) }),
         },
       });
       return { status_code: 201, body: result };

--- a/src/triggers/events.ts
+++ b/src/triggers/events.ts
@@ -3,7 +3,7 @@ import type { CompressedObservation, HookPayload, Session } from "../types.js";
 import { KV, STREAM } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
 import { isReflectEnabled } from "../functions/slots.js";
-import { getAgentId, isGraphExtractionEnabled } from "../config.js";
+import { getAgentId, isGraphExtractionEnabled, sanitizeAgentId } from "../config.js";
 import { logger } from "../logger.js";
 
 export function registerEventTriggers(sdk: ISdk, kv: StateKV): void {
@@ -15,10 +15,7 @@ export function registerEventTriggers(sdk: ISdk, kv: StateKV): void {
       cwd: string;
       agentId?: string;
     }) => {
-      const requestAgentId =
-        typeof data.agentId === "string" && data.agentId.trim().length > 0
-          ? data.agentId.trim().slice(0, 128)
-          : undefined;
+      const requestAgentId = sanitizeAgentId(data.agentId);
       const agentId = requestAgentId ?? getAgentId();
       const session: Session = {
         id: data.sessionId,

--- a/test/agent-id-scope.test.ts
+++ b/test/agent-id-scope.test.ts
@@ -43,6 +43,31 @@ describe("loadAgentScope (#554)", () => {
   });
 });
 
+describe("sanitizeAgentId / parseOptionalAgentIdField", () => {
+  it("sanitizes trim + cap and rejects blank/non-string", async () => {
+    const { sanitizeAgentId, parseOptionalAgentIdField, AGENT_ID_MAX_LEN } =
+      await import("../src/config.js");
+    expect(sanitizeAgentId(undefined)).toBeUndefined();
+    expect(sanitizeAgentId(null)).toBeUndefined();
+    expect(sanitizeAgentId(12)).toBeUndefined();
+    expect(sanitizeAgentId("   ")).toBeUndefined();
+    expect(sanitizeAgentId("  hermes  ")).toBe("hermes");
+    expect(sanitizeAgentId("a".repeat(200))).toBe("a".repeat(AGENT_ID_MAX_LEN));
+
+    expect(parseOptionalAgentIdField(undefined)).toEqual({ ok: true, value: undefined });
+    expect(parseOptionalAgentIdField(null)).toEqual({ ok: true, value: undefined });
+    expect(parseOptionalAgentIdField("  se  ")).toEqual({ ok: true, value: "se" });
+    expect(parseOptionalAgentIdField("")).toEqual({
+      ok: false,
+      error: "agentId must be a non-empty string",
+    });
+    expect(parseOptionalAgentIdField(0)).toEqual({
+      ok: false,
+      error: "agentId must be a non-empty string",
+    });
+  });
+});
+
 describe("mem::remember stamps agentId on the Memory (#554)", () => {
   const ORIG = process.env["AGENT_ID"];
   beforeEach(() => {

--- a/test/mcp-standalone.test.ts
+++ b/test/mcp-standalone.test.ts
@@ -15,9 +15,13 @@ vi.mock("../src/mcp/transport.js", () => ({
   createStdioTransport: vi.fn(() => ({ start: vi.fn(), stop: vi.fn() })),
 }));
 
-vi.mock("../src/config.js", () => ({
-  getStandalonePersistPath: vi.fn(() => "/tmp/test-standalone.json"),
-}));
+vi.mock("../src/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/config.js")>();
+  return {
+    ...actual,
+    getStandalonePersistPath: vi.fn(() => "/tmp/test-standalone.json"),
+  };
+});
 
 import {
   getAllTools,
@@ -206,6 +210,42 @@ describe("handleToolCall", () => {
         handleToolCall("memory_save", { content: bogus }, kv),
       ).rejects.toThrow("content is required");
     }
+  });
+
+  it("memory_save rejects blank/non-string agentId when provided", async () => {
+    const kv = new InMemoryKV();
+    await expect(
+      handleToolCall("memory_save", { content: "x", agentId: "   " }, kv),
+    ).rejects.toThrow("agentId must be a non-empty string");
+    await expect(
+      handleToolCall("memory_save", { content: "x", agentId: 12 }, kv),
+    ).rejects.toThrow("agentId must be a non-empty string");
+  });
+
+  it("memory_save rejects blank/non-string project when provided", async () => {
+    const kv = new InMemoryKV();
+    await expect(
+      handleToolCall("memory_save", { content: "x", project: "" }, kv),
+    ).rejects.toThrow("project must be a non-empty string");
+    await expect(
+      handleToolCall("memory_save", { content: "x", project: 1 }, kv),
+    ).rejects.toThrow("project must be a non-empty string");
+  });
+
+  it("memory_save stamps project and agentId on local-mode memories", async () => {
+    const kv = new InMemoryKV();
+    const result = await handleToolCall(
+      "memory_save",
+      {
+        content: "scoped entry",
+        project: "  demo  ",
+        agentId: `  ${"b".repeat(200)}  `,
+      },
+      kv,
+    );
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.memory.project).toBe("demo");
+    expect(parsed.memory.agentId).toBe("b".repeat(128));
   });
 
   it("memory_recall returns matching memories", async () => {

--- a/test/remember-project-scope.test.ts
+++ b/test/remember-project-scope.test.ts
@@ -117,6 +117,32 @@ describe("mem::remember — project field stamping", () => {
     expect(result.memory.project).toBe("api");
   });
 
+  it("persists agentId on the saved memory when provided", async () => {
+    const sdk = mockSdk();
+    const kv = mockKV();
+    registerRememberFunction(sdk as never, kv as never);
+
+    const result = await sdk.trigger({
+      function_id: "mem::remember",
+      payload: {
+        content: "hermes multi-profile provenance stamp",
+        type: "fact",
+        project: "software-engineer",
+        agentId: "software-engineer",
+      },
+    }) as { success: boolean; memory: { id: string; project?: string; agentId?: string } };
+
+    expect(result.success).toBe(true);
+    expect(result.memory.project).toBe("software-engineer");
+    expect(result.memory.agentId).toBe("software-engineer");
+
+    const stored = await kv.get<{ project?: string; agentId?: string }>(
+      "mem:memories",
+      result.memory.id,
+    );
+    expect(stored?.agentId).toBe("software-engineer");
+  });
+
   it("treats a blank project string the same as no project", async () => {
     const sdk = mockSdk();
     const kv = mockKV();

--- a/test/remember-project-scope.test.ts
+++ b/test/remember-project-scope.test.ts
@@ -143,6 +143,23 @@ describe("mem::remember — project field stamping", () => {
     expect(stored?.agentId).toBe("software-engineer");
   });
 
+  it("trims and caps agentId at 128 characters", async () => {
+    const sdk = mockSdk();
+    const kv = mockKV();
+    registerRememberFunction(sdk as never, kv as never);
+
+    const longId = `  ${"a".repeat(200)}  `;
+    const result = await sdk.trigger({
+      function_id: "mem::remember",
+      payload: {
+        content: "capped agent id",
+        agentId: longId,
+      },
+    }) as { success: boolean; memory: { agentId?: string } };
+
+    expect(result.memory.agentId).toBe("a".repeat(128));
+  });
+
   it("treats a blank project string the same as no project", async () => {
     const sdk = mockSdk();
     const kv = mockKV();


### PR DESCRIPTION
## What

Two related write-path fixes so multi-agent / multi-profile setups can tag memories reliably:

1. **Core remember path** — `POST /agentmemory/remember` and MCP `memory_save` now forward `agentId`. Standalone MCP also forwards `project` (it was advertised in the tool schema but dropped in the REST body).
2. **Hermes integration** — `integrations/hermes` stamps stable `project` + `agentId` on session start, remember, observe, and memory-write hooks instead of using raw cwd paths as `project`.

## Why

Shared daemons (e.g. several Hermes profiles on one host) need:

| Field | Meaning |
|-------|---------|
| `project` | What the memory is about (repo / domain slug) |
| `agentId` | Who wrote it (agent / profile id) |

Without this, MCP/plugin writes become unscoped orphans (they always pass project filters), and `agentId` provenance is silently discarded on REST even when clients send it. `mem::remember` and session start already supported `agentId`; the HTTP/MCP allow-lists did not.

Search stays **unfiltered** by default (shared soft-read). This PR only fixes write tagging.

## How to verify

```bash
npm install
npm run build
npm test
# optional focused:
npm test -- test/remember-project-scope.test.ts test/integration-plaintext-http.test.ts
python3 integrations/hermes/tests/test_scoping.py -v
```

Manual (with a running server on `:3111`):

```bash
# expect memory.project and memory.agentId set
curl -sS -X POST http://127.0.0.1:3111/agentmemory/remember \
  -H 'Content-Type: application/json' \
  -d '{"content":"probe","type":"fact","project":"demo","agentId":"agent-a"}'
```

Standalone MCP `memory_save` with `project` / `agentId` args should persist the same fields via `POST /remember`.

## Commits

1. `fix(remember): forward agentId on REST and MCP remember paths`
2. `feat(hermes): multi-profile project and agentId write tagging`

## Notes

- No package version bump (release process is maintainer-owned).
- No CHANGELOG touch (per CONTRIBUTING).
- DCO sign-off on both commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional `project` and `agentId` support to memory-saving tools and APIs (including MCP schema/validation) with proper local stamping and request forwarding.
  - Enhanced Hermes agentmemory scoping with multi-profile project tagging and deterministic slug/project/workdir/agent resolution.
- **Bug Fixes**
  - Improved Hermes base URL/auth handling and failure diagnostics with safe, per-user debug logging (no secret leakage).
  - Added consistent `agentId` parsing/validation across session start and remember flows.
- **Documentation**
  - Updated Hermes environment variable and tagging/scoping precedence documentation.
- **Tests**
  - Added Hermes scoping/work-root/slug resolution tests and agent ID normalization/validation tests for config and MCP flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->