### PR TITLE
fix(providers): OpenRouter reasoning-model content:null fallback

### DIFF
--- a/deploy/coolify/Dockerfile
+++ b/deploy/coolify/Dockerfile
@@ -19,6 +19,12 @@ RUN printf '{"name":"agentmemory-deploy","version":"1.0.0","private":true,"overr
  && npm install "@agentmemory/agentmemory@${AGENTMEMORY_VERSION}" --omit=optional --no-fund --no-audit \
  && ln -s /opt/agentmemory/node_modules/.bin/agentmemory /usr/local/bin/agentmemory
 
+# Reasoning-model fallback: OpenRouter reasoning models return content:null
+# with the answer in message.reasoning when finish_reason:"length". Fall back
+# so mem::summarize chunk calls do not hard-fail (empty_provider_response).
+COPY openrouter-reasoning-patch.mjs /tmp/openrouter-reasoning-patch.mjs
+RUN node /tmp/openrouter-reasoning-patch.mjs && rm /tmp/openrouter-reasoning-patch.mjs
+
 ENV AGENTMEMORY_III_VERSION=${III_VERSION} \
     TINI_SUBREAPER=1
 

--- a/deploy/coolify/openrouter-reasoning-patch.mjs
+++ b/deploy/coolify/openrouter-reasoning-patch.mjs
@@ -1,0 +1,35 @@
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Reasoning models on OpenRouter (DeepSeek V4/R1, etc.) return the final
+// answer in message.content but, when reasoning exhausts the token budget
+// (finish_reason:"length"), content is null and only reasoning /
+// reasoning_details are populated. Fall back so mem::summarize chunk calls
+// do not hard-fail with empty_provider_response. The reasoning text is
+// degraded (truncated) in the length case, but the chunk+reduce layer
+// tolerates partial output better than a hard throw.
+const dir = "/opt/agentmemory/node_modules/@agentmemory/agentmemory/dist";
+const old =
+  "const content = data.choices?.[0]?.message?.content;\n" +
+  "\t\tif (!content) throw new Error(`${this.name} returned unexpected response";
+const replacement =
+  "const _msg = data.choices?.[0]?.message;\n" +
+  "\t\tlet content = _msg?.content;\n" +
+  "\t\tif (!content) { const _rd = _msg?.reasoning_details; content = (Array.isArray(_rd) ? _rd.find(d => d && d.text)?.text : undefined) ?? _msg?.reasoning; }\n" +
+  "\t\tif (!content) throw new Error(`${this.name} returned unexpected response";
+
+let patched = 0;
+for (const f of readdirSync(dir)) {
+  if (!f.endsWith(".mjs")) continue;
+  const p = join(dir, f);
+  const s = readFileSync(p, "utf8");
+  if (!s.includes(old)) continue;
+  writeFileSync(p, s.replace(old, replacement));
+  console.log("openrouter-reasoning-patch: patched", p);
+  patched++;
+}
+if (patched === 0) {
+  console.error("openrouter-reasoning-patch: PATTERN NOT FOUND — aborting build");
+  process.exit(1);
+}
+console.log("openrouter-reasoning-patch: " + patched + " file(s) patched");

--- a/src/providers/openrouter.ts
+++ b/src/providers/openrouter.ts
@@ -59,9 +59,30 @@ export class OpenRouterProvider implements MemoryProvider {
 
     const data = (await response.json()) as Record<string, unknown>;
     const choices = data.choices as
-      | Array<{ message: { content: string } }>
+      | Array<{
+        message: {
+          content: string | null;
+          reasoning?: string | null;
+          reasoning_details?: Array<{ text?: string }> | null;
+        };
+      }>
       | undefined;
-    const content = choices?.[0]?.message?.content;
+    const msg = choices?.[0]?.message;
+    let content = msg?.content;
+    // Reasoning models on OpenRouter (DeepSeek V4/R1, etc.) return the final
+    // answer in `message.content` but, when reasoning exhausts the token
+    // budget (finish_reason:"length"), `content` is null and only
+    // `reasoning`/`reasoning_details` are populated. Fall back so summarize
+    // chunk calls do not hard-fail with empty_provider_response. The
+    // reasoning text is degraded (truncated) in the length case, but the
+    // chunk+reduce layer tolerates partial output better than a hard throw.
+    if (!content) {
+      const details = msg?.reasoning_details;
+      content =
+        (Array.isArray(details)
+          ? details.find((d) => d.text)?.text
+          : undefined) ?? msg?.reasoning ?? undefined;
+    }
     if (!content) {
       throw new Error(
         `${this.name} returned unexpected response: ${JSON.stringify(data).slice(0, 200)}`,


### PR DESCRIPTION
## Problem

`OpenRouterProvider.call()` reads only `message.content`:

```ts
const content = choices?.[0]?.message?.content;
if (!content) {
  throw new Error(`${this.name} returned unexpected response: ...`);
}
return content;
```

Reasoning models on OpenRouter (DeepSeek V4/R1, etc.) return the final answer in `message.content`, but when reasoning exhausts the token budget (`finish_reason: "length"`), `content` is `null` and only `message.reasoning` / `message.reasoning_details` are populated. This makes the provider throw `"returned unexpected response"`, surfacing as `empty_provider_response` from `mem::summarize` chunk calls. The chunk+skip+reduce layer absorbs the failures (sessions still produce valid summaries), but it wastes a retry per failing chunk — observed ~227 chunk-level `mem::summarize` failures over ~26h on one deployment.

## Fix

Fall back to `reasoning_details[].text ?? message.reasoning` when `content` is null, so the chunk gets degraded-but-usable output instead of a hard throw:

```ts
const msg = choices?.[0]?.message;
let content = msg?.content;
if (!content) {
  const details = msg?.reasoning_details;
  content = (Array.isArray(details) ? details.find((d) => d.text)?.text : undefined)
    ?? msg?.reasoning ?? undefined;
}
if (!content) { throw new Error(`${this.name} returned unexpected response: ...`); }
return content;
```

The reasoning text is truncated in the `length` case, but the chunk+reduce layer tolerates partial output better than a hard throw; when the model finishes (`finish_reason: "stop"`) `content` is populated and the fallback is not used.

## Verification

Forced the `content:null` case against the live OpenRouter API (deepseek-v4-pro, `max_tokens=20` → `finish_reason: "length"`, `content: null`, `reasoning_details` populated). The patched extraction returns the reasoning text instead of throwing. Deployed in a coolify Docker image on mfc1; container rebuilt + healthy, `code_memory_consolidate` succeeds.

## Deploy-time dist patch (included)

The coolify Dockerfile installs the pre-built npm package (`@agentmemory/agentmemory@<ver>`) rather than building from source, so this PR also adds `deploy/coolify/openrouter-reasoning-patch.mjs` + a `Dockerfile` `RUN` that applies the same fix to the bundled `dist/*.mjs` at image-build time. This lets existing coolify deploys get the fix before a new npm release ships the compiled source change. The source fix is the real fix; the dist patch is a stopgap for pre-built-package deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of OpenRouter reasoning-model responses when standard message content is unavailable.
  * Responses can now use available reasoning text as a fallback, preventing valid answers from being incorrectly treated as empty or invalid.
  * Added deployment-time compatibility support for packaged builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->