### PR TITLE
docs: document Novita AI as an OpenAI-compatible LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,7 +29,7 @@
 # → GEMINI_API_KEY → OPENROUTER_API_KEY → noop.
 
 # OPENAI_API_KEY=sk-...                          # Activates both the OpenAI-compatible LLM provider (DeepSeek, SiliconFlow, vLLM, LM Studio, Ollama via `/v1`) and OpenAI embeddings. Set OPENAI_API_KEY_FOR_LLM=false to scope it to embeddings only.
-# OPENAI_BASE_URL=https://api.openai.com         # Override for OpenAI-compatible providers
+# OPENAI_BASE_URL=https://api.openai.com         # Override for OpenAI-compatible providers (e.g. Novita AI: https://api.novita.ai/openai/v1)
 # OPENAI_MODEL=gpt-5.6-luna                      # Default OpenAI-compatible chat model
 # OPENAI_API_KEY_FOR_LLM=false                   # Skip OpenAI auto-detection for LLM; key stays active for embeddings
 

--- a/.env.example
+++ b/.env.example
@@ -28,7 +28,7 @@
 # The detection order is OPENAI_API_KEY → MINIMAX_API_KEY → ANTHROPIC_API_KEY
 # → GEMINI_API_KEY → OPENROUTER_API_KEY → noop.
 
-# OPENAI_API_KEY=sk-...                          # Activates both the OpenAI-compatible LLM provider (DeepSeek, SiliconFlow, vLLM, LM Studio, Ollama via `/v1`) and OpenAI embeddings. Set OPENAI_API_KEY_FOR_LLM=false to scope it to embeddings only.
+# OPENAI_API_KEY=sk-...                          # Activates both the OpenAI-compatible LLM provider (DeepSeek, SiliconFlow, Novita AI, vLLM, LM Studio, Ollama via `/v1`) and OpenAI embeddings. Set OPENAI_API_KEY_FOR_LLM=false to scope it to embeddings only.
 # OPENAI_BASE_URL=https://api.openai.com         # Override for OpenAI-compatible providers (e.g. Novita AI: https://api.novita.ai/openai/v1)
 # OPENAI_MODEL=gpt-5.6-luna                      # Default OpenAI-compatible chat model
 # OPENAI_API_KEY_FOR_LLM=false                   # Skip OpenAI auto-detection for LLM; key stays active for embeddings

--- a/.env.example
+++ b/.env.example
@@ -29,8 +29,8 @@
 # → GEMINI_API_KEY → OPENROUTER_API_KEY → noop.
 
 # OPENAI_API_KEY=sk-...                          # Activates both the OpenAI-compatible LLM provider (DeepSeek, SiliconFlow, Novita AI, vLLM, LM Studio, Ollama via `/v1`) and OpenAI embeddings. Set OPENAI_API_KEY_FOR_LLM=false to scope it to embeddings only.
-# OPENAI_BASE_URL=https://api.openai.com         # Override for OpenAI-compatible providers (e.g. Novita AI: https://api.novita.ai/openai/v1)
-# OPENAI_MODEL=gpt-5.6-luna                      # Default OpenAI-compatible chat model
+# OPENAI_BASE_URL=https://api.openai.com         # Override for OpenAI-compatible providers (e.g. Novita AI: https://api.novita.ai/openai/v1). Non-default, non-Azure base URLs require OPENAI_MODEL below.
+# OPENAI_MODEL=gpt-5.6-luna                      # Default OpenAI-compatible chat model; required (no default) once OPENAI_BASE_URL points elsewhere
 # OPENAI_API_KEY_FOR_LLM=false                   # Skip OpenAI auto-detection for LLM; key stays active for embeddings
 
 # ANTHROPIC_API_KEY=sk-ant-...

--- a/README.md
+++ b/README.md
@@ -1323,7 +1323,7 @@ agentmemory auto-detects providers from your environment. A provider makes LLM-b
 | Gemini | `GEMINI_API_KEY` | Also enables embeddings |
 | OpenRouter | `OPENROUTER_API_KEY` | Any model |
 | OpenAI API | `OPENAI_API_KEY` | Default `gpt-5.6-luna`, override with `OPENAI_MODEL` |
-| Novita AI | `OPENAI_API_KEY` + `OPENAI_BASE_URL=https://api.novita.ai/openai/v1` | OpenAI-compatible; pick a model with `OPENAI_MODEL` from Novita's [model list](https://novita.ai/llm-api) |
+| Novita AI | `OPENAI_API_KEY` + `OPENAI_BASE_URL=https://api.novita.ai/openai/v1` + `OPENAI_MODEL=<model from Novita's [model list](https://novita.ai/llm-api)>` | OpenAI-compatible; `OPENAI_MODEL` is required — `gpt-5.6-luna` isn't served here. |
 | **Local (Ollama / LM Studio / vLLM / llama.cpp)** | `OPENAI_API_KEY=local` + `OPENAI_BASE_URL=http://localhost:11434/v1` (Ollama) or `http://localhost:1234/v1` (LM Studio) + `OPENAI_MODEL=<your model>` | Anything OpenAI-API-compatible. Zero cost, runs on your hardware. See [Local models](#local-models-ollama--lm-studio--vllm) below. |
 | Claude subscription fallback | `AGENTMEMORY_ALLOW_AGENT_SDK=true` | Opt-in only. Spawns `@anthropic-ai/claude-agent-sdk` sessions; it used to cause unbounded Stop-hook recursion, so it is no longer the default. |
 

--- a/README.md
+++ b/README.md
@@ -1323,6 +1323,7 @@ agentmemory auto-detects providers from your environment. A provider makes LLM-b
 | Gemini | `GEMINI_API_KEY` | Also enables embeddings |
 | OpenRouter | `OPENROUTER_API_KEY` | Any model |
 | OpenAI API | `OPENAI_API_KEY` | Default `gpt-5.6-luna`, override with `OPENAI_MODEL` |
+| Novita AI | `OPENAI_API_KEY` + `OPENAI_BASE_URL=https://api.novita.ai/openai/v1` | OpenAI-compatible; pick a model with `OPENAI_MODEL` from Novita's [model list](https://novita.ai/llm-api) |
 | **Local (Ollama / LM Studio / vLLM / llama.cpp)** | `OPENAI_API_KEY=local` + `OPENAI_BASE_URL=http://localhost:11434/v1` (Ollama) or `http://localhost:1234/v1` (LM Studio) + `OPENAI_MODEL=<your model>` | Anything OpenAI-API-compatible. Zero cost, runs on your hardware. See [Local models](#local-models-ollama--lm-studio--vllm) below. |
 | Claude subscription fallback | `AGENTMEMORY_ALLOW_AGENT_SDK=true` | Opt-in only. Spawns `@anthropic-ai/claude-agent-sdk` sessions; it used to cause unbounded Stop-hook recursion, so it is no longer the default. |
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -87,7 +87,6 @@ export function hydrateProcessEnvFromFile(): void {
 function detectProvider(env: Record<string, string>): ProviderConfig {
   const maxTokens = parseInt(env["MAX_TOKENS"] || "4096", 10);
 
-  // OpenAI-compatible: supports OpenAI, DeepSeek, SiliconFlow, Novita, Azure, vLLM, LM Studio
   if (hasRealValue(env["OPENAI_API_KEY"]) && env["OPENAI_API_KEY_FOR_LLM"] !== "false") {
     if (!hasRealValue(env["OPENAI_MODEL"]) && requiresExplicitModel(env["OPENAI_BASE_URL"])) {
       throw new Error(

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,7 @@ import type {
   ClaudeBridgeConfig,
   TeamConfig,
 } from "./types.js";
+import { requiresExplicitModel } from "./providers/_openai-shared.js";
 
 function safeParseInt(value: string | undefined, fallback: number): number {
   if (!value) return fallback;
@@ -86,8 +87,14 @@ export function hydrateProcessEnvFromFile(): void {
 function detectProvider(env: Record<string, string>): ProviderConfig {
   const maxTokens = parseInt(env["MAX_TOKENS"] || "4096", 10);
 
-  // OpenAI-compatible: supports OpenAI, DeepSeek, SiliconFlow, Azure, vLLM, LM Studio
+  // OpenAI-compatible: supports OpenAI, DeepSeek, SiliconFlow, Novita, Azure, vLLM, LM Studio
   if (hasRealValue(env["OPENAI_API_KEY"]) && env["OPENAI_API_KEY_FOR_LLM"] !== "false") {
+    if (!hasRealValue(env["OPENAI_MODEL"]) && requiresExplicitModel(env["OPENAI_BASE_URL"])) {
+      throw new Error(
+        `OPENAI_MODEL is required when OPENAI_BASE_URL points at a non-default, non-Azure endpoint (got ${env["OPENAI_BASE_URL"]}). ` +
+          `The gpt-5.6-luna default only exists on api.openai.com; set OPENAI_MODEL to a model your provider actually serves.`,
+      );
+    }
     return {
       provider: "openai",
       model: env["OPENAI_MODEL"] || "gpt-5.6-luna",

--- a/src/providers/_openai-shared.ts
+++ b/src/providers/_openai-shared.ts
@@ -164,3 +164,17 @@ export function buildAuthHeaders(
 export function normalizeBaseUrl(raw: string | undefined): string {
   return (raw || DEFAULT_OPENAI_BASE_URL).replace(/\/+$/, "");
 }
+
+// True when baseUrl points at an OpenAI-compatible endpoint whose model
+// catalog we cannot assume (DeepSeek, SiliconFlow, Novita, vLLM, LM Studio,
+// ...). Only the real OpenAI endpoint and Azure OpenAI ship the
+// gpt-5.6-luna-family models our DEFAULT_MODEL constants name, so every
+// other base URL needs an explicit OPENAI_MODEL rather than silently
+// inheriting that default and 404ing against a model the target provider
+// doesn't serve.
+export function requiresExplicitModel(baseUrl: string | undefined): boolean {
+  if (!baseUrl) return false;
+  const normalized = normalizeBaseUrl(baseUrl);
+  if (normalized === DEFAULT_OPENAI_BASE_URL) return false;
+  return !detectAzure(normalized);
+}

--- a/src/providers/_openai-shared.ts
+++ b/src/providers/_openai-shared.ts
@@ -165,13 +165,12 @@ export function normalizeBaseUrl(raw: string | undefined): string {
   return (raw || DEFAULT_OPENAI_BASE_URL).replace(/\/+$/, "");
 }
 
-// True when baseUrl points at api.openai.com, with or without an explicit
-// /v1 suffix (appendOpenAIRoute() treats both the same — see case 1/2
-// above), ignoring trailing slashes.
 function isDefaultOpenAIHost(baseUrl: string): boolean {
   try {
     const u = new URL(baseUrl);
+    if (u.protocol !== "https:") return false;
     if (u.hostname !== "api.openai.com") return false;
+    if (u.port !== "") return false;
     const path = u.pathname.replace(/\/+$/, "");
     return path === "" || path === "/v1";
   } catch {
@@ -179,13 +178,6 @@ function isDefaultOpenAIHost(baseUrl: string): boolean {
   }
 }
 
-// True when baseUrl points at an OpenAI-compatible endpoint whose model
-// catalog we cannot assume (DeepSeek, SiliconFlow, Novita, vLLM, LM Studio,
-// ...). Only the real OpenAI endpoint and Azure OpenAI ship the
-// gpt-5.6-luna-family models our DEFAULT_MODEL constants name, so every
-// other base URL needs an explicit OPENAI_MODEL rather than silently
-// inheriting that default and 404ing against a model the target provider
-// doesn't serve.
 export function requiresExplicitModel(baseUrl: string | undefined): boolean {
   if (!baseUrl) return false;
   const normalized = normalizeBaseUrl(baseUrl);

--- a/src/providers/_openai-shared.ts
+++ b/src/providers/_openai-shared.ts
@@ -165,6 +165,20 @@ export function normalizeBaseUrl(raw: string | undefined): string {
   return (raw || DEFAULT_OPENAI_BASE_URL).replace(/\/+$/, "");
 }
 
+// True when baseUrl points at api.openai.com, with or without an explicit
+// /v1 suffix (appendOpenAIRoute() treats both the same — see case 1/2
+// above), ignoring trailing slashes.
+function isDefaultOpenAIHost(baseUrl: string): boolean {
+  try {
+    const u = new URL(baseUrl);
+    if (u.hostname !== "api.openai.com") return false;
+    const path = u.pathname.replace(/\/+$/, "");
+    return path === "" || path === "/v1";
+  } catch {
+    return false;
+  }
+}
+
 // True when baseUrl points at an OpenAI-compatible endpoint whose model
 // catalog we cannot assume (DeepSeek, SiliconFlow, Novita, vLLM, LM Studio,
 // ...). Only the real OpenAI endpoint and Azure OpenAI ship the
@@ -175,6 +189,6 @@ export function normalizeBaseUrl(raw: string | undefined): string {
 export function requiresExplicitModel(baseUrl: string | undefined): boolean {
   if (!baseUrl) return false;
   const normalized = normalizeBaseUrl(baseUrl);
-  if (normalized === DEFAULT_OPENAI_BASE_URL) return false;
+  if (isDefaultOpenAIHost(normalized)) return false;
   return !detectAzure(normalized);
 }

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -12,6 +12,7 @@ import { OpenRouterProvider } from "./openrouter.js";
 import { ResilientProvider } from "./resilient.js";
 import { FallbackChainProvider } from "./fallback-chain.js";
 import { getEnvVar } from "../config.js";
+import { requiresExplicitModel } from "./_openai-shared.js";
 
 export { createEmbeddingProvider, createImageEmbeddingProvider } from "./embedding/index.js";
 
@@ -34,8 +35,19 @@ function requireEnvVar(key: string): string {
 // provider's default model is.
 function defaultModelFor(providerType: ProviderConfig["provider"]): string {
   switch (providerType) {
-    case "openai":
-      return getEnvVar("OPENAI_MODEL") || "gpt-5.6-luna";
+    case "openai": {
+      const model = getEnvVar("OPENAI_MODEL");
+      if (!model && requiresExplicitModel(getEnvVar("OPENAI_BASE_URL"))) {
+        // Caller (createFallbackProvider) wraps this in try/catch and skips
+        // fallback providers that fail to construct — same as a missing
+        // API key. gpt-5.6-luna only exists on api.openai.com, so silently
+        // returning it here would 404 against DeepSeek/SiliconFlow/Novita/etc.
+        throw new Error(
+          `OPENAI_MODEL is required when OPENAI_BASE_URL points at a non-default, non-Azure endpoint (got ${getEnvVar("OPENAI_BASE_URL")}).`,
+        );
+      }
+      return model || "gpt-5.6-luna";
+    }
     case "anthropic":
       return getEnvVar("ANTHROPIC_MODEL") || "claude-sonnet-5";
     case "gemini":

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -38,10 +38,6 @@ function defaultModelFor(providerType: ProviderConfig["provider"]): string {
     case "openai": {
       const model = getEnvVar("OPENAI_MODEL");
       if (!model && requiresExplicitModel(getEnvVar("OPENAI_BASE_URL"))) {
-        // Caller (createFallbackProvider) wraps this in try/catch and skips
-        // fallback providers that fail to construct — same as a missing
-        // API key. gpt-5.6-luna only exists on api.openai.com, so silently
-        // returning it here would 404 against DeepSeek/SiliconFlow/Novita/etc.
         throw new Error(
           `OPENAI_MODEL is required when OPENAI_BASE_URL points at a non-default, non-Azure endpoint (got ${getEnvVar("OPENAI_BASE_URL")}).`,
         );

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -20,6 +20,7 @@ const DEFAULT_TIMEOUT_MS = 60_000;
  *   - Azure OpenAI (auto-detected from .openai.azure.com host)
  *   - DeepSeek
  *   - 硅基流动 (SiliconFlow)
+ *   - Novita AI (https://api.novita.ai/openai/v1)
  *   - vLLM / LM Studio / Ollama (with OpenAI compatibility layer)
  *   - Any other proxy implementing /v1/chat/completions
  *

--- a/test/fallback-model-resolution.test.ts
+++ b/test/fallback-model-resolution.test.ts
@@ -77,6 +77,7 @@ describe("Fallback provider model resolution (#778)", () => {
   const envKeys = [
     "OPENAI_API_KEY",
     "OPENAI_MODEL",
+    "OPENAI_BASE_URL",
     "GEMINI_API_KEY",
     "GEMINI_MODEL",
     "GOOGLE_API_KEY",
@@ -186,5 +187,34 @@ describe("Fallback provider model resolution (#778)", () => {
 
     const openaiCalls = captured.filter((c) => c.provider === "openai");
     expect(openaiCalls.length).toBe(1);
+  });
+
+  it("openai fallback with a non-default base URL and no OPENAI_MODEL is skipped instead of inheriting gpt-5.6-luna", () => {
+    process.env.ANTHROPIC_API_KEY = "anth-key";
+    process.env.OPENAI_API_KEY = "sk";
+    process.env.OPENAI_BASE_URL = "https://api.novita.ai/openai/v1";
+
+    createFallbackProvider(
+      { provider: "anthropic", model: "claude-sonnet-5", maxTokens: 4096 },
+      { providers: ["openai"] },
+    );
+
+    expect(captured.find((c) => c.provider === "openai")).toBeUndefined();
+  });
+
+  it("openai fallback with a non-default base URL uses OPENAI_MODEL when set", () => {
+    process.env.ANTHROPIC_API_KEY = "anth-key";
+    process.env.OPENAI_API_KEY = "sk";
+    process.env.OPENAI_BASE_URL = "https://api.novita.ai/openai/v1";
+    process.env.OPENAI_MODEL = "deepseek/deepseek-v4-pro";
+
+    createFallbackProvider(
+      { provider: "anthropic", model: "claude-sonnet-5", maxTokens: 4096 },
+      { providers: ["openai"] },
+    );
+
+    expect(captured.find((c) => c.provider === "openai")?.model).toBe(
+      "deepseek/deepseek-v4-pro",
+    );
   });
 });

--- a/test/openai-model-required.test.ts
+++ b/test/openai-model-required.test.ts
@@ -85,6 +85,15 @@ describe("detectProvider — OPENAI_MODEL required for non-default OpenAI-compat
     expect(loaded.provider.model).toBe("gpt-5.6-luna");
   });
 
+  it("does not require OPENAI_MODEL when OPENAI_BASE_URL is the default endpoint with an explicit /v1 suffix (QA regression)", async () => {
+    writeEnv(
+      "OPENAI_API_KEY=sk-test\nOPENAI_BASE_URL=https://api.openai.com/v1",
+    );
+    const cfg = await freshConfig();
+    const loaded = cfg.loadConfig();
+    expect(loaded.provider.model).toBe("gpt-5.6-luna");
+  });
+
   it("does not require OPENAI_MODEL for Azure OpenAI", async () => {
     writeEnv(
       "OPENAI_API_KEY=sk-test\nOPENAI_BASE_URL=https://myresource.openai.azure.com/openai/deployments/mydeploy",

--- a/test/openai-model-required.test.ts
+++ b/test/openai-model-required.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Regression for the Novita PR review: OPENAI_BASE_URL pointed at a
+// non-default, non-Azure endpoint (Novita, DeepSeek, SiliconFlow, local
+// servers) with OPENAI_MODEL unset used to silently fall back to
+// gpt-5.6-luna, a model those providers don't serve, producing failing
+// requests instead of a clear misconfiguration error.
+
+const ENV_KEYS = [
+  "OPENAI_API_KEY",
+  "OPENAI_API_KEY_FOR_LLM",
+  "OPENAI_BASE_URL",
+  "OPENAI_MODEL",
+  "MINIMAX_API_KEY",
+  "ANTHROPIC_API_KEY",
+  "GEMINI_API_KEY",
+  "GOOGLE_API_KEY",
+  "OPENROUTER_API_KEY",
+];
+
+const ORIGINAL_HOME = process.env["HOME"];
+const ORIGINAL_USERPROFILE = process.env["USERPROFILE"];
+const ORIGINAL: Record<string, string | undefined> = {};
+
+let sandboxHome: string;
+
+async function freshConfig() {
+  vi.resetModules();
+  return await import("../src/config.js");
+}
+
+function writeEnv(contents: string) {
+  const dir = join(sandboxHome, ".agentmemory");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, ".env"), contents);
+}
+
+describe("detectProvider — OPENAI_MODEL required for non-default OpenAI-compatible base URLs", () => {
+  beforeEach(() => {
+    sandboxHome = mkdtempSync(join(tmpdir(), "agentmemory-openai-model-"));
+    process.env["HOME"] = sandboxHome;
+    process.env["USERPROFILE"] = sandboxHome;
+    for (const k of ENV_KEYS) {
+      ORIGINAL[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_HOME === undefined) delete process.env["HOME"];
+    else process.env["HOME"] = ORIGINAL_HOME;
+    if (ORIGINAL_USERPROFILE === undefined) delete process.env["USERPROFILE"];
+    else process.env["USERPROFILE"] = ORIGINAL_USERPROFILE;
+    for (const k of ENV_KEYS) {
+      if (ORIGINAL[k] === undefined) delete process.env[k];
+      else process.env[k] = ORIGINAL[k];
+    }
+    rmSync(sandboxHome, { recursive: true, force: true });
+  });
+
+  it("throws when OPENAI_BASE_URL=Novita and OPENAI_MODEL is unset", async () => {
+    writeEnv(
+      "OPENAI_API_KEY=sk-test\nOPENAI_BASE_URL=https://api.novita.ai/openai/v1",
+    );
+    const cfg = await freshConfig();
+    expect(() => cfg.loadConfig()).toThrow(/OPENAI_MODEL is required/);
+  });
+
+  it("succeeds when OPENAI_BASE_URL=Novita and OPENAI_MODEL is set", async () => {
+    writeEnv(
+      "OPENAI_API_KEY=sk-test\nOPENAI_BASE_URL=https://api.novita.ai/openai/v1\nOPENAI_MODEL=deepseek/deepseek-v4-pro",
+    );
+    const cfg = await freshConfig();
+    const loaded = cfg.loadConfig();
+    expect(loaded.provider.model).toBe("deepseek/deepseek-v4-pro");
+  });
+
+  it("does not require OPENAI_MODEL for the default OpenAI endpoint", async () => {
+    writeEnv("OPENAI_API_KEY=sk-test");
+    const cfg = await freshConfig();
+    const loaded = cfg.loadConfig();
+    expect(loaded.provider.model).toBe("gpt-5.6-luna");
+  });
+
+  it("does not require OPENAI_MODEL for Azure OpenAI", async () => {
+    writeEnv(
+      "OPENAI_API_KEY=sk-test\nOPENAI_BASE_URL=https://myresource.openai.azure.com/openai/deployments/mydeploy",
+    );
+    const cfg = await freshConfig();
+    expect(() => cfg.loadConfig()).not.toThrow();
+  });
+
+  it("does not require OPENAI_MODEL when OPENAI_API_KEY_FOR_LLM=false scopes the key to embeddings only", async () => {
+    writeEnv(
+      "OPENAI_API_KEY=sk-test\nOPENAI_API_KEY_FOR_LLM=false\nOPENAI_BASE_URL=https://api.novita.ai/openai/v1",
+    );
+    const cfg = await freshConfig();
+    expect(() => cfg.loadConfig()).not.toThrow();
+  });
+});

--- a/test/openai-shared.test.ts
+++ b/test/openai-shared.test.ts
@@ -207,6 +207,17 @@ describe("_openai-shared — requiresExplicitModel", () => {
     expect(requiresExplicitModel("https://api.openai.com")).toBe(false);
   });
 
+  it("does not require a model for the default OpenAI endpoint with an explicit /v1 suffix (QA regression)", () => {
+    expect(requiresExplicitModel("https://api.openai.com/v1")).toBe(false);
+    expect(requiresExplicitModel("https://api.openai.com/v1/")).toBe(false);
+  });
+
+  it("still requires a model for a different host that happens to end in /v1", () => {
+    expect(requiresExplicitModel("https://api.openai.com.evil.example/v1")).toBe(
+      true,
+    );
+  });
+
   it("does not require a model for Azure OpenAI", () => {
     expect(
       requiresExplicitModel(

--- a/test/openai-shared.test.ts
+++ b/test/openai-shared.test.ts
@@ -5,6 +5,7 @@ import {
   buildEmbeddingUrl,
   detectAzure,
   normalizeBaseUrl,
+  requiresExplicitModel,
 } from "../src/providers/_openai-shared.js";
 import { OpenAIEmbeddingProvider } from "../src/providers/embedding/openai.js";
 
@@ -197,6 +198,31 @@ describe("_openai-shared — non-OpenAI base URLs (#628, #646)", () => {
     expect(
       buildChatUrl("http://localhost:8000/v1", false, "2024-08-01-preview"),
     ).toBe("http://localhost:8000/v1/chat/completions");
+  });
+});
+
+describe("_openai-shared — requiresExplicitModel", () => {
+  it("does not require a model for the default OpenAI endpoint", () => {
+    expect(requiresExplicitModel(undefined)).toBe(false);
+    expect(requiresExplicitModel("https://api.openai.com")).toBe(false);
+  });
+
+  it("does not require a model for Azure OpenAI", () => {
+    expect(
+      requiresExplicitModel(
+        "https://myresource.openai.azure.com/openai/deployments/mydeploy",
+      ),
+    ).toBe(false);
+  });
+
+  it("requires a model for Novita AI's OpenAI-compatible base URL", () => {
+    expect(requiresExplicitModel("https://api.novita.ai/openai/v1")).toBe(true);
+  });
+
+  it("requires a model for DeepSeek / SiliconFlow / local OpenAI-compatible servers", () => {
+    expect(requiresExplicitModel("https://api.deepseek.com/v1")).toBe(true);
+    expect(requiresExplicitModel("https://api.siliconflow.cn")).toBe(true);
+    expect(requiresExplicitModel("http://localhost:11434/v1")).toBe(true);
   });
 });
 

--- a/test/openai-shared.test.ts
+++ b/test/openai-shared.test.ts
@@ -21,9 +21,10 @@ describe("_openai-shared — detectAzure", () => {
     expect(detectAzure("https://api.openai.com")).toBe(false);
   });
 
-  it("does not flag DeepSeek / SiliconFlow / Ollama / vLLM", () => {
+  it("does not flag DeepSeek / SiliconFlow / Novita / Ollama / vLLM", () => {
     expect(detectAzure("https://api.deepseek.com/v1")).toBe(false);
     expect(detectAzure("https://api.siliconflow.cn")).toBe(false);
+    expect(detectAzure("https://api.novita.ai/openai/v1")).toBe(false);
     expect(detectAzure("http://localhost:11434/v1")).toBe(false);
     expect(detectAzure("http://localhost:8000/v1")).toBe(false);
   });
@@ -158,6 +159,12 @@ describe("_openai-shared — non-OpenAI base URLs (#628, #646)", () => {
     expect(
       buildEmbeddingUrl("https://api.deepseek.com/v1", false, "2024-08-01-preview"),
     ).toBe("https://api.deepseek.com/v1/embeddings");
+  });
+
+  it("routes Novita AI's /openai/v1 base through the v1 anchor", () => {
+    expect(
+      buildChatUrl("https://api.novita.ai/openai/v1", false, "2024-08-01-preview"),
+    ).toBe("https://api.novita.ai/openai/v1/chat/completions");
   });
 
   it("does not inject /v1 when provider uses non-OpenAI version segment (Zhipu /api/paas/v4, #646)", () => {

--- a/test/openai-shared.test.ts
+++ b/test/openai-shared.test.ts
@@ -218,6 +218,11 @@ describe("_openai-shared — requiresExplicitModel", () => {
     );
   });
 
+  it("still requires a model for api.openai.com over plain http or a non-default port", () => {
+    expect(requiresExplicitModel("http://api.openai.com/v1")).toBe(true);
+    expect(requiresExplicitModel("https://api.openai.com:8443/v1")).toBe(true);
+  });
+
   it("does not require a model for Azure OpenAI", () => {
     expect(
       requiresExplicitModel(


### PR DESCRIPTION
## Summary
- `OpenAIProvider` already speaks the plain OpenAI wire shape against any `/v1/chat/completions`-compatible endpoint via `OPENAI_API_KEY` + `OPENAI_BASE_URL`. Novita AI (`https://api.novita.ai/openai/v1`) fits that same shape, so this documents it alongside DeepSeek, SiliconFlow, Azure, and local servers rather than adding a new provider class.

## Changes
- `README.md`: new row in the LLM Providers table.
- `.env.example`: mentions Novita as an `OPENAI_BASE_URL` example.
- `src/providers/openai.ts`: adds Novita to the JSDoc list of supported OpenAI-compatible backends.
- `test/openai-shared.test.ts`: asserts `detectAzure()` does not misclassify Novita's host, and that its `/openai/v1` base builds the expected chat-completions URL (mirrors the existing DeepSeek `/v1` coverage).

## Verification
- `npm run build` and `npm test` pass.
- Verified against a live Novita endpoint: `OpenAIProvider.summarize()` against `https://api.novita.ai/openai/v1` with model `zai-org/glm-4.6` returned a successful completion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Novita AI as an OpenAI-compatible provider.
  * Updated the default OpenAI model to `gpt-5.6-luna`.
  * Added clearer configuration guidance for API keys, base URLs, and model selection.
  * Preserved versioned API paths when connecting to chat completions.

* **Bug Fixes**
  * Alternate OpenAI-compatible endpoints now require an explicit `OPENAI_MODEL`, preventing unsupported fallback models.
  * Default OpenAI and Azure configurations continue working without an explicit model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->