### PR TITLE
feat(providers): add Cloudflare Workers AI as an LLM and embedding provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,11 +23,27 @@
 # Without a provider key, agentmemory runs in noop mode: observations are
 # indexed via zero-LLM synthetic compression, hybrid search still works,
 # but LLM-backed summarisation / reflection / consolidation are disabled.
-# The detection order is OPENAI_API_KEY → MINIMAX_API_KEY → ANTHROPIC_API_KEY
-# → GEMINI_API_KEY → OPENROUTER_API_KEY → noop.
+# The detection order is OPENAI_API_KEY → MINIMAX_API_KEY → CLOUDFLARE_API_TOKEN
+# → ANTHROPIC_API_KEY → GEMINI_API_KEY → OPENROUTER_API_KEY → noop.
 
 # OPENAI_API_KEY=sk-...                          # Used for OpenAI-compatible embeddings today. PR #307 will extend this to chat completions (DeepSeek, SiliconFlow, vLLM, LM Studio, Ollama via `/v1`).
 # OPENAI_BASE_URL=https://api.openai.com         # Override for OpenAI-compatible providers
+
+# CLOUDFLARE_API_TOKEN=...                      # Cloudflare Workers AI API token
+# CLOUDFLARE_ACCOUNT_ID=...                      # Required when CLOUDFLARE_AI_BASE_URL is not set
+# CLOUDFLARE_MODEL=@cf/meta/llama-3.1-8b-instruct-fp8    # Default chat model
+# CLOUDFLARE_AI_BASE_URL=https://api.cloudflare.com/client/v4/accounts/<account-id>/ai/v1/chat/completions
+# CLOUDFLARE_AI_GATEWAY_ID=my-gateway            # Optional: pin a named AI Gateway.
+#                                                # The default endpoint above already routes through your
+#                                                # account's default gateway, so logging / caching / rate
+#                                                # limiting / guardrails apply with no config. Set this only
+#                                                # to target a specific gateway (sent as cf-aig-gateway-id).
+# CLOUDFLARE_TIMEOUT_MS=60000                    # Per-request timeout; falls back to AGENTMEMORY_LLM_TIMEOUT_MS
+#
+# Reasoning models (@cf/zai-org/glm-*, @cf/qwen/qwq-*, deepseek-r1) spend the
+# token budget thinking before emitting content. They need a generous MAX_TOKENS
+# (4096+) or every call fails with finish_reason=length, and they cost 10-100x
+# a small instruct model per background compression. Prefer a small model here.
 
 # ANTHROPIC_API_KEY=sk-ant-...
 # ANTHROPIC_MODEL=claude-sonnet-4-20250514       # Default Anthropic model
@@ -64,10 +80,10 @@
 #
 # Without an embedding key, agentmemory runs in BM25-only mode for hybrid
 # search. Detection order: EMBEDDING_PROVIDER override → GEMINI_API_KEY →
-# OPENAI_API_KEY → VOYAGE_API_KEY → COHERE_API_KEY → OPENROUTER_API_KEY →
-# local (Xenova/all-MiniLM-L6-v2, 384-dim).
+# OPENAI_API_KEY → CLOUDFLARE_API_TOKEN → VOYAGE_API_KEY → COHERE_API_KEY →
+# OPENROUTER_API_KEY → local (Xenova/all-MiniLM-L6-v2, 384-dim).
 
-# EMBEDDING_PROVIDER=local                       # local | openai | voyage | cohere | gemini | openrouter
+# EMBEDDING_PROVIDER=local                       # local | openai | cloudflare | voyage | cohere | gemini | openrouter
 
 # VOYAGE_API_KEY=pa-...                          # Optimised for code embeddings
 
@@ -76,6 +92,12 @@
 # Reuses OPENAI_API_KEY / OPENAI_BASE_URL above when EMBEDDING_PROVIDER=openai.
 # OPENAI_EMBEDDING_MODEL=text-embedding-3-small  # Embedding model when EMBEDDING_PROVIDER=openai
 # OPENAI_EMBEDDING_DIMENSIONS=1536               # Required when the model is not in the known-models table
+
+# CLOUDFLARE_API_TOKEN=...                       # Reused from the LLM section; set if only using Cloudflare embeddings
+# CLOUDFLARE_ACCOUNT_ID=...                      # Required when CLOUDFLARE_EMBEDDING_BASE_URL is not set
+# CLOUDFLARE_EMBEDDING_MODEL=@cf/baai/bge-base-en-v1.5
+# CLOUDFLARE_EMBEDDING_DIMENSIONS=768            # Required when the model is not in the known-models table
+# CLOUDFLARE_EMBEDDING_BASE_URL=https://api.cloudflare.com/client/v4/accounts/<account-id>/ai/v1/embeddings
 
 # OPENROUTER_EMBEDDING_MODEL=openai/text-embedding-3-small  # When EMBEDDING_PROVIDER=openrouter
 

--- a/README.md
+++ b/README.md
@@ -1385,6 +1385,8 @@ Create `~/.agentmemory/.env`:
 # MINIMAX_API_KEY=...
 # CLOUDFLARE_API_TOKEN=...            # Workers AI; also enables Cloudflare embeddings
 # CLOUDFLARE_ACCOUNT_ID=...           # Required unless CLOUDFLARE_AI_BASE_URL is set
+# CLOUDFLARE_AI_BASE_URL=...          # Override the chat endpoint
+# CLOUDFLARE_AI_GATEWAY_ID=...        # Pin a named AI Gateway (cf-aig-gateway-id)
 # OPENAI_API_KEY=***                       # NOTE: this same key auto-activates BOTH the
 #                                          # OpenAI LLM provider (here) AND the OpenAI
 #                                          # embedding provider (further below). Set
@@ -1424,6 +1426,7 @@ Create `~/.agentmemory/.env`:
 # CLOUDFLARE_ACCOUNT_ID=...
 # CLOUDFLARE_EMBEDDING_MODEL=@cf/baai/bge-base-en-v1.5
 # CLOUDFLARE_EMBEDDING_DIMENSIONS=768     # Required when the model is not in the known-models table
+# CLOUDFLARE_EMBEDDING_BASE_URL=...       # Override the embedding endpoint
 
 # Outbound LLM / embedding timeout
 # AGENTMEMORY_LLM_TIMEOUT_MS=60000       # Default: 60 000 ms (60 s). Applies to every

--- a/README.md
+++ b/README.md
@@ -1226,6 +1226,7 @@ agentmemory auto-detects from your environment. By default, no LLM calls are mad
 | Gemini | `GEMINI_API_KEY` | Also enables embeddings |
 | OpenRouter | `OPENROUTER_API_KEY` | Any model |
 | OpenAI API | `OPENAI_API_KEY` | Default `gpt-4o-mini`, override with `OPENAI_MODEL` |
+| Cloudflare Workers AI | `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` | Default `@cf/meta/llama-3.1-8b-instruct-fp8`, override with `CLOUDFLARE_MODEL`. Same token also enables Cloudflare embeddings. Requests already flow through your account's default [AI Gateway](https://developers.cloudflare.com/ai-gateway/) (logging, caching, rate limiting, guardrails); set `CLOUDFLARE_AI_GATEWAY_ID` to pin a named one. Reasoning models (`@cf/zai-org/glm-*`, `qwq`, `deepseek-r1`) need `MAX_TOKENS` ≥ 4096 and cost far more per background compression — prefer a small instruct model. |
 | **Local (Ollama / LM Studio / vLLM / llama.cpp)** | `OPENAI_API_KEY=local` + `OPENAI_BASE_URL=http://localhost:11434/v1` (Ollama) or `http://localhost:1234/v1` (LM Studio) + `OPENAI_MODEL=<your model>` | Anything OpenAI-API-compatible. Zero cost, runs on your hardware. See [Local models](#local-models-ollama--lm-studio--vllm) below. |
 | Claude subscription fallback | `AGENTMEMORY_ALLOW_AGENT_SDK=true` | Opt-in only. Spawns `@anthropic-ai/claude-agent-sdk` sessions — used to cause unbounded Stop-hook recursion so it is no longer the default. |
 
@@ -1382,6 +1383,8 @@ Create `~/.agentmemory/.env`:
 # GEMINI_API_KEY=...
 # OPENROUTER_API_KEY=...
 # MINIMAX_API_KEY=...
+# CLOUDFLARE_API_TOKEN=...            # Workers AI; also enables Cloudflare embeddings
+# CLOUDFLARE_ACCOUNT_ID=...           # Required unless CLOUDFLARE_AI_BASE_URL is set
 # OPENAI_API_KEY=***                       # NOTE: this same key auto-activates BOTH the
 #                                          # OpenAI LLM provider (here) AND the OpenAI
 #                                          # embedding provider (further below). Set
@@ -1417,6 +1420,10 @@ Create `~/.agentmemory/.env`:
 # OPENAI_BASE_URL=https://api.openai.com   # Override for Azure / vLLM / LM Studio / proxies
 # OPENAI_EMBEDDING_MODEL=text-embedding-3-small
 # OPENAI_EMBEDDING_DIMENSIONS=1536        # Required when the model is not in the known-models table
+# CLOUDFLARE_API_TOKEN=...
+# CLOUDFLARE_ACCOUNT_ID=...
+# CLOUDFLARE_EMBEDDING_MODEL=@cf/baai/bge-base-en-v1.5
+# CLOUDFLARE_EMBEDDING_DIMENSIONS=768     # Required when the model is not in the known-models table
 
 # Outbound LLM / embedding timeout
 # AGENTMEMORY_LLM_TIMEOUT_MS=60000       # Default: 60 000 ms (60 s). Applies to every

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1794,14 +1794,18 @@ async function passiveServerChecks(): Promise<DoctorCheck[]> {
     {
       name: "LLM provider",
       ok: hasLlm,
-      hint: hasLlm ? undefined : "set ANTHROPIC_API_KEY (or OPENAI/CLOUDFLARE/GEMINI/OPENROUTER/MINIMAX) in ~/.agentmemory/.env",
+      hint: hasLlm
+        ? undefined
+        : "set ANTHROPIC_API_KEY (or OPENAI/CLOUDFLARE/GEMINI/OPENROUTER/MINIMAX) in ~/.agentmemory/.env. " +
+          "Cloudflare also needs CLOUDFLARE_ACCOUNT_ID (or CLOUDFLARE_AI_BASE_URL)",
     },
     {
       name: "Embedding provider",
       ok: hasEmbed,
       hint: hasEmbed
         ? undefined
-        : "Running BM25-only. Add OPENAI_API_KEY / CLOUDFLARE_API_TOKEN / VOYAGE_API_KEY / COHERE_API_KEY / OLLAMA_HOST",
+        : "Running BM25-only. Add OPENAI_API_KEY / CLOUDFLARE_API_TOKEN (plus CLOUDFLARE_ACCOUNT_ID) / " +
+          "VOYAGE_API_KEY / COHERE_API_KEY / OLLAMA_HOST",
     },
   );
 
@@ -2229,7 +2233,7 @@ async function runInit() {
       "All keys are commented out by default. Uncomment the ones you want.",
       "",
       "Common next steps:",
-      "  1. Pick an LLM provider key (ANTHROPIC_API_KEY / OPENAI_API_KEY / CLOUDFLARE_API_TOKEN / GEMINI_API_KEY / etc.)",
+      "  1. Pick an LLM provider key (ANTHROPIC_API_KEY / OPENAI_API_KEY / CLOUDFLARE_API_TOKEN + CLOUDFLARE_ACCOUNT_ID / GEMINI_API_KEY / etc.)",
       "  2. Run `npx @agentmemory/agentmemory doctor` to verify the daemon sees them",
       "  3. Run `npx @agentmemory/agentmemory` to start the worker",
     ].join("\n"),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1794,14 +1794,14 @@ async function passiveServerChecks(): Promise<DoctorCheck[]> {
     {
       name: "LLM provider",
       ok: hasLlm,
-      hint: hasLlm ? undefined : "set ANTHROPIC_API_KEY (or GEMINI/OPENROUTER/MINIMAX) in ~/.agentmemory/.env",
+      hint: hasLlm ? undefined : "set ANTHROPIC_API_KEY (or OPENAI/CLOUDFLARE/GEMINI/OPENROUTER/MINIMAX) in ~/.agentmemory/.env",
     },
     {
       name: "Embedding provider",
       ok: hasEmbed,
       hint: hasEmbed
         ? undefined
-        : "Running BM25-only. Add OPENAI_API_KEY / VOYAGE_API_KEY / COHERE_API_KEY / OLLAMA_HOST",
+        : "Running BM25-only. Add OPENAI_API_KEY / CLOUDFLARE_API_TOKEN / VOYAGE_API_KEY / COHERE_API_KEY / OLLAMA_HOST",
     },
   );
 
@@ -2229,7 +2229,7 @@ async function runInit() {
       "All keys are commented out by default. Uncomment the ones you want.",
       "",
       "Common next steps:",
-      "  1. Pick an LLM provider key (ANTHROPIC_API_KEY / OPENAI_API_KEY / GEMINI_API_KEY / etc.)",
+      "  1. Pick an LLM provider key (ANTHROPIC_API_KEY / OPENAI_API_KEY / CLOUDFLARE_API_TOKEN / GEMINI_API_KEY / etc.)",
       "  2. Run `npx @agentmemory/agentmemory doctor` to verify the daemon sees them",
       "  3. Run `npx @agentmemory/agentmemory` to start the worker",
     ].join("\n"),

--- a/src/cli/doctor-diagnostics.ts
+++ b/src/cli/doctor-diagnostics.ts
@@ -89,6 +89,7 @@ const PLACEHOLDER_VALUES = new Set([
 const PROVIDER_KEY_NAMES = [
   "ANTHROPIC_API_KEY",
   "OPENAI_API_KEY",
+  "CLOUDFLARE_API_TOKEN",
   "GEMINI_API_KEY",
   "GOOGLE_API_KEY",
   "OPENROUTER_API_KEY",
@@ -197,7 +198,7 @@ export function buildDiagnostics(effects: DoctorEffects): Diagnostic[] {
       message: "No LLM provider API key found in ~/.agentmemory/.env.",
       fixPreview: "Open ~/.agentmemory/.env in $EDITOR and paste your key, then re-check.",
       moreInfo:
-        "Set at least one of: ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY, " +
+        "Set at least one of: ANTHROPIC_API_KEY, OPENAI_API_KEY, CLOUDFLARE_API_TOKEN, GEMINI_API_KEY, " +
         "OPENROUTER_API_KEY, MINIMAX_API_KEY. The daemon picks the first that resolves " +
         "to a real (non-placeholder) value at startup.",
       check: async () => {

--- a/src/cli/doctor-diagnostics.ts
+++ b/src/cli/doctor-diagnostics.ts
@@ -200,7 +200,8 @@ export function buildDiagnostics(effects: DoctorEffects): Diagnostic[] {
       moreInfo:
         "Set at least one of: ANTHROPIC_API_KEY, OPENAI_API_KEY, CLOUDFLARE_API_TOKEN, GEMINI_API_KEY, " +
         "OPENROUTER_API_KEY, MINIMAX_API_KEY. The daemon picks the first that resolves " +
-        "to a real (non-placeholder) value at startup.",
+        "to a real (non-placeholder) value at startup. CLOUDFLARE_API_TOKEN additionally " +
+        "requires CLOUDFLARE_ACCOUNT_ID unless a Cloudflare base URL is set.",
       check: async () => {
         if (!effects.envFileExists()) {
           return { ok: false, detail: "env file missing (run env-missing fix first)" };

--- a/src/cli/onboarding.ts
+++ b/src/cli/onboarding.ts
@@ -51,6 +51,7 @@ const AGENT_GLYPH: Record<string, string> = {
 const PROVIDERS: { value: string; label: string; envKey: string | null }[] = [
   { value: "anthropic", label: "Anthropic — claude", envKey: "ANTHROPIC_API_KEY" },
   { value: "openai", label: "OpenAI — gpt", envKey: "OPENAI_API_KEY" },
+  { value: "cloudflare", label: "Cloudflare Workers AI — @cf/*", envKey: "CLOUDFLARE_API_TOKEN" },
   { value: "gemini", label: "Google — gemini", envKey: "GEMINI_API_KEY" },
   { value: "openrouter", label: "OpenRouter — multi-model", envKey: "OPENROUTER_API_KEY" },
   { value: "minimax", label: "MiniMax — minimax-m1", envKey: "MINIMAX_API_KEY" },
@@ -60,6 +61,7 @@ const PROVIDERS: { value: string; label: string; envKey: string | null }[] = [
 const PROVIDER_COST_HINTS: Record<string, string> = {
   anthropic: "rough cost: a fast Haiku-class model keeps compress/consolidate at fractions of a cent per session.",
   openai: "rough cost: a mini-class model keeps compress/consolidate at fractions of a cent per session.",
+  cloudflare: "rough cost: scales with the chosen @cf model's per-token price on Cloudflare Workers AI.",
   gemini: "rough cost: a Flash-class model keeps compress/consolidate at fractions of a cent per session.",
   openrouter: "rough cost: pick a small model; spend tracks your chosen model's per-token price.",
   minimax: "rough cost: scales with the MiniMax model price per token.",

--- a/src/config.ts
+++ b/src/config.ts
@@ -105,6 +105,18 @@ function detectProvider(env: Record<string, string>): ProviderConfig {
     };
   }
 
+  if (hasRealValue(env["CLOUDFLARE_API_TOKEN"])) {
+    return {
+      provider: "cloudflare",
+      // Literal rather than CLOUDFLARE_DEFAULT_CHAT_MODEL: providers/ imports
+      // config.ts, so importing back would cycle. Same trade-off every other
+      // provider default in this function makes.
+      model: env["CLOUDFLARE_MODEL"] || "@cf/meta/llama-3.1-8b-instruct-fp8",
+      maxTokens,
+      baseURL: env["CLOUDFLARE_AI_BASE_URL"],
+    };
+  }
+
   if (hasRealValue(env["ANTHROPIC_API_KEY"])) {
     return {
       provider: "anthropic",
@@ -162,7 +174,7 @@ function detectProvider(env: Record<string, string>): ProviderConfig {
     process.stderr.write(
       pc.dim(
         "[agentmemory] No LLM provider key set — running zero-LLM (BM25 + on-device embeddings). " +
-          "Set ANTHROPIC_API_KEY (or GEMINI/OPENAI/OPENROUTER/MINIMAX) in ~/.agentmemory/.env for LLM compression and summaries. " +
+          "Set ANTHROPIC_API_KEY (or OPENAI/CLOUDFLARE/GEMINI/OPENROUTER/MINIMAX) in ~/.agentmemory/.env for LLM compression and summaries. " +
           "Agent-SDK fallback stays off by default to avoid a Stop-hook recursion loop; opt in with AGENTMEMORY_AUTO_COMPRESS=true + AGENTMEMORY_ALLOW_AGENT_SDK=true.\n",
       ),
     );
@@ -236,6 +248,7 @@ export function detectLlmProviderKind(): "llm" | "noop" {
   const env = getMergedEnv();
   if (
     hasRealValue(env["ANTHROPIC_API_KEY"]) ||
+    hasRealValue(env["CLOUDFLARE_API_TOKEN"]) ||
     hasRealValue(env["GEMINI_API_KEY"]) ||
     hasRealValue(env["GOOGLE_API_KEY"]) ||
     hasRealValue(env["OPENROUTER_API_KEY"]) ||
@@ -272,6 +285,7 @@ export function detectEmbeddingProvider(
 
   if (source["GEMINI_API_KEY"]) return "gemini";
   if (source["OPENAI_API_KEY"]) return "openai";
+  if (source["CLOUDFLARE_API_TOKEN"]) return "cloudflare";
   if (source["VOYAGE_API_KEY"]) return "voyage";
   if (source["COHERE_API_KEY"]) return "cohere";
   if (source["OPENROUTER_API_KEY"]) return "openrouter";
@@ -483,6 +497,7 @@ const VALID_PROVIDERS = new Set([
   "agent-sdk",
   "minimax",
   "openai",
+  "cloudflare",
 ]);
 
 export function loadFallbackConfig(): FallbackConfig {

--- a/src/functions/consolidation-pipeline.ts
+++ b/src/functions/consolidation-pipeline.ts
@@ -50,7 +50,7 @@ export function registerConsolidationPipelineFunction(
   sdk.registerFunction("mem::consolidate-pipeline", 
     async (data?: { tier?: string; force?: boolean; project?: string }) => {
       if (!data?.force && !isConsolidationEnabled()) {
-        return { success: false, skipped: true, reason: "Consolidation disabled: set CONSOLIDATION_ENABLED=true or configure an LLM provider (ANTHROPIC_API_KEY / OPENAI_API_KEY / OPENROUTER_API_KEY / GEMINI_API_KEY / GOOGLE_API_KEY / MINIMAX_API_KEY / OPENAI_BASE_URL / AGENTMEMORY_PROVIDER=agent-sdk)" };
+        return { success: false, skipped: true, reason: "Consolidation disabled: set CONSOLIDATION_ENABLED=true or configure an LLM provider (ANTHROPIC_API_KEY / OPENAI_API_KEY / CLOUDFLARE_API_TOKEN / OPENROUTER_API_KEY / GEMINI_API_KEY / GOOGLE_API_KEY / MINIMAX_API_KEY / OPENAI_BASE_URL / AGENTMEMORY_PROVIDER=agent-sdk)" };
       }
       const tier = data?.tier || "all";
       const decayDays = getConsolidationDecayDays();

--- a/src/functions/summarize.ts
+++ b/src/functions/summarize.ts
@@ -268,7 +268,7 @@ export function registerSummarizeFunction(
           success: false,
           error: "no_provider",
           reason:
-            "No LLM provider key set; Summarize is a no-op. Set ANTHROPIC_API_KEY (or GEMINI/OPENROUTER/MINIMAX) in ~/.agentmemory/.env to enable.",
+            "No LLM provider key set; Summarize is a no-op. Set ANTHROPIC_API_KEY (or OPENAI/CLOUDFLARE/GEMINI/OPENROUTER/MINIMAX) in ~/.agentmemory/.env to enable.",
         };
       }
 

--- a/src/providers/_cloudflare-shared.ts
+++ b/src/providers/_cloudflare-shared.ts
@@ -41,6 +41,21 @@ export function resolveGatewayId(): string | undefined {
 }
 
 /**
+ * Strict positive-integer parse: the whole string must be digits.
+ *
+ * parseInt() would accept "1024abc" as 1024 and "10.5" as 10. For a dimension
+ * count that silently produces vectors withDimensionGuard rejects on every
+ * embed, so a typo has to fail at parse time, not at first use.
+ */
+export function parsePositiveInt(raw: string | undefined): number | undefined {
+  if (!raw) return undefined;
+  const trimmed = raw.trim();
+  if (!/^\d+$/.test(trimmed)) return undefined;
+  const n = Number(trimmed);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
+}
+
+/**
  * Auth + content headers, plus AI Gateway selection.
  *
  * The default endpoint already routes through the account's default gateway,

--- a/src/providers/_cloudflare-shared.ts
+++ b/src/providers/_cloudflare-shared.ts
@@ -1,0 +1,59 @@
+// Shared transport for the Cloudflare Workers AI LLM + embedding providers.
+// Both surfaces speak the OpenAI-compatible wire shape on the same host and
+// differ only in the trailing route, so endpoint construction, auth headers
+// and AI Gateway selection live here rather than being mirrored in two files.
+// Mirrors the _openai-shared.ts split.
+
+import { getEnvVar } from "../config.js";
+
+const ACCOUNTS_BASE = "https://api.cloudflare.com/client/v4/accounts";
+
+export const CLOUDFLARE_DEFAULT_CHAT_MODEL = "@cf/meta/llama-3.1-8b-instruct-fp8";
+export const CLOUDFLARE_DEFAULT_EMBEDDING_MODEL = "@cf/baai/bge-base-en-v1.5";
+
+/**
+ * Resolve a Workers AI endpoint: the operator's full-URL override if set,
+ * otherwise the account-scoped default.
+ *
+ * `overrideVar` is threaded through so the error names the knob that surface
+ * actually reads (CLOUDFLARE_AI_BASE_URL vs CLOUDFLARE_EMBEDDING_BASE_URL)
+ * instead of a generic one the operator may not have.
+ */
+export function resolveEndpoint(
+  route: "chat/completions" | "embeddings",
+  overrideVar: string,
+  surface: string,
+): string {
+  const override = getEnvVar(overrideVar);
+  if (override) return override;
+
+  const accountId = getEnvVar("CLOUDFLARE_ACCOUNT_ID");
+  if (!accountId) {
+    throw new Error(
+      `CLOUDFLARE_ACCOUNT_ID or ${overrideVar} is required for the cloudflare ${surface} provider`,
+    );
+  }
+  return `${ACCOUNTS_BASE}/${accountId}/ai/v1/${route}`;
+}
+
+export function resolveGatewayId(): string | undefined {
+  return getEnvVar("CLOUDFLARE_AI_GATEWAY_ID") || undefined;
+}
+
+/**
+ * Auth + content headers, plus AI Gateway selection.
+ *
+ * The default endpoint already routes through the account's default gateway,
+ * so logging/caching/rate limiting apply with no config. Cloudflare pins a
+ * *named* gateway by the cf-aig-gateway-id header, not by a different URL.
+ */
+export function buildHeaders(
+  apiKey: string,
+  gatewayId?: string,
+): Record<string, string> {
+  return {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${apiKey}`,
+    ...(gatewayId ? { "cf-aig-gateway-id": gatewayId } : {}),
+  };
+}

--- a/src/providers/cloudflare.ts
+++ b/src/providers/cloudflare.ts
@@ -1,0 +1,131 @@
+import type { MemoryProvider } from "../types.js";
+import { getEnvVar } from "../config.js";
+import { fetchWithTimeout } from "./_fetch.js";
+import {
+  CLOUDFLARE_DEFAULT_CHAT_MODEL,
+  buildHeaders,
+  resolveEndpoint,
+  resolveGatewayId,
+} from "./_cloudflare-shared.js";
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+/**
+ * Cloudflare Workers AI chat-completion provider.
+ *
+ * Talks to the OpenAI-compatible `/ai/v1/chat/completions` endpoint.
+ *
+ * Required env vars:
+ *   CLOUDFLARE_API_TOKEN  — Workers AI API token
+ *   CLOUDFLARE_ACCOUNT_ID — used to build the endpoint URL; not needed when
+ *                           CLOUDFLARE_AI_BASE_URL is set
+ *
+ * Optional:
+ *   CLOUDFLARE_MODEL          — chat model (default: CLOUDFLARE_DEFAULT_CHAT_MODEL)
+ *   CLOUDFLARE_AI_BASE_URL    — full chat endpoint override
+ *   CLOUDFLARE_AI_GATEWAY_ID  — route through a named AI Gateway (see below)
+ *   CLOUDFLARE_TIMEOUT_MS     — per-request timeout; falls back to
+ *                               AGENTMEMORY_LLM_TIMEOUT_MS, then 60s
+ *
+ * AI Gateway: the default endpoint already flows through the account's default
+ * gateway, so logging, caching, rate limiting and guardrails apply without any
+ * configuration. CLOUDFLARE_AI_GATEWAY_ID pins a specific gateway instead —
+ * Cloudflare selects it by the cf-aig-gateway-id header, not by a different URL.
+ */
+export class CloudflareProvider implements MemoryProvider {
+  name = "cloudflare";
+  private apiKey: string;
+  private model: string;
+  private maxTokens: number;
+  private baseUrl: string;
+  private timeoutMs: number;
+  private gatewayId: string | undefined;
+
+  constructor(apiKey: string, model: string, maxTokens: number, baseURL?: string) {
+    this.apiKey = apiKey;
+    this.model = model || CLOUDFLARE_DEFAULT_CHAT_MODEL;
+    this.maxTokens = maxTokens;
+    this.baseUrl =
+      baseURL || resolveEndpoint("chat/completions", "CLOUDFLARE_AI_BASE_URL", "chat");
+    this.timeoutMs = resolveTimeout();
+    this.gatewayId = resolveGatewayId();
+  }
+
+  async compress(systemPrompt: string, userPrompt: string): Promise<string> {
+    return this.call(systemPrompt, userPrompt);
+  }
+
+  async summarize(systemPrompt: string, userPrompt: string): Promise<string> {
+    return this.call(systemPrompt, userPrompt);
+  }
+
+  private async call(systemPrompt: string, userPrompt: string): Promise<string> {
+    const response = await fetchWithTimeout(
+      this.baseUrl,
+      {
+        method: "POST",
+        headers: buildHeaders(this.apiKey, this.gatewayId),
+        body: JSON.stringify({
+          model: this.model,
+          // Workers AI accepts max_tokens across its catalogue; newer
+          // OpenAI-compatible shims read max_completion_tokens instead and
+          // ignore unknown keys, so sending both keeps every @cf model bounded.
+          max_tokens: this.maxTokens,
+          max_completion_tokens: this.maxTokens,
+          messages: [
+            { role: "system", content: systemPrompt },
+            { role: "user", content: userPrompt },
+          ],
+        }),
+      },
+      this.timeoutMs,
+    );
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Cloudflare API error (${response.status}): ${text}`);
+    }
+
+    const data = (await response.json()) as {
+      choices?: Array<{
+        finish_reason?: string | null;
+        message?: { content?: string | null };
+        text?: string | null;
+      }>;
+    };
+    const choice = data.choices?.[0];
+    // Deliberately no `reasoning` fallback. Reasoning models (@cf/zai-org/glm-*,
+    // qwq, deepseek-r1) return content:null plus a populated `reasoning` field
+    // when the token budget is spent thinking. Treating that chain-of-thought as
+    // the answer writes model scratchpad into memory and feeds it to the XML
+    // parsers in summarize.ts, which is worse than failing loudly.
+    const content = choice?.message?.content ?? choice?.text;
+    if (!content || !content.trim()) {
+      if (choice?.finish_reason === "length") {
+        throw new Error(
+          `Cloudflare model ${this.model} hit the token limit before emitting content ` +
+            `(finish_reason=length). Reasoning models need a larger MAX_TOKENS, ` +
+            `currently ${this.maxTokens}.`,
+        );
+      }
+      throw new Error(
+        `Cloudflare returned unexpected response: ${JSON.stringify(data).slice(0, 200)}`,
+      );
+    }
+    return content;
+  }
+}
+
+function resolveTimeout(): number {
+  const raw = getEnvVar("CLOUDFLARE_TIMEOUT_MS") || getEnvVar("AGENTMEMORY_LLM_TIMEOUT_MS");
+  const parsed = parsePositiveInt(raw);
+  return parsed ?? DEFAULT_TIMEOUT_MS;
+}
+
+function parsePositiveInt(raw: string | undefined): number | undefined {
+  if (!raw) return undefined;
+  const trimmed = raw.trim();
+  if (!/^\d+$/.test(trimmed)) return undefined;
+  const n = Number(trimmed);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
+}

--- a/src/providers/cloudflare.ts
+++ b/src/providers/cloudflare.ts
@@ -4,6 +4,7 @@ import { fetchWithTimeout } from "./_fetch.js";
 import {
   CLOUDFLARE_DEFAULT_CHAT_MODEL,
   buildHeaders,
+  parsePositiveInt,
   resolveEndpoint,
   resolveGatewayId,
 } from "./_cloudflare-shared.js";
@@ -120,12 +121,4 @@ function resolveTimeout(): number {
   const raw = getEnvVar("CLOUDFLARE_TIMEOUT_MS") || getEnvVar("AGENTMEMORY_LLM_TIMEOUT_MS");
   const parsed = parsePositiveInt(raw);
   return parsed ?? DEFAULT_TIMEOUT_MS;
-}
-
-function parsePositiveInt(raw: string | undefined): number | undefined {
-  if (!raw) return undefined;
-  const trimmed = raw.trim();
-  if (!/^\d+$/.test(trimmed)) return undefined;
-  const n = Number(trimmed);
-  return Number.isFinite(n) && n > 0 ? n : undefined;
 }

--- a/src/providers/embedding/cloudflare.ts
+++ b/src/providers/embedding/cloudflare.ts
@@ -4,15 +4,18 @@ import { fetchWithTimeout } from "../_fetch.js";
 import {
   CLOUDFLARE_DEFAULT_EMBEDDING_MODEL,
   buildHeaders,
+  parsePositiveInt,
   resolveEndpoint,
   resolveGatewayId,
 } from "../_cloudflare-shared.js";
 
 /**
  * Known Workers AI embedding model dimensions. Extend as new models ship.
- * Override in any case via CLOUDFLARE_EMBEDDING_DIMENSIONS — a wrong value
- * here makes withDimensionGuard throw on every embed call, so an unknown
- * model falling back to the default size is a hard failure, not a silent one.
+ *
+ * A model absent from this table reports DEFAULT_DIMENSIONS rather than
+ * throwing; if that guess is wrong, withDimensionGuard rejects the first embed
+ * with the real size in the message. Set CLOUDFLARE_EMBEDDING_DIMENSIONS to
+ * skip that round trip.
  */
 const MODEL_DIMENSIONS: Record<string, number> = {
   "@cf/baai/bge-small-en-v1.5": 384,
@@ -27,8 +30,8 @@ const DEFAULT_DIMENSIONS = MODEL_DIMENSIONS[CLOUDFLARE_DEFAULT_EMBEDDING_MODEL] 
 
 function resolveDimensions(model: string, override: string | undefined): number {
   if (override !== undefined && override.trim().length > 0) {
-    const parsed = parseInt(override, 10);
-    if (!Number.isFinite(parsed) || parsed <= 0) {
+    const parsed = parsePositiveInt(override);
+    if (parsed === undefined) {
       throw new Error(
         `CLOUDFLARE_EMBEDDING_DIMENSIONS must be a positive integer, got: ${override}`,
       );
@@ -53,8 +56,10 @@ function resolveDimensions(model: string, override: string | undefined): number 
  * Optional:
  *   CLOUDFLARE_EMBEDDING_MODEL      — model name (default:
  *                                     CLOUDFLARE_DEFAULT_EMBEDDING_MODEL)
- *   CLOUDFLARE_EMBEDDING_DIMENSIONS — override reported dimensions (required for
- *                                     models not in the MODEL_DIMENSIONS table above)
+ *   CLOUDFLARE_EMBEDDING_DIMENSIONS — override reported dimensions; set it for
+ *                                     models absent from the MODEL_DIMENSIONS
+ *                                     table above, which otherwise report the
+ *                                     default size
  *   CLOUDFLARE_EMBEDDING_BASE_URL   — full embedding endpoint override
  *   CLOUDFLARE_AI_GATEWAY_ID        — route through a named AI Gateway; shared
  *                                     with the chat provider, selected by the

--- a/src/providers/embedding/cloudflare.ts
+++ b/src/providers/embedding/cloudflare.ts
@@ -1,0 +1,116 @@
+import type { EmbeddingProvider } from "../../types.js";
+import { getEnvVar } from "../../config.js";
+import { fetchWithTimeout } from "../_fetch.js";
+import {
+  CLOUDFLARE_DEFAULT_EMBEDDING_MODEL,
+  buildHeaders,
+  resolveEndpoint,
+  resolveGatewayId,
+} from "../_cloudflare-shared.js";
+
+/**
+ * Known Workers AI embedding model dimensions. Extend as new models ship.
+ * Override in any case via CLOUDFLARE_EMBEDDING_DIMENSIONS — a wrong value
+ * here makes withDimensionGuard throw on every embed call, so an unknown
+ * model falling back to the default size is a hard failure, not a silent one.
+ */
+const MODEL_DIMENSIONS: Record<string, number> = {
+  "@cf/baai/bge-small-en-v1.5": 384,
+  "@cf/baai/bge-base-en-v1.5": 768,
+  "@cf/baai/bge-large-en-v1.5": 1024,
+  "@cf/baai/bge-m3": 1024,
+  "@cf/qwen/qwen3-embedding-0.6b": 1024,
+  "@cf/google/embeddinggemma-300m": 768,
+};
+
+const DEFAULT_DIMENSIONS = MODEL_DIMENSIONS[CLOUDFLARE_DEFAULT_EMBEDDING_MODEL] ?? 768;
+
+function resolveDimensions(model: string, override: string | undefined): number {
+  if (override !== undefined && override.trim().length > 0) {
+    const parsed = parseInt(override, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      throw new Error(
+        `CLOUDFLARE_EMBEDDING_DIMENSIONS must be a positive integer, got: ${override}`,
+      );
+    }
+    return parsed;
+  }
+  return MODEL_DIMENSIONS[model] ?? DEFAULT_DIMENSIONS;
+}
+
+/**
+ * Cloudflare Workers AI embedding provider.
+ *
+ * Talks to the OpenAI-compatible `/ai/v1/embeddings` endpoint, so the request
+ * and response shapes match `OpenAIEmbeddingProvider`.
+ *
+ * Required env vars:
+ *   CLOUDFLARE_API_TOKEN            — Workers AI API token
+ *   CLOUDFLARE_ACCOUNT_ID           — used to build the endpoint URL; not
+ *                                     needed when CLOUDFLARE_EMBEDDING_BASE_URL
+ *                                     is set
+ *
+ * Optional:
+ *   CLOUDFLARE_EMBEDDING_MODEL      — model name (default:
+ *                                     CLOUDFLARE_DEFAULT_EMBEDDING_MODEL)
+ *   CLOUDFLARE_EMBEDDING_DIMENSIONS — override reported dimensions (required for
+ *                                     models not in the MODEL_DIMENSIONS table above)
+ *   CLOUDFLARE_EMBEDDING_BASE_URL   — full embedding endpoint override
+ *   CLOUDFLARE_AI_GATEWAY_ID        — route through a named AI Gateway; shared
+ *                                     with the chat provider, selected by the
+ *                                     cf-aig-gateway-id header
+ */
+export class CloudflareEmbeddingProvider implements EmbeddingProvider {
+  readonly name = "cloudflare";
+  readonly dimensions: number;
+  private apiKey: string;
+  private model: string;
+  private baseUrl: string;
+  private gatewayId: string | undefined;
+
+  constructor(apiKey?: string) {
+    this.apiKey = apiKey || getEnvVar("CLOUDFLARE_API_TOKEN") || "";
+    if (!this.apiKey) {
+      throw new Error("CLOUDFLARE_API_TOKEN is required");
+    }
+    this.model =
+      getEnvVar("CLOUDFLARE_EMBEDDING_MODEL") || CLOUDFLARE_DEFAULT_EMBEDDING_MODEL;
+    this.dimensions = resolveDimensions(
+      this.model,
+      getEnvVar("CLOUDFLARE_EMBEDDING_DIMENSIONS"),
+    );
+    this.baseUrl = resolveEndpoint(
+      "embeddings",
+      "CLOUDFLARE_EMBEDDING_BASE_URL",
+      "embedding",
+    );
+    this.gatewayId = resolveGatewayId();
+  }
+
+  async embed(text: string): Promise<Float32Array> {
+    const [result] = await this.embedBatch([text]);
+    return result;
+  }
+
+  async embedBatch(texts: string[]): Promise<Float32Array[]> {
+    const response = await fetchWithTimeout(this.baseUrl, {
+      method: "POST",
+      headers: buildHeaders(this.apiKey, this.gatewayId),
+      body: JSON.stringify({
+        model: this.model,
+        input: texts,
+      }),
+    });
+
+    if (!response.ok) {
+      const err = await response.text();
+      throw new Error(`Cloudflare embedding failed (${response.status}): ${err}`);
+    }
+
+    const data = (await response.json()) as {
+      data: Array<{ embedding: number[] }>;
+    };
+
+    return data.data.map((d) => new Float32Array(d.embedding));
+  }
+}

--- a/src/providers/embedding/index.ts
+++ b/src/providers/embedding/index.ts
@@ -7,6 +7,7 @@ import { CohereEmbeddingProvider } from "./cohere.js";
 import { OpenRouterEmbeddingProvider } from "./openrouter.js";
 import { LocalEmbeddingProvider } from "./local.js";
 import { ClipEmbeddingProvider } from "./clip.js";
+import { CloudflareEmbeddingProvider } from "./cloudflare.js";
 
 export {
   GeminiEmbeddingProvider,
@@ -16,6 +17,7 @@ export {
   OpenRouterEmbeddingProvider,
   LocalEmbeddingProvider,
   ClipEmbeddingProvider,
+  CloudflareEmbeddingProvider,
 };
 
 let imageEmbeddingProvider: EmbeddingProvider | null = null;
@@ -36,6 +38,8 @@ export function createEmbeddingProvider(): EmbeddingProvider | null {
       return withDimensionGuard(new GeminiEmbeddingProvider(getEnvVar("GEMINI_API_KEY")!));
     case "openai":
       return withDimensionGuard(new OpenAIEmbeddingProvider(getEnvVar("OPENAI_API_KEY")!));
+    case "cloudflare":
+      return withDimensionGuard(new CloudflareEmbeddingProvider(getEnvVar("CLOUDFLARE_API_TOKEN")!));
     case "voyage":
       return withDimensionGuard(new VoyageEmbeddingProvider(getEnvVar("VOYAGE_API_KEY")!));
     case "cohere":

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -5,6 +5,8 @@ import type {
 } from "../types.js";
 import { AgentSDKProvider } from "./agent-sdk.js";
 import { AnthropicProvider } from "./anthropic.js";
+import { CloudflareProvider } from "./cloudflare.js";
+import { CLOUDFLARE_DEFAULT_CHAT_MODEL } from "./_cloudflare-shared.js";
 import { MinimaxProvider } from "./minimax.js";
 import { NoopProvider } from "./noop.js";
 import { OpenAIProvider } from "./openai.js";
@@ -36,6 +38,8 @@ function defaultModelFor(providerType: ProviderConfig["provider"]): string {
   switch (providerType) {
     case "openai":
       return getEnvVar("OPENAI_MODEL") || "gpt-4o-mini";
+    case "cloudflare":
+      return getEnvVar("CLOUDFLARE_MODEL") || CLOUDFLARE_DEFAULT_CHAT_MODEL;
     case "anthropic":
       return getEnvVar("ANTHROPIC_MODEL") || "claude-sonnet-4-20250514";
     case "gemini":
@@ -99,6 +103,13 @@ function createBaseProvider(config: ProviderConfig): MemoryProvider {
         requireEnvVar("MINIMAX_API_KEY"),
         config.model,
         config.maxTokens,
+      );
+    case "cloudflare":
+      return new CloudflareProvider(
+        requireEnvVar("CLOUDFLARE_API_TOKEN"),
+        config.model,
+        config.maxTokens,
+        config.baseURL,
       );
     case "anthropic":
       return new AnthropicProvider(

--- a/src/types.ts
+++ b/src/types.ts
@@ -147,7 +147,7 @@ export interface ProviderConfig {
   baseURL?: string;
 }
 
-export type ProviderType = "agent-sdk" | "anthropic" | "gemini" | "openrouter" | "minimax" | "openai" | "noop";
+export type ProviderType = "agent-sdk" | "anthropic" | "cloudflare" | "gemini" | "openrouter" | "minimax" | "openai" | "noop";
 
 export interface MemoryProvider {
   name: string;

--- a/src/viewer/index.html
+++ b/src/viewer/index.html
@@ -3749,7 +3749,7 @@
           icon: '&#9888;',
           title: f.label,
           keyLabel: f.key,
-          desc: f.description + (f.needsLlm ? ' Requires an LLM provider key (ANTHROPIC_API_KEY, GEMINI_API_KEY, etc.).' : ''),
+          desc: f.description + (f.needsLlm ? ' Requires an LLM provider key (ANTHROPIC_API_KEY, OPENAI_API_KEY, CLOUDFLARE_API_TOKEN, etc.).' : ''),
           enable: f.enableHow,
           docs: f.docsHref,
           dismissKey: f.key,
@@ -3762,7 +3762,7 @@
           title: 'No LLM provider key set',
           keyLabel: 'ANTHROPIC_API_KEY',
           desc: 'Compression, summarization, and graph extraction stay disabled until a key is provided.',
-          enable: 'export ANTHROPIC_API_KEY=sk-ant-...\n# then restart: npx @agentmemory/agentmemory',
+          enable: 'export ANTHROPIC_API_KEY=sk-ant-...\n# or OPENAI_API_KEY, CLOUDFLARE_API_TOKEN, GEMINI_API_KEY, etc.\n# then restart: npx @agentmemory/agentmemory',
           docs: 'https://github.com/rohitg00/agentmemory#quick-start',
           dismissKey: '__provider_noop',
         });
@@ -3774,7 +3774,7 @@
           title: 'Running in BM25-only mode',
           keyLabel: 'OPENAI_API_KEY',
           desc: 'Semantic vector search is off. BM25 keyword search is active and good for exact matches.',
-          enable: 'export OPENAI_API_KEY=sk-...\n# or VOYAGE_API_KEY, COHERE_API_KEY, OLLAMA_HOST',
+          enable: 'export OPENAI_API_KEY=sk-...\n# or CLOUDFLARE_API_TOKEN, VOYAGE_API_KEY, COHERE_API_KEY, OLLAMA_HOST',
           docs: 'https://github.com/rohitg00/agentmemory#embedding-providers',
           dismissKey: '__embedding_none',
         });

--- a/src/viewer/index.html
+++ b/src/viewer/index.html
@@ -3749,7 +3749,7 @@
           icon: '&#9888;',
           title: f.label,
           keyLabel: f.key,
-          desc: f.description + (f.needsLlm ? ' Requires an LLM provider key (ANTHROPIC_API_KEY, OPENAI_API_KEY, CLOUDFLARE_API_TOKEN, etc.).' : ''),
+          desc: f.description + (f.needsLlm ? ' Requires an LLM provider key (ANTHROPIC_API_KEY, OPENAI_API_KEY, CLOUDFLARE_API_TOKEN + CLOUDFLARE_ACCOUNT_ID, etc.).' : ''),
           enable: f.enableHow,
           docs: f.docsHref,
           dismissKey: f.key,
@@ -3762,7 +3762,7 @@
           title: 'No LLM provider key set',
           keyLabel: 'ANTHROPIC_API_KEY',
           desc: 'Compression, summarization, and graph extraction stay disabled until a key is provided.',
-          enable: 'export ANTHROPIC_API_KEY=sk-ant-...\n# or OPENAI_API_KEY, CLOUDFLARE_API_TOKEN, GEMINI_API_KEY, etc.\n# then restart: npx @agentmemory/agentmemory',
+          enable: 'export ANTHROPIC_API_KEY=sk-ant-...\n# or OPENAI_API_KEY, GEMINI_API_KEY, etc.\n# Cloudflare: export CLOUDFLARE_API_TOKEN=... CLOUDFLARE_ACCOUNT_ID=...\n# then restart: npx @agentmemory/agentmemory',
           docs: 'https://github.com/rohitg00/agentmemory#quick-start',
           dismissKey: '__provider_noop',
         });
@@ -3774,7 +3774,7 @@
           title: 'Running in BM25-only mode',
           keyLabel: 'OPENAI_API_KEY',
           desc: 'Semantic vector search is off. BM25 keyword search is active and good for exact matches.',
-          enable: 'export OPENAI_API_KEY=sk-...\n# or CLOUDFLARE_API_TOKEN, VOYAGE_API_KEY, COHERE_API_KEY, OLLAMA_HOST',
+          enable: 'export OPENAI_API_KEY=sk-...\n# or VOYAGE_API_KEY, COHERE_API_KEY, OLLAMA_HOST\n# Cloudflare: export CLOUDFLARE_API_TOKEN=... CLOUDFLARE_ACCOUNT_ID=...',
           docs: 'https://github.com/rohitg00/agentmemory#embedding-providers',
           dismissKey: '__embedding_none',
         });

--- a/test/cloudflare-provider.test.ts
+++ b/test/cloudflare-provider.test.ts
@@ -143,6 +143,18 @@ describe("CloudflareEmbeddingProvider — dimensions", () => {
     );
   });
 
+  // parseInt would take "1024abc" as 1024 and "10.5" as 10, producing vectors
+  // withDimensionGuard rejects on every embed. Typos fail at parse time.
+  it.each(["1024abc", "10.5", "-768", "abc", "1e3"])(
+    "rejects the malformed dimensions override %j",
+    (value) => {
+      process.env["CLOUDFLARE_EMBEDDING_DIMENSIONS"] = value;
+      expect(() => new CloudflareEmbeddingProvider("test-token")).toThrow(
+        /must be a positive integer/,
+      );
+    },
+  );
+
   it("throws without an API token", () => {
     expect(() => new CloudflareEmbeddingProvider()).toThrow(/CLOUDFLARE_API_TOKEN is required/);
   });

--- a/test/cloudflare-provider.test.ts
+++ b/test/cloudflare-provider.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { CloudflareProvider } from "../src/providers/cloudflare.js";
+import { CloudflareEmbeddingProvider } from "../src/providers/embedding/cloudflare.js";
+import { loadConfig, loadFallbackConfig } from "../src/config.js";
+
+const CLOUDFLARE_KEYS = [
+  "CLOUDFLARE_API_TOKEN",
+  "CLOUDFLARE_ACCOUNT_ID",
+  "CLOUDFLARE_MODEL",
+  "CLOUDFLARE_AI_BASE_URL",
+  "CLOUDFLARE_AI_GATEWAY_ID",
+  "CLOUDFLARE_TIMEOUT_MS",
+  "CLOUDFLARE_EMBEDDING_MODEL",
+  "CLOUDFLARE_EMBEDDING_BASE_URL",
+  "CLOUDFLARE_EMBEDDING_DIMENSIONS",
+];
+
+// Keys that would win the detectProvider / detectEmbeddingProvider race and
+// mask the Cloudflare branch under test.
+const COMPETING_KEYS = [
+  "OPENAI_API_KEY",
+  "MINIMAX_API_KEY",
+  "ANTHROPIC_API_KEY",
+  "GEMINI_API_KEY",
+  "GOOGLE_API_KEY",
+  "OPENROUTER_API_KEY",
+  "AGENTMEMORY_LLM_TIMEOUT_MS",
+  "FALLBACK_PROVIDERS",
+];
+
+// Blank rather than delete: getMergedEnv layers process.env over the
+// developer's real ~/.agentmemory/.env, so deleting a key here would let that
+// file's value through. Every read path treats "" as absent (hasRealValue
+// trims, the rest test truthiness), so blanking neutralises both layers.
+function clearEnv(keys: string[]): void {
+  for (const key of keys) process.env[key] = "";
+}
+
+const baseUrlOf = (p: CloudflareProvider) =>
+  (p as unknown as { baseUrl: string }).baseUrl;
+const timeoutOf = (p: CloudflareProvider) =>
+  (p as unknown as { timeoutMs: number }).timeoutMs;
+
+describe("CloudflareProvider", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    clearEnv([...CLOUDFLARE_KEYS, ...COMPETING_KEYS]);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("builds the account-scoped OpenAI-compatible chat endpoint", () => {
+    process.env["CLOUDFLARE_ACCOUNT_ID"] = "acct-123";
+    const provider = new CloudflareProvider("test-token", "@cf/meta/llama-3.1-8b-instruct-fp8", 800);
+    expect(baseUrlOf(provider)).toBe(
+      "https://api.cloudflare.com/client/v4/accounts/acct-123/ai/v1/chat/completions",
+    );
+  });
+
+  it("prefers an explicit base URL over the account-derived one", () => {
+    process.env["CLOUDFLARE_ACCOUNT_ID"] = "acct-123";
+    process.env["CLOUDFLARE_AI_BASE_URL"] = "https://gateway.example.com/v1/chat/completions";
+    const provider = new CloudflareProvider("test-token", "@cf/meta/llama-3.1-8b-instruct-fp8", 800);
+    expect(baseUrlOf(provider)).toBe("https://gateway.example.com/v1/chat/completions");
+  });
+
+  it("throws when neither account id nor base URL is available", () => {
+    expect(
+      () => new CloudflareProvider("test-token", "@cf/meta/llama-3.1-8b-instruct-fp8", 800),
+    ).toThrow(/CLOUDFLARE_ACCOUNT_ID or CLOUDFLARE_AI_BASE_URL/);
+  });
+
+  it("honors CLOUDFLARE_TIMEOUT_MS ahead of AGENTMEMORY_LLM_TIMEOUT_MS", () => {
+    process.env["CLOUDFLARE_ACCOUNT_ID"] = "acct-123";
+    process.env["AGENTMEMORY_LLM_TIMEOUT_MS"] = "5000";
+    process.env["CLOUDFLARE_TIMEOUT_MS"] = "12000";
+    const provider = new CloudflareProvider("test-token", "@cf/meta/llama-3.1-8b-instruct-fp8", 800);
+    expect(timeoutOf(provider)).toBe(12000);
+  });
+
+  it("falls back to the 60s default when both timeout vars are unparseable", () => {
+    process.env["CLOUDFLARE_ACCOUNT_ID"] = "acct-123";
+    process.env["CLOUDFLARE_TIMEOUT_MS"] = "not-a-number";
+    const provider = new CloudflareProvider("test-token", "@cf/meta/llama-3.1-8b-instruct-fp8", 800);
+    expect(timeoutOf(provider)).toBe(60_000);
+  });
+
+  it("is selected by detectProvider when CLOUDFLARE_API_TOKEN is the only key", () => {
+    process.env["CLOUDFLARE_API_TOKEN"] = "test-token";
+    process.env["CLOUDFLARE_ACCOUNT_ID"] = "acct-123";
+    const config = loadConfig();
+    expect(config.provider.provider).toBe("cloudflare");
+    expect(config.provider.model).toBe("@cf/meta/llama-3.1-8b-instruct-fp8");
+  });
+
+  it("is accepted as a FALLBACK_PROVIDERS entry", () => {
+    process.env["FALLBACK_PROVIDERS"] = "cloudflare";
+    expect(loadFallbackConfig().providers).toContain("cloudflare");
+  });
+});
+
+describe("CloudflareEmbeddingProvider — dimensions", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    clearEnv([...CLOUDFLARE_KEYS, ...COMPETING_KEYS]);
+    process.env["CLOUDFLARE_ACCOUNT_ID"] = "acct-123";
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("defaults to 768 for bge-base-en-v1.5", () => {
+    expect(new CloudflareEmbeddingProvider("test-token").dimensions).toBe(768);
+  });
+
+  it("resolves 1024 for bge-large-en-v1.5 from the known-models table", () => {
+    process.env["CLOUDFLARE_EMBEDDING_MODEL"] = "@cf/baai/bge-large-en-v1.5";
+    expect(new CloudflareEmbeddingProvider("test-token").dimensions).toBe(1024);
+  });
+
+  it("resolves 384 for bge-small-en-v1.5 from the known-models table", () => {
+    process.env["CLOUDFLARE_EMBEDDING_MODEL"] = "@cf/baai/bge-small-en-v1.5";
+    expect(new CloudflareEmbeddingProvider("test-token").dimensions).toBe(384);
+  });
+
+  it("lets CLOUDFLARE_EMBEDDING_DIMENSIONS override a known model", () => {
+    process.env["CLOUDFLARE_EMBEDDING_MODEL"] = "@cf/baai/bge-large-en-v1.5";
+    process.env["CLOUDFLARE_EMBEDDING_DIMENSIONS"] = "256";
+    expect(new CloudflareEmbeddingProvider("test-token").dimensions).toBe(256);
+  });
+
+  it("rejects a non-positive dimensions override", () => {
+    process.env["CLOUDFLARE_EMBEDDING_DIMENSIONS"] = "0";
+    expect(() => new CloudflareEmbeddingProvider("test-token")).toThrow(
+      /must be a positive integer/,
+    );
+  });
+
+  it("throws without an API token", () => {
+    expect(() => new CloudflareEmbeddingProvider()).toThrow(/CLOUDFLARE_API_TOKEN is required/);
+  });
+
+  it("builds the account-scoped embeddings endpoint", () => {
+    const provider = new CloudflareEmbeddingProvider("test-token");
+    expect((provider as unknown as { baseUrl: string }).baseUrl).toBe(
+      "https://api.cloudflare.com/client/v4/accounts/acct-123/ai/v1/embeddings",
+    );
+  });
+});
+
+describe("CloudflareProvider — response parsing", () => {
+  const originalEnv = process.env;
+
+  const reply = (choice: unknown) =>
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(JSON.stringify({ choices: [choice] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+
+  const provider = () =>
+    new CloudflareProvider("test-token", "@cf/zai-org/glm-4.7-flash", 64);
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    clearEnv([...CLOUDFLARE_KEYS, ...COMPETING_KEYS]);
+    process.env["CLOUDFLARE_ACCOUNT_ID"] = "acct-123";
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.unstubAllGlobals();
+  });
+
+  it("returns message content when present", async () => {
+    reply({ finish_reason: "stop", message: { content: "a summary" } });
+    await expect(provider().summarize("sys", "user")).resolves.toBe("a summary");
+  });
+
+  // Reasoning models return content:null plus a populated `reasoning` field when
+  // the budget is spent thinking. That scratchpad must never reach memory.
+  it("never returns chain-of-thought when a reasoning model truncates", async () => {
+    reply({
+      finish_reason: "length",
+      message: { content: null, reasoning: "1. **Analyze the input:** the user wants..." },
+    });
+    await expect(provider().summarize("sys", "user")).rejects.toThrow(
+      /hit the token limit before emitting content/,
+    );
+  });
+
+  it("names MAX_TOKENS in the truncation error so the fix is obvious", async () => {
+    reply({ finish_reason: "length", message: { content: "" } });
+    await expect(provider().compress("sys", "user")).rejects.toThrow(/MAX_TOKENS/);
+  });
+
+  it("falls back to the completion-style text field", async () => {
+    reply({ finish_reason: "stop", text: "legacy shape" });
+    await expect(provider().summarize("sys", "user")).resolves.toBe("legacy shape");
+  });
+
+  const headersOfLastCall = () => {
+    const mock = globalThis.fetch as unknown as { mock: { calls: unknown[][] } };
+    return (mock.mock.calls[0]![1] as RequestInit).headers as Record<string, string>;
+  };
+
+  // AI Gateway selects a named gateway by header, not by a different base URL.
+  it("omits cf-aig-gateway-id when no gateway is pinned", async () => {
+    reply({ finish_reason: "stop", message: { content: "x" } });
+    await provider().summarize("sys", "user");
+    expect(headersOfLastCall()).not.toHaveProperty("cf-aig-gateway-id");
+  });
+
+  it("sends cf-aig-gateway-id when CLOUDFLARE_AI_GATEWAY_ID is set", async () => {
+    process.env["CLOUDFLARE_AI_GATEWAY_ID"] = "my-gateway";
+    reply({ finish_reason: "stop", message: { content: "x" } });
+    await provider().summarize("sys", "user");
+    expect(headersOfLastCall()["cf-aig-gateway-id"]).toBe("my-gateway");
+  });
+});

--- a/test/embedding-provider.test.ts
+++ b/test/embedding-provider.test.ts
@@ -5,6 +5,7 @@ import {
 } from "../src/providers/embedding/index.js";
 import { GeminiEmbeddingProvider } from "../src/providers/embedding/gemini.js";
 import { OpenAIEmbeddingProvider } from "../src/providers/embedding/openai.js";
+import { CloudflareEmbeddingProvider } from "../src/providers/embedding/cloudflare.js";
 import type { EmbeddingProvider } from "../src/types.js";
 
 describe("createEmbeddingProvider", () => {
@@ -14,6 +15,7 @@ describe("createEmbeddingProvider", () => {
     process.env = { ...originalEnv };
     delete process.env["GEMINI_API_KEY"];
     delete process.env["OPENAI_API_KEY"];
+    delete process.env["CLOUDFLARE_API_TOKEN"];
     delete process.env["VOYAGE_API_KEY"];
     delete process.env["COHERE_API_KEY"];
     delete process.env["OPENROUTER_API_KEY"];
@@ -41,6 +43,14 @@ describe("createEmbeddingProvider", () => {
     const provider = createEmbeddingProvider();
     expect(provider).toBeInstanceOf(OpenAIEmbeddingProvider);
     expect(provider!.name).toBe("openai");
+  });
+
+  it("returns CloudflareEmbeddingProvider when CLOUDFLARE_API_TOKEN is set", () => {
+    process.env["CLOUDFLARE_API_TOKEN"] = "test-key-789";
+    process.env["CLOUDFLARE_ACCOUNT_ID"] = "test-account";
+    const provider = createEmbeddingProvider();
+    expect(provider).toBeInstanceOf(CloudflareEmbeddingProvider);
+    expect(provider!.name).toBe("cloudflare");
   });
 
   it("EMBEDDING_PROVIDER override takes precedence", () => {


### PR DESCRIPTION
## What

Adds Cloudflare Workers AI as a first-class LLM **and** embedding provider.

`CLOUDFLARE_API_TOKEN` alone enables both roles. Workers AI exposes OpenAI-compatible `/ai/v1/chat/completions` and `/ai/v1/embeddings` endpoints, so both providers reuse the existing `fetchWithTimeout` transport and the same wire shapes as the OpenAI providers — no new dependencies.

## Why

Workers AI is a cheap, no-egress option for the background compress/summarize workload, and it is the only major provider that covers **both** chat and embeddings from a single token. For anyone already on Cloudflare it removes a second vendor from the setup.

Concretely, on the compress-a-short-observation workload this PR's default model costs **0.8 neurons** per call — roughly two orders of magnitude below a reasoning-class model (measured, table below).

## Detection order

Cloudflare slots in so it never displaces a working setup:

- **LLM:** `OPENAI_API_KEY` → `MINIMAX_API_KEY` → **`CLOUDFLARE_API_TOKEN`** → `ANTHROPIC_API_KEY` → `GEMINI_API_KEY` → `OPENROUTER_API_KEY` → noop
- **Embedding:** `EMBEDDING_PROVIDER` → `GEMINI_API_KEY` → `OPENAI_API_KEY` → **`CLOUDFLARE_API_TOKEN`** → `VOYAGE_API_KEY` → `COHERE_API_KEY` → `OPENROUTER_API_KEY` → local

`EMBEDDING_PROVIDER=cloudflare` still works as an explicit override, and `FALLBACK_PROVIDERS=cloudflare` is accepted.

## Environment variables

| Var | Purpose |
|---|---|
| `CLOUDFLARE_API_TOKEN` | Auth for both LLM and embeddings |
| `CLOUDFLARE_ACCOUNT_ID` | Builds the endpoint URL; not needed if a `*_BASE_URL` is set |
| `CLOUDFLARE_MODEL` | Chat model (default `@cf/meta/llama-3.1-8b-instruct-fp8`) |
| `CLOUDFLARE_AI_BASE_URL` | Full chat endpoint override |
| `CLOUDFLARE_AI_GATEWAY_ID` | Pin a named AI Gateway |
| `CLOUDFLARE_TIMEOUT_MS` | Per-request timeout; falls back to `AGENTMEMORY_LLM_TIMEOUT_MS` |
| `CLOUDFLARE_EMBEDDING_MODEL` | Embedding model (default `@cf/baai/bge-base-en-v1.5`) |
| `CLOUDFLARE_EMBEDDING_DIMENSIONS` | Required for models outside the known-models table |
| `CLOUDFLARE_EMBEDDING_BASE_URL` | Full embedding endpoint override |

## Three decisions worth reviewing

**1. The default chat model is the `-fp8` variant.** The obvious pick, `@cf/meta/llama-3.1-8b-instruct`, was **deprecated on 2026-05-30** and now returns HTTP 410 — it is gone from the model catalogue entirely. `@cf/meta/llama-3.1-8b-instruct-fp8` is the live successor and carries no deprecation flag.

**2. There is deliberately no `reasoning` fallback when extracting content.** Reasoning models (`@cf/zai-org/glm-*`, `qwq`, `deepseek-r1`) return `content: null` alongside a populated `reasoning` field once the token budget is spent thinking. Treating that as the answer writes model scratchpad into memory and feeds it to the XML parsers in `summarize.ts`. Truncation now raises an error naming `MAX_TOKENS` instead. Two tests cover this.

**3. Embedding dimensions come from a `MODEL_DIMENSIONS` table**, mirroring `embedding/openai.ts`. `withDimensionGuard` throws on *every* embed when the reported size is wrong, so guessing one size for all models turns a config mistake into a total outage. `CLOUDFLARE_EMBEDDING_DIMENSIONS` covers anything not in the table.

## AI Gateway

The default endpoint already routes through the account's default gateway, so logging, caching, rate limiting and guardrails apply with no configuration. `CLOUDFLARE_AI_GATEWAY_ID` pins a *named* gateway — Cloudflare selects it via the `cf-aig-gateway-id` header, not a different base URL. Applies to both chat and embeddings.

## Structure

`src/providers/_cloudflare-shared.ts` holds endpoint construction, auth headers and gateway selection so the chat and embedding providers don't mirror them — the same split as the existing `_openai-shared.ts`.

One knowing exception: `detectProvider()` in `config.ts` repeats the default model as a literal rather than importing the constant, because `providers/` imports `config.ts` and importing back would cycle. Every other provider default in that function makes the same trade-off; there's a comment saying so.

## Testing

`test/cloudflare-provider.test.ts` — 20 tests covering endpoint resolution, the missing-account-id error, timeout precedence, `detectProvider` selection, `FALLBACK_PROVIDERS` acceptance, every dimension path, response parsing, and gateway header behaviour. Plus a detection case in `test/embedding-provider.test.ts`.

Tests blank competing env keys to `""` rather than `delete`-ing them: `getMergedEnv()` layers `process.env` over the developer's real `~/.agentmemory/.env`, so deleting a key lets that file's value through and the suite fails on any machine that has an `OPENAI_API_KEY` configured.

**Also verified against live Workers AI** (not just mocked): `compress`, `summarize`, the full `loadConfig()` → `createProvider()` → `ResilientProvider` path, 384/768/1024-dim embeddings through `withDimensionGuard`, gateway routing (unpinned / named / bad-id → 400), and the bad-token error path.

Measured cost, identical prompt, `neurons` as reported by the API:

| model | neurons | completion tokens |
|---|---|---|
| `@cf/meta/llama-3.1-8b-instruct-fp8` (default) | 0.8 | 13 |
| `@cf/meta/llama-3.2-3b-instruct` | 0.6 | 12 |
| `@cf/zai-org/glm-5.2` | 9.3 | 14 |
| `@cf/zai-org/glm-4.7-flash` | 15.2 | 415 |

## How to verify

```bash
export CLOUDFLARE_API_TOKEN=... CLOUDFLARE_ACCOUNT_ID=...
npx @agentmemory/agentmemory doctor          # LLM + embedding provider both green
npx vitest run test/cloudflare-provider.test.ts test/embedding-provider.test.ts
```

## Checks

- `npm run build` — clean
- `npm test` — 1431 passing. The 5 failures in `test/hook-project.test.ts` are pre-existing and reproduce on an unmodified `main`; they assert `basename(cwd) === "agentmemory"` and fail whenever the clone directory has another name.
- `npx tsc --noEmit` — 25 errors, all pre-existing on `main`, none in the files this PR touches.
- No CHANGELOG change, per CONTRIBUTING.

## Not in scope

- Per-task model selection (`AGENTMEMORY_SUMMARIZE_MODEL` and friends). That needs task identity at the `MemoryProvider` boundary and overlaps #954 — worth its own issue, and provider-agnostic rather than Cloudflare-specific.
- Deduplicating `resolveDimensions` across `embedding/openai.ts` and `embedding/cloudflare.ts`. Real duplication, but collapsing it means editing the OpenAI provider, which doesn't belong in a PR that adds a provider. Happy to follow up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Cloudflare Workers AI support for chat, summarization, and embeddings.
  * Added Cloudflare to provider detection, fallback options, and interactive setup.
  * Added support for custom models, endpoints, timeouts, AI Gateway routing, and embedding dimensions.
* **Documentation**
  * Expanded setup, environment variable, and troubleshooting guidance for Cloudflare Workers AI.
* **Bug Fixes**
  * Improved missing-credential diagnostics with Cloudflare token, account, and endpoint guidance.
  * Enhanced errors for responses truncated by token limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->