### PR TITLE
fix(api): join session summaries via kv.list instead of per-session kv.get fan-out

### DIFF
--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -851,14 +851,18 @@ export function registerApiTriggers(
       const filtered = filterAgentId
         ? sessions.filter((s) => s.agentId === filterAgentId)
         : sessions;
-      const summaries = await Promise.all(
-        filtered.map((s) =>
-          kv.get<SessionSummary>(KV.summaries, s.id).catch(() => null),
+      // Fetch summaries with a single list + in-memory join. Fanning out one
+      // kv.get per session in a Promise.all deadlocks the engine channel once
+      // the session count grows into the hundreds (#1100).
+      const summariesById = new Map(
+        (await kv.list<SessionSummary>(KV.summaries).catch(() => [])).map(
+          (summary): [string, SessionSummary] => [summary.sessionId, summary],
         ),
       );
-      const withSummary = filtered.map((s, i) =>
-        summaries[i] ? { ...s, summary: summaries[i] } : s,
-      );
+      const withSummary = filtered.map((s) => {
+        const summary = summariesById.get(s.id);
+        return summary ? { ...s, summary } : s;
+      });
       return { status_code: 200, body: { sessions: withSummary } };
     },
   );


### PR DESCRIPTION
Fixes #1100

## Problem

`api::sessions` fires one `kv.get(KV.summaries, id)` per session inside a single `Promise.all`. Once the session count grows into the hundreds (615 in my store), the burst of concurrent kv calls is never serviced: the promises neither resolve nor reject (no timeout on `kv.get`, and `.catch` only handles rejections), so `GET /agentmemory/sessions` hangs permanently (HTTP 000 after 180s+) and every attempt parks its in-flight kv invocations on the worker — `active_invocations` climbs without bound (327 → 1,403 while a dashboard was polling), heap hits ~94%, health goes `degraded`. Dashboard and `agentmemory status` then show 0 sessions / 0% token savings.

Full bisection evidence is in #1100 (zero-fanout filter responds in 0.17s, list-only endpoints respond in ~50ms, only the unbounded fan-out deadlocks).

## Fix

Fetch summaries with a single `kv.list(KV.summaries)` and join in memory by `sessionId` — the same pattern `mem::diagnose` already uses. One engine roundtrip instead of N.

## Verification

- Patched the identical logic into the bundled dist of a live v0.9.28 install with 615 sessions / 9,525 observations / 114 summaries:
  - `/agentmemory/sessions`: 0.02–0.08s, HTTP 200, all 114 summaries attached (previously: permanent hang)
  - `agentmemory status`: `Sessions: 615, Observations: 9,526` (previously `Sessions: 0`)
  - `active_invocations` stable in single digits while polling the dashboard (previously leaking ~600 per request)
- `npx tsc --noEmit`: no new diagnostics in `src/triggers/api.ts` (the 4 pre-existing ones there are at lines 252/288/2454, untouched)
- `npm test`: 1,402 passed / 13 failed — the same 13 environment-dependent tests (embedding-provider key detection, auto-compress env gate, hook-project cwd basename, fs-watcher timing) fail identically on unmodified `main` in my environment; `test/mcp-standalone-proxy.test.ts`, the only suite touching `/agentmemory/sessions`, passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved session summary loading efficiency.
  * Session lists continue to include optional summaries while preserving existing filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->