### PR TITLE
feat(opencode): allow AGENTMEMORY_PROJECT_NAME to override project name

### DIFF
--- a/plugin/opencode/agentmemory-capture.ts
+++ b/plugin/opencode/agentmemory-capture.ts
@@ -168,7 +168,8 @@ function extractErrorMessage(err: unknown): string {
 }
 
 export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
-  projectPath = ctx.worktree || ctx.project?.id || process.cwd();
+  const explicitProject = process.env.AGENTMEMORY_PROJECT_NAME?.trim();
+  projectPath = explicitProject || ctx.worktree || ctx.project?.id || process.cwd();
 
   return {
     event: async ({ event }) => {

--- a/test/opencode-auto-context.test.ts
+++ b/test/opencode-auto-context.test.ts
@@ -35,3 +35,17 @@ describe("OpenCode plugin auto-context injection (#431)", () => {
     expect(deletedBlock).toMatch(/startContextCache\.delete\(sid\)/);
   });
 });
+
+describe("OpenCode plugin project name override", () => {
+  const plugin = readFileSync(
+    "plugin/opencode/agentmemory-capture.ts",
+    "utf-8",
+  );
+
+  it("honours AGENTMEMORY_PROJECT_NAME before falling back to ctx/cwd", () => {
+    expect(plugin).toMatch(/AGENTMEMORY_PROJECT_NAME/);
+    expect(plugin).toMatch(
+      /explicitProject\s*\|\|\s*ctx\.worktree\s*\|\|\s*ctx\.project\?\.id\s*\|\|\s*process\.cwd\(\)/,
+    );
+  });
+});

--- a/test/opencode-auto-context.test.ts
+++ b/test/opencode-auto-context.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { readFileSync } from "node:fs";
 
 // OpenCode plugin needs zero-config memory injection. Plugin
@@ -36,16 +36,59 @@ describe("OpenCode plugin auto-context injection (#431)", () => {
   });
 });
 
-describe("OpenCode plugin project name override", () => {
-  const plugin = readFileSync(
-    "plugin/opencode/agentmemory-capture.ts",
-    "utf-8",
-  );
+describe("OpenCode plugin project name resolution", () => {
+  const savedProjectName = process.env.AGENTMEMORY_PROJECT_NAME;
+  let fetchMock: ReturnType<typeof vi.fn>;
 
-  it("honours AGENTMEMORY_PROJECT_NAME before falling back to ctx/cwd", () => {
-    expect(plugin).toMatch(/AGENTMEMORY_PROJECT_NAME/);
-    expect(plugin).toMatch(
-      /explicitProject\s*\|\|\s*ctx\.worktree\s*\|\|\s*ctx\.project\?\.id\s*\|\|\s*process\.cwd\(\)/,
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.resetModules();
+    delete process.env.AGENTMEMORY_PROJECT_NAME;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    if (savedProjectName === undefined) delete process.env.AGENTMEMORY_PROJECT_NAME;
+    else process.env.AGENTMEMORY_PROJECT_NAME = savedProjectName;
+  });
+
+  async function projectFor(ctx: Record<string, unknown>): Promise<unknown> {
+    const { AgentmemoryCapturePlugin } = await import(
+      "../plugin/opencode/agentmemory-capture.ts"
     );
+    const handlers = await (AgentmemoryCapturePlugin as (c: unknown) => Promise<{
+      event: (msg: unknown) => Promise<void>;
+    }>)(ctx);
+    await handlers.event({
+      event: { type: "session.created", properties: { info: { id: "s1" } } },
+    });
+    const startCall = fetchMock.mock.calls.find(
+      (c: unknown[]) => typeof c[0] === "string" && (c[0] as string).includes("/session/start"),
+    );
+    if (!startCall) throw new Error("no /session/start call captured");
+    return JSON.parse((startCall[1] as { body: string }).body).project;
+  }
+
+  it("uses trimmed AGENTMEMORY_PROJECT_NAME when set", async () => {
+    process.env.AGENTMEMORY_PROJECT_NAME = "  my-proj  ";
+    expect(await projectFor({ worktree: "/should/be/ignored" })).toBe("my-proj");
+  });
+
+  it("treats whitespace-only env value as unset and falls back", async () => {
+    process.env.AGENTMEMORY_PROJECT_NAME = "   ";
+    expect(await projectFor({ worktree: "/repo/alpha" })).toBe("/repo/alpha");
+  });
+
+  it("falls back to ctx.worktree when env is unset", async () => {
+    expect(await projectFor({ worktree: "/repo/alpha" })).toBe("/repo/alpha");
+  });
+
+  it("falls back to ctx.project.id when worktree is absent", async () => {
+    expect(await projectFor({ project: { id: "/repo/beta" } })).toBe("/repo/beta");
+  });
+
+  it("falls back to process.cwd() when no ctx field is present", async () => {
+    expect(await projectFor({})).toBe(process.cwd());
   });
 });


### PR DESCRIPTION
## What it does

The OpenCode capture plugin now consults `AGENTMEMORY_PROJECT_NAME` before falling back to its existing resolution (`ctx.worktree || ctx.project?.id || process.cwd()`). When the env var is set to a non-empty value, that value is used as the `project` on every observe/session-start call; otherwise behavior is unchanged.

## Why

1. **No override existed.** The OpenCode plugin resolved the project from the OpenCode context only — a user couldn't pin a stable project name (across machines, monorepo subdirs, or containerized setups where `cwd` differs).

2. **Cross-client consistency.** The Claude hooks already resolve the project via `AGENTMEMORY_PROJECT_NAME` → git toplevel basename → cwd basename (`src/hooks/_project.ts`). The OpenCode plugin was the only client that ignored this env var and sent a **full filesystem path** as the project. Since the daemon filters memory strictly by the `project` string (`s.project === projectName`), an OpenCode session (`/Users/.../myrepo`) and a Claude session (`myrepo`) on the same repo never shared memory. Setting `AGENTMEMORY_PROJECT_NAME=myrepo` on both now aligns them.

Same env var name the hooks use — one knob across both plugin ecosystems, no new variable to learn.

## How to verify

- `npm test` — 1432 passing, 1 skipped.
- Structural assertion in `test/opencode-auto-context.test.ts` confirms the plugin source checks `AGENTMEMORY_PROJECT_NAME` and that it precedes the `ctx.worktree` fallback.
- Manual: set `AGENTMEMORY_PROJECT_NAME=test-proj`, run a session, confirm `/session/start` and `/observe` calls carry `project: "test-proj"`. Unset it and confirm the previous behavior (ctx/cwd path) resumes.

## Scope

One-line behavior change in `plugin/opencode/agentmemory-capture.ts`. No daemon changes — the server already stores/filters by whatever `project` string it receives. Reuses the existing `AGENTMEMORY_PROJECT_NAME` the hooks already document; no new env var introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for overriding the project name using the `AGENTMEMORY_PROJECT_NAME` environment variable, including trimming surrounding whitespace.
  * Preserved existing project-name detection as the fallback when the variable is unset or blank.

* **Tests**
  * Added coverage for environment-based project name selection and fallback precedence across available project context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->