### PR TITLE
fix: forward createdBy in memory_action_create MCP tool

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -678,7 +678,7 @@ export function registerMcpEndpoints(
               title: args.title,
               description: args.description,
               priority: args.priority,
-              createdBy: args.createdBy,
+              createdBy: typeof args.createdBy === "string" ? args.createdBy : undefined,
               project: args.project,
               tags,
               parentId: args.parentId,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -678,6 +678,7 @@ export function registerMcpEndpoints(
               title: args.title,
               description: args.description,
               priority: args.priority,
+              createdBy: args.createdBy,
               project: args.project,
               tags,
               parentId: args.parentId,

--- a/src/mcp/tools-registry.ts
+++ b/src/mcp/tools-registry.ts
@@ -374,6 +374,10 @@ export const V050_TOOLS: McpToolDef[] = [
           type: "number",
           description: "Priority 1-10 (10 highest)",
         },
+        createdBy: {
+          type: "string",
+          description: "Agent or user ID creating this action",
+        },
         project: { type: "string", description: "Project path" },
         tags: {
           type: "string",

--- a/test/actions.test.ts
+++ b/test/actions.test.ts
@@ -498,4 +498,33 @@ describe("memory_action_create MCP tool", () => {
 
     expect(parsed.action.createdBy).toBe("unknown");
   });
+
+  it("advertises createdBy as an optional string in the tool schema", async () => {
+    const result = (await sdk.trigger("mcp::tools::list", {
+      body: {},
+      headers: {},
+    })) as {
+      status_code: number;
+      body: {
+        tools: Array<{
+          name: string;
+          inputSchema: {
+            properties: Record<string, { type: string }>;
+            required?: string[];
+          };
+        }>;
+      };
+    };
+
+    const tool = result.body.tools.find(
+      (t) => t.name === "memory_action_create",
+    );
+
+    expect(tool).toBeDefined();
+    expect(tool!.inputSchema.properties.createdBy).toEqual({
+      type: "string",
+      description: "Agent or user ID creating this action",
+    });
+    expect(tool!.inputSchema.required).not.toContain("createdBy");
+  });
 });

--- a/test/actions.test.ts
+++ b/test/actions.test.ts
@@ -5,6 +5,7 @@ vi.mock("../src/logger.js", () => ({
 }));
 
 import { registerActionsFunction } from "../src/functions/actions.js";
+import { registerMcpEndpoints } from "../src/mcp/server.js";
 import type { Action, ActionEdge } from "../src/types.js";
 import { mockKV, mockSdk } from "./helpers/mocks.js";
 
@@ -449,5 +450,52 @@ describe("Actions Functions", () => {
       expect(result.success).toBe(false);
       expect(result.error).toContain("action not found");
     });
+  });
+});
+
+describe("memory_action_create MCP tool", () => {
+  let sdk: ReturnType<typeof mockSdk>;
+  let kv: ReturnType<typeof mockKV>;
+
+  beforeEach(() => {
+    sdk = mockSdk();
+    kv = mockKV();
+    registerActionsFunction(sdk as never, kv as never);
+    registerMcpEndpoints(sdk as never, kv as never);
+  });
+
+  it("forwards createdBy from tool arguments to the created action", async () => {
+    const result = (await sdk.trigger("mcp::tools::call", {
+      body: {
+        name: "memory_action_create",
+        arguments: { title: "Review PR", createdBy: "agent-42" },
+      },
+      headers: {},
+    })) as { status_code: number; body: { content: [{ text: string }] } };
+
+    const parsed = JSON.parse(result.body.content[0].text) as {
+      success: boolean;
+      action: Action;
+    };
+
+    expect(result.status_code).toBe(200);
+    expect(parsed.success).toBe(true);
+    expect(parsed.action.createdBy).toBe("agent-42");
+  });
+
+  it("defaults to unknown when createdBy is omitted", async () => {
+    const result = (await sdk.trigger("mcp::tools::call", {
+      body: {
+        name: "memory_action_create",
+        arguments: { title: "Review PR" },
+      },
+      headers: {},
+    })) as { status_code: number; body: { content: [{ text: string }] } };
+
+    const parsed = JSON.parse(result.body.content[0].text) as {
+      action: Action;
+    };
+
+    expect(parsed.action.createdBy).toBe("unknown");
   });
 });


### PR DESCRIPTION
## Summary

`memory_action_create`'s MCP tool handler rebuilds its payload to `mem::action-create` field by field and never reads `args.createdBy` — every action created through the MCP tool ends up with `createdBy: "unknown"`, regardless of who actually created it.

- `mem::action-create` already supports and correctly sets `createdBy` (tested at the function level in `test/actions.test.ts`).
- The REST endpoint (`api::action-create`) already works correctly too — it forwards the entire `req.body`, so `createdBy` passes straight through with no field-picking.
- The sibling multi-agent tools — `memory_lease`, `memory_frontier`, `memory_next` — all correctly read and forward `agentId`.

So this is an isolated gap in one tool's argument-forwarding, not a design or architecture issue — everything around it already handles agent attribution correctly.

## What it does

- Adds `createdBy` to `memory_action_create`'s input schema in `tools-registry.ts`.
- Forwards `args.createdBy` into the `mem::action-create` payload in `server.ts`.
- Adds test coverage at the `mcp::tools::call` layer (there was no existing test exercising this tool through the actual MCP dispatcher — the existing `actions.test.ts` coverage calls `mem::action-create` directly). Two tests: `createdBy` forwards correctly, and it still defaults to `"unknown"` when omitted (no behavior change for existing callers).

## How to verify

```bash
npm test -- test/actions.test.ts
```

I confirmed the new tests actually catch the bug by reverting the two source changes and re-running — the "forwards createdBy" test fails as expected (`received "unknown"`), everything else is unaffected.

## Note on the full suite

`npm test` currently has 7 pre-existing failures across `test/context-slots.test.ts`, `test/embedding-provider.test.ts`, and `test/fetch-timeout.test.ts` on a clean `main` checkout (confirmed by stashing this change and re-running) — they look like test-isolation leakage (a couple of `it` blocks in `fetch-timeout.test.ts` set `process.env["AGENTMEMORY_LLM_TIMEOUT_MS"]`/`OPENAI_TIMEOUT_MS"` directly with no `afterEach` cleanup in that `describe` block, and a later test in the same file asserts the *unset* default). None of this is related to the change here — flagging in case it's not already known, happy to open a separate issue for it if useful.

Fixes #1105

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional creator attribution when creating actions through the MCP tool.
  * Actions now store the provided agent/user identifier, defaulting to “unknown” when omitted.
* **Tests**
  * Added coverage to verify creator attribution forwarding, default behavior, and that the MCP tool advertises the new optional field in its input schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->