### PR TITLE
feat: add Atlas Cloud provider

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -54,10 +54,7 @@ function detectProvider(env: Record<string, string>): ProviderConfig {
   const maxTokens = parseInt(env["MAX_TOKENS"] || "4096", 10);
 
   // OpenAI-compatible: supports OpenAI, DeepSeek, SiliconFlow, Azure, vLLM, LM Studio
-  if (
-    hasRealValue(env["OPENAI_API_KEY"]) &&
-    env["OPENAI_API_KEY_FOR_LLM"] !== "false"
-  ) {
+  if (hasRealValue(env["OPENAI_API_KEY"]) && env["OPENAI_API_KEY_FOR_LLM"] !== "false") {
     return {
       provider: "openai",
       model: env["OPENAI_MODEL"] || "gpt-4o-mini",
@@ -92,14 +89,8 @@ function detectProvider(env: Record<string, string>): ProviderConfig {
       baseURL: env["ANTHROPIC_BASE_URL"],
     };
   }
-  if (
-    hasRealValue(env["GEMINI_API_KEY"]) ||
-    hasRealValue(env["GOOGLE_API_KEY"])
-  ) {
-    if (
-      !hasRealValue(env["GEMINI_API_KEY"]) &&
-      hasRealValue(env["GOOGLE_API_KEY"])
-    ) {
+  if (hasRealValue(env["GEMINI_API_KEY"]) || hasRealValue(env["GOOGLE_API_KEY"])) {
+    if (!hasRealValue(env["GEMINI_API_KEY"]) && hasRealValue(env["GOOGLE_API_KEY"])) {
       process.stderr.write(
         "[agentmemory] GOOGLE_API_KEY detected — treating as GEMINI_API_KEY. " +
           "Set GEMINI_API_KEY in ~/.agentmemory/.env to silence this warning.\n",
@@ -315,8 +306,9 @@ export function loadAgentScope(): {
   if (!raw) return null;
   const agentId = raw.trim().slice(0, 128);
   if (!agentId) return null;
-  const mode =
-    env["AGENTMEMORY_AGENT_SCOPE"] === "isolated" ? "isolated" : "shared";
+  const mode = env["AGENTMEMORY_AGENT_SCOPE"] === "isolated"
+    ? "isolated"
+    : "shared";
   return { agentId, mode };
 }
 
@@ -373,24 +365,22 @@ export function isConsolidationEnabled(): boolean {
   return hasLLMProviderConfigured(env);
 }
 
-function hasLLMProviderConfigured(
-  env: Record<string, string | undefined>,
-): boolean {
+function hasLLMProviderConfigured(env: Record<string, string | undefined>): boolean {
   const provider = (env["AGENTMEMORY_PROVIDER"] || "").toLowerCase();
   if (provider === "noop") return false;
   const openaiKeyForLlm =
     env["OPENAI_API_KEY"] &&
     (env["OPENAI_API_KEY_FOR_LLM"] || "").toLowerCase() !== "false";
   return Boolean(
-    env["ANTHROPIC_API_KEY"] ||
-    env["ATLASCLOUD_API_KEY"] ||
-    openaiKeyForLlm ||
-    env["OPENROUTER_API_KEY"] ||
-    env["GEMINI_API_KEY"] ||
-    env["GOOGLE_API_KEY"] ||
-    env["MINIMAX_API_KEY"] ||
-    env["OPENAI_BASE_URL"] ||
-    provider === "agent-sdk",
+      env["ANTHROPIC_API_KEY"] ||
+      env["ATLASCLOUD_API_KEY"] ||
+      openaiKeyForLlm ||
+      env["OPENROUTER_API_KEY"] ||
+      env["GEMINI_API_KEY"] ||
+      env["GOOGLE_API_KEY"] ||
+      env["MINIMAX_API_KEY"] ||
+      env["OPENAI_BASE_URL"] ||
+      provider === "agent-sdk",
   );
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -63,6 +63,15 @@ function detectProvider(env: Record<string, string>): ProviderConfig {
     };
   }
 
+  if (hasRealValue(env["ATLASCLOUD_API_KEY"])) {
+    return {
+      provider: "atlascloud",
+      model: env["ATLASCLOUD_MODEL"] || "deepseek-ai/deepseek-v4-pro",
+      maxTokens,
+      baseURL: env["ATLASCLOUD_BASE_URL"] || "https://api.atlascloud.ai/v1",
+    };
+  }
+
   // MiniMax: Anthropic-compatible API, requires raw fetch to avoid SDK stainless headers
   if (hasRealValue(env["MINIMAX_API_KEY"])) {
     return {
@@ -203,6 +212,7 @@ export function detectLlmProviderKind(): "llm" | "noop" {
   const env = getMergedEnv();
   if (
     hasRealValue(env["ANTHROPIC_API_KEY"]) ||
+    hasRealValue(env["ATLASCLOUD_API_KEY"]) ||
     hasRealValue(env["GEMINI_API_KEY"]) ||
     hasRealValue(env["GOOGLE_API_KEY"]) ||
     hasRealValue(env["OPENROUTER_API_KEY"]) ||
@@ -362,7 +372,8 @@ function hasLLMProviderConfigured(env: Record<string, string | undefined>): bool
     env["OPENAI_API_KEY"] &&
     (env["OPENAI_API_KEY_FOR_LLM"] || "").toLowerCase() !== "false";
   return Boolean(
-    env["ANTHROPIC_API_KEY"] ||
+      env["ANTHROPIC_API_KEY"] ||
+      env["ATLASCLOUD_API_KEY"] ||
       openaiKeyForLlm ||
       env["OPENROUTER_API_KEY"] ||
       env["GEMINI_API_KEY"] ||
@@ -414,6 +425,7 @@ export function getStandalonePersistPath(): string {
 
 const VALID_PROVIDERS = new Set([
   "anthropic",
+  "atlascloud",
   "gemini",
   "openrouter",
   "agent-sdk",

--- a/src/config.ts
+++ b/src/config.ts
@@ -54,7 +54,10 @@ function detectProvider(env: Record<string, string>): ProviderConfig {
   const maxTokens = parseInt(env["MAX_TOKENS"] || "4096", 10);
 
   // OpenAI-compatible: supports OpenAI, DeepSeek, SiliconFlow, Azure, vLLM, LM Studio
-  if (hasRealValue(env["OPENAI_API_KEY"]) && env["OPENAI_API_KEY_FOR_LLM"] !== "false") {
+  if (
+    hasRealValue(env["OPENAI_API_KEY"]) &&
+    env["OPENAI_API_KEY_FOR_LLM"] !== "false"
+  ) {
     return {
       provider: "openai",
       model: env["OPENAI_MODEL"] || "gpt-4o-mini",
@@ -89,8 +92,14 @@ function detectProvider(env: Record<string, string>): ProviderConfig {
       baseURL: env["ANTHROPIC_BASE_URL"],
     };
   }
-  if (hasRealValue(env["GEMINI_API_KEY"]) || hasRealValue(env["GOOGLE_API_KEY"])) {
-    if (!hasRealValue(env["GEMINI_API_KEY"]) && hasRealValue(env["GOOGLE_API_KEY"])) {
+  if (
+    hasRealValue(env["GEMINI_API_KEY"]) ||
+    hasRealValue(env["GOOGLE_API_KEY"])
+  ) {
+    if (
+      !hasRealValue(env["GEMINI_API_KEY"]) &&
+      hasRealValue(env["GOOGLE_API_KEY"])
+    ) {
       process.stderr.write(
         "[agentmemory] GOOGLE_API_KEY detected — treating as GEMINI_API_KEY. " +
           "Set GEMINI_API_KEY in ~/.agentmemory/.env to silence this warning.\n",
@@ -306,9 +315,8 @@ export function loadAgentScope(): {
   if (!raw) return null;
   const agentId = raw.trim().slice(0, 128);
   if (!agentId) return null;
-  const mode = env["AGENTMEMORY_AGENT_SCOPE"] === "isolated"
-    ? "isolated"
-    : "shared";
+  const mode =
+    env["AGENTMEMORY_AGENT_SCOPE"] === "isolated" ? "isolated" : "shared";
   return { agentId, mode };
 }
 
@@ -365,22 +373,24 @@ export function isConsolidationEnabled(): boolean {
   return hasLLMProviderConfigured(env);
 }
 
-function hasLLMProviderConfigured(env: Record<string, string | undefined>): boolean {
+function hasLLMProviderConfigured(
+  env: Record<string, string | undefined>,
+): boolean {
   const provider = (env["AGENTMEMORY_PROVIDER"] || "").toLowerCase();
   if (provider === "noop") return false;
   const openaiKeyForLlm =
     env["OPENAI_API_KEY"] &&
     (env["OPENAI_API_KEY_FOR_LLM"] || "").toLowerCase() !== "false";
   return Boolean(
-      env["ANTHROPIC_API_KEY"] ||
-      env["ATLASCLOUD_API_KEY"] ||
-      openaiKeyForLlm ||
-      env["OPENROUTER_API_KEY"] ||
-      env["GEMINI_API_KEY"] ||
-      env["GOOGLE_API_KEY"] ||
-      env["MINIMAX_API_KEY"] ||
-      env["OPENAI_BASE_URL"] ||
-      provider === "agent-sdk",
+    env["ANTHROPIC_API_KEY"] ||
+    env["ATLASCLOUD_API_KEY"] ||
+    openaiKeyForLlm ||
+    env["OPENROUTER_API_KEY"] ||
+    env["GEMINI_API_KEY"] ||
+    env["GOOGLE_API_KEY"] ||
+    env["MINIMAX_API_KEY"] ||
+    env["OPENAI_BASE_URL"] ||
+    provider === "agent-sdk",
   );
 }
 

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -13,7 +13,10 @@ import { ResilientProvider } from "./resilient.js";
 import { FallbackChainProvider } from "./fallback-chain.js";
 import { getEnvVar } from "../config.js";
 
-export { createEmbeddingProvider, createImageEmbeddingProvider } from "./embedding/index.js";
+export {
+  createEmbeddingProvider,
+  createImageEmbeddingProvider,
+} from "./embedding/index.js";
 
 function requireEnvVar(key: string): string {
   const value = getEnvVar(key);
@@ -141,9 +144,7 @@ function createBaseProvider(config: ProviderConfig): MemoryProvider {
     case "openai": {
       const openaiKey = getEnvVar("OPENAI_API_KEY");
       if (!openaiKey) {
-        throw new Error(
-          "OPENAI_API_KEY is required for the openai provider",
-        );
+        throw new Error("OPENAI_API_KEY is required for the openai provider");
       }
       return new OpenAIProvider(
         openaiKey,

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -36,6 +36,8 @@ function defaultModelFor(providerType: ProviderConfig["provider"]): string {
   switch (providerType) {
     case "openai":
       return getEnvVar("OPENAI_MODEL") || "gpt-4o-mini";
+    case "atlascloud":
+      return getEnvVar("ATLASCLOUD_MODEL") || "deepseek-ai/deepseek-v4-pro";
     case "anthropic":
       return getEnvVar("ANTHROPIC_MODEL") || "claude-sonnet-4-20250514";
     case "gemini":
@@ -94,6 +96,13 @@ export function createFallbackProvider(
 
 function createBaseProvider(config: ProviderConfig): MemoryProvider {
   switch (config.provider) {
+    case "atlascloud":
+      return new OpenAIProvider(
+        requireEnvVar("ATLASCLOUD_API_KEY"),
+        config.model,
+        config.maxTokens,
+        config.baseURL || "https://api.atlascloud.ai/v1",
+      );
     case "minimax":
       return new MinimaxProvider(
         requireEnvVar("MINIMAX_API_KEY"),

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -13,10 +13,7 @@ import { ResilientProvider } from "./resilient.js";
 import { FallbackChainProvider } from "./fallback-chain.js";
 import { getEnvVar } from "../config.js";
 
-export {
-  createEmbeddingProvider,
-  createImageEmbeddingProvider,
-} from "./embedding/index.js";
+export { createEmbeddingProvider, createImageEmbeddingProvider } from "./embedding/index.js";
 
 function requireEnvVar(key: string): string {
   const value = getEnvVar(key);
@@ -144,7 +141,9 @@ function createBaseProvider(config: ProviderConfig): MemoryProvider {
     case "openai": {
       const openaiKey = getEnvVar("OPENAI_API_KEY");
       if (!openaiKey) {
-        throw new Error("OPENAI_API_KEY is required for the openai provider");
+        throw new Error(
+          "OPENAI_API_KEY is required for the openai provider",
+        );
       }
       return new OpenAIProvider(
         openaiKey,

--- a/src/types.ts
+++ b/src/types.ts
@@ -161,7 +161,11 @@ export interface MemoryProvider {
   name: string;
   compress(systemPrompt: string, userPrompt: string): Promise<string>;
   summarize(systemPrompt: string, userPrompt: string): Promise<string>;
-  describeImage?(imageData: string, mimeType: string, prompt: string): Promise<string>;
+  describeImage?(
+    imageData: string,
+    mimeType: string,
+    prompt: string,
+  ): Promise<string>;
 }
 
 export interface AgentMemoryConfig {
@@ -315,7 +319,63 @@ export interface ExportPagination {
 }
 
 export interface ExportData {
-  version: "0.3.0" | "0.4.0" | "0.5.0" | "0.6.0" | "0.6.1" | "0.7.0" | "0.7.2" | "0.7.3" | "0.7.4" | "0.7.5" | "0.7.6" | "0.7.7" | "0.7.9" | "0.8.0" | "0.8.1" | "0.8.2" | "0.8.3" | "0.8.4" | "0.8.5" | "0.8.6" | "0.8.7" | "0.8.8" | "0.8.9" | "0.8.10" | "0.8.11" | "0.8.12" | "0.8.13" | "0.9.0" | "0.9.1" | "0.9.2" | "0.9.3" | "0.9.4" | "0.9.5" | "0.9.6" | "0.9.7" | "0.9.8" | "0.9.9" | "0.9.10" | "0.9.11" | "0.9.12" | "0.9.13" | "0.9.14" | "0.9.15" | "0.9.16" | "0.9.17" | "0.9.18" | "0.9.19" | "0.9.20" | "0.9.21" | "0.9.22" | "0.9.23" | "0.9.24" | "0.9.25" | "0.9.26" | "0.9.27" | "0.9.28";
+  version:
+    | "0.3.0"
+    | "0.4.0"
+    | "0.5.0"
+    | "0.6.0"
+    | "0.6.1"
+    | "0.7.0"
+    | "0.7.2"
+    | "0.7.3"
+    | "0.7.4"
+    | "0.7.5"
+    | "0.7.6"
+    | "0.7.7"
+    | "0.7.9"
+    | "0.8.0"
+    | "0.8.1"
+    | "0.8.2"
+    | "0.8.3"
+    | "0.8.4"
+    | "0.8.5"
+    | "0.8.6"
+    | "0.8.7"
+    | "0.8.8"
+    | "0.8.9"
+    | "0.8.10"
+    | "0.8.11"
+    | "0.8.12"
+    | "0.8.13"
+    | "0.9.0"
+    | "0.9.1"
+    | "0.9.2"
+    | "0.9.3"
+    | "0.9.4"
+    | "0.9.5"
+    | "0.9.6"
+    | "0.9.7"
+    | "0.9.8"
+    | "0.9.9"
+    | "0.9.10"
+    | "0.9.11"
+    | "0.9.12"
+    | "0.9.13"
+    | "0.9.14"
+    | "0.9.15"
+    | "0.9.16"
+    | "0.9.17"
+    | "0.9.18"
+    | "0.9.19"
+    | "0.9.20"
+    | "0.9.21"
+    | "0.9.22"
+    | "0.9.23"
+    | "0.9.24"
+    | "0.9.25"
+    | "0.9.26"
+    | "0.9.27"
+    | "0.9.28";
   exportedAt: string;
   sessions: Session[];
   observations: Record<string, CompressedObservation[]>;
@@ -500,10 +560,7 @@ export interface GraphSnapshot {
 }
 
 export type ConsolidationTier =
-  | "working"
-  | "episodic"
-  | "semantic"
-  | "procedural";
+  "working" | "episodic" | "semantic" | "procedural";
 
 export interface SemanticMemory {
   id: string;
@@ -674,11 +731,7 @@ export interface Action {
 }
 
 export type ActionEdgeType =
-  | "requires"
-  | "unlocks"
-  | "spawned_by"
-  | "gated_by"
-  | "conflicts_with";
+  "requires" | "unlocks" | "spawned_by" | "gated_by" | "conflicts_with";
 
 export interface ActionEdge {
   id: string;
@@ -861,7 +914,6 @@ export interface MeshPeer {
   sharedScopes: string[];
   syncFilter?: { project?: string };
 }
-
 
 export interface EnrichedChunk {
   id: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -161,11 +161,7 @@ export interface MemoryProvider {
   name: string;
   compress(systemPrompt: string, userPrompt: string): Promise<string>;
   summarize(systemPrompt: string, userPrompt: string): Promise<string>;
-  describeImage?(
-    imageData: string,
-    mimeType: string,
-    prompt: string,
-  ): Promise<string>;
+  describeImage?(imageData: string, mimeType: string, prompt: string): Promise<string>;
 }
 
 export interface AgentMemoryConfig {
@@ -319,63 +315,7 @@ export interface ExportPagination {
 }
 
 export interface ExportData {
-  version:
-    | "0.3.0"
-    | "0.4.0"
-    | "0.5.0"
-    | "0.6.0"
-    | "0.6.1"
-    | "0.7.0"
-    | "0.7.2"
-    | "0.7.3"
-    | "0.7.4"
-    | "0.7.5"
-    | "0.7.6"
-    | "0.7.7"
-    | "0.7.9"
-    | "0.8.0"
-    | "0.8.1"
-    | "0.8.2"
-    | "0.8.3"
-    | "0.8.4"
-    | "0.8.5"
-    | "0.8.6"
-    | "0.8.7"
-    | "0.8.8"
-    | "0.8.9"
-    | "0.8.10"
-    | "0.8.11"
-    | "0.8.12"
-    | "0.8.13"
-    | "0.9.0"
-    | "0.9.1"
-    | "0.9.2"
-    | "0.9.3"
-    | "0.9.4"
-    | "0.9.5"
-    | "0.9.6"
-    | "0.9.7"
-    | "0.9.8"
-    | "0.9.9"
-    | "0.9.10"
-    | "0.9.11"
-    | "0.9.12"
-    | "0.9.13"
-    | "0.9.14"
-    | "0.9.15"
-    | "0.9.16"
-    | "0.9.17"
-    | "0.9.18"
-    | "0.9.19"
-    | "0.9.20"
-    | "0.9.21"
-    | "0.9.22"
-    | "0.9.23"
-    | "0.9.24"
-    | "0.9.25"
-    | "0.9.26"
-    | "0.9.27"
-    | "0.9.28";
+  version: "0.3.0" | "0.4.0" | "0.5.0" | "0.6.0" | "0.6.1" | "0.7.0" | "0.7.2" | "0.7.3" | "0.7.4" | "0.7.5" | "0.7.6" | "0.7.7" | "0.7.9" | "0.8.0" | "0.8.1" | "0.8.2" | "0.8.3" | "0.8.4" | "0.8.5" | "0.8.6" | "0.8.7" | "0.8.8" | "0.8.9" | "0.8.10" | "0.8.11" | "0.8.12" | "0.8.13" | "0.9.0" | "0.9.1" | "0.9.2" | "0.9.3" | "0.9.4" | "0.9.5" | "0.9.6" | "0.9.7" | "0.9.8" | "0.9.9" | "0.9.10" | "0.9.11" | "0.9.12" | "0.9.13" | "0.9.14" | "0.9.15" | "0.9.16" | "0.9.17" | "0.9.18" | "0.9.19" | "0.9.20" | "0.9.21" | "0.9.22" | "0.9.23" | "0.9.24" | "0.9.25" | "0.9.26" | "0.9.27" | "0.9.28";
   exportedAt: string;
   sessions: Session[];
   observations: Record<string, CompressedObservation[]>;
@@ -560,7 +500,10 @@ export interface GraphSnapshot {
 }
 
 export type ConsolidationTier =
-  "working" | "episodic" | "semantic" | "procedural";
+  | "working"
+  | "episodic"
+  | "semantic"
+  | "procedural";
 
 export interface SemanticMemory {
   id: string;
@@ -731,7 +674,11 @@ export interface Action {
 }
 
 export type ActionEdgeType =
-  "requires" | "unlocks" | "spawned_by" | "gated_by" | "conflicts_with";
+  | "requires"
+  | "unlocks"
+  | "spawned_by"
+  | "gated_by"
+  | "conflicts_with";
 
 export interface ActionEdge {
   id: string;
@@ -914,6 +861,7 @@ export interface MeshPeer {
   sharedScopes: string[];
   syncFilter?: { project?: string };
 }
+
 
 export interface EnrichedChunk {
   id: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -147,7 +147,15 @@ export interface ProviderConfig {
   baseURL?: string;
 }
 
-export type ProviderType = "agent-sdk" | "anthropic" | "gemini" | "openrouter" | "minimax" | "openai" | "noop";
+export type ProviderType =
+  | "agent-sdk"
+  | "anthropic"
+  | "atlascloud"
+  | "gemini"
+  | "openrouter"
+  | "minimax"
+  | "openai"
+  | "noop";
 
 export interface MemoryProvider {
   name: string;

--- a/test/atlascloud-provider.test.ts
+++ b/test/atlascloud-provider.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadConfig, loadFallbackConfig } from "../src/config.js";
+import { createProvider } from "../src/providers/index.js";
+
+const providerEnvKeys = [
+  "ANTHROPIC_API_KEY",
+  "ATLASCLOUD_API_KEY",
+  "ATLASCLOUD_BASE_URL",
+  "ATLASCLOUD_MODEL",
+  "GEMINI_API_KEY",
+  "GOOGLE_API_KEY",
+  "MINIMAX_API_KEY",
+  "OPENAI_API_KEY",
+  "OPENROUTER_API_KEY",
+  "FALLBACK_PROVIDERS",
+];
+
+describe("Atlas Cloud provider", () => {
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of providerEnvKeys) {
+      savedEnv[key] = process.env[key];
+      process.env[key] = "";
+    }
+  });
+
+  afterEach(() => {
+    for (const key of providerEnvKeys) {
+      if (savedEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = savedEnv[key];
+    }
+  });
+
+  it("selects Atlas Cloud defaults from ATLASCLOUD_API_KEY", () => {
+    process.env.ATLASCLOUD_API_KEY = "atlas-test-key";
+
+    const config = loadConfig();
+
+    expect(config.provider).toEqual({
+      provider: "atlascloud",
+      model: "deepseek-ai/deepseek-v4-pro",
+      maxTokens: 4096,
+      baseURL: "https://api.atlascloud.ai/v1",
+    });
+    expect(() => createProvider(config.provider)).not.toThrow();
+  });
+
+  it("supports Atlas Cloud as a fallback provider", () => {
+    process.env.FALLBACK_PROVIDERS = "atlascloud";
+
+    expect(loadFallbackConfig().providers).toEqual(["atlascloud"]);
+  });
+});


### PR DESCRIPTION
## What

- add Atlas Cloud as a first-class LLM provider
- use the existing OpenAI-compatible provider with `ATLASCLOUD_API_KEY`, optional `ATLASCLOUD_BASE_URL`, and optional `ATLASCLOUD_MODEL`
- default to `https://api.atlascloud.ai/v1` and `deepseek-ai/deepseek-v4-pro`
- support Atlas Cloud in consolidation detection and fallback-provider configuration

## Why

This lets agentmemory use Atlas Cloud for compression and summaries without mapping Atlas credentials into the OpenAI-specific environment variables. Existing OpenAI provider precedence remains unchanged.

## Validation

- `npx vitest run test/atlascloud-provider.test.ts` (2 passed)
- `npm run build`
- `npm test` (1433 passed, 1 skipped)
- live Atlas Cloud summary through `loadConfig()` and `createProvider()` (non-empty response)
- `git diff --check`

No README, docs, logo, dependency, or lockfile changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Atlas Cloud as a supported LLM provider.
  * Atlas Cloud can be selected automatically or configured as a fallback provider.
  * Added support for configuring Atlas Cloud models, token limits, and API endpoints.
  * Added a default Atlas Cloud model and API URL when no custom values are provided.

* **Tests**
  * Added coverage for Atlas Cloud configuration, provider creation, and fallback selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->