### PR TITLE
fix(claude-bridge): restore memory/ subdir in MEMORY.md path

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -252,19 +252,20 @@ export function loadClaudeBridgeConfig(): ClaudeBridgeConfig {
   const lineBudget = safeParseInt(env["CLAUDE_MEMORY_LINE_BUDGET"], 200);
   let memoryFilePath = "";
   if (enabled && projectPath) {
-    // Claude Code stores MEMORY.md at
-    //   ~/.claude/projects/<slug>/MEMORY.md
+    // Claude Code stores project memory at
+    //   ~/.claude/projects/<slug>/memory/MEMORY.md
     // where <slug> is the project path with `/` and `\` swapped for `-`.
     // The leading `-` from an absolute POSIX path is preserved (Claude
     // Code keeps it; stripping it produced a slug Claude never reads).
-    // There's also no `memory/` subdirectory — the file sits directly
-    // under the slug dir.
+    // The `memory/` subdirectory holds MEMORY.md (the index) plus one
+    // per-topic `.md` file per memory (verified against Claude Code 2.x).
     const safePath = projectPath.replace(/[/\\]/g, "-");
     memoryFilePath = join(
       homedir(),
       ".claude",
       "projects",
       safePath,
+      "memory",
       "MEMORY.md",
     );
   }

--- a/test/claude-bridge-path.test.ts
+++ b/test/claude-bridge-path.test.ts
@@ -4,10 +4,10 @@ import { join } from "node:path";
 import { loadClaudeBridgeConfig } from "../src/config.js";
 
 // bridge path must match Claude Code's slug convention exactly:
-//   ~/.claude/projects/<slug>/MEMORY.md
+//   ~/.claude/projects/<slug>/memory/MEMORY.md
 // where <slug> replaces every / and \ with - and KEEPS any leading -.
-// The previous code stripped the leading - and added a /memory/
-// subdirectory; the bridge then wrote a file Claude Code never read.
+// The memory/ subdirectory holds MEMORY.md (the index) plus per-topic
+// .md files — this is where Claude Code 2.x actually reads/writes.
 describe("loadClaudeBridgeConfig path (#625)", () => {
   const ORIG_ENV = { ...process.env };
   beforeEach(() => {
@@ -24,16 +24,15 @@ describe("loadClaudeBridgeConfig path (#625)", () => {
     process.env["CLAUDE_PROJECT_PATH"] = "/home/user/repos/my-project";
     const cfg = loadClaudeBridgeConfig();
     expect(cfg.memoryFilePath).toBe(
-      join(homedir(), ".claude", "projects", "-home-user-repos-my-project", "MEMORY.md"),
+      join(homedir(), ".claude", "projects", "-home-user-repos-my-project", "memory", "MEMORY.md"),
     );
   });
 
-  it("writes MEMORY.md directly under the slug dir, no memory/ subdir", () => {
+  it("writes MEMORY.md inside the memory/ subdir under the slug dir", () => {
     process.env["CLAUDE_MEMORY_BRIDGE"] = "true";
     process.env["CLAUDE_PROJECT_PATH"] = "/Users/x/agentmemory";
     const cfg = loadClaudeBridgeConfig();
-    expect(cfg.memoryFilePath).not.toMatch(/[/\\]memory[/\\]MEMORY\.md$/);
-    expect(cfg.memoryFilePath).toMatch(/-Users-x-agentmemory[/\\]MEMORY\.md$/);
+    expect(cfg.memoryFilePath).toMatch(/-Users-x-agentmemory[/\\]memory[/\\]MEMORY\.md$/);
   });
 
   it("returns empty memoryFilePath when bridge disabled", () => {
@@ -53,6 +52,6 @@ describe("loadClaudeBridgeConfig path (#625)", () => {
     process.env["CLAUDE_MEMORY_BRIDGE"] = "true";
     process.env["CLAUDE_PROJECT_PATH"] = "C:\\Users\\x\\project";
     const cfg = loadClaudeBridgeConfig();
-    expect(cfg.memoryFilePath).toMatch(/C:-Users-x-project[/\\]MEMORY\.md$/);
+    expect(cfg.memoryFilePath).toMatch(/C:-Users-x-project[/\\]memory[/\\]MEMORY\.md$/);
   });
 });


### PR DESCRIPTION
## Summary

`CLAUDE_MEMORY_BRIDGE` writes `MEMORY.md` to a path Claude Code never reads, so the bridge is silently broken on every platform.

### The bug

`loadClaudeBridgeConfig()` in `src/config.ts` computes:

```
~/.claude/projects/<slug>/MEMORY.md
```

But Claude Code 2.x stores **project memory** at:

```
~/.claude/projects/<slug>/memory/MEMORY.md
```

The `memory/` subdirectory holds `MEMORY.md` (the index) plus one per-topic `.md` file per memory. Issue #625 fixed the leading-dash slug problem (`.replace(/^-/, "")` removal) but in the same change also dropped the `memory/` segment, pointing the bridge at a file Claude Code never reads — the written index simply disappears.

### Evidence

- Verified against the **Claude Code 2.1.141 bundle**: path constants `memory` + `MEMORY.md` are joined under `~/.claude/projects/<slug>/`, and the loader filters `.md` files with `basename !== "MEMORY.md"` inside that dir (i.e. index + topic files live together in `memory/`).
- Verified on disk: a real project memory dir contains `memory/MEMORY.md` (a `# Memory Index` with links) alongside `memory/<topic>.md` files.
- Also confirmed the **latest npm release v0.9.28 still ships the bug** — the dist still joins `"projects", safePath, "MEMORY.md"`.

### The fix

Restore the `memory` segment in the join, keeping the #625 leading-dash fix:

```ts
memoryFilePath = join(
  homedir(),
  ".claude",
  "projects",
  safePath,
  "memory",
  "MEMORY.md",
);
```

Plus updated path tests (`test/claude-bridge-path.test.ts`) to assert the `memory/` subdir.

## Test plan

- `npx vitest run test/claude-bridge-path.test.ts test/claude-bridge.test.ts` → **10 passed, 0 failed**
- Full suite `npx vitest run` → **1449 tests: 1448 passed, 0 failed, 1 pending** (442/442 suites)

## Notes (out of scope)

- `direction=read` on `memory_claude_bridge_sync` currently only reads + returns the file; the tool description says "import from MEMORY.md" but nothing is imported into memories. Worth a follow-up.
- `serializeToMemoryMd` writes a `# Agent Memory (auto-synced by agentmemory)` layout rather than Claude Code's native `# Memory Index` bullet format, so after a `write` the file is no longer in Claude's native shape. Follow-up candidate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Claude bridge memory files are now stored in the standardized `memory/MEMORY.md` location within each project directory.
  - Project paths with leading hyphens are preserved correctly across supported operating systems.
  - Improved path handling helps ensure existing Claude bridge memory is located consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->