### PR TITLE
fix: bound the audit log with AGENTMEMORY_AUDIT_MAX

### DIFF
--- a/src/functions/audit.ts
+++ b/src/functions/audit.ts
@@ -2,6 +2,7 @@ import type { AuditEntry } from "../types.js";
 import { KV, generateId } from "../state/schema.js";
 import type { StateKV } from "../state/kv.js";
 import { logger } from "../logger.js";
+import { getEnvVar } from "../config.js";
 
 // Audit coverage policy (issue #125).
 //
@@ -31,6 +32,40 @@ import { logger } from "../logger.js";
 // When adding a new deletion path, add an explicit recordAudit call
 // BEFORE kv.delete(...) and match one of the two shapes above.
 
+/**
+ * The audit log has no retention of its own: it grows for the life of the
+ * install, and because the KV adapter rewrites a whole scope on every set, each
+ * audit write costs more as the log gets longer. Keep the most recent
+ * AGENTMEMORY_AUDIT_MAX rows (0 disables the bound), checked every
+ * TRIM_INTERVAL writes so the common path stays a single set.
+ */
+const DEFAULT_AUDIT_MAX = 5000;
+const TRIM_INTERVAL = 100;
+let writesSinceTrim = 0;
+
+function auditMax(): number {
+  const raw = parseInt(getEnvVar("AGENTMEMORY_AUDIT_MAX") || "", 10);
+  if (Number.isFinite(raw) && raw >= 0) return raw;
+  return DEFAULT_AUDIT_MAX;
+}
+
+async function trimAuditLog(kv: StateKV): Promise<void> {
+  const max = auditMax();
+  if (max === 0) return;
+  const all = await kv.list<AuditEntry>(KV.audit);
+  if (all.length <= max) return;
+  const stale = [...all]
+    .sort(
+      (a, b) =>
+        new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
+    )
+    .slice(0, all.length - max);
+  for (const old of stale) {
+    await kv.delete(KV.audit, old.id).catch(() => {});
+  }
+  logger.info("audit log trimmed", { removed: stale.length, kept: max });
+}
+
 export async function recordAudit(
   kv: StateKV,
   operation: AuditEntry["operation"],
@@ -51,6 +86,15 @@ export async function recordAudit(
     qualityScore,
   };
   await kv.set(KV.audit, entry.id, entry);
+  if (++writesSinceTrim >= TRIM_INTERVAL) {
+    writesSinceTrim = 0;
+    // Never fail the audited operation because pruning failed.
+    await trimAuditLog(kv).catch((err) => {
+      logger.warn("audit log trim failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+  }
   return entry;
 }
 

--- a/test/audit-retention.test.ts
+++ b/test/audit-retention.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../src/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+function mockKV() {
+  const store = new Map<string, Map<string, unknown>>();
+  return {
+    store,
+    get: async <T>(scope: string, key: string): Promise<T | null> =>
+      (store.get(scope)?.get(key) as T) ?? null,
+    set: async <T>(scope: string, key: string, data: T): Promise<T> => {
+      if (!store.has(scope)) store.set(scope, new Map());
+      store.get(scope)!.set(key, data);
+      return data;
+    },
+    delete: async (scope: string, key: string) => {
+      store.get(scope)?.delete(key);
+    },
+    list: async <T>(scope: string): Promise<T[]> => {
+      const m = store.get(scope);
+      return m ? (Array.from(m.values()) as T[]) : [];
+    },
+  };
+}
+
+const AUDIT = "mem:audit";
+
+async function writeN(recordAudit: Function, kv: ReturnType<typeof mockKV>, n: number) {
+  for (let i = 0; i < n; i++) {
+    await recordAudit(kv, "observe", "mem::observe", [`t${i}`]);
+  }
+}
+
+describe("audit log retention", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    delete process.env.AGENTMEMORY_AUDIT_MAX;
+  });
+
+  afterEach(() => {
+    delete process.env.AGENTMEMORY_AUDIT_MAX;
+  });
+
+  // The trim runs every 100 writes, so the log is bounded at max + one interval
+  // rather than exactly max — the point is that it stops growing without limit.
+  it("keeps the log bounded near AGENTMEMORY_AUDIT_MAX and drops the oldest rows", async () => {
+    process.env.AGENTMEMORY_AUDIT_MAX = "150";
+    const { recordAudit } = await import("../src/functions/audit.js");
+    const kv = mockKV();
+
+    await writeN(recordAudit, kv, 260);
+
+    const rows = Array.from(kv.store.get(AUDIT)!.values()) as Array<{
+      timestamp: string;
+      targetIds: string[];
+    }>;
+    expect(rows.length).toBeLessThanOrEqual(150 + 100);
+    expect(rows.length).toBeLessThan(260);
+    // the survivors are the newest ones
+    const kept = new Set(rows.flatMap((r) => r.targetIds));
+    expect(kept.has("t259")).toBe(true);
+    expect(kept.has("t0")).toBe(false);
+  });
+
+  it("does not trim when the log is under the bound", async () => {
+    process.env.AGENTMEMORY_AUDIT_MAX = "500";
+    const { recordAudit } = await import("../src/functions/audit.js");
+    const kv = mockKV();
+
+    await writeN(recordAudit, kv, 120);
+
+    expect(kv.store.get(AUDIT)!.size).toBe(120);
+  });
+
+  it("treats 0 as unbounded, preserving the pre-existing behaviour", async () => {
+    process.env.AGENTMEMORY_AUDIT_MAX = "0";
+    const { recordAudit } = await import("../src/functions/audit.js");
+    const kv = mockKV();
+
+    await writeN(recordAudit, kv, 250);
+
+    expect(kv.store.get(AUDIT)!.size).toBe(250);
+  });
+
+  it("still returns the entry when trimming fails", async () => {
+    process.env.AGENTMEMORY_AUDIT_MAX = "10";
+    const { recordAudit } = await import("../src/functions/audit.js");
+    const kv = mockKV();
+    const broken = { ...kv, list: async () => { throw new Error("kv down"); } };
+
+    let last;
+    for (let i = 0; i < 120; i++) {
+      last = await recordAudit(broken as never, "observe", "mem::observe", [`t${i}`]);
+    }
+    expect(last?.id).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Problem

`recordAudit` has no retention. The `mem:audit` scope grows for the life of the install, and because the KV adapter rewrites a **whole scope** on every `set`, each audit write gets more expensive as the log gets longer — the slowdown compounds on exactly the installs that have been running longest.

On a two-month-old install here that scope held ~14k rows in a 4.5MB blob, rewritten on every audited operation (every observe, compress, remember, slot write, eviction…).

## Change

Keep the most recent `AGENTMEMORY_AUDIT_MAX` rows, oldest dropped first.

- default `5000`
- `0` restores today's unbounded behaviour for anyone who wants the full log
- the check runs every 100 writes so the common path stays a single `set`; the log is therefore bounded at `max + one interval` rather than exactly `max`, which the test asserts explicitly rather than pretending otherwise
- a failed trim is logged and swallowed — the audited operation must never fail because pruning did

## Verification

`test/audit-retention.test.ts` (new, 4 cases): bounded near the max with the newest rows surviving and the oldest gone; no trimming under the bound; `0` stays unbounded; `recordAudit` still returns its entry when the trim throws.

Full suite green (1600 passed, 1 skipped).

Run the suite with an isolated `HOME` — on a machine with a real `~/.agentmemory/.env`, config merging pulls the developer's keys and flags into 14 unrelated tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable audit-log retention with a default limit of 5,000 entries.
  * Supports disabling retention limits or setting a custom maximum.
  * Automatically removes the oldest entries when the limit is exceeded.
  * Audit logging continues successfully even if cleanup fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->