### PR TITLE
fix(openclaw): scope memory per agent and stop dropping captures

### DIFF
--- a/integrations/openclaw/plugin.mjs
+++ b/integrations/openclaw/plugin.mjs
@@ -46,8 +46,41 @@ function lastAssistantText(messages) {
     if (message.role !== "assistant") continue;
     const text = extractText(message.content);
     if (text) return text;
+    // Agents running on a Codex app-server (e.g. gpt-5.6-*) do not emit a plain
+    // assistant text block: they answer by CALLING a message-sending tool, so
+    // the user-visible reply lives in that tool call's arguments.
+    if (!Array.isArray(message.content)) continue;
+    for (const block of [...message.content].reverse()) {
+      if (!block || typeof block !== "object") continue;
+      if (block.type !== "toolCall") continue;
+      const args = block.arguments || block.input || {};
+      const candidate = args.message || args.text || args.body || args.content;
+      if (typeof candidate === "string" && candidate.trim()) return candidate.trim();
+    }
   }
   return "";
+}
+
+/**
+ * Resolve the id of the agent this turn belongs to.
+ *
+ * OpenClaw invokes plugin hooks as (event, ctx) where ctx is a
+ * PluginHookAgentContext carrying agentId/sessionKey/sessionId/workspaceDir
+ * (see openclaw src/plugins/hook-types.ts). Without this, every agent shares a
+ * single memory pool.
+ */
+function resolveAgentId(ctx, event) {
+  const context = ctx || {};
+  if (context.agentId) return String(context.agentId);
+  const sessionKey =
+    context.sessionKey ||
+    context.sessionId ||
+    (event && (event.sessionKey || event.sessionId)) ||
+    "";
+  const match = /^agent:([^:]+):/.exec(String(sessionKey));
+  if (match) return match[1];
+  if (event && event.agentId) return String(event.agentId);
+  return "main";
 }
 
 function latestUserText(messages) {
@@ -175,13 +208,16 @@ const plugin = {
       });
     }
 
-    api.on("before_agent_start", async (event) => {
+    api.on("before_agent_start", async (event, ctx) => {
       if (!cfg.enabled) return;
       const prompt = typeof event?.prompt === "string" ? event.prompt.trim() : "";
       if (!prompt) return;
+      const agentId = resolveAgentId(ctx, event);
       const result = await client.postJson("/agentmemory/smart-search", {
         query: prompt,
         limit: 5,
+        project: agentId,
+        agentId,
       });
       const block = formatResults(result?.results || []);
       if (!block) return;
@@ -190,19 +226,35 @@ const plugin = {
       };
     });
 
-    api.on("agent_end", async (event) => {
+    api.on("agent_end", async (event, ctx) => {
       if (!cfg.enabled || !event?.success || !Array.isArray(event.messages)) return;
       const userText = latestUserText(event.messages);
       const assistantText = lastAssistantText(event.messages);
       if (!userText || !assistantText) return;
+      const agentId = resolveAgentId(ctx, event);
       const sessionId =
+        ctx?.sessionId ||
+        ctx?.sessionKey ||
         event.sessionId ||
         event.sessionKey ||
         event.runId ||
         `openclaw-${Date.now()}`;
+      // Tag the session with agentId first: /agentmemory/observe does not accept
+      // an agentId itself, it inherits it from an already-existing session.
+      await client.postJson("/agentmemory/session/start", {
+        sessionId,
+        project: agentId,
+        cwd: ctx?.workspaceDir || agentId,
+        agentId,
+      });
       await client.postJson("/agentmemory/observe", {
         hookType: "post_tool_use",
         sessionId,
+        // project and cwd are required by the server; without them the request
+        // is rejected with HTTP 400 and, because fallback_on_error defaults to
+        // true, the failure is swallowed and nothing is ever captured.
+        project: agentId,
+        cwd: ctx?.workspaceDir || agentId,
         timestamp: new Date().toISOString(),
         data: {
           tool_name: "conversation",

--- a/test/openclaw-plugin.test.ts
+++ b/test/openclaw-plugin.test.ts
@@ -60,3 +60,98 @@ describe("openclaw plugin — memory capability registration (closes #286 follow
     expect(lines.join("\n")).toMatch(/memory\.internal:9999/);
   });
 });
+
+type HookHandler = (event: unknown, ctx?: unknown) => Promise<unknown>;
+
+async function registerAndCollect() {
+  const mod = await import("../integrations/openclaw/plugin.mjs");
+  const plugin = (mod as unknown as { default: { register(api: FakeApi): void } }).default;
+  const api = makeApi();
+  plugin.register(api);
+  const handlers = new Map<string, HookHandler>();
+  for (const [name, fn] of (api.on as ReturnType<typeof vi.fn>).mock.calls) {
+    handlers.set(name as string, fn as HookHandler);
+  }
+  const requests: { path: string; body: Record<string, unknown> }[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string, init: { body: string }) => {
+      requests.push({ path: new URL(url).pathname, body: JSON.parse(init.body) });
+      return { ok: true, json: async () => ({ results: [] }) };
+    }),
+  );
+  return { handlers, requests };
+}
+
+describe("openclaw plugin — per-agent memory scoping", () => {
+  it("scopes recall to the agent from the hook context", async () => {
+    const { handlers, requests } = await registerAndCollect();
+    await handlers.get("before_agent_start")?.(
+      { prompt: "what did we decide?" },
+      { agentId: "prompt-engineer", sessionKey: "agent:prompt-engineer:cli" },
+    );
+    const search = requests.find((r) => r.path === "/agentmemory/smart-search");
+    expect(search?.body.agentId).toBe("prompt-engineer");
+    expect(search?.body.project).toBe("prompt-engineer");
+  });
+
+  it("falls back to parsing sessionKey when ctx.agentId is absent", async () => {
+    const { handlers, requests } = await registerAndCollect();
+    await handlers.get("before_agent_start")?.(
+      { prompt: "hello" },
+      { sessionKey: "agent:trading-agent:telegram:direct:42" },
+    );
+    const search = requests.find((r) => r.path === "/agentmemory/smart-search");
+    expect(search?.body.agentId).toBe("trading-agent");
+  });
+
+  it("tags the session with agentId and sends the fields observe requires", async () => {
+    const { handlers, requests } = await registerAndCollect();
+    await handlers.get("agent_end")?.(
+      {
+        success: true,
+        runId: "run-1",
+        messages: [
+          { role: "user", content: "remember X" },
+          { role: "assistant", content: [{ type: "text", text: "noted" }] },
+        ],
+      },
+      { agentId: "prompt-engineer", workspaceDir: "/w/prompt-engineer" },
+    );
+    const start = requests.find((r) => r.path === "/agentmemory/session/start");
+    expect(start?.body.agentId).toBe("prompt-engineer");
+
+    const observe = requests.find((r) => r.path === "/agentmemory/observe");
+    // The server rejects observe without project/cwd, and fallback_on_error
+    // hides the 400 - so a regression here silently disables capture entirely.
+    expect(observe?.body.project).toBe("prompt-engineer");
+    expect(observe?.body.cwd).toBe("/w/prompt-engineer");
+  });
+
+  it("captures replies delivered as a tool call instead of an assistant text block", async () => {
+    const { handlers, requests } = await registerAndCollect();
+    await handlers.get("agent_end")?.(
+      {
+        success: true,
+        runId: "run-2",
+        messages: [
+          { role: "user", content: "ping" },
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "toolCall",
+                name: "message",
+                arguments: { action: "send", message: "pong" },
+              },
+            ],
+          },
+          { role: "toolResult", content: [{ type: "toolResult", content: "{\"ok\":true}" }] },
+        ],
+      },
+      { agentId: "main" },
+    );
+    const observe = requests.find((r) => r.path === "/agentmemory/observe");
+    expect((observe?.body.data as { tool_output: string }).tool_output).toBe("pong");
+  });
+});


### PR DESCRIPTION
## Summary

On a two-agent OpenClaw setup the agentmemory integration stored nothing at all, and once it did store something, every agent read and wrote the same pool. Digging into it turned up three separate causes in `integrations/openclaw/plugin.mjs`, all of which fail silently.

### 1. The agent identity is never read

OpenClaw invokes plugin hooks with **two** arguments:

```ts
agent_end: (event: PluginHookAgentEndEvent, ctx: PluginHookAgentContext) => ...
```

`PluginHookAgentContext` is where `agentId` lives, along with `sessionKey`, `sessionId` and `workspaceDir` (see `openclaw/src/plugins/hook-types.ts`). Both handlers here were declared as `(event) => ...`, so `ctx` was discarded — the event object itself carries only `{prompt, runId}` / `{messages, success, durationMs, runId}`. With no id available every turn collapsed onto the same scope.

### 2. `observe` was rejected with HTTP 400

`/agentmemory/observe` requires `project` and `cwd` as strings; the plugin sent neither. The server answered `400 hookType, sessionId, project, cwd, and timestamp are required strings`, and since `fallback_on_error` defaults to `true`, `postJson` swallowed it and returned `null`. Nothing was ever captured, and nothing was ever logged.

### 3. Replies delivered as a tool call were treated as empty

Agents running on a Codex app-server (`gpt-5.6-*`) do not emit an assistant text block — they answer by calling a message-sending tool, so the turn looks like:

```jsonc
{ "role": "assistant", "content": [
  { "type": "toolCall", "name": "message",
    "arguments": { "action": "send", "message": "<the actual reply>" } } ] }
```

`lastAssistantText()` only reads `{type:"text"}` blocks, so it returned `""` and `agent_end` hit `if (!userText || !assistantText) return;` — skipping capture entirely.

## Changes

- `resolveAgentId(ctx, event)`: prefer `ctx.agentId`, fall back to parsing `ctx.sessionKey` (`agent:<id>:...`), then `"main"`.
- Both hook handlers now accept `(event, ctx)`.
- `smart-search` sends `agentId` (and `project`) so recall is scoped to the calling agent.
- Before `observe`, the session is tagged via `/agentmemory/session/start` with `agentId` — `observe` does not accept an `agentId` itself, it inherits one from an existing session.
- `observe` now sends the required `project` and `cwd` (using `ctx.workspaceDir` when available).
- `lastAssistantText()` falls back to the last `toolCall` block's `arguments.message` / `.text` / `.body` / `.content`.

## Verification

Environment: OpenClaw `2026.7.1`, agentmemory `0.9.28`, two agents (`main`, `prompt-engineer`).

```
openclaw agent --agent prompt-engineer -m "Remember this codeword: OKAPI99..."
openclaw agent --agent main            -m "Remember this codeword: NARWHAL88..."
```

Before this change all sessions were stored as `agentId: "main"` (the second agent never appeared in the store at all), and before fixes 2 and 3 no observation was written under any id.

After:

```
sessions by agentId: { main: 20, prompt-engineer: 1 }

codeword     as prompt-engineer   as main
OKAPI99      1                    0
NARWHAL88    0                    1
```

Each agent retrieves only its own memories, and neither can see the other's.

## Tests

`test/openclaw-plugin.test.ts` gains four cases covering: scoping recall by `ctx.agentId`; falling back to `sessionKey` parsing; sending `agentId`/`project`/`cwd` on session-start and observe; and capturing a reply delivered as a tool call. Existing tests are unchanged and still pass (7/7).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory separation so each agent’s searches and conversations are stored independently.
  * Ensured assistant replies delivered through tool calls are captured correctly.
  * Improved session tracking with workspace and session details for more reliable conversation history.

* **Tests**
  * Added coverage for agent-specific memory scoping, session tracking, workspace details, and tool-call responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->