### PR TITLE
feat(mcp): add per-tool risk annotations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ agentmemory is a persistent memory system for AI coding agents, built on iii-eng
 ## Consistency Rules
 
 **When adding or removing MCP tools, you MUST update ALL of the following:**
-1. `src/mcp/tools-registry.ts` — tool definition + `getAllTools()` array
+1. `src/mcp/tools-registry.ts` — tool definition + `getAllTools()` array (every tool must include `annotations` with `readOnlyHint`/`destructiveHint`: read-only tools get `readOnlyHint: true`, destructive tools get `destructiveHint: true`)
 2. `src/mcp/server.ts` — handler case in the `mcp::tools::call` switch
 3. `src/triggers/api.ts` — REST endpoint registration
 4. `src/index.ts` — function registration + endpoint count in the log line

--- a/src/mcp/tools-registry.ts
+++ b/src/mcp/tools-registry.ts
@@ -1,3 +1,11 @@
+export type McpToolAnnotations = {
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+  idempotentHint?: boolean;
+  openWorldHint?: boolean;
+  title?: string;
+};
+
 export type McpToolDef = {
   name: string;
   description: string;
@@ -6,6 +14,7 @@ export type McpToolDef = {
     properties: Record<string, { type: string; description: string }>;
     required?: string[];
   };
+  annotations?: McpToolAnnotations;
 };
 
 export const CORE_TOOLS: McpToolDef[] = [
@@ -35,6 +44,7 @@ export const CORE_TOOLS: McpToolDef[] = [
       },
       required: ["query"],
     },
+    annotations: { readOnlyHint: true, destructiveHint: false },
   },
   {
     name: "memory_compress_file",
@@ -50,6 +60,7 @@ export const CORE_TOOLS: McpToolDef[] = [
       },
       required: ["filePath"],
     },
+    annotations: { readOnlyHint: false, destructiveHint: false },
   },
   {
     name: "memory_save",
@@ -92,6 +103,7 @@ export const CORE_TOOLS: McpToolDef[] = [
       },
       required: ["content"],
     },
+    annotations: { readOnlyHint: false, destructiveHint: false },
   },
   {
     name: "memory_file_history",
@@ -107,6 +119,7 @@ export const CORE_TOOLS: McpToolDef[] = [
       },
       required: ["files"],
     },
+    annotations: { readOnlyHint: true, destructiveHint: false },
   },
   {
     name: "memory_patterns",
@@ -117,12 +130,14 @@ export const CORE_TOOLS: McpToolDef[] = [
         project: { type: "string", description: "Project path to analyze" },
       },
     },
+    annotations: { readOnlyHint: true, destructiveHint: false },
   },
   {
     name: "memory_sessions",
     description:
       "List recent sessions with their status and observation counts.",
     inputSchema: { type: "object", properties: {} },
+    annotations: { readOnlyHint: true, destructiveHint: false },
   },
   {
     name: "memory_smart_search",
@@ -139,6 +154,7 @@ export const CORE_TOOLS: McpToolDef[] = [
       },
       required: ["query"],
     },
+    annotations: { readOnlyHint: true, destructiveHint: false },
   },
   {
     name: "memory_vision_search",
@@ -154,6 +170,7 @@ export const CORE_TOOLS: McpToolDef[] = [
         sessionId: { type: "string", description: "Filter to a single session" },
       },
     },
+    annotations: { readOnlyHint: true, destructiveHint: false },
   },
   {
     name: "memory_timeline",
@@ -177,6 +194,7 @@ export const CORE_TOOLS: McpToolDef[] = [
       },
       required: ["anchor"],
     },
+    annotations: { readOnlyHint: true, destructiveHint: false },
   },
   {
     name: "memory_profile",
@@ -192,11 +210,13 @@ export const CORE_TOOLS: McpToolDef[] = [
       },
       required: ["project"],
     },
+    annotations: { readOnlyHint: false, destructiveHint: false },
   },
   {
     name: "memory_export",
     description: "Export all memory data as JSON.",
     inputSchema: { type: "object", properties: {} },
+    annotations: { readOnlyHint: true, destructiveHint: false },
   },
   {
     name: "memory_relations",
@@ -219,6 +239,7 @@ export const CORE_TOOLS: McpToolDef[] = [
       },
       required: ["memoryId"],
     },
+    annotations: { readOnlyHint: true, destructiveHint: false },
   },
   {
     name: "memory_commit_lookup",
@@ -231,6 +252,7 @@ export const CORE_TOOLS: McpToolDef[] = [
       },
       required: ["sha"],
     },
+    annotations: { readOnlyHint: true, destructiveHint: false },
   },
   {
     name: "memory_commits",
@@ -244,6 +266,7 @@ export const CORE_TOOLS: McpToolDef[] = [
         limit: { type: "number", description: "Max results (default 100, max 500)" },
       },
     },
+    annotations: { readOnlyHint: true, destructiveHint: false },
   },
 ];
 
@@ -263,6 +286,7 @@ export const V040_TOOLS: McpToolDef[] = [
       },
       required: ["direction"],
     },
+    annotations: { readOnlyHint: false, destructiveHint: false },
   },
   {
     name: "memory_graph_query",
@@ -282,6 +306,7 @@ export const V040_TOOLS: McpToolDef[] = [
         query: { type: "string", description: "Search nodes by name" },
       },
     },
+    annotations: { readOnlyHint: true, destructiveHint: false },
   },
   {
     name: "memory_consolidate",
@@ -296,6 +321,7 @@ export const V040_TOOLS: McpToolDef[] = [
         },
       },
     },
+    annotations: { readOnlyHint: false, destructiveHint: false },
   },
   {
     name: "memory_team_share",
@@ -314,6 +340,7 @@ export const V040_TOOLS: McpToolDef[] = [
       },
       required: ["itemId", "itemType"],
     },
+    annotations: { readOnlyHint: false, destructiveHint: false },
   },
   {
     name: "memory_team_feed",
@@ -324,6 +351,7 @@ export const V040_TOOLS: McpToolDef[] = [
         limit: { type: "number", description: "Max items (default 20)" },
       },
     },
+    annotations: { readOnlyHint: true, destructiveHint: false },
   },
   {
     name: "memory_audit",
@@ -335,6 +363,7 @@ export const V040_TOOLS: McpToolDef[] = [
         limit: { type: "number", description: "Max entries (default 50)" },
       },
     },
+    annotations: { readOnlyHint: true, destructiveHint: false },
   },
   {
     name: "memory_governance_delete",
@@ -350,6 +379,7 @@ export const V040_TOOLS: McpToolDef[] = [
       },
       required: ["memoryIds"],
     },
+    annotations: { readOnlyHint: false, destructiveHint: true },
   },
   {
     name: "memory_snapshot_create",
@@ -360,6 +390,7 @@ export const V040_TOOLS: McpToolDef[] = [
         message: { type: "string", description: "Snapshot description" },
       },
     },
+    annotations: { readOnlyHint: false, destructiveHint: false },
   },
 ];
 
@@ -397,6 +428,7 @@ export const V050_TOOLS: McpToolDef[] = [
       },
       required: ["title"],
     },
+    annotations: { readOnlyHint: false, destructiveHint: false },
   },
   {
     name: "memory_action_update",
@@ -418,6 +450,7 @@ export const V050_TOOLS: McpToolDef[] = [
       },
       required: ["actionId"],
     },
+    annotations: { readOnlyHint: false, destructiveHint: false },
   },
   {
     name: "memory_frontier",
@@ -434,6 +467,7 @@ export const V050_TOOLS: McpToolDef[] = [
         limit: { type: "number", description: "Max results (default 20)" },
       },
     },
+    annotations: { readOnlyHint: true, destructiveHint: false },
   },
   {
     name: "memory_next",
@@ -446,6 +480,7 @@ export const V050_TOOLS: McpToolDef[] = [
         agentId: { type: "string", description: "Current agent ID" },
       },
     },
+    annotations: { readOnlyHint: true, destructiveHint: false },
   },
   {
     name: "memory_lease",
@@ -471,6 +506,7 @@ export const V050_TOOLS: McpToolDef[] = [
       },
       required: ["actionId", "agentId", "operation"],
     },
+    annotations: { readOnlyHint: false, destructiveHint: false },
   },
   {
     name: "memory_routine_run",
@@ -485,6 +521,7 @@ export const V050_TOOLS: McpToolDef[] = [
       },
       required: ["routineId"],
     },
+    annotations: { readOnlyHint: false, destructiveHint: false },
   },
   {
     name: "memory_signal_send",
@@ -510,6 +547,7 @@ export const V050_TOOLS: McpToolDef[] = [
       },
       required: ["from", "content"],
     },
+    annotations: { readOnlyHint: false, destructiveHint: false },
   },
   {
     name: "memory_signal_read",
@@ -531,6 +569,7 @@ export const V050_TOOLS: McpToolDef[] = [
       },
       required: ["agentId"],
     },
+    annotations: { readOnlyHint: false, destructiveHint: false },
   },
   {
     name: "memory_checkpoint",
@@ -564,6 +603,7 @@ export const V050_TOOLS: McpToolDef[] = [
       },
       required: ["operation"],
     },
+    annotations: { readOnlyHint: false, destructiveHint: false },
   },
   {
     name: "memory_mesh_sync",
@@ -582,6 +622,7 @@ export const V050_TOOLS: McpToolDef[] = [
         },
       },
     },
+    annotations: { readOnlyHint: false, destructiveHint: false },
   },
 ];
 
@@ -610,6 +651,7 @@ export const V051_TOOLS: McpToolDef[] = [
       },
       required: ["name", "type"],
     },
+    annotations: { readOnlyHint: false, destructiveHint: false },
   },
   {
     name: "memory_sentinel_trigger",
@@ -623,6 +665,7 @@ export const V051_TOOLS: McpToolDef[] = [
       },
       required: ["sentinelId"],
     },
+    annotations: { readOnlyHint: false, destructiveHint: false },
   },
   {
     name: "memory_sketch_create",
@@ -638,6 +681,7 @@ export const V051_TOOLS: McpToolDef[] = [
       },
       required: ["title"],
     },
+    annotations: { readOnlyHint: false, destructiveHint: false },
   },
   {
     name: "memory_sketch_promote",
@@ -651,6 +695,7 @@ export const V051_TOOLS: McpToolDef[] = [
       },
       required: ["sketchId"],
     },
+    annotations: { readOnlyHint: false, destructiveHint: false },
   },
   {
     name: "memory_crystallize",
@@ -668,6 +713,7 @@ export const V051_TOOLS: McpToolDef[] = [
       },
       required: ["actionIds"],
     },
+    annotations: { readOnlyHint: false, destructiveHint: false },
   },
   {
     name: "memory_diagnose",
@@ -682,6 +728,7 @@ export const V051_TOOLS: McpToolDef[] = [
         },
       },
     },
+    annotations: { readOnlyHint: true, destructiveHint: false },
   },
   {
     name: "memory_heal",
@@ -700,6 +747,7 @@ export const V051_TOOLS: McpToolDef[] = [
         },
       },
     },
+    annotations: { readOnlyHint: false, destructiveHint: true },
   },
   {
     name: "memory_facet_tag",
@@ -718,6 +766,7 @@ export const V051_TOOLS: McpToolDef[] = [
       },
       required: ["targetId", "targetType", "dimension", "value"],
     },
+    annotations: { readOnlyHint: false, destructiveHint: false },
   },
   {
     name: "memory_facet_query",
@@ -740,6 +789,7 @@ export const V051_TOOLS: McpToolDef[] = [
         },
       },
     },
+    annotations: { readOnlyHint: true, destructiveHint: false },
   },
 ];
 
@@ -758,6 +808,7 @@ export const V061_TOOLS: McpToolDef[] = [
       },
       required: ["id"],
     },
+    annotations: { readOnlyHint: true, destructiveHint: false },
   },
 ];
 
@@ -786,6 +837,7 @@ export const V070_TOOLS: McpToolDef[] = [
       },
       required: ["content"],
     },
+    annotations: { readOnlyHint: false, destructiveHint: false },
   },
   {
     name: "memory_lesson_recall",
@@ -804,6 +856,7 @@ export const V070_TOOLS: McpToolDef[] = [
       },
       required: ["query"],
     },
+    annotations: { readOnlyHint: true, destructiveHint: false },
   },
   {
     name: "memory_lesson_delete",
@@ -834,6 +887,7 @@ export const V070_TOOLS: McpToolDef[] = [
         },
       },
     },
+    annotations: { readOnlyHint: false, destructiveHint: false },
   },
 ];
 
@@ -852,6 +906,7 @@ export const V073_TOOLS: McpToolDef[] = [
         },
       },
     },
+    annotations: { readOnlyHint: false, destructiveHint: false },
   },
   {
     name: "memory_insight_list",
@@ -868,6 +923,7 @@ export const V073_TOOLS: McpToolDef[] = [
         limit: { type: "number", description: "Max results (default 50)" },
       },
     },
+    annotations: { readOnlyHint: true, destructiveHint: false },
   },
 ];
 
@@ -877,6 +933,7 @@ export const V010_SLOTS_TOOLS: McpToolDef[] = [
     description:
       "List all memory slots (pinned + project + global). Slots are editable, size-limited memory units the agent can read and modify across sessions.",
     inputSchema: { type: "object", properties: {} },
+    annotations: { readOnlyHint: true, destructiveHint: false },
   },
   {
     name: "memory_slot_get",
@@ -888,6 +945,7 @@ export const V010_SLOTS_TOOLS: McpToolDef[] = [
       },
       required: ["label"],
     },
+    annotations: { readOnlyHint: true, destructiveHint: false },
   },
   {
     name: "memory_slot_create",
@@ -904,6 +962,7 @@ export const V010_SLOTS_TOOLS: McpToolDef[] = [
       },
       required: ["label"],
     },
+    annotations: { readOnlyHint: false, destructiveHint: false },
   },
   {
     name: "memory_slot_append",
@@ -917,6 +976,7 @@ export const V010_SLOTS_TOOLS: McpToolDef[] = [
       },
       required: ["label", "text"],
     },
+    annotations: { readOnlyHint: false, destructiveHint: false },
   },
   {
     name: "memory_slot_replace",
@@ -929,6 +989,7 @@ export const V010_SLOTS_TOOLS: McpToolDef[] = [
       },
       required: ["label", "content"],
     },
+    annotations: { readOnlyHint: false, destructiveHint: false },
   },
   {
     name: "memory_slot_delete",
@@ -940,6 +1001,7 @@ export const V010_SLOTS_TOOLS: McpToolDef[] = [
       },
       required: ["label"],
     },
+    annotations: { readOnlyHint: false, destructiveHint: true },
   },
 ];
 

--- a/src/mcp/tools-registry.ts
+++ b/src/mcp/tools-registry.ts
@@ -869,6 +869,7 @@ export const V070_TOOLS: McpToolDef[] = [
       },
       required: ["lessonId"],
     },
+    annotations: { readOnlyHint: false, destructiveHint: true },
   },
   {
     name: "memory_obsidian_export",

--- a/test/mcp-tool-annotations.test.ts
+++ b/test/mcp-tool-annotations.test.ts
@@ -145,14 +145,17 @@ describe("MCP tool risk annotations", () => {
     expect(counts.invalid).toBe(0);
   });
 
-  it("getVisibleTools under AGENTMEMORY_TOOLS=all preserves annotations on every tool", () => {
+  it("getVisibleTools preserves annotations in every visibility mode", () => {
     const prev = process.env["AGENTMEMORY_TOOLS"];
-    process.env["AGENTMEMORY_TOOLS"] = "all";
     try {
-      const visible = getVisibleTools();
-      expect(visible.length).toBe(53);
-      for (const tool of visible) {
-        expect(tool.annotations, `tool ${tool.name} lost annotations`).toBeDefined();
+      for (const mode of ["all", "core"]) {
+        process.env["AGENTMEMORY_TOOLS"] = mode;
+        const visible = getVisibleTools();
+        if (mode === "all") expect(visible.length).toBe(53);
+        if (mode === "core") expect(visible.length).toBe(8);
+        for (const tool of visible) {
+          expect(tool.annotations, `tool ${tool.name} lost annotations in ${mode} mode`).toBeDefined();
+        }
       }
     } finally {
       if (prev === undefined) delete process.env["AGENTMEMORY_TOOLS"];

--- a/test/mcp-tool-annotations.test.ts
+++ b/test/mcp-tool-annotations.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("../src/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn().mockReturnValue(false),
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+}));
+
+vi.mock("../src/mcp/transport.js", () => ({
+  createStdioTransport: vi.fn(() => ({ start: vi.fn(), stop: vi.fn() })),
+}));
+
+vi.mock("../src/config.js", () => ({
+  getStandalonePersistPath: vi.fn(() => "/tmp/test-annotations.json"),
+}));
+
+import {
+  getAllTools,
+  getVisibleTools,
+  type McpToolDef,
+} from "../src/mcp/tools-registry.js";
+import { handleToolsList } from "../src/mcp/standalone.js";
+import {
+  resetHandleForTests,
+  setLivezProbe,
+} from "../src/mcp/rest-proxy.js";
+
+const READ_ONLY_TOOLS = new Set([
+  "memory_recall",
+  "memory_file_history",
+  "memory_patterns",
+  "memory_sessions",
+  "memory_smart_search",
+  "memory_vision_search",
+  "memory_timeline",
+  "memory_export",
+  "memory_relations",
+  "memory_commit_lookup",
+  "memory_commits",
+  "memory_graph_query",
+  "memory_team_feed",
+  "memory_audit",
+  "memory_frontier",
+  "memory_next",
+  "memory_diagnose",
+  "memory_facet_query",
+  "memory_verify",
+  "memory_lesson_recall",
+  "memory_insight_list",
+  "memory_slot_list",
+  "memory_slot_get",
+]);
+
+const DESTRUCTIVE_TOOLS = new Set([
+  "memory_governance_delete",
+  "memory_heal",
+  "memory_slot_delete",
+]);
+
+const instantLocalFallbackProbe = vi.fn(async () => ({
+  ok: false,
+  status: 0,
+  statusText: "stubbed: forced local fallback",
+}));
+
+const fetchTrap = vi.fn(async (url: unknown) => {
+  throw new Error(
+    `unexpected real fetch() in mcp-tool-annotations.test.ts: ${String(url)}`,
+  );
+});
+
+function classification(tool: McpToolDef): string {
+  const ro = tool.annotations?.readOnlyHint === true;
+  const de = tool.annotations?.destructiveHint === true;
+  if (ro && !de) return "read-only";
+  if (!ro && de) return "destructive";
+  if (!ro && !de) return "state-changing";
+  return "invalid";
+}
+
+describe("MCP tool risk annotations", () => {
+  it("every tool carries an annotations object", () => {
+    for (const tool of getAllTools()) {
+      expect(tool.annotations, `tool ${tool.name} missing annotations`).toBeDefined();
+      expect(typeof tool.annotations).toBe("object");
+    }
+  });
+
+  it("no tool is both read-only and destructive", () => {
+    for (const tool of getAllTools()) {
+      const a = tool.annotations;
+      if (a?.readOnlyHint && a?.destructiveHint) {
+        throw new Error(`tool ${tool.name} is both readOnly and destructive`);
+      }
+    }
+  });
+
+  it("read-only set is exactly 23 tools with readOnlyHint true + destructiveHint false", () => {
+    const tools = getAllTools();
+    const ro = tools.filter((t) => classification(t) === "read-only");
+    expect(new Set(ro.map((t) => t.name))).toEqual(READ_ONLY_TOOLS);
+    expect(ro.length).toBe(23);
+    for (const t of ro) {
+      expect(t.annotations?.readOnlyHint).toBe(true);
+      expect(t.annotations?.destructiveHint).toBe(false);
+    }
+  });
+
+  it("destructive set is exactly 3 tools with destructiveHint true + readOnlyHint false", () => {
+    const tools = getAllTools();
+    const de = tools.filter((t) => classification(t) === "destructive");
+    expect(new Set(de.map((t) => t.name))).toEqual(DESTRUCTIVE_TOOLS);
+    expect(de.length).toBe(3);
+    for (const t of de) {
+      expect(t.annotations?.destructiveHint).toBe(true);
+      expect(t.annotations?.readOnlyHint).toBe(false);
+    }
+  });
+
+  it("remaining 27 tools are state-changing (readOnlyHint false, destructiveHint false)", () => {
+    const tools = getAllTools();
+    const sc = tools.filter((t) => classification(t) === "state-changing");
+    expect(sc.length).toBe(27);
+    for (const t of sc) {
+      expect(t.annotations?.readOnlyHint).toBe(false);
+      expect(t.annotations?.destructiveHint).toBe(false);
+      expect(READ_ONLY_TOOLS.has(t.name)).toBe(false);
+      expect(DESTRUCTIVE_TOOLS.has(t.name)).toBe(false);
+    }
+  });
+
+  it("every tool falls into exactly one classification (23 + 3 + 27 covers total)", () => {
+    const tools = getAllTools();
+    expect(tools.length).toBe(53);
+    const counts = { "read-only": 0, destructive: 0, "state-changing": 0, invalid: 0 };
+    for (const t of tools) counts[classification(t) as keyof typeof counts]++;
+    expect(counts["read-only"]).toBe(23);
+    expect(counts.destructive).toBe(3);
+    expect(counts["state-changing"]).toBe(27);
+    expect(counts.invalid).toBe(0);
+  });
+
+  it("getVisibleTools under AGENTMEMORY_TOOLS=all preserves annotations on every tool", () => {
+    const prev = process.env["AGENTMEMORY_TOOLS"];
+    process.env["AGENTMEMORY_TOOLS"] = "all";
+    try {
+      const visible = getVisibleTools();
+      expect(visible.length).toBe(53);
+      for (const tool of visible) {
+        expect(tool.annotations, `tool ${tool.name} lost annotations`).toBeDefined();
+      }
+    } finally {
+      if (prev === undefined) delete process.env["AGENTMEMORY_TOOLS"];
+      else process.env["AGENTMEMORY_TOOLS"] = prev;
+    }
+  });
+});
+
+describe("MCP tools/list wire response carries annotations", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    instantLocalFallbackProbe.mockClear();
+    fetchTrap.mockClear();
+    resetHandleForTests();
+    setLivezProbe(instantLocalFallbackProbe);
+    (globalThis as { fetch: typeof fetch }).fetch =
+      fetchTrap as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    (globalThis as { fetch: typeof fetch }).fetch = originalFetch;
+    resetHandleForTests();
+  });
+
+  it("handleToolsList returns tools whose annotations match the registry", async () => {
+    const registry = new Map(getAllTools().map((t) => [t.name, t]));
+    const res = await handleToolsList();
+    expect(Array.isArray(res.tools)).toBe(true);
+    expect(res.tools.length).toBeGreaterThan(0);
+    for (const wire of res.tools as McpToolDef[]) {
+      const reg = registry.get(wire.name);
+      expect(reg, `wire tool ${wire.name} not in registry`).toBeDefined();
+      expect(wire.annotations).toEqual(reg?.annotations);
+    }
+  });
+});

--- a/test/mcp-tool-annotations.test.ts
+++ b/test/mcp-tool-annotations.test.ts
@@ -60,6 +60,7 @@ const READ_ONLY_TOOLS = new Set([
 const DESTRUCTIVE_TOOLS = new Set([
   "memory_governance_delete",
   "memory_heal",
+  "memory_lesson_delete",
   "memory_slot_delete",
 ]);
 
@@ -114,11 +115,11 @@ describe("MCP tool risk annotations", () => {
     }
   });
 
-  it("destructive set is exactly 3 tools with destructiveHint true + readOnlyHint false", () => {
+  it("destructive set is exactly 4 tools with destructiveHint true + readOnlyHint false", () => {
     const tools = getAllTools();
     const de = tools.filter((t) => classification(t) === "destructive");
     expect(new Set(de.map((t) => t.name))).toEqual(DESTRUCTIVE_TOOLS);
-    expect(de.length).toBe(3);
+    expect(de.length).toBe(4);
     for (const t of de) {
       expect(t.annotations?.destructiveHint).toBe(true);
       expect(t.annotations?.readOnlyHint).toBe(false);
@@ -137,13 +138,13 @@ describe("MCP tool risk annotations", () => {
     }
   });
 
-  it("every tool falls into exactly one classification (23 + 3 + 27 covers total)", () => {
+  it("every tool falls into exactly one classification (23 + 4 + 27 covers total)", () => {
     const tools = getAllTools();
     expect(tools.length).toBe(TOTAL);
     const counts = { "read-only": 0, destructive: 0, "state-changing": 0, invalid: 0 };
     for (const t of tools) counts[classification(t) as keyof typeof counts]++;
     expect(counts["read-only"]).toBe(23);
-    expect(counts.destructive).toBe(3);
+    expect(counts.destructive).toBe(4);
     expect(counts["state-changing"]).toBe(27);
     expect(counts.invalid).toBe(0);
     expect(counts["read-only"] + counts.destructive + counts["state-changing"]).toBe(TOTAL);

--- a/test/mcp-tool-annotations.test.ts
+++ b/test/mcp-tool-annotations.test.ts
@@ -22,6 +22,7 @@ vi.mock("../src/config.js", () => ({
 import {
   getAllTools,
   getVisibleTools,
+  ESSENTIAL_TOOLS,
   type McpToolDef,
 } from "../src/mcp/tools-registry.js";
 import { handleToolsList } from "../src/mcp/standalone.js";
@@ -61,6 +62,8 @@ const DESTRUCTIVE_TOOLS = new Set([
   "memory_heal",
   "memory_slot_delete",
 ]);
+
+const TOTAL = getAllTools().length;
 
 const instantLocalFallbackProbe = vi.fn(async () => ({
   ok: false,
@@ -136,13 +139,14 @@ describe("MCP tool risk annotations", () => {
 
   it("every tool falls into exactly one classification (23 + 3 + 27 covers total)", () => {
     const tools = getAllTools();
-    expect(tools.length).toBe(53);
+    expect(tools.length).toBe(TOTAL);
     const counts = { "read-only": 0, destructive: 0, "state-changing": 0, invalid: 0 };
     for (const t of tools) counts[classification(t) as keyof typeof counts]++;
     expect(counts["read-only"]).toBe(23);
     expect(counts.destructive).toBe(3);
     expect(counts["state-changing"]).toBe(27);
     expect(counts.invalid).toBe(0);
+    expect(counts["read-only"] + counts.destructive + counts["state-changing"]).toBe(TOTAL);
   });
 
   it("getVisibleTools preserves annotations in every visibility mode", () => {
@@ -151,8 +155,8 @@ describe("MCP tool risk annotations", () => {
       for (const mode of ["all", "core"]) {
         process.env["AGENTMEMORY_TOOLS"] = mode;
         const visible = getVisibleTools();
-        if (mode === "all") expect(visible.length).toBe(53);
-        if (mode === "core") expect(visible.length).toBe(8);
+        if (mode === "all") expect(visible.length).toBe(TOTAL);
+        if (mode === "core") expect(visible.length).toBe(ESSENTIAL_TOOLS.size);
         for (const tool of visible) {
           expect(tool.annotations, `tool ${tool.name} lost annotations in ${mode} mode`).toBeDefined();
         }


### PR DESCRIPTION
## What

Adds MCP-standard `annotations` (`readOnlyHint` / `destructiveHint`) to all 53 tools in `src/mcp/tools-registry.ts` so that MCP clients (notably Droid, via its Autonomy Level risk classification) can auto-run read-only agentmemory tools in low and medium autonomy modes, instead of defaulting every tool to high risk and prompting on each call.

## Why

Droid compares each MCP tool's risk level to the session's Autonomy Level and auto-runs when risk is at or below that level ([docs](https://docs.factory.ai/cli/user-guides/auto-run)).

Tools missing safety metadata are classified as `high`, so they prompt at every level below Auto (High). Today every agentmemory tool — even pure reads like `memory_recall`, `memory_sessions`, `memory_slot_list` — prompts under Auto (Low) and Auto (Medium), making low/medium autonomy unusable with agentmemory.

With per-tool annotations, the classification becomes:

<!-- obsidian -->
Risk tier | Tools | Hint
-- | -- | --
read-only (23) | search, recall, list, get, query, export, audit, etc. | { readOnlyHint: true, destructiveHint: false }
non-destructive writes (26) | save, consolidate, actions, signals, slots create/append/replace, etc. | { readOnlyHint: false, destructiveHint: false }
destructive (4) | memory_compress_file, memory_governance_delete, memory_heal, memory_slot_delete | { readOnlyHint: false, destructiveHint: true }

Behavioral matrix:

<!-- obsidian -->
Autonomy | Read-only (23) | Non-destructive writes (26) | Destructive (4)
-- | -- | -- | --
Off | prompt | prompt | prompt
Low | auto-run | prompt | prompt
Medium | auto-run | auto-run | prompt
High | auto-run | auto-run | auto-run

Auto (High) is unchanged. The change is purely additive metadata.

## How

- `src/mcp/tools-registry.ts`: extended `McpToolDef` with an optional `McpToolAnnotations` field and added `annotations` to every tool definition. (I admit I let Droid categorize each definition for me.)
- `test/mcp-tool-annotations.test.ts`: new behavior-named test asserting the 23/26/4 classification, the mutual-exclusivity of read-only/destructive hints, `getVisibleTools()` annotation preservation under `AGENTMEMORY_TOOLS=all`, and that `handleToolsList()` (standalone `tools/list` response) carries the same annotations as the registry.
- `AGENTS.md`: one-line note on the "adding/removing MCP tools" consistency checklist so future tools carry `annotations`.

The annotations propagate through the existing `tools/list` response in both transports (proxy `mcp::tools::list` returns `getVisibleTools()`; standalone `handleToolsList` returns `getAllTools()`/local fallback), so no `server.ts`, `standalone.ts`, `transport.ts`, or `src/triggers/api.ts` changes are needed.

## How to verify

- `npm install` (Node >=20), `npm run build` — compiles clean.
- `npm test` — new test passes; the only failing tests in this worktree are pre-existing and unrelated (`test/hook-project.test.ts` asserts cwd basename `agentmemory` but the worktree dir differs; `test/embedding-provider.test.ts` is env-dependent).
- Wire-shape: `node dist/standalone.mjs` in local-fallback mode, issue `tools/list`, confirm `memory_recall` reports `annotations: { readOnlyHint: true, destructiveHint: false }`.
- End-to-end (manual, in Droid): at Auto (Low) `memory_recall` auto-runs while `memory_save` / `memory_slot_delete` prompt; at Auto (Medium) read-only and non-destructive writes auto-run while destructive still prompts; at Auto (High) everything auto-runs (base case preserved).

## Before

I have some nice screenvids of the before and after, but they are too big for GitHub. :) With most recent release of agentmemory, and in a medium autonomy Droid session, I'm testing the memory_export tool call:

<img width="428" height="186" alt="image" src="https://github.com/user-attachments/assets/c61bc3a1-26f5-4c1d-bc49-3b632c504853" />

Note that Droid calls this a high impact tool.

<img width="324" height="224" alt="image" src="https://github.com/user-attachments/assets/d61897a0-f8d4-4ced-b188-3a9d3d8c04d6" />

(It does this for all of the agentmemory tools.)

## After

After running my build of agentmemory and in a low autonomy Droid session:

<img width="618" height="293" alt="image" src="https://github.com/user-attachments/assets/185b1159-289c-412e-ae41-fde6c32029c0" />

Note that Droid now classifies memory_export as `low impact`. I change autonomy to medium, which lifts the safety floor:

<img width="378" height="140" alt="image" src="https://github.com/user-attachments/assets/39a505e5-fb85-42af-8fa8-a3de7dc1e012" />

I am not prompted:

<img width="395" height="294" alt="image" src="https://github.com/user-attachments/assets/e650f3fc-6b6a-4c46-b780-eebe7bff7d57" />

Closes #1097.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added risk and behavior annotations to every MCP tool, distinguishing read-only, state-changing, and destructive actions.
  * Preserved annotations across tool visibility modes and tool-list responses.

* **Tests**
  * Added coverage verifying complete annotation coverage, accurate classifications, and consistent tool-list results.

* **Documentation**
  * Updated maintenance guidance to require appropriate annotations for every MCP tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->