### PR TITLE
fix: evict lowest-value observations at the session cap instead of refusing writes

### DIFF
--- a/src/functions/observe.ts
+++ b/src/functions/observe.ts
@@ -7,10 +7,17 @@ import { DedupMap } from "./dedup.js";
 import { withKeyedLock } from "../state/keyed-mutex.js";
 import { isAutoCompressEnabled } from "../config.js";
 import { buildSyntheticCompression } from "./compress-synthetic.js";
-import { getSearchIndex, vectorIndexAddGuarded } from "./search.js";
+import {
+  getSearchIndex,
+  vectorIndexAddGuarded,
+  vectorIndexRemove,
+} from "./search.js";
 import { getAgentId } from "../config.js";
 import { logger } from "../logger.js";
 import { saveImageToDisk } from "../utils/image-store.js";
+
+/** Importance assumed for an observation that has not been compressed yet. */
+const DEFAULT_EVICTION_IMPORTANCE = 3;
 
 export function extractImage(d: unknown): string | undefined {
   if (!d) return undefined;
@@ -126,12 +133,47 @@ export function registerObserveFunction(
 
       return withKeyedLock(`obs:${payload.sessionId}`, async () => {
         if (maxObservationsPerSession && maxObservationsPerSession > 0) {
-          const existing = await kv.list(KV.observations(payload.sessionId));
+          const existing = await kv.list<RawObservation & { importance?: number }>(
+            KV.observations(payload.sessionId),
+          );
           if (existing.length >= maxObservationsPerSession) {
-            return {
-              success: false,
-              error: `Session observation limit reached (${maxObservationsPerSession})`,
-            };
+            // Refusing the write silently drops the NEWEST observations of the
+            // longest sessions — exactly the part worth keeping. Evict the
+            // lowest-value rows instead so capture keeps working inside the
+            // same bound. Least valuable first: lowest importance, then oldest.
+            const victims = [...existing]
+              .sort((a, b) => {
+                const ia = a.importance ?? DEFAULT_EVICTION_IMPORTANCE;
+                const ib = b.importance ?? DEFAULT_EVICTION_IMPORTANCE;
+                if (ia !== ib) return ia - ib;
+                return (
+                  new Date(a.timestamp ?? 0).getTime() -
+                  new Date(b.timestamp ?? 0).getTime()
+                );
+              })
+              .slice(0, existing.length - maxObservationsPerSession + 1);
+
+            let evicted = 0;
+            for (const victim of victims) {
+              try {
+                await kv.delete(KV.observations(payload.sessionId), victim.id);
+                evicted++;
+                getSearchIndex().remove(victim.id);
+                vectorIndexRemove(victim.id);
+              } catch {
+                // A failed delete just leaves the cap tight for this write;
+                // the next observation retries the eviction.
+              }
+            }
+
+            logger.warn(
+              "Session observation cap reached — evicted lowest-value observations",
+              {
+                sessionId: payload.sessionId,
+                cap: maxObservationsPerSession,
+                evicted,
+              },
+            );
           }
         }
 

--- a/test/observe-session-cap.test.ts
+++ b/test/observe-session-cap.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../src/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const removedFromBm25: string[] = [];
+const removedFromVector: string[] = [];
+
+vi.mock("../src/functions/search.js", () => ({
+  getSearchIndex: () => ({
+    remove: (id: string) => {
+      removedFromBm25.push(id);
+    },
+    add: () => {},
+  }),
+  vectorIndexAddGuarded: async () => false,
+  vectorIndexRemove: (id: string) => {
+    removedFromVector.push(id);
+  },
+}));
+
+function mockKV() {
+  const store = new Map<string, Map<string, unknown>>();
+  return {
+    store,
+    get: async <T>(scope: string, key: string): Promise<T | null> =>
+      (store.get(scope)?.get(key) as T) ?? null,
+    set: async <T>(scope: string, key: string, data: T): Promise<T> => {
+      if (!store.has(scope)) store.set(scope, new Map());
+      store.get(scope)!.set(key, data);
+      return data;
+    },
+    update: async () => {},
+    delete: async (scope: string, key: string) => {
+      store.get(scope)?.delete(key);
+    },
+    list: async <T>(scope: string): Promise<T[]> => {
+      const m = store.get(scope);
+      return m ? (Array.from(m.values()) as T[]) : [];
+    },
+  };
+}
+
+function mockSdk() {
+  const fns = new Map<string, Function>();
+  return {
+    fns,
+    registerFunction: (idOrOpts: string | { id: string }, fn: Function) => {
+      const id = typeof idOrOpts === "string" ? idOrOpts : idOrOpts.id;
+      fns.set(id, fn);
+    },
+    trigger: async (
+      idOrInput: string | { function_id: string; payload: unknown },
+      data?: unknown,
+    ) => {
+      const id = typeof idOrInput === "string" ? idOrInput : idOrInput.function_id;
+      const payload = typeof idOrInput === "string" ? data : idOrInput.payload;
+      const fn = fns.get(id);
+      if (fn) return fn(payload);
+      return null;
+    },
+    triggerVoid: () => {},
+  };
+}
+
+const SESSION = "ses_capped";
+const SCOPE = `mem:obs:${SESSION}`;
+
+function seed(kv: ReturnType<typeof mockKV>, rows: Array<{ id: string; importance?: number; ts: string }>) {
+  for (const row of rows) {
+    kv.store.set(SCOPE, kv.store.get(SCOPE) ?? new Map());
+    kv.store.get(SCOPE)!.set(row.id, {
+      id: row.id,
+      sessionId: SESSION,
+      timestamp: row.ts,
+      hookType: "post_tool_use",
+      importance: row.importance,
+      raw: {},
+    });
+  }
+}
+
+async function observeOnce(sdk: ReturnType<typeof mockSdk>, text: string) {
+  return (await sdk.trigger("mem::observe", {
+    sessionId: SESSION,
+    hookType: "post_tool_use",
+    timestamp: new Date().toISOString(),
+    data: { tool_name: "Bash", tool_input: { command: text } },
+  })) as { success?: boolean; observationId?: string; error?: string };
+}
+
+describe("session observation cap evicts instead of refusing", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    removedFromBm25.length = 0;
+    removedFromVector.length = 0;
+  });
+
+  it("accepts the new observation at the cap and drops the least valuable row", async () => {
+    const { registerObserveFunction } = await import("../src/functions/observe.js");
+    const sdk = mockSdk();
+    const kv = mockKV();
+    registerObserveFunction(sdk as never, kv as never, undefined, 3);
+
+    seed(kv, [
+      { id: "obs_keep_high", importance: 9, ts: "2026-01-01T00:00:00.000Z" },
+      { id: "obs_evict_low", importance: 1, ts: "2026-01-02T00:00:00.000Z" },
+      { id: "obs_keep_mid", importance: 5, ts: "2026-01-03T00:00:00.000Z" },
+    ]);
+
+    const result = await observeOnce(sdk, "the newest command");
+
+    expect(result.observationId).toBeTruthy();
+    expect(result.error).toBeUndefined();
+
+    const ids = Array.from(kv.store.get(SCOPE)!.keys());
+    expect(ids).toHaveLength(3);
+    expect(ids).not.toContain("obs_evict_low");
+    expect(ids).toContain("obs_keep_high");
+    expect(ids).toContain("obs_keep_mid");
+  });
+
+  it("evicts the oldest row when importance ties, and clears it from both indexes", async () => {
+    const { registerObserveFunction } = await import("../src/functions/observe.js");
+    const sdk = mockSdk();
+    const kv = mockKV();
+    registerObserveFunction(sdk as never, kv as never, undefined, 2);
+
+    seed(kv, [
+      { id: "obs_older", importance: 4, ts: "2026-01-01T00:00:00.000Z" },
+      { id: "obs_newer", importance: 4, ts: "2026-02-01T00:00:00.000Z" },
+    ]);
+
+    await observeOnce(sdk, "another command");
+
+    const ids = Array.from(kv.store.get(SCOPE)!.keys());
+    expect(ids).not.toContain("obs_older");
+    expect(ids).toContain("obs_newer");
+    expect(removedFromBm25).toContain("obs_older");
+    expect(removedFromVector).toContain("obs_older");
+  });
+
+  it("leaves capture untouched when the session is under the cap", async () => {
+    const { registerObserveFunction } = await import("../src/functions/observe.js");
+    const sdk = mockSdk();
+    const kv = mockKV();
+    registerObserveFunction(sdk as never, kv as never, undefined, 10);
+
+    seed(kv, [{ id: "obs_only", importance: 1, ts: "2026-01-01T00:00:00.000Z" }]);
+
+    await observeOnce(sdk, "still room");
+
+    expect(Array.from(kv.store.get(SCOPE)!.keys())).toContain("obs_only");
+    expect(removedFromBm25).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Problem

Once a session reaches `MAX_OBS_PER_SESSION` (default 500), `mem::observe` returns `Session observation limit reached (N)` and every subsequent observation in that session is discarded. Two consequences:

1. **The dropped observations are the newest ones in the longest sessions.** A session only reaches the cap because a lot happened in it, and the work at the end is usually what a later session needs to recall.
2. **Nothing is logged server-side.** A capped session is indistinguishable from an idle one in the journal, so the loss is invisible until someone counts rows. On the install where this surfaced, three sessions had been pinned at exactly 500 rows for days.

## Change

At the cap, evict instead of refuse:

- sort by least valuable first — lowest `importance`, oldest `timestamp` breaking ties (uncompressed rows have no importance yet, so they are treated as 3)
- delete just enough rows to admit the incoming observation, so the storage bound the cap expresses is unchanged
- remove each evicted id from the BM25 index and the vector index, so search cannot rank an observation that no longer exists
- `logger.warn` with the session id, the cap and the number evicted

A failed delete is swallowed deliberately: the cap simply stays tight for that write and the next observation retries the eviction, which is strictly better than failing the capture.

## Verification

`test/observe-session-cap.test.ts` (new, 3 cases):

- at the cap the new observation is accepted and the lowest-importance row is the one gone
- on an importance tie the older row is evicted, and it is removed from both indexes
- under the cap nothing is evicted and no index entry is touched

Full suite: 1599 passed, 1 skipped.

**Unrelated finding while running the suite:** on a machine that has a real `~/.agentmemory/.env`, 14 tests fail (embedding-provider, fetch-timeout, auto-compress, context-slots, claude-bridge-path) because config loading merges that file, so the suite picks up the developer's own keys and flags. Everything passes with an isolated `HOME`. Happy to open that as a separate issue if it is not already known.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions now continue accepting observations when the observation limit is reached.
  * Lower-importance observations are automatically removed first; ties are resolved by removing the oldest observation.
  * Removed observations are cleared from search results and storage.

* **Bug Fixes**
  * Observation cleanup continues even if an individual removal fails.
  * Uncompressed observations now receive a default importance score.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->