### PR TITLE
fix(fs-watcher): validate roots before watch() for Node 24/26 compat

### DIFF
--- a/integrations/filesystem-watcher/watcher.mjs
+++ b/integrations/filesystem-watcher/watcher.mjs
@@ -248,6 +248,8 @@ export class FilesystemWatcher {
     const failures = [];
     for (const root of this.roots) {
       try {
+        const st = statSync(root);
+        if (!st.isDirectory()) throw new Error("not a directory");
         const handle = watch(
           root,
           { recursive: true, persistent: true },


### PR DESCRIPTION
## What

`FilesystemWatcher.start()` now validates each root with `statSync` + `isDirectory()` before calling `fs.watch()`. Nonexistent or non-directory roots are recorded as failures synchronously, so the "could not watch any of the configured roots" guard fires deterministically.

## Why

`fs.watch(path, { recursive: true })` on Linux does not throw synchronously for a nonexistent root on Node 24/26. Recursive watch initialization on Linux is asynchronous ([nodejs/node#45098](https://github.com/nodejs/node/pull/45098), Node 20), and [nodejs/node#63686](https://github.com/nodejs/node/pull/63686) (2026-06-03) changed the directory scan to suppress `ENOENT` — treating it as a deletion race rather than emitting an `'error'` event. The net effect: a nonexistent root now produces neither a synchronous throw nor an async error signal, so the watcher handle is always pushed and the `watchers.length === 0` guard never fired.

This surfaced as a CI failure (`test/fs-watcher.test.ts > throws if no watched roots could be attached`) on the `[ubuntu-latest, 24]` and `[ubuntu-latest, 26]` matrix cells added in #1096, while 20/22 and all macOS cells passed (no #63686 backport there). It's pre-existing — unrelated to any other change on `main`.

## How to verify

- `npm test` — 1431 passing, 1 skipped; `fs-watcher.test.ts` 15/15 green (was 14/15 on ubuntu Node 24/26).
- The "throws if no watched roots could be attached" test now passes deterministically because `statSync("/definitely/does/not/exist/xyz123")` throws `ENOENT` on every platform before `watch()` is reached.

## Scope

Two lines in `integrations/filesystem-watcher/watcher.mjs` — the `statSync`/`isDirectory` check sits at the top of the existing `try` block, reusing the already-imported `statSync`. No behavior change for valid roots; no new dependencies.
