### PR TITLE
feat(export): paginate the non-session collections the frame guard's hint calls out

### DIFF
--- a/plugin/skills/agentmemory-mcp-tools/REFERENCE.md
+++ b/plugin/skills/agentmemory-mcp-tools/REFERENCE.md
@@ -18,7 +18,7 @@ agentmemory exposes 54 MCP tools. 8 are in the lean core set (`--tools core` or 
 | `memory_consolidate` | yes | `tier`: string | Run the 4-tier memory consolidation pipeline (working -> episodic -> semantic -> procedural). |
 | `memory_crystallize` |  | `actionIds`*: string, `project`: string, `sessionId`: string | Compress completed action chains into compact crystal digests using LLM summarization. Extracts narrative, key outcomes, files affected, and lessons. |
 | `memory_diagnose` | yes | `categories`: string | Run health checks across all subsystems (actions, leases, sentinels, sketches, signals, sessions, memories, mesh). Identifies stuck, orphaned, and inconsistent state. |
-| `memory_export` |  | none | Export all memory data as JSON. |
+| `memory_export` |  | `maxSessions`: number, `offset`: number, `collectionLimit`: number, `collectionOffset`: number, `collections`: string | Export memory data as JSON. Past the transport size limit the export is refused, so use the paging arguments on a large store. |
 | `memory_facet_query` |  | `matchAll`: string, `matchAny`: string, `targetType`: string | Query targets by facet tags with AND/OR logic. Find all actions tagged priority:urgent AND team:backend. |
 | `memory_facet_tag` |  | `targetId`*: string, `targetType`*: string, `dimension`*: string, `value`*: string | Attach a structured tag (dimension:value) to an action, memory, or observation for multi-dimensional categorization. |
 | `memory_file_history` |  | `files`*: string, `sessionId`: string | Get past observations about specific files. |

--- a/src/functions/export-import.ts
+++ b/src/functions/export-import.ts
@@ -58,20 +58,101 @@ async function runChunked<T>(
   }
 }
 
+// Every collection mem::export can put in the payload — the vocabulary
+// `?collections=` is matched against. sessions, observations and profiles
+// are absent on purpose: they are windowed by maxSessions/offset, and
+// profiles are derived from the session page rather than listed.
+const EXPORT_COLLECTION_NAMES: ReadonlySet<string> = new Set([
+  "memories",
+  "summaries",
+  "graphNodes",
+  "graphEdges",
+  "semanticMemories",
+  "proceduralMemories",
+  "actions",
+  "actionEdges",
+  "sentinels",
+  "sketches",
+  "crystals",
+  "facets",
+  "lessons",
+  "insights",
+  "routines",
+  "signals",
+  "checkpoints",
+  "accessLogs",
+]);
+
+// Absent means every collection — the behaviour before this parameter
+// existed. Present means the caller chose, so an empty or all-unknown
+// list selects nothing: falling back to everything there would turn a
+// client-side typo into the full multi-megabyte dump this parameter
+// exists to avoid. Unknown names are dropped rather than refused so a
+// client can name a collection an older build does not have and still
+// get the ones it does.
+function parseCollections(raw: unknown): ReadonlySet<string> | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  const names = Array.isArray(raw) ? raw : String(raw).split(",");
+  return new Set(
+    names
+      .map((name) => String(name).trim())
+      .filter((name) => EXPORT_COLLECTION_NAMES.has(name)),
+  );
+}
+
 export function registerExportImportFunction(sdk: ISdk, kv: StateKV): void {
-  sdk.registerFunction("mem::export", 
-    async (data?: { maxSessions?: number; offset?: number }) => {
+  sdk.registerFunction("mem::export",
+    async (data?: {
+      maxSessions?: number;
+      offset?: number;
+      collectionLimit?: number;
+      collectionOffset?: number;
+      collections?: string[] | string;
+    }) => {
       const rawMax = Number(data?.maxSessions);
       const maxSessions = Number.isFinite(rawMax) && rawMax > 0 ? Math.min(Math.floor(rawMax), 1000) : undefined;
       const rawOffset = Number(data?.offset);
       const offset = Number.isFinite(rawOffset) && rawOffset >= 0 ? Math.floor(rawOffset) : 0;
+      const rawCollectionLimit = Number(data?.collectionLimit);
+      const collectionLimit =
+        Number.isFinite(rawCollectionLimit) && rawCollectionLimit > 0
+          ? Math.floor(rawCollectionLimit)
+          : undefined;
+      const rawCollectionOffset = Number(data?.collectionOffset);
+      const collectionOffset =
+        Number.isFinite(rawCollectionOffset) && rawCollectionOffset >= 0
+          ? Math.floor(rawCollectionOffset)
+          : 0;
+
+      const collections = parseCollections(data?.collections);
+      const isSelected = (name: string): boolean =>
+        collections === undefined || collections.has(name);
+
+      // Records every collection's full size before slicing, so the
+      // caller can tell how far it still has to page even though the
+      // response only carries one window. Deselected collections are
+      // counted too: totals are what clients read for corpus size, and
+      // an allowlist is about what travels, not about what is known.
+      const collectionTotals: Record<string, number> = {};
+      const sliceCollection = <T>(name: string, rows: T[]): T[] => {
+        collectionTotals[name] = rows.length;
+        if (!isSelected(name)) return [];
+        if (collectionLimit === undefined) return rows;
+        return rows.slice(collectionOffset, collectionOffset + collectionLimit);
+      };
 
       const allSessions = await kv.list<Session>(KV.sessions);
       const paginatedSessions = maxSessions !== undefined
         ? allSessions.slice(offset, offset + maxSessions)
         : allSessions;
-      const memories = await kv.list<Memory>(KV.memories);
-      const summaries = await kv.list<SessionSummary>(KV.summaries);
+      const memories = sliceCollection(
+        "memories",
+        await kv.list<Memory>(KV.memories),
+      );
+      const summaries = sliceCollection(
+        "summaries",
+        await kv.list<SessionSummary>(KV.summaries),
+      );
 
       const observations: Record<string, CompressedObservation[]> = {};
       const obsResults = await Promise.all(
@@ -117,22 +198,22 @@ export function registerExportImportFunction(sdk: ISdk, kv: StateKV): void {
         checkpoints,
         accessLogs,
       ] = await Promise.all([
-        kv.list<GraphNode>(KV.graphNodes).catch(() => []),
-        kv.list<GraphEdge>(KV.graphEdges).catch(() => []),
-        kv.list<SemanticMemory>(KV.semantic).catch(() => []),
-        kv.list<ProceduralMemory>(KV.procedural).catch(() => []),
-        kv.list<Action>(KV.actions).catch(() => []),
-        kv.list<ActionEdge>(KV.actionEdges).catch(() => []),
-        kv.list<Sentinel>(KV.sentinels).catch(() => []),
-        kv.list<Sketch>(KV.sketches).catch(() => []),
-        kv.list<Crystal>(KV.crystals).catch(() => []),
-        kv.list<Facet>(KV.facets).catch(() => []),
-        kv.list<Lesson>(KV.lessons).catch(() => []),
-        kv.list<Insight>(KV.insights).catch(() => []),
-        kv.list<Routine>(KV.routines).catch(() => []),
-        kv.list<Signal>(KV.signals).catch(() => []),
-        kv.list<Checkpoint>(KV.checkpoints).catch(() => []),
-        kv.list<AccessLogExport>(KV.accessLog).catch(() => []),
+        kv.list<GraphNode>(KV.graphNodes).catch(() => []).then((r) => sliceCollection("graphNodes", r)),
+        kv.list<GraphEdge>(KV.graphEdges).catch(() => []).then((r) => sliceCollection("graphEdges", r)),
+        kv.list<SemanticMemory>(KV.semantic).catch(() => []).then((r) => sliceCollection("semanticMemories", r)),
+        kv.list<ProceduralMemory>(KV.procedural).catch(() => []).then((r) => sliceCollection("proceduralMemories", r)),
+        kv.list<Action>(KV.actions).catch(() => []).then((r) => sliceCollection("actions", r)),
+        kv.list<ActionEdge>(KV.actionEdges).catch(() => []).then((r) => sliceCollection("actionEdges", r)),
+        kv.list<Sentinel>(KV.sentinels).catch(() => []).then((r) => sliceCollection("sentinels", r)),
+        kv.list<Sketch>(KV.sketches).catch(() => []).then((r) => sliceCollection("sketches", r)),
+        kv.list<Crystal>(KV.crystals).catch(() => []).then((r) => sliceCollection("crystals", r)),
+        kv.list<Facet>(KV.facets).catch(() => []).then((r) => sliceCollection("facets", r)),
+        kv.list<Lesson>(KV.lessons).catch(() => []).then((r) => sliceCollection("lessons", r)),
+        kv.list<Insight>(KV.insights).catch(() => []).then((r) => sliceCollection("insights", r)),
+        kv.list<Routine>(KV.routines).catch(() => []).then((r) => sliceCollection("routines", r)),
+        kv.list<Signal>(KV.signals).catch(() => []).then((r) => sliceCollection("signals", r)),
+        kv.list<Checkpoint>(KV.checkpoints).catch(() => []).then((r) => sliceCollection("checkpoints", r)),
+        kv.list<AccessLogExport>(KV.accessLog).catch(() => []).then((r) => sliceCollection("accessLogs", r)),
       ]);
 
       const exportData: ExportData = {
@@ -172,6 +253,22 @@ export function registerExportImportFunction(sdk: ISdk, kv: StateKV): void {
         };
       }
 
+      if (collectionLimit !== undefined) {
+        exportData.collectionPagination = {
+          offset: collectionOffset,
+          limit: collectionLimit,
+          totals: collectionTotals,
+          // Only the selected collections can move the flag: a client
+          // that asked for six of eighteen has to be able to stop on
+          // hasMore instead of hand-rolling an early stop against
+          // totals, and graphEdges still having rows is not its problem.
+          hasMore: Object.entries(collectionTotals).some(
+            ([name, total]) =>
+              isSelected(name) && collectionOffset + collectionLimit < total,
+          ),
+        };
+      }
+
       const totalObs = Object.values(observations).reduce(
         (sum, arr) => sum + arr.length,
         0,
@@ -182,13 +279,19 @@ export function registerExportImportFunction(sdk: ISdk, kv: StateKV): void {
         observations: totalObs,
         memories: memories.length,
         summaries: summaries.length,
+        // Logged post-filter so a caller whose names all got dropped can
+        // see an empty selection here rather than guess why the payload
+        // came back empty while totals looked healthy.
+        collections: collections && [...collections],
       });
 
-      // Only session collections page on ?maxSessions/?offset, so a large
-      // store can exceed the transport cap even at ?maxSessions=1.
+      // Sessions and their observations page on ?maxSessions/?offset; the
+      // rest page on ?collectionLimit/?collectionOffset. A store can still
+      // exceed the cap if one session's observations do, since those are
+      // atomic.
       const oversized = checkPayloadFrameSize(
         exportData,
-        "narrow the range with ?maxSessions / ?offset, or export fewer collections; the non-session collections (memories, graph, semantic, actions, lessons, ...) are not yet paginated",
+        "narrow the range with ?maxSessions / ?offset, page the rest with ?collectionLimit / ?collectionOffset, or ask for a subset with ?collections=",
       );
       if (oversized) {
         logger.warn("Export exceeds transport frame limit", {

--- a/src/functions/export-import.ts
+++ b/src/functions/export-import.ts
@@ -56,20 +56,101 @@ async function runChunked<T>(
   }
 }
 
+// Every collection mem::export can put in the payload — the vocabulary
+// `?collections=` is matched against. sessions, observations and profiles
+// are absent on purpose: they are windowed by maxSessions/offset, and
+// profiles are derived from the session page rather than listed.
+const EXPORT_COLLECTION_NAMES: ReadonlySet<string> = new Set([
+  "memories",
+  "summaries",
+  "graphNodes",
+  "graphEdges",
+  "semanticMemories",
+  "proceduralMemories",
+  "actions",
+  "actionEdges",
+  "sentinels",
+  "sketches",
+  "crystals",
+  "facets",
+  "lessons",
+  "insights",
+  "routines",
+  "signals",
+  "checkpoints",
+  "accessLogs",
+]);
+
+// Absent means every collection — the behaviour before this parameter
+// existed. Present means the caller chose, so an empty or all-unknown
+// list selects nothing: falling back to everything there would turn a
+// client-side typo into the full multi-megabyte dump this parameter
+// exists to avoid. Unknown names are dropped rather than refused so a
+// client can name a collection an older build does not have and still
+// get the ones it does.
+function parseCollections(raw: unknown): ReadonlySet<string> | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  const names = Array.isArray(raw) ? raw : String(raw).split(",");
+  return new Set(
+    names
+      .map((name) => String(name).trim())
+      .filter((name) => EXPORT_COLLECTION_NAMES.has(name)),
+  );
+}
+
 export function registerExportImportFunction(sdk: ISdk, kv: StateKV): void {
-  sdk.registerFunction("mem::export", 
-    async (data?: { maxSessions?: number; offset?: number }) => {
+  sdk.registerFunction("mem::export",
+    async (data?: {
+      maxSessions?: number;
+      offset?: number;
+      collectionLimit?: number;
+      collectionOffset?: number;
+      collections?: string[] | string;
+    }) => {
       const rawMax = Number(data?.maxSessions);
       const maxSessions = Number.isFinite(rawMax) && rawMax > 0 ? Math.min(Math.floor(rawMax), 1000) : undefined;
       const rawOffset = Number(data?.offset);
       const offset = Number.isFinite(rawOffset) && rawOffset >= 0 ? Math.floor(rawOffset) : 0;
+      const rawCollectionLimit = Number(data?.collectionLimit);
+      const collectionLimit =
+        Number.isFinite(rawCollectionLimit) && rawCollectionLimit > 0
+          ? Math.floor(rawCollectionLimit)
+          : undefined;
+      const rawCollectionOffset = Number(data?.collectionOffset);
+      const collectionOffset =
+        Number.isFinite(rawCollectionOffset) && rawCollectionOffset >= 0
+          ? Math.floor(rawCollectionOffset)
+          : 0;
+
+      const collections = parseCollections(data?.collections);
+      const isSelected = (name: string): boolean =>
+        collections === undefined || collections.has(name);
+
+      // Records every collection's full size before slicing, so the
+      // caller can tell how far it still has to page even though the
+      // response only carries one window. Deselected collections are
+      // counted too: totals are what clients read for corpus size, and
+      // an allowlist is about what travels, not about what is known.
+      const collectionTotals: Record<string, number> = {};
+      const sliceCollection = <T>(name: string, rows: T[]): T[] => {
+        collectionTotals[name] = rows.length;
+        if (!isSelected(name)) return [];
+        if (collectionLimit === undefined) return rows;
+        return rows.slice(collectionOffset, collectionOffset + collectionLimit);
+      };
 
       const allSessions = await kv.list<Session>(KV.sessions);
       const paginatedSessions = maxSessions !== undefined
         ? allSessions.slice(offset, offset + maxSessions)
         : allSessions;
-      const memories = await kv.list<Memory>(KV.memories);
-      const summaries = await kv.list<SessionSummary>(KV.summaries);
+      const memories = sliceCollection(
+        "memories",
+        await kv.list<Memory>(KV.memories),
+      );
+      const summaries = sliceCollection(
+        "summaries",
+        await kv.list<SessionSummary>(KV.summaries),
+      );
 
       const observations: Record<string, CompressedObservation[]> = {};
       const obsResults = await Promise.all(
@@ -115,22 +196,22 @@ export function registerExportImportFunction(sdk: ISdk, kv: StateKV): void {
         checkpoints,
         accessLogs,
       ] = await Promise.all([
-        kv.list<GraphNode>(KV.graphNodes).catch(() => []),
-        kv.list<GraphEdge>(KV.graphEdges).catch(() => []),
-        kv.list<SemanticMemory>(KV.semantic).catch(() => []),
-        kv.list<ProceduralMemory>(KV.procedural).catch(() => []),
-        kv.list<Action>(KV.actions).catch(() => []),
-        kv.list<ActionEdge>(KV.actionEdges).catch(() => []),
-        kv.list<Sentinel>(KV.sentinels).catch(() => []),
-        kv.list<Sketch>(KV.sketches).catch(() => []),
-        kv.list<Crystal>(KV.crystals).catch(() => []),
-        kv.list<Facet>(KV.facets).catch(() => []),
-        kv.list<Lesson>(KV.lessons).catch(() => []),
-        kv.list<Insight>(KV.insights).catch(() => []),
-        kv.list<Routine>(KV.routines).catch(() => []),
-        kv.list<Signal>(KV.signals).catch(() => []),
-        kv.list<Checkpoint>(KV.checkpoints).catch(() => []),
-        kv.list<AccessLogExport>(KV.accessLog).catch(() => []),
+        kv.list<GraphNode>(KV.graphNodes).catch(() => []).then((r) => sliceCollection("graphNodes", r)),
+        kv.list<GraphEdge>(KV.graphEdges).catch(() => []).then((r) => sliceCollection("graphEdges", r)),
+        kv.list<SemanticMemory>(KV.semantic).catch(() => []).then((r) => sliceCollection("semanticMemories", r)),
+        kv.list<ProceduralMemory>(KV.procedural).catch(() => []).then((r) => sliceCollection("proceduralMemories", r)),
+        kv.list<Action>(KV.actions).catch(() => []).then((r) => sliceCollection("actions", r)),
+        kv.list<ActionEdge>(KV.actionEdges).catch(() => []).then((r) => sliceCollection("actionEdges", r)),
+        kv.list<Sentinel>(KV.sentinels).catch(() => []).then((r) => sliceCollection("sentinels", r)),
+        kv.list<Sketch>(KV.sketches).catch(() => []).then((r) => sliceCollection("sketches", r)),
+        kv.list<Crystal>(KV.crystals).catch(() => []).then((r) => sliceCollection("crystals", r)),
+        kv.list<Facet>(KV.facets).catch(() => []).then((r) => sliceCollection("facets", r)),
+        kv.list<Lesson>(KV.lessons).catch(() => []).then((r) => sliceCollection("lessons", r)),
+        kv.list<Insight>(KV.insights).catch(() => []).then((r) => sliceCollection("insights", r)),
+        kv.list<Routine>(KV.routines).catch(() => []).then((r) => sliceCollection("routines", r)),
+        kv.list<Signal>(KV.signals).catch(() => []).then((r) => sliceCollection("signals", r)),
+        kv.list<Checkpoint>(KV.checkpoints).catch(() => []).then((r) => sliceCollection("checkpoints", r)),
+        kv.list<AccessLogExport>(KV.accessLog).catch(() => []).then((r) => sliceCollection("accessLogs", r)),
       ]);
 
       const exportData: ExportData = {
@@ -170,6 +251,22 @@ export function registerExportImportFunction(sdk: ISdk, kv: StateKV): void {
         };
       }
 
+      if (collectionLimit !== undefined) {
+        exportData.collectionPagination = {
+          offset: collectionOffset,
+          limit: collectionLimit,
+          totals: collectionTotals,
+          // Only the selected collections can move the flag: a client
+          // that asked for six of eighteen has to be able to stop on
+          // hasMore instead of hand-rolling an early stop against
+          // totals, and graphEdges still having rows is not its problem.
+          hasMore: Object.entries(collectionTotals).some(
+            ([name, total]) =>
+              isSelected(name) && collectionOffset + collectionLimit < total,
+          ),
+        };
+      }
+
       const totalObs = Object.values(observations).reduce(
         (sum, arr) => sum + arr.length,
         0,
@@ -180,13 +277,19 @@ export function registerExportImportFunction(sdk: ISdk, kv: StateKV): void {
         observations: totalObs,
         memories: memories.length,
         summaries: summaries.length,
+        // Logged post-filter so a caller whose names all got dropped can
+        // see an empty selection here rather than guess why the payload
+        // came back empty while totals looked healthy.
+        collections: collections && [...collections],
       });
 
-      // Only session collections page on ?maxSessions/?offset, so a large
-      // store can exceed the transport cap even at ?maxSessions=1.
+      // Sessions and their observations page on ?maxSessions/?offset; the
+      // rest page on ?collectionLimit/?collectionOffset. A store can still
+      // exceed the cap if one session's observations do, since those are
+      // atomic.
       const oversized = checkPayloadFrameSize(
         exportData,
-        "narrow the range with ?maxSessions / ?offset, or export fewer collections; the non-session collections (memories, graph, semantic, actions, lessons, ...) are not yet paginated",
+        "narrow the range with ?maxSessions / ?offset, page the rest with ?collectionLimit / ?collectionOffset, or ask for a subset with ?collections=",
       );
       if (oversized) {
         logger.warn("Export exceeds transport frame limit", {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -367,7 +367,31 @@ export function registerMcpEndpoints(
           }
 
           case "memory_export": {
-            const result = await sdk.trigger({ function_id: "mem::export", payload: {} });
+            // The tool is where an agent actually reaches export, so the
+            // paging arguments have to survive this layer or a large store
+            // stays unreachable from MCP. `collections` is forwarded raw,
+            // empty string included: mem::export reads an empty selection
+            // as "no collections", which only stays distinguishable from
+            // an absent argument if this layer does not drop it.
+            const exportPayload: {
+              maxSessions?: number;
+              offset?: number;
+              collectionLimit?: number;
+              collectionOffset?: number;
+              collections?: string;
+            } = {};
+            for (const key of ["maxSessions", "collectionLimit"] as const) {
+              const n = Number(args[key]);
+              if (Number.isInteger(n) && n > 0) exportPayload[key] = n;
+            }
+            for (const key of ["offset", "collectionOffset"] as const) {
+              const n = Number(args[key]);
+              if (Number.isInteger(n) && n >= 0) exportPayload[key] = n;
+            }
+            if (typeof args.collections === "string") {
+              exportPayload.collections = args.collections;
+            }
+            const result = await sdk.trigger({ function_id: "mem::export", payload: exportPayload });
             return {
               status_code: 200,
               body: {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -362,7 +362,31 @@ export function registerMcpEndpoints(
           }
 
           case "memory_export": {
-            const result = await sdk.trigger({ function_id: "mem::export", payload: {} });
+            // The tool is where an agent actually reaches export, so the
+            // paging arguments have to survive this layer or a large store
+            // stays unreachable from MCP. `collections` is forwarded raw,
+            // empty string included: mem::export reads an empty selection
+            // as "no collections", which only stays distinguishable from
+            // an absent argument if this layer does not drop it.
+            const exportPayload: {
+              maxSessions?: number;
+              offset?: number;
+              collectionLimit?: number;
+              collectionOffset?: number;
+              collections?: string;
+            } = {};
+            for (const key of ["maxSessions", "collectionLimit"] as const) {
+              const n = Number(args[key]);
+              if (Number.isInteger(n) && n > 0) exportPayload[key] = n;
+            }
+            for (const key of ["offset", "collectionOffset"] as const) {
+              const n = Number(args[key]);
+              if (Number.isInteger(n) && n >= 0) exportPayload[key] = n;
+            }
+            if (typeof args.collections === "string") {
+              exportPayload.collections = args.collections;
+            }
+            const result = await sdk.trigger({ function_id: "mem::export", payload: exportPayload });
             return {
               status_code: 200,
               body: {

--- a/src/mcp/tools-registry.ts
+++ b/src/mcp/tools-registry.ts
@@ -195,8 +195,32 @@ export const CORE_TOOLS: McpToolDef[] = [
   },
   {
     name: "memory_export",
-    description: "Export all memory data as JSON.",
-    inputSchema: { type: "object", properties: {} },
+    description:
+      "Export memory data as JSON. Past the transport size limit the export is refused, so use the paging arguments on a large store.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        maxSessions: {
+          type: "number",
+          description: "Sessions per page (with their observations)",
+        },
+        offset: { type: "number", description: "Session offset" },
+        collectionLimit: {
+          type: "number",
+          description:
+            "Rows per page for memories, graph, lessons and the other top-level collections",
+        },
+        collectionOffset: {
+          type: "number",
+          description: "Row offset for the top-level collections",
+        },
+        collections: {
+          type: "string",
+          description:
+            "Comma-separated allowlist of top-level collections to return, e.g. memories,summaries,lessons. Unknown names are ignored. Omit for all of them; totals still cover every collection either way.",
+        },
+      },
+    },
   },
   {
     name: "memory_relations",

--- a/src/mcp/tools-registry.ts
+++ b/src/mcp/tools-registry.ts
@@ -189,8 +189,32 @@ export const CORE_TOOLS: McpToolDef[] = [
   },
   {
     name: "memory_export",
-    description: "Export all memory data as JSON.",
-    inputSchema: { type: "object", properties: {} },
+    description:
+      "Export memory data as JSON. Past the transport size limit the export is refused, so use the paging arguments on a large store.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        maxSessions: {
+          type: "number",
+          description: "Sessions per page (with their observations)",
+        },
+        offset: { type: "number", description: "Session offset" },
+        collectionLimit: {
+          type: "number",
+          description:
+            "Rows per page for memories, graph, lessons and the other top-level collections",
+        },
+        collectionOffset: {
+          type: "number",
+          description: "Row offset for the top-level collections",
+        },
+        collections: {
+          type: "string",
+          description:
+            "Comma-separated allowlist of top-level collections to return, e.g. memories,summaries,lessons. Unknown names are ignored. Omit for all of them; totals still cover every collection either way.",
+        },
+      },
+    },
   },
   {
     name: "memory_relations",

--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -1316,9 +1316,18 @@ export function registerApiTriggers(
       // real corpus (40 sessions × 34K observations × 8K memories) hit the
       // iii engine invocation timeout and `agentmemory status` reported 0.
       // Pass through the query-string pagination so callers can chunk.
+      const payload: {
+        maxSessions?: number;
+        offset?: number;
+        collectionLimit?: number;
+        collectionOffset?: number;
+        collections?: string;
+      } = {};
       const rawMax = req.query_params?.["maxSessions"];
       const rawOffset = req.query_params?.["offset"];
-      const payload: { maxSessions?: number; offset?: number } = {};
+      const rawCollectionLimit = req.query_params?.["collectionLimit"];
+      const rawCollectionOffset = req.query_params?.["collectionOffset"];
+      const rawCollections = req.query_params?.["collections"];
       if (typeof rawMax === "string") {
         const n = Number(rawMax);
         if (Number.isInteger(n) && n > 0) payload.maxSessions = n;
@@ -1326,6 +1335,20 @@ export function registerApiTriggers(
       if (typeof rawOffset === "string") {
         const n = Number(rawOffset);
         if (Number.isInteger(n) && n >= 0) payload.offset = n;
+      }
+      if (typeof rawCollectionLimit === "string") {
+        const n = Number(rawCollectionLimit);
+        if (Number.isInteger(n) && n > 0) payload.collectionLimit = n;
+      }
+      if (typeof rawCollectionOffset === "string") {
+        const n = Number(rawCollectionOffset);
+        if (Number.isInteger(n) && n >= 0) payload.collectionOffset = n;
+      }
+      // Forwarded raw, empty value included: mem::export owns the name
+      // vocabulary, and only it can tell "?collections=" (an explicit
+      // empty selection) from an absent parameter (every collection).
+      if (typeof rawCollections === "string") {
+        payload.collections = rawCollections;
       }
       const result = await sdk.trigger({
         function_id: "mem::export",

--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -1299,9 +1299,18 @@ export function registerApiTriggers(
       // real corpus (40 sessions × 34K observations × 8K memories) hit the
       // iii engine invocation timeout and `agentmemory status` reported 0.
       // Pass through the query-string pagination so callers can chunk.
+      const payload: {
+        maxSessions?: number;
+        offset?: number;
+        collectionLimit?: number;
+        collectionOffset?: number;
+        collections?: string;
+      } = {};
       const rawMax = req.query_params?.["maxSessions"];
       const rawOffset = req.query_params?.["offset"];
-      const payload: { maxSessions?: number; offset?: number } = {};
+      const rawCollectionLimit = req.query_params?.["collectionLimit"];
+      const rawCollectionOffset = req.query_params?.["collectionOffset"];
+      const rawCollections = req.query_params?.["collections"];
       if (typeof rawMax === "string") {
         const n = Number(rawMax);
         if (Number.isInteger(n) && n > 0) payload.maxSessions = n;
@@ -1309,6 +1318,20 @@ export function registerApiTriggers(
       if (typeof rawOffset === "string") {
         const n = Number(rawOffset);
         if (Number.isInteger(n) && n >= 0) payload.offset = n;
+      }
+      if (typeof rawCollectionLimit === "string") {
+        const n = Number(rawCollectionLimit);
+        if (Number.isInteger(n) && n > 0) payload.collectionLimit = n;
+      }
+      if (typeof rawCollectionOffset === "string") {
+        const n = Number(rawCollectionOffset);
+        if (Number.isInteger(n) && n >= 0) payload.collectionOffset = n;
+      }
+      // Forwarded raw, empty value included: mem::export owns the name
+      // vocabulary, and only it can tell "?collections=" (an explicit
+      // empty selection) from an absent parameter (every collection).
+      if (typeof rawCollections === "string") {
+        payload.collections = rawCollections;
       }
       const result = await sdk.trigger({
         function_id: "mem::export",

--- a/src/types.ts
+++ b/src/types.ts
@@ -327,6 +327,25 @@ export interface ExportPagination {
   hasMore: boolean;
 }
 
+// Pagination for the top-level collections (memories, graph, lessons, …).
+// Separate from ExportPagination because that one slices sessions and the
+// observations hanging off them, which left every other collection
+// unbounded: a corpus could reach a size where even ?maxSessions=1 was
+// undeliverable, making the export permanently impossible at any
+// parameter.
+export interface ExportCollectionPagination {
+  offset: number;
+  limit: number;
+  // Every collection, always — including the ones a `collections`
+  // allowlist kept out of this response. Clients read totals for corpus
+  // counts, not only to size their own walk.
+  totals: Record<string, number>;
+  // True when any *selected* collection has rows past this window. With
+  // no allowlist that is every collection, as before.
+  hasMore: boolean;
+}
+
+
 export interface ExportData {
   version: "0.3.0" | "0.4.0" | "0.5.0" | "0.6.0" | "0.6.1" | "0.7.0" | "0.7.2" | "0.7.3" | "0.7.4" | "0.7.5" | "0.7.6" | "0.7.7" | "0.7.9" | "0.8.0" | "0.8.1" | "0.8.2" | "0.8.3" | "0.8.4" | "0.8.5" | "0.8.6" | "0.8.7" | "0.8.8" | "0.8.9" | "0.8.10" | "0.8.11" | "0.8.12" | "0.8.13" | "0.9.0" | "0.9.1" | "0.9.2" | "0.9.3" | "0.9.4" | "0.9.5" | "0.9.6" | "0.9.7" | "0.9.8" | "0.9.9" | "0.9.10" | "0.9.11" | "0.9.12" | "0.9.13" | "0.9.14" | "0.9.15" | "0.9.16" | "0.9.17" | "0.9.18" | "0.9.19" | "0.9.20" | "0.9.21" | "0.9.22" | "0.9.23" | "0.9.24" | "0.9.25" | "0.9.26" | "0.9.27" | "0.9.28" | "0.9.29";
   exportedAt: string;
@@ -352,6 +371,7 @@ export interface ExportData {
   insights?: Insight[];
   accessLogs?: AccessLogExport[];
   pagination?: ExportPagination;
+  collectionPagination?: ExportCollectionPagination;
 }
 
 export interface AccessLogExport {

--- a/src/types.ts
+++ b/src/types.ts
@@ -306,6 +306,25 @@ export interface ExportPagination {
   hasMore: boolean;
 }
 
+// Pagination for the top-level collections (memories, graph, lessons, …).
+// Separate from ExportPagination because that one slices sessions and the
+// observations hanging off them, which left every other collection
+// unbounded: a corpus could reach a size where even ?maxSessions=1 was
+// undeliverable, making the export permanently impossible at any
+// parameter.
+export interface ExportCollectionPagination {
+  offset: number;
+  limit: number;
+  // Every collection, always — including the ones a `collections`
+  // allowlist kept out of this response. Clients read totals for corpus
+  // counts, not only to size their own walk.
+  totals: Record<string, number>;
+  // True when any *selected* collection has rows past this window. With
+  // no allowlist that is every collection, as before.
+  hasMore: boolean;
+}
+
+
 export interface ExportData {
   version: "0.3.0" | "0.4.0" | "0.5.0" | "0.6.0" | "0.6.1" | "0.7.0" | "0.7.2" | "0.7.3" | "0.7.4" | "0.7.5" | "0.7.6" | "0.7.7" | "0.7.9" | "0.8.0" | "0.8.1" | "0.8.2" | "0.8.3" | "0.8.4" | "0.8.5" | "0.8.6" | "0.8.7" | "0.8.8" | "0.8.9" | "0.8.10" | "0.8.11" | "0.8.12" | "0.8.13" | "0.9.0" | "0.9.1" | "0.9.2" | "0.9.3" | "0.9.4" | "0.9.5" | "0.9.6" | "0.9.7" | "0.9.8" | "0.9.9" | "0.9.10" | "0.9.11" | "0.9.12" | "0.9.13" | "0.9.14" | "0.9.15" | "0.9.16" | "0.9.17" | "0.9.18" | "0.9.19" | "0.9.20" | "0.9.21" | "0.9.22" | "0.9.23" | "0.9.24" | "0.9.25" | "0.9.26" | "0.9.27" | "0.9.28" | "0.9.29";
   exportedAt: string;
@@ -331,6 +350,7 @@ export interface ExportData {
   insights?: Insight[];
   accessLogs?: AccessLogExport[];
   pagination?: ExportPagination;
+  collectionPagination?: ExportCollectionPagination;
 }
 
 export interface AccessLogExport {

--- a/test/export-import.test.ts
+++ b/test/export-import.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
 vi.mock("../src/logger.js", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
@@ -132,6 +132,24 @@ describe("Export/Import Functions", () => {
     expect(result.observations["ses_1"].length).toBe(1);
     expect(result.memories.length).toBe(1);
     expect(result.summaries.length).toBe(1);
+  });
+
+  it("export without params returns the complete corpus unchanged", async () => {
+    const result = (await sdk.trigger("mem::export", {})) as ExportData;
+
+    // Pins the contract every consumer depends on: no query params means
+    // the whole corpus, in exactly this shape. Empty collections stay
+    // absent rather than becoming empty arrays, and no pagination block
+    // appears. exportedAt is the only time-varying field.
+    const { exportedAt, ...stable } = result;
+    expect(exportedAt).toBeDefined();
+    expect(stable).toEqual({
+      version: VERSION,
+      sessions: [testSession],
+      observations: { ses_1: [testObs] },
+      memories: [testMemory],
+      summaries: [testSummary],
+    });
   });
 
   it("import with merge strategy adds data", async () => {
@@ -307,5 +325,178 @@ describe("Export/Import Functions", () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toContain("Unsupported export version");
+  });
+});
+
+describe("Export collection pagination", () => {
+  let sdk: ReturnType<typeof mockSdk>;
+  let kv: ReturnType<typeof mockKV>;
+
+  beforeEach(async () => {
+    sdk = mockSdk();
+    kv = mockKV();
+    registerExportImportFunction(sdk as never, kv as never);
+    await kv.set("mem:sessions", "ses_1", testSession);
+    for (let i = 0; i < 7; i++) {
+      await kv.set("mem:memories", `mem_${i}`, { ...testMemory, id: `mem_${i}` });
+    }
+    for (let i = 0; i < 5; i++) {
+      await kv.set("mem:graph:nodes", `node_${i}`, { id: `node_${i}`, label: `n${i}` });
+    }
+  });
+
+  it("returns every collection in full when no collection limit is given", async () => {
+    const result = (await sdk.trigger("mem::export", {})) as ExportData;
+
+    expect(result.memories.length).toBe(7);
+    expect(result.graphNodes?.length).toBe(5);
+    expect(result.collectionPagination).toBeUndefined();
+  });
+
+  it("bounds every collection, not just sessions, when a collection limit is given", async () => {
+    const result = (await sdk.trigger("mem::export", {
+      collectionLimit: 3,
+    })) as ExportData;
+
+    expect(result.memories.length).toBe(3);
+    expect(result.graphNodes?.length).toBe(3);
+    expect(result.collectionPagination?.limit).toBe(3);
+    expect(result.collectionPagination?.offset).toBe(0);
+    expect(result.collectionPagination?.totals["memories"]).toBe(7);
+    expect(result.collectionPagination?.totals["graphNodes"]).toBe(5);
+    expect(result.collectionPagination?.hasMore).toBe(true);
+  });
+
+  it("walks a collection to its end across pages", async () => {
+    const page2 = (await sdk.trigger("mem::export", {
+      collectionLimit: 3,
+      collectionOffset: 3,
+    })) as ExportData;
+    expect(page2.memories.length).toBe(3);
+    expect(page2.collectionPagination?.hasMore).toBe(true);
+
+    const page3 = (await sdk.trigger("mem::export", {
+      collectionLimit: 3,
+      collectionOffset: 6,
+    })) as ExportData;
+    expect(page3.memories.length).toBe(1);
+    expect(page3.collectionPagination?.hasMore).toBe(false);
+  });
+});
+
+describe("Export collection allowlist", () => {
+  let sdk: ReturnType<typeof mockSdk>;
+  let kv: ReturnType<typeof mockKV>;
+
+  beforeEach(async () => {
+    sdk = mockSdk();
+    kv = mockKV();
+    registerExportImportFunction(sdk as never, kv as never);
+    await kv.set("mem:sessions", "ses_1", testSession);
+    await kv.set("mem:obs:ses_1", "obs_1", testObs);
+    await kv.set("mem:summaries", "ses_1", testSummary);
+    for (let i = 0; i < 7; i++) {
+      await kv.set("mem:memories", `mem_${i}`, { ...testMemory, id: `mem_${i}` });
+    }
+    // graphNodes deliberately outlasts every other collection: a client
+    // that reads only memories+summaries must not be told to keep paging
+    // for rows it throws away.
+    for (let i = 0; i < 20; i++) {
+      await kv.set("mem:graph:nodes", `node_${i}`, { id: `node_${i}`, label: `n${i}` });
+    }
+  });
+
+  it("returns every collection when no allowlist is given", async () => {
+    const result = (await sdk.trigger("mem::export", {})) as ExportData;
+
+    expect(result.memories.length).toBe(7);
+    expect(result.summaries.length).toBe(1);
+    expect(result.graphNodes?.length).toBe(20);
+  });
+
+  it("drops the collections outside the allowlist", async () => {
+    const result = (await sdk.trigger("mem::export", {
+      collections: ["memories", "summaries"],
+    })) as ExportData;
+
+    expect(result.memories.length).toBe(7);
+    expect(result.summaries.length).toBe(1);
+    expect(result.graphNodes).toBeUndefined();
+  });
+
+  it("accepts the allowlist as a comma-separated string", async () => {
+    const result = (await sdk.trigger("mem::export", {
+      collections: "memories, summaries",
+    })) as ExportData;
+
+    expect(result.memories.length).toBe(7);
+    expect(result.summaries.length).toBe(1);
+    expect(result.graphNodes).toBeUndefined();
+  });
+
+  it("keeps collectionTotals reporting every collection", async () => {
+    const result = (await sdk.trigger("mem::export", {
+      collections: ["memories"],
+      collectionLimit: 3,
+    })) as ExportData;
+
+    expect(result.collectionPagination?.totals["memories"]).toBe(7);
+    expect(result.collectionPagination?.totals["summaries"]).toBe(1);
+    expect(result.collectionPagination?.totals["graphNodes"]).toBe(20);
+  });
+
+  it("computes hasMore from the allowlist alone", async () => {
+    const selected = (await sdk.trigger("mem::export", {
+      collections: ["memories"],
+      collectionLimit: 7,
+    })) as ExportData;
+    expect(selected.collectionPagination?.hasMore).toBe(false);
+
+    const everything = (await sdk.trigger("mem::export", {
+      collectionLimit: 7,
+    })) as ExportData;
+    expect(everything.collectionPagination?.hasMore).toBe(true);
+  });
+
+  it("ignores unknown collection names instead of failing", async () => {
+    const result = (await sdk.trigger("mem::export", {
+      collections: ["memories", "notACollection"],
+      collectionLimit: 7,
+    })) as ExportData;
+
+    expect(result.memories.length).toBe(7);
+    expect(result.graphNodes).toBeUndefined();
+    expect(result.collectionPagination?.hasMore).toBe(false);
+  });
+
+  it("selects nothing when the allowlist names no known collection", async () => {
+    const result = (await sdk.trigger("mem::export", {
+      collections: ["notACollection"],
+      collectionLimit: 3,
+    })) as ExportData;
+
+    expect(result.memories).toEqual([]);
+    expect(result.summaries).toEqual([]);
+    expect(result.graphNodes).toBeUndefined();
+    expect(result.collectionPagination?.totals["memories"]).toBe(7);
+    expect(result.collectionPagination?.hasMore).toBe(false);
+  });
+
+  it("treats an empty allowlist as an explicit empty selection", async () => {
+    const result = (await sdk.trigger("mem::export", {
+      collections: "",
+    })) as ExportData;
+
+    expect(result.memories).toEqual([]);
+    expect(result.graphNodes).toBeUndefined();
+  });
+
+  it("leaves sessions and observations outside the allowlist", async () => {
+    const result = (await sdk.trigger("mem::export", {
+      collections: ["memories"],
+    })) as ExportData;
+
+    expect(result.sessions.length).toBe(1);
+    expect(result.observations["ses_1"].length).toBe(1);
   });
 });

--- a/test/mcp-export-tool.test.ts
+++ b/test/mcp-export-tool.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../src/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { registerMcpEndpoints } from "../src/mcp/server.js";
+
+function mockKV() {
+  const store = new Map<string, Map<string, unknown>>();
+  return {
+    get: async <T>(scope: string, key: string): Promise<T | null> =>
+      (store.get(scope)?.get(key) as T) ?? null,
+    set: async <T>(scope: string, key: string, data: T): Promise<T> => {
+      if (!store.has(scope)) store.set(scope, new Map());
+      store.get(scope)!.set(key, data);
+      return data;
+    },
+    delete: async (scope: string, key: string): Promise<void> => {
+      store.get(scope)?.delete(key);
+    },
+    list: async <T>(scope: string): Promise<T[]> => {
+      const entries = store.get(scope);
+      return entries ? (Array.from(entries.values()) as T[]) : [];
+    },
+  };
+}
+
+function mockSdk() {
+  const functions = new Map<string, Function>();
+  const overrides = new Map<string, Function>();
+  return {
+    registerFunction: (idOrOpts: string | { id: string }, handler: Function) => {
+      functions.set(
+        typeof idOrOpts === "string" ? idOrOpts : idOrOpts.id,
+        handler,
+      );
+    },
+    registerTrigger: () => {},
+    trigger: async (
+      idOrInput: string | { function_id: string; payload: unknown },
+      data?: unknown,
+    ) => {
+      const id =
+        typeof idOrInput === "string" ? idOrInput : idOrInput.function_id;
+      const payload = typeof idOrInput === "string" ? data : idOrInput.payload;
+      if (overrides.has(id)) return overrides.get(id)!(payload);
+      const fn = functions.get(id);
+      if (!fn) throw new Error(`No function: ${id}`);
+      return fn(payload);
+    },
+    overrideTrigger: (id: string, handler: Function) => {
+      overrides.set(id, handler);
+    },
+    getFunction: (id: string) => functions.get(id),
+  };
+}
+
+function callTool(sdk: ReturnType<typeof mockSdk>, args: unknown) {
+  const fn = sdk.getFunction("mcp::tools::call")!;
+  return fn({
+    body: { name: "memory_export", arguments: args },
+    headers: {},
+    query_params: {},
+  }) as Promise<{ status_code: number; body: unknown }>;
+}
+
+describe("memory_export MCP tool", () => {
+  let sdk: ReturnType<typeof mockSdk>;
+
+  beforeEach(() => {
+    sdk = mockSdk();
+    registerMcpEndpoints(sdk as never, mockKV() as never);
+  });
+
+  it("forwards the paging arguments to mem::export", async () => {
+    let seen: unknown;
+    sdk.overrideTrigger("mem::export", (payload: unknown) => {
+      seen = payload;
+      return { version: "0.9.28", sessions: [], memories: [] };
+    });
+
+    await callTool(sdk, {
+      maxSessions: 100,
+      offset: 200,
+      collectionLimit: 300,
+      collectionOffset: 400,
+    });
+
+    expect(seen).toEqual({
+      maxSessions: 100,
+      offset: 200,
+      collectionLimit: 300,
+      collectionOffset: 400,
+    });
+  });
+
+  it("drops arguments that are not usable page bounds", async () => {
+    let seen: unknown;
+    sdk.overrideTrigger("mem::export", (payload: unknown) => {
+      seen = payload;
+      return { version: "0.9.28", sessions: [], memories: [] };
+    });
+
+    await callTool(sdk, {
+      maxSessions: 0,
+      offset: -1,
+      collectionLimit: "many",
+      collectionOffset: 1.5,
+    });
+
+    expect(seen).toEqual({});
+  });
+
+  it("forwards the collections allowlist as given", async () => {
+    let seen: unknown;
+    sdk.overrideTrigger("mem::export", (payload: unknown) => {
+      seen = payload;
+      return { version: "0.9.28", sessions: [], memories: [] };
+    });
+
+    await callTool(sdk, { collections: "memories,lessons" });
+
+    expect(seen).toEqual({ collections: "memories,lessons" });
+  });
+
+  it("keeps an empty allowlist distinguishable from an absent one", async () => {
+    const seen: unknown[] = [];
+    sdk.overrideTrigger("mem::export", (payload: unknown) => {
+      seen.push(payload);
+      return { version: "0.9.28", sessions: [], memories: [] };
+    });
+
+    await callTool(sdk, { collections: "" });
+    await callTool(sdk, {});
+
+    // An empty selection means "no collections" downstream, so dropping it
+    // here would silently turn it into a full dump.
+    expect(seen).toEqual([{ collections: "" }, {}]);
+  });
+
+  it("still returns a normal export as 200", async () => {
+    sdk.overrideTrigger("mem::export", () => ({
+      version: "0.9.28",
+      sessions: [],
+      memories: [],
+    }));
+
+    const result = await callTool(sdk, {});
+
+    expect(result.status_code).toBe(200);
+    expect(result.body).toHaveProperty("content");
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to the frame guard that shipped in v0.9.29. Its hint says the non-session
collections "are not yet paginated" — this makes them paginated.

Originally this PR carried its own size guard for #1142. v0.9.29 landed `frame-guard.ts`
first, so that half is dropped and what remains builds on `checkPayloadFrameSize` rather than
competing with it.

## What this changes

**`?collectionLimit=` / `?collectionOffset=`** window `memories`, `summaries` and the sixteen
top-level collections, which previously came in full no matter what `?maxSessions=` said. On a
store I reproduced against, `?maxSessions=1` still returned 5.50 MB, of which ~4.9 MB was that
floor. It grows with the store, and once it alone crosses the cap the export returns nothing at
any parameter combination — the dead end #890 describes for `mesh/export`.

**`?collections=`** narrows the payload to the collections a caller actually reads, so an agent
after a lesson is not also pulling `graphEdges`. `sessions`, `observations` and `profiles` are
outside the vocabulary on purpose: they are windowed by `maxSessions`/`offset`, and profiles are
derived from the session page rather than listed. Unknown names are dropped rather than refused,
so a client can name a collection an older build lacks and still get the ones it has.

**`collectionPagination`** reports per-collection `totals` and a combined `hasMore`. `totals`
cover every collection even when deselected, since that is what clients read for corpus size;
`hasMore` looks only at the selected ones, so a client that asked for six of eighteen can stop
on the flag instead of comparing against `totals` by hand.

**The MCP tool** declared no properties and always triggered `mem::export` with an empty
payload, so none of this was reachable from MCP — which is where an agent actually calls
export. It now declares and forwards the same arguments.

The frame guard's hint is updated to name the new parameters instead of describing the gap.

## Behaviour

An unparameterised export returns exactly what it returns today. A test pins the full-corpus
response field by field so that cannot drift.

## What this doesn't fix

- **Observations stay atomic per session.** `collectionLimit` does not slice them; they follow
  the session window. A single session whose observations alone exceed the cap still cannot be
  exported.
- **`api::export` returns 200 for a refusal.** The guard's `OversizedPayload` travels as a
  successful HTTP response, so a client has to inspect the body to notice. Left alone here since
  it is the guard's contract, not this change's — happy to send a 413 mapping separately if you
  want one.
- **`mesh/export` (#890)** has the same shape and is untouched.

## Testing

- `test/export-import.test.ts`: full-corpus shape pinned; `collectionLimit` bounds every
  collection while the unparameterised call still returns everything; a three-page walk ends on
  `hasMore: false`; `collections` selects, drops unknown names, and treats an empty list as
  "none".
- `test/mcp-export-tool.test.ts`: arguments forwarded, unusable bounds dropped, empty allowlist
  kept distinct from an absent one.
- `npx vitest run --exclude test/integration.test.ts` → 1614 passed, 0 failed.
- `npx tsc --noEmit` → 25 errors, byte-identical to `main`.
- `npm run skills:check` and `npm run build` clean.
