### PR TITLE
test(hooks): decouple resolveProject tests from checkout directory name

### DIFF
--- a/test/hook-project.test.ts
+++ b/test/hook-project.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from "vitest";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { basename, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { resolveProject } from "../src/hooks/_project.js";
 
 // The checkout directory is not necessarily named "agentmemory" — contributors clone
@@ -67,10 +67,22 @@ describe("resolveProject — hook project basename resolver", () => {
   });
 
   it("falls back to basename(cwd) when not in a git repo", () => {
-    const dir = mkdtempSync(join(tmpdir(), "amem-noproj-"));
+    // mkdtemp lands under os.tmpdir(), which is not always outside a repository —
+    // TMPDIR pointed at a working directory makes git walk up and find one, and the
+    // fallback under test never runs. Ceiling the upward search at the parent so the
+    // directory is genuinely repo-less. The ceiling must be a resolved path: git
+    // compares it after resolving symlinks, and on macOS tmpdir() is one.
+    const dir = realpathSync(mkdtempSync(join(tmpdir(), "amem-noproj-")));
+    const priorCeiling = process.env.GIT_CEILING_DIRECTORIES;
+    process.env.GIT_CEILING_DIRECTORIES = dirname(dir);
     try {
       expect(resolveProject(dir)).toBe(basename(dir));
     } finally {
+      if (priorCeiling === undefined) {
+        delete process.env.GIT_CEILING_DIRECTORIES;
+      } else {
+        process.env.GIT_CEILING_DIRECTORIES = priorCeiling;
+      }
       rmSync(dir, { recursive: true, force: true });
     }
   });

--- a/test/hook-project.test.ts
+++ b/test/hook-project.test.ts
@@ -1,17 +1,40 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync } from "node:fs";
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { resolveProject } from "../src/hooks/_project.js";
+
+// The checkout directory is not necessarily named "agentmemory" — contributors clone
+// into forks, worktrees and arbitrary paths — so the git-toplevel assertions run against
+// a throwaway repo whose name we control instead of against process.cwd().
+const REPO_NAME = "amem-fixture-repo";
 
 describe("resolveProject — hook project basename resolver", () => {
   const originalEnv = process.env.AGENTMEMORY_PROJECT_NAME;
+
+  let tmpRoot: string;
+  let repoDir: string;
+  let nestedDir: string;
+
+  beforeAll(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), "amem-project-"));
+    repoDir = join(tmpRoot, REPO_NAME);
+    nestedDir = join(repoDir, "src", "hooks");
+    mkdirSync(nestedDir, { recursive: true });
+    execFileSync("git", ["init", "--quiet"], { cwd: repoDir, stdio: "ignore" });
+  });
+
+  afterAll(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
 
   beforeEach(() => {
     delete process.env.AGENTMEMORY_PROJECT_NAME;
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     if (originalEnv === undefined) {
       delete process.env.AGENTMEMORY_PROJECT_NAME;
     } else {
@@ -22,7 +45,7 @@ describe("resolveProject — hook project basename resolver", () => {
   it("AGENTMEMORY_PROJECT_NAME env wins over everything", () => {
     process.env.AGENTMEMORY_PROJECT_NAME = "my-override";
     expect(resolveProject("/var/log")).toBe("my-override");
-    expect(resolveProject(process.cwd())).toBe("my-override");
+    expect(resolveProject(repoDir)).toBe("my-override");
   });
 
   it("trims whitespace on env override", () => {
@@ -32,35 +55,34 @@ describe("resolveProject — hook project basename resolver", () => {
 
   it("ignores empty env override", () => {
     process.env.AGENTMEMORY_PROJECT_NAME = "   ";
-    const repoBasename = "agentmemory";
-    expect(resolveProject(process.cwd())).toBe(repoBasename);
+    expect(resolveProject(repoDir)).toBe(REPO_NAME);
   });
 
   it("returns git toplevel basename when cwd is inside a repo", () => {
-    const top = resolveProject(process.cwd());
-    expect(top).toBe("agentmemory");
+    expect(resolveProject(repoDir)).toBe(REPO_NAME);
   });
 
   it("returns git toplevel basename from a nested subdir", () => {
-    const nested = join(process.cwd(), "src", "hooks");
-    expect(resolveProject(nested)).toBe("agentmemory");
+    expect(resolveProject(nestedDir)).toBe(REPO_NAME);
   });
 
   it("falls back to basename(cwd) when not in a git repo", () => {
     const dir = mkdtempSync(join(tmpdir(), "amem-noproj-"));
     try {
-      expect(resolveProject(dir)).toBe(dir.split("/").pop());
+      expect(resolveProject(dir)).toBe(basename(dir));
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
   });
 
   it("defaults to process.cwd() when no cwd argument given", () => {
-    expect(resolveProject()).toBe("agentmemory");
+    vi.spyOn(process, "cwd").mockReturnValue(repoDir);
+    expect(resolveProject()).toBe(REPO_NAME);
   });
 
   it("defaults to process.cwd() when cwd argument is empty", () => {
-    expect(resolveProject("")).toBe("agentmemory");
-    expect(resolveProject("   ")).toBe("agentmemory");
+    vi.spyOn(process, "cwd").mockReturnValue(repoDir);
+    expect(resolveProject("")).toBe(REPO_NAME);
+    expect(resolveProject("   ")).toBe(REPO_NAME);
   });
 });


### PR DESCRIPTION
Fixes #1137.

`test/hook-project.test.ts` asserted that `resolveProject()` returns the literal string `"agentmemory"`. Since `resolveProject()` returns `basename(git rev-parse --show-toplevel)`, that holds only when the working copy lives in a directory named exactly `agentmemory`, so 5 of the 8 tests fail on a clean `main` for anyone working in a fork or a worktree under a different name.

The tests now use a fixture they control instead of the checkout path. `src/hooks/_project.ts` is unchanged.

- `beforeAll` creates a repo under `os.tmpdir()` named `amem-fixture-repo` with a nested `src/hooks` subdirectory and runs `git init --quiet` in it. The git-toplevel cases resolve against that repo, so the expected name is one the test picked.
- The two "defaults to `process.cwd()`" cases stub the call with `vi.spyOn(process, "cwd").mockReturnValue(repoDir)` and restore it in `afterEach`. They still check that `resolveProject()` consults `process.cwd()` when given no argument, an empty string, or whitespace.
- The non-git fallback case compares against `basename(dir)` from `node:path` instead of `dir.split("/").pop()`.

Deriving the expected value from `basename(process.cwd())` would have been shorter, but then the test would compute its expectation the same way the implementation does and could never fail. The tmpdir fixture keeps the two independent.

## How to verify

```bash
npx vitest run test/hook-project.test.ts   # 8 passed
npm test                                   # 1431 passed, 1 skipped, 0 failed
npm run build                              # clean
```

Clone into a directory not named `agentmemory` and run the file before and after this change to see the original failure.

To check the tests still bite, I broke `src/hooks/_project.ts` two ways and reverted both:

- dropping `if (top) return basename(top);` fails "returns git toplevel basename from a nested subdir" (`expected 'hooks' to be 'amem-fixture-repo'`)
- replacing the `process.cwd()` default with a literal path fails both "defaults to `process.cwd()`" tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by using isolated temporary Git repositories.
  * Added coverage for Git root detection, nested directories, fallback behavior, default directories, mocked working directories, and whitespace-only inputs.
  * Enhanced handling of non-repository paths, including constrained Git searches and symlink resolution.
  * Ensured test fixtures are cleaned up and mocks are restored after each test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->