### PR TITLE
Fix smart-search durable expansion and project scoping

### DIFF
--- a/src/functions/smart-search.ts
+++ b/src/functions/smart-search.ts
@@ -5,6 +5,7 @@ import type {
   CompressedObservation,
   HybridSearchResult,
   Lesson,
+  Memory,
 } from "../types.js";
 import { KV } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
@@ -17,6 +18,7 @@ import {
 } from "../config.js";
 import { logger } from "../logger.js";
 import { getCounters } from "../telemetry/setup.js";
+import { memoryToObservation } from "../state/memory-utils.js";
 
 // #771: smart-search followup-rate diagnostic. Stored per session as
 // the most recent search payload, used to detect whether the next
@@ -115,6 +117,10 @@ export function registerSmartSearchFunction(
       const filterAgentId = wildcardAgent
         ? undefined
         : explicitAgentId ?? envAgentId;
+      const project =
+        typeof data.project === "string" && data.project.trim()
+          ? data.project.trim()
+          : undefined;
       if (
         isolated &&
         !wildcardAgent &&
@@ -156,9 +162,24 @@ export function registerSmartSearchFunction(
           if (r) expanded.push(r);
         }
 
+        const projectMatches = project
+          ? await Promise.all(
+              expanded.map((entry) =>
+                observationMatchesProject(
+                  kv,
+                  entry.obsId,
+                  entry.sessionId,
+                  project,
+                ),
+              ),
+            )
+          : expanded.map(() => true);
+        const projectScoped = expanded.filter(
+          (_, index) => projectMatches[index],
+        );
         const scoped = filterAgentId
-          ? expanded.filter((e) => e.observation.agentId === filterAgentId)
-          : expanded;
+          ? projectScoped.filter((e) => e.observation.agentId === filterAgentId)
+          : projectScoped;
 
         void recordAccessBatch(
           kv,
@@ -185,15 +206,14 @@ export function registerSmartSearchFunction(
       // observations so 10 covers most recall flows.
       const lessonLimit = Math.min(limit, 10);
       const includeLessons = data.includeLessons !== false;
-
       // Over-fetch when filtering. Hybrid search can't filter on
       // agentId (BM25/vector indexes don't carry it), so we ask the
       // searcher for more hits than we need and trim post-filter. 3×
       // is a defensible middle ground: enough headroom for a small
       // workload, capped at 300 so a 100-limit request never asks for
       // thousands of hits.
-      const overFetchLimit = filterAgentId
-        ? Math.min(limit * 3, 300)
+      const overFetchLimit = filterAgentId || project
+        ? Math.max(Math.min(limit * 10, 300), 100)
         : limit;
 
       const [hybridResults, lessons] = await Promise.all([
@@ -203,11 +223,26 @@ export function registerSmartSearchFunction(
           : Promise.resolve([]),
       ]);
 
+      let projectResults = hybridResults;
+      if (project) {
+        const matches = await Promise.all(
+          hybridResults.map((result) =>
+            observationMatchesProject(
+              kv,
+              result.observation.id,
+              result.sessionId,
+              project,
+            ),
+          ),
+        );
+        projectResults = hybridResults.filter((_, index) => matches[index]);
+      }
+
       const filteredHybrid = filterAgentId
-        ? hybridResults
+        ? projectResults
             .filter((r) => r.observation.agentId === filterAgentId)
             .slice(0, limit)
-        : hybridResults.slice(0, limit);
+        : projectResults.slice(0, limit);
 
       const compact: CompactSearchResult[] = filteredHybrid.map((r) => ({
         obsId: r.observation.id,
@@ -364,6 +399,9 @@ async function findObservation(
   obsId: string,
   sessionIdHint?: string,
 ): Promise<CompressedObservation | null> {
+  const memory = await kv.get<Memory>(KV.memories, obsId).catch(() => null);
+  if (memory) return memoryToObservation(memory);
+
   if (sessionIdHint) {
     const obs = await kv
       .get<CompressedObservation>(KV.observations(sessionIdHint), obsId)
@@ -383,4 +421,18 @@ async function findObservation(
     if (found) return found;
   }
   return null;
+}
+
+async function observationMatchesProject(
+  kv: StateKV,
+  obsId: string,
+  sessionId: string,
+  project: string,
+): Promise<boolean> {
+  const memory = await kv.get<Memory>(KV.memories, obsId).catch(() => null);
+  if (memory) return memory.project === project;
+  const session = await kv
+    .get<{ project?: string }>(KV.sessions, sessionId)
+    .catch(() => null);
+  return session?.project === project;
 }

--- a/src/state/memory-utils.ts
+++ b/src/state/memory-utils.ts
@@ -20,5 +20,6 @@ export function memoryToObservation(memory: Memory): CompressedObservation {
     concepts: memory.concepts,
     files: memory.files,
     importance: memory.strength,
+    agentId: memory.agentId,
   };
 }

--- a/test/smart-search.test.ts
+++ b/test/smart-search.test.ts
@@ -9,6 +9,7 @@ import type {
   CompressedObservation,
   HybridSearchResult,
   CompactSearchResult,
+  Memory,
   Session,
 } from "../src/types.js";
 
@@ -137,6 +138,125 @@ describe("Smart Search Function", () => {
     expect(result.mode).toBe("expanded");
     expect(result.results.length).toBe(1);
     expect(result.results[0].observation.title).toBe("Auth handler");
+  });
+
+  it("expand mode returns full durable memories", async () => {
+    const memory: Memory = {
+      id: "mem_wiki",
+      createdAt: "2026-07-19T00:00:00Z",
+      updatedAt: "2026-07-19T00:00:00Z",
+      type: "architecture",
+      title: "AgentMemory knowledge backend",
+      content: "Full durable wiki content that must not be truncated.",
+      concepts: ["agentmemory"],
+      files: ["wiki/agentmemory.md"],
+      sessionIds: [],
+      strength: 7,
+      version: 1,
+      supersedes: [],
+      sourceObservationIds: [],
+      isLatest: true,
+      project: "obsidian-vault",
+    };
+    await kv.set("mem:memories", memory.id, memory);
+
+    const result = (await sdk.trigger("mem::smart-search", {
+      expandIds: [memory.id],
+    })) as {
+      mode: string;
+      results: Array<{ obsId: string; observation: CompressedObservation }>;
+    };
+
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0].observation.narrative).toBe(memory.content);
+  });
+
+  it("filters expanded durable memories to the requested project", async () => {
+    const memory: Memory = {
+      id: "mem_other_project",
+      createdAt: "2026-07-19T00:00:00Z",
+      updatedAt: "2026-07-19T00:00:00Z",
+      type: "architecture",
+      title: "Other project memory",
+      content: "This memory must not cross the project boundary.",
+      concepts: [],
+      files: [],
+      sessionIds: [],
+      strength: 5,
+      version: 1,
+      supersedes: [],
+      sourceObservationIds: [],
+      isLatest: true,
+      project: "other-project",
+    };
+    await kv.set("mem:memories", memory.id, memory);
+
+    const result = (await sdk.trigger("mem::smart-search", {
+      expandIds: [memory.id],
+      project: "my-project",
+    })) as { results: Array<{ obsId: string }> };
+
+    expect(result.results).toEqual([]);
+  });
+
+  it("preserves durable memory agent scope during expansion", async () => {
+    const memory: Memory = {
+      id: "mem_scoped",
+      createdAt: "2026-07-19T00:00:00Z",
+      updatedAt: "2026-07-19T00:00:00Z",
+      type: "architecture",
+      title: "Scoped memory",
+      content: "Only the owning agent may expand this memory.",
+      concepts: [],
+      files: [],
+      sessionIds: [],
+      strength: 5,
+      version: 1,
+      supersedes: [],
+      sourceObservationIds: [],
+      isLatest: true,
+      project: "my-project",
+      agentId: "agent-owner",
+    };
+    await kv.set("mem:memories", memory.id, memory);
+
+    const result = (await sdk.trigger("mem::smart-search", {
+      expandIds: [memory.id],
+      agentId: "agent-owner",
+    })) as { results: Array<{ obsId: string }> };
+
+    expect(result.results.map((item) => item.obsId)).toEqual([memory.id]);
+  });
+
+  it("filters compact candidates to the requested project", async () => {
+    const other = makeObs({
+      id: "obs_other",
+      sessionId: "ses_other",
+      title: "Unrelated project",
+    });
+    await kv.set("mem:sessions", "ses_other", {
+      id: "ses_other",
+      project: "other-project",
+      cwd: "/other",
+      startedAt: "2026-02-01T00:00:00Z",
+      status: "completed",
+      observationCount: 1,
+    });
+    await kv.set("mem:obs:ses_other", other.id, other);
+    searchResults.unshift({
+      observation: other,
+      bm25Score: 1,
+      vectorScore: 1,
+      combinedScore: 1,
+      sessionId: "ses_other",
+    });
+
+    const result = (await sdk.trigger("mem::smart-search", {
+      query: "auth",
+      project: "my-project",
+    })) as { results: CompactSearchResult[] };
+
+    expect(result.results.map((item) => item.obsId)).toEqual(["obs_1", "obs_2"]);
   });
 
   it("returns error when query is missing and no expandIds", async () => {


### PR DESCRIPTION
# Fix smart-search durable expansion and project scoping

## Summary

- expand durable `mem_*` records through `smart-search.expandIds`
- preserve durable-memory agent identity during expansion
- enforce `project` on compact and expanded results
- over-fetch before project/agent filtering to avoid underfilled pages
- resolve durable records before scanning session observations

## Why

Smart search can return compact durable-memory hits, but expansion only scans
session observations. Its `project` argument is also forwarded to lesson recall
without consistently scoping hybrid or expanded results.

This makes compact-to-expanded recall work for durable memories while keeping
project and agent isolation fail-closed.

Fixes rohitg00/agentmemory#1080.

## Validation

- `npx vitest run test/smart-search.test.ts`: 17 passed
- `npm run build`: passed
- `npm run skills:check`: 15 skills passed
- `npm test` under Node 20: 1,419 passed
- `npm test` under Node 22: 1,419 passed
- `npm run test:integration`: 17 passed
- `git diff --check main...HEAD`: passed

## Review notes

- one signed-off commit
- no generated build artifacts committed
- no changelog changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project-based filtering to smart search results and expanded memories.
  * Durable memory searches now preserve full narrative content when expanded.
  * Expanded results respect agent ownership filtering.

* **Bug Fixes**
  * Improved search accuracy by excluding observations and memories from unrelated projects.
  * Ensured project filtering works consistently across standard, hybrid, compact, and expanded searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->