### PR TITLE
feat(slots): reject stale slot overwrites, keep an undo copy, report headroom

### DIFF
--- a/src/functions/slots.ts
+++ b/src/functions/slots.ts
@@ -6,10 +6,104 @@ import { withKeyedLock } from "../state/keyed-mutex.js";
 import { recordAudit } from "./audit.js";
 import { getEnvVar } from "../config.js";
 import { logger } from "../logger.js";
+import { createHash } from "node:crypto";
 
 type SlotScope = "project" | "global";
 
 const DEFAULT_SIZE_LIMIT = 2000;
+
+/** KV scope holding the pre-write copy of every slot mutation. */
+const SLOT_HISTORY_SCOPE = "mem:slots:history";
+const DEFAULT_SLOT_HISTORY = 20;
+/** Fractions of sizeLimit at which a read starts telling the caller to compact. */
+const SLOT_WARN_PCT = 70;
+const SLOT_URGENT_PCT = 90;
+
+export interface SlotHistoryEntry {
+  id: string;
+  label: string;
+  operation: "append" | "replace";
+  content: string;
+  size: number;
+  rev: number;
+  at: string;
+}
+
+export interface SlotStats {
+  size: number;
+  sizeLimit: number;
+  free: number;
+  pctUsed: number;
+  rev: number;
+  contentHash: string;
+  warning?: string;
+}
+
+/**
+ * Headroom and revision of a slot, returned alongside every read and write so a
+ * caller can see it is running out of room before an append starts failing, and
+ * can pass the revision back to prove it merged from the current content.
+ */
+export function slotStats(slot: MemorySlot): SlotStats {
+  const size = slot.content.length;
+  const sizeLimit = slot.sizeLimit || 1;
+  const pctUsed = Math.round((size / sizeLimit) * 100);
+  const stats: SlotStats = {
+    size,
+    sizeLimit,
+    free: Math.max(0, sizeLimit - size),
+    pctUsed,
+    rev: slot.rev ?? 0,
+    contentHash: createHash("sha1").update(slot.content).digest("hex").slice(0, 12),
+  };
+  if (pctUsed >= SLOT_URGENT_PCT) {
+    stats.warning = `slot is ${pctUsed}% full (${stats.free} chars free) — compact it now; the next append of this size will fail`;
+  } else if (pctUsed >= SLOT_WARN_PCT) {
+    stats.warning = `slot is ${pctUsed}% full (${stats.free} chars free) — compact before the next large append`;
+  }
+  return stats;
+}
+
+function slotHistoryLimit(): number {
+  const raw = parseInt(getEnvVar("AGENTMEMORY_SLOT_HISTORY") || "", 10);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_SLOT_HISTORY;
+}
+
+/**
+ * Copy the slot as it stands before a mutation, keeping the most recent N per
+ * label. History is best-effort: a slot write is never failed because its undo
+ * copy could not be stored.
+ */
+async function snapshotSlot(
+  kv: StateKV,
+  slot: MemorySlot,
+  operation: SlotHistoryEntry["operation"],
+): Promise<void> {
+  try {
+    const entry: SlotHistoryEntry = {
+      id: `${slot.label}_${Date.now().toString(36)}`,
+      label: slot.label,
+      operation,
+      content: slot.content,
+      size: slot.content.length,
+      rev: slot.rev ?? 0,
+      at: nowIso(),
+    };
+    await kv.set(SLOT_HISTORY_SCOPE, entry.id, entry);
+    const keep = slotHistoryLimit();
+    const mine = (await kv.list<SlotHistoryEntry>(SLOT_HISTORY_SCOPE))
+      .filter((e) => e.label === slot.label)
+      .sort((a, b) => (a.at || "").localeCompare(b.at || ""));
+    for (const old of mine.slice(0, Math.max(0, mine.length - keep))) {
+      await kv.delete(SLOT_HISTORY_SCOPE, old.id).catch(() => {});
+    }
+  } catch (err) {
+    logger.warn("slot history snapshot failed", {
+      label: slot.label,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
 
 export const DEFAULT_SLOTS: ReadonlyArray<
   Omit<MemorySlot, "createdAt" | "updatedAt">
@@ -208,9 +302,9 @@ export function registerSlotsFunctions(sdk: ISdk, kv: StateKV): void {
     const merged = new Map<string, MemorySlot>();
     for (const s of global) merged.set(s.label, s);
     for (const s of project) merged.set(s.label, s);
-    const slots = Array.from(merged.values()).sort((a, b) =>
-      a.label.localeCompare(b.label),
-    );
+    const slots = Array.from(merged.values())
+      .sort((a, b) => a.label.localeCompare(b.label))
+      .map((slot) => ({ ...slot, ...slotStats(slot) }));
     return { success: true, slots };
   });
 
@@ -221,7 +315,7 @@ export function registerSlotsFunctions(sdk: ISdk, kv: StateKV): void {
       if (!label) return { success: false, error: "label required (lowercase, starts with letter, [a-z0-9_])" };
       const { slot, scope } = await readSlot(kv, label);
       if (!slot) return { success: false, error: "slot not found" };
-      return { success: true, slot, scope };
+      return { success: true, slot, scope, ...slotStats(slot) };
     },
   );
 
@@ -298,44 +392,118 @@ export function registerSlotsFunctions(sdk: ISdk, kv: StateKV): void {
             sizeLimit: slot.sizeLimit,
           };
         }
-        const updated: MemorySlot = { ...slot, content: next, updatedAt: nowIso() };
+        await snapshotSlot(kv, slot, "append");
+        const updated: MemorySlot = {
+          ...slot,
+          content: next,
+          rev: (slot.rev ?? 0) + 1,
+          updatedAt: nowIso(),
+        };
         await kv.set(scopeKv(scope), label, updated);
         await recordAudit(kv, "slot_append", "mem::slot-append", [label], {
           scope,
           added: text.length,
           total: next.length,
         });
-        return { success: true, slot: updated, size: next.length };
+        return { success: true, slot: updated, ...slotStats(updated) };
       });
     },
   );
 
   sdk.registerFunction(
     "mem::slot-replace",
-    async (data: { label?: string; content?: string }) => {
+    async (data: {
+      label?: string;
+      content?: string;
+      expectedRev?: number;
+      expectedHash?: string;
+    }) => {
       const label = validateLabel(data?.label);
       if (!label) return { success: false, error: "label required" };
       if (typeof data?.content !== "string") return { success: false, error: "content required (string)" };
+      const content: string = data.content;
       return withKeyedLock(`slot:${label}`, async () => {
         const { slot, scope } = await readSlot(kv, label);
         if (!slot) return { success: false, error: "slot not found (use mem::slot-create first)" };
         if (slot.readOnly) return { success: false, error: "slot is read-only" };
-        if (data.content.length > slot.sizeLimit) {
+        if (content.length > slot.sizeLimit) {
           return {
             success: false,
-            error: `content exceeds sizeLimit (${data.content.length} > ${slot.sizeLimit})`,
+            error: `content exceeds sizeLimit (${content.length} > ${slot.sizeLimit})`,
             sizeLimit: slot.sizeLimit,
           };
         }
-        const updated: MemorySlot = { ...slot, content: data.content, updatedAt: nowIso() };
+        const current = slotStats(slot);
+        if (data.expectedRev !== undefined && Number(data.expectedRev) !== current.rev) {
+          return {
+            success: false,
+            error: `slot changed since you read it (expectedRev ${data.expectedRev}, current ${current.rev}) — re-read the slot and merge, do not overwrite`,
+            current,
+          };
+        }
+        if (typeof data.expectedHash === "string" && data.expectedHash !== current.contentHash) {
+          return {
+            success: false,
+            error: `slot changed since you read it (expectedHash ${data.expectedHash}, current ${current.contentHash}) — re-read the slot and merge, do not overwrite`,
+            current,
+          };
+        }
+        await snapshotSlot(kv, slot, "replace");
+        const updated: MemorySlot = {
+          ...slot,
+          content,
+          rev: (slot.rev ?? 0) + 1,
+          updatedAt: nowIso(),
+        };
         await kv.set(scopeKv(scope), label, updated);
         await recordAudit(kv, "slot_replace", "mem::slot-replace", [label], {
           scope,
           before: slot.content.length,
-          after: data.content.length,
+          after: content.length,
         });
-        return { success: true, slot: updated, size: data.content.length };
+        return {
+          success: true,
+          slot: updated,
+          previousSize: slot.content.length,
+          ...slotStats(updated),
+        };
       });
+    },
+  );
+
+  sdk.registerFunction(
+    "mem::slot-history",
+    async (data: { label?: string; id?: string; restore?: boolean }) => {
+      const label = validateLabel(data?.label);
+      if (!label) return { success: false, error: "label required" };
+      const entries = (await kv.list<SlotHistoryEntry>(SLOT_HISTORY_SCOPE))
+        .filter((e) => e.label === label)
+        .sort((a, b) => (b.at || "").localeCompare(a.at || ""));
+      if (data?.restore === true) {
+        const target = data.id ? entries.find((e) => e.id === data.id) : entries[0];
+        if (!target) return { success: false, error: "no history entry to restore" };
+        return {
+          success: true,
+          entry: target,
+          restoreWith: {
+            function_id: "mem::slot-replace",
+            label,
+            content: target.content,
+          },
+        };
+      }
+      return {
+        success: true,
+        label,
+        entries: entries.map((e) => ({
+          id: e.id,
+          at: e.at,
+          operation: e.operation,
+          size: e.size,
+          rev: e.rev,
+          preview: (e.content || "").slice(0, 200),
+        })),
+      };
     },
   );
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1213,7 +1213,17 @@ export function registerMcpEndpoints(
             if (!label || typeof args.content !== "string") {
               return { status_code: 400, body: { error: "label and content (string) required" } };
             }
-            const result = await sdk.trigger({ function_id: "mem::slot-replace", payload: { label, content: args.content } });
+            // The dispatcher rebuilds the payload, so any new function parameter is a
+            // silent no-op until it is forwarded here as well.
+            const result = await sdk.trigger({
+              function_id: "mem::slot-replace",
+              payload: {
+                label,
+                content: args.content,
+                ...(typeof args.expectedRev === "number" ? { expectedRev: args.expectedRev } : {}),
+                ...(typeof args.expectedHash === "string" ? { expectedHash: args.expectedHash } : {}),
+              },
+            });
             return {
               status_code: 200,
               body: { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] },

--- a/src/mcp/tools-registry.ts
+++ b/src/mcp/tools-registry.ts
@@ -914,12 +914,22 @@ export const V010_SLOTS_TOOLS: McpToolDef[] = [
   },
   {
     name: "memory_slot_replace",
-    description: "Replace slot content in place. Fails if content exceeds sizeLimit.",
+    description:
+      "Replace slot content in place. Fails if content exceeds sizeLimit. Pass expectedRev (or expectedHash) from your memory_slot_get read so a concurrent write by another session is rejected instead of silently clobbered; the previous content is snapshotted to slot history either way.",
     inputSchema: {
       type: "object",
       properties: {
         label: { type: "string", description: "Slot label" },
         content: { type: "string", description: "New full content" },
+        expectedRev: {
+          type: "number",
+          description:
+            "rev returned by memory_slot_get. If it no longer matches, the replace is rejected — re-read and merge.",
+        },
+        expectedHash: {
+          type: "string",
+          description: "contentHash returned by memory_slot_get; alternative to expectedRev.",
+        },
       },
       required: ["label", "content"],
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -227,6 +227,8 @@ export interface MemorySlot {
   label: string;
   content: string;
   sizeLimit: number;
+  /** Bumped on every write; pass it back as expectedRev to reject a stale overwrite. */
+  rev?: number;
   description: string;
   pinned: boolean;
   readOnly: boolean;

--- a/test/slots-concurrency.test.ts
+++ b/test/slots-concurrency.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../src/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+function mockKV() {
+  const store = new Map<string, Map<string, unknown>>();
+  return {
+    store,
+    get: async <T>(scope: string, key: string): Promise<T | null> =>
+      (store.get(scope)?.get(key) as T) ?? null,
+    set: async <T>(scope: string, key: string, data: T): Promise<T> => {
+      if (!store.has(scope)) store.set(scope, new Map());
+      store.get(scope)!.set(key, data);
+      return data;
+    },
+    update: async () => {},
+    delete: async (scope: string, key: string) => {
+      store.get(scope)?.delete(key);
+    },
+    list: async <T>(scope: string): Promise<T[]> => {
+      const m = store.get(scope);
+      return m ? (Array.from(m.values()) as T[]) : [];
+    },
+  };
+}
+
+function mockSdk() {
+  const fns = new Map<string, Function>();
+  return {
+    fns,
+    registerFunction: (idOrOpts: string | { id: string }, fn: Function) => {
+      const id = typeof idOrOpts === "string" ? idOrOpts : idOrOpts.id;
+      fns.set(id, fn);
+    },
+    trigger: async (
+      idOrInput: string | { function_id: string; payload: unknown },
+      data?: unknown,
+    ) => {
+      const id = typeof idOrInput === "string" ? idOrInput : idOrInput.function_id;
+      const payload = typeof idOrInput === "string" ? data : idOrInput.payload;
+      const fn = fns.get(id);
+      if (fn) return fn(payload);
+      return null;
+    },
+  };
+}
+
+type Res = {
+  success: boolean;
+  error?: string;
+  rev?: number;
+  size?: number;
+  free?: number;
+  pctUsed?: number;
+  contentHash?: string;
+  warning?: string;
+  current?: { rev: number; contentHash: string };
+  entries?: Array<{ operation: string; size: number; preview: string }>;
+  restoreWith?: { content: string };
+};
+
+async function setup(sizeLimit = 100, content = "base") {
+  const { registerSlotsFunctions } = await import("../src/functions/slots.js");
+  const sdk = mockSdk();
+  const kv = mockKV();
+  registerSlotsFunctions(sdk as never, kv as never);
+  await kv.set("mem:slots", "shared_index", {
+    label: "shared_index",
+    content,
+    sizeLimit,
+    description: "test",
+    pinned: true,
+    readOnly: false,
+    scope: "project",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  });
+  return { sdk, kv };
+}
+
+describe("slot concurrency guard, history and headroom", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("reports headroom on read and warns as the slot fills", async () => {
+    const { sdk } = await setup(100, "x".repeat(95));
+    const res = (await sdk.trigger("mem::slot-get", { label: "shared_index" })) as Res;
+    expect(res.size).toBe(95);
+    expect(res.free).toBe(5);
+    expect(res.pctUsed).toBe(95);
+    expect(res.warning).toMatch(/compact it now/);
+  });
+
+  it("rejects a replace carrying a stale expectedRev and leaves the content alone", async () => {
+    const { sdk } = await setup();
+    await sdk.trigger("mem::slot-append", { label: "shared_index", text: "lane A line" });
+
+    const stale = (await sdk.trigger("mem::slot-replace", {
+      label: "shared_index",
+      content: "lane B rewrote everything",
+      expectedRev: 0,
+    })) as Res;
+
+    expect(stale.success).toBe(false);
+    expect(stale.error).toMatch(/changed since you read it/);
+    expect(stale.current?.rev).toBe(1);
+
+    const after = (await sdk.trigger("mem::slot-get", { label: "shared_index" })) as Res & {
+      slot: { content: string };
+    };
+    expect(after.slot.content).toContain("lane A line");
+  });
+
+  it("accepts a replace carrying the current rev and bumps it", async () => {
+    const { sdk } = await setup();
+    const read = (await sdk.trigger("mem::slot-get", { label: "shared_index" })) as Res;
+    const res = (await sdk.trigger("mem::slot-replace", {
+      label: "shared_index",
+      content: "compacted",
+      expectedRev: read.rev,
+    })) as Res;
+    expect(res.success).toBe(true);
+    expect(res.rev).toBe((read.rev ?? 0) + 1);
+  });
+
+  it("honours expectedHash the same way", async () => {
+    const { sdk } = await setup();
+    const bad = (await sdk.trigger("mem::slot-replace", {
+      label: "shared_index",
+      content: "nope",
+      expectedHash: "deadbeefdead",
+    })) as Res;
+    expect(bad.success).toBe(false);
+
+    const read = (await sdk.trigger("mem::slot-get", { label: "shared_index" })) as Res;
+    const good = (await sdk.trigger("mem::slot-replace", {
+      label: "shared_index",
+      content: "yes",
+      expectedHash: read.contentHash,
+    })) as Res;
+    expect(good.success).toBe(true);
+  });
+
+  it("keeps a pre-write copy of every mutation and can hand back the undo", async () => {
+    const { sdk } = await setup(200, "original");
+    await sdk.trigger("mem::slot-append", { label: "shared_index", text: "appended" });
+    await sdk.trigger("mem::slot-replace", { label: "shared_index", content: "clobbered" });
+
+    const history = (await sdk.trigger("mem::slot-history", { label: "shared_index" })) as Res;
+    expect(history.entries?.map((e) => e.operation)).toEqual(["replace", "append"]);
+    expect(history.entries?.[1].preview).toBe("original");
+
+    const restore = (await sdk.trigger("mem::slot-history", {
+      label: "shared_index",
+      restore: true,
+    })) as Res;
+    expect(restore.restoreWith?.content).toContain("appended");
+  });
+
+  it("writes without an expectation still work, so existing callers are unaffected", async () => {
+    const { sdk } = await setup();
+    const res = (await sdk.trigger("mem::slot-replace", {
+      label: "shared_index",
+      content: "no expectation supplied",
+    })) as Res;
+    expect(res.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

Slots are the one part of agentmemory that several sessions write to by hand, and `mem::slot-replace` is a whole-object write with no guard:

- Two sessions that both `memory_slot_get` and then `memory_slot_replace` produce a **silent clobber** — the second write wins and the first lane's content is gone, with no error and no copy anywhere. The audit row records only lengths.
- There is **no way to see a slot filling up**. `sizeLimit` is only felt when an append fails, and by then the only fix is a full replace — i.e. the risky operation above.
- On a shared "index" slot at 11 990 / 12 000 characters, that combination leaves an agent with three bad options: rewrite the whole slot (risking the clobber), shave another lane's text, or skip recording. All three are worse than the thing they are working around.

## Change

Backward compatible; a caller that passes nothing behaves exactly as today.

**1. Optimistic concurrency.** `mem::slot-replace` accepts `expectedRev` (or `expectedHash`) from the read it merged from. If the slot has moved on, the write is rejected with the current rev and hash instead of overwriting:

```
slot changed since you read it (expectedRev 3, current 5) — re-read the slot and merge, do not overwrite
```

`rev` starts at 0 for existing slots and increments on every append/replace.

**2. Write history.** Every append and replace snapshots the previous content to `mem:slots:history`, keeping the most recent `AGENTMEMORY_SLOT_HISTORY` per label (default 20). `mem::slot-history` lists entries; `restore: true` returns the exact `mem::slot-replace` call that puts the old content back. Snapshotting is best-effort — a slot write is never failed because its undo copy could not be stored.

**3. Headroom on every read and write.** `size`, `sizeLimit`, `free`, `pctUsed`, `rev`, `contentHash`, plus `warning` at ≥70% and ≥90%:

```json
{ "size": 11596, "sizeLimit": 12000, "free": 404, "pctUsed": 97,
  "warning": "slot is 97% full (404 chars free) — compact it now; the next append of this size will fail" }
```

**MCP plumbing.** `src/mcp/server.ts` rebuilds the slot-replace payload field by field, so `expectedRev`/`expectedHash` are forwarded there and declared in the tool schema. Without that the guard exists server-side and never fires for the agents that actually call it — which is how I first "verified" it working when it wasn't.

## Verification

`test/slots-concurrency.test.ts` (new, 6 cases): headroom + warning on read; stale `expectedRev` rejected and content untouched; current rev accepted and bumped; `expectedHash` both ways; history records both operations in order and hands back the undo; a replace with no expectation still succeeds.

Full suite green (1602 passed, 1 skipped) and `npm run build` clean.

Note for anyone reproducing: run the suite with an isolated `HOME`. On a machine with a real `~/.agentmemory/.env`, config merging pulls the developer's own keys and flags into 14 unrelated tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Slot responses now include usage statistics, content hashes, revision numbers, and capacity warnings.
  - Added slot history viewing with snapshot listings and restore instructions.
  - Slot updates can be protected with expected revision numbers or content hashes to prevent stale overwrites.
  - Added configurable mutation history retention for slot changes.
- **Bug Fixes**
  - Improved protection against unintended overwrites during concurrent slot updates.
- **Tests**
  - Added coverage for statistics, concurrency checks, history, restoration, and backward-compatible updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->