### PR TITLE
feat(health): surface search-index freshness

### DIFF
--- a/src/health/monitor.ts
+++ b/src/health/monitor.ts
@@ -1,4 +1,5 @@
 import type { ISdk } from "iii-sdk";
+import { getIndexPersistenceStatus } from "../state/index-persistence.js";
 import type { HealthSnapshot } from "../types.js";
 import type { StateKV } from "../state/kv.js";
 import { KV } from "../state/schema.js";
@@ -80,6 +81,7 @@ export function registerHealthMonitor(
       eventLoopLagMs,
       uptimeSeconds: uptime,
       kvConnectivity,
+      indexPersistence: getIndexPersistenceStatus(),
       status: "healthy",
       alerts: [],
     };

--- a/src/health/thresholds.ts
+++ b/src/health/thresholds.ts
@@ -76,6 +76,23 @@ export function evaluateHealth(
     notes.push(`memory_heap_tight_${Math.round(memPercent)}%_rss${memMb}mb`);
   }
 
+  const index = snapshot.indexPersistence;
+  if (index) {
+    if (index.lastError) {
+      alerts.push("index_persist_error");
+      degraded = true;
+    } else if (index.stale && index.dirtySince !== null) {
+      const staleMin = Math.round((Date.now() - index.dirtySince) / 60000);
+      alerts.push(`index_persist_stale_${staleMin}m`);
+      degraded = true;
+    } else {
+      const savedAt = index.lastSavedAt
+        ? `${Math.round((Date.now() - new Date(index.lastSavedAt).getTime()) / 60000)}m_ago`
+        : "never";
+      notes.push(`index_docs_${index.bm25Docs}_vec_${index.vectors}_saved_${savedAt}`);
+    }
+  }
+
   const status = critical ? "critical" : degraded ? "degraded" : "healthy";
   return { status, alerts, notes };
 }

--- a/src/state/index-persistence.ts
+++ b/src/state/index-persistence.ts
@@ -6,6 +6,7 @@ import { logger } from "../logger.js";
 import { safeAudit } from "../functions/audit.js";
 
 const DEBOUNCE_MS = 5000;
+const STALE_AFTER_MS = 60 * 60 * 1000;
 const FAILURE_LOG_THROTTLE_MS = 60_000;
 const INDEX_PERSISTENCE_FUNCTION_ID = "mem::index-persistence";
 const BM25_KEY = "data";
@@ -23,6 +24,50 @@ type IndexShardManifest = {
   shards: Array<{ scope: string; key: string; chars: number }>;
   chars: number;
 };
+
+/**
+ * What the index persistence layer knows about itself. A search index that
+ * stops being written is invisible from the outside: search keeps answering
+ * from memory and only a restart reveals that the last snapshot is old.
+ */
+export interface IndexPersistenceStatus {
+  bm25Docs: number;
+  vectors: number;
+  lastSavedAt: string | null;
+  lastError: string | null;
+  /** When the index first went dirty without a successful save since. */
+  dirtySince: number | null;
+  stale: boolean;
+}
+
+let status: IndexPersistenceStatus = {
+  bm25Docs: 0,
+  vectors: 0,
+  lastSavedAt: null,
+  lastError: null,
+  dirtySince: null,
+  stale: false,
+};
+
+/** Snapshot of index persistence health, for /agentmemory/health. */
+export function getIndexPersistenceStatus(): IndexPersistenceStatus {
+  return {
+    ...status,
+    stale: status.dirtySince !== null && Date.now() - status.dirtySince > STALE_AFTER_MS,
+  };
+}
+
+/** Test seam. */
+export function resetIndexPersistenceStatus(): void {
+  status = {
+    bm25Docs: 0,
+    vectors: 0,
+    lastSavedAt: null,
+    lastError: null,
+    dirtySince: null,
+    stale: false,
+  };
+}
 
 type IndexPersistenceOptions = {
   shardChars?: number;
@@ -77,6 +122,7 @@ export class IndexPersistence {
   ) {}
 
   scheduleSave(): void {
+    if (status.dirtySince === null) status.dirtySince = Date.now();
     if (this.timer) clearTimeout(this.timer);
     // setTimeout discards the returned promise, so any rejection inside
     // save() would surface as unhandledRejection and crash the process
@@ -97,7 +143,13 @@ export class IndexPersistence {
       if (this.vector) {
         await this.saveVectorIndex(this.vector.serialize());
       }
+      status.bm25Docs = this.bm25.size;
+      status.vectors = this.vector ? this.vector.size : 0;
+      status.lastSavedAt = new Date().toISOString();
+      status.lastError = null;
+      status.dirtySince = null;
     } catch (err) {
+      status.lastError = err instanceof Error ? err.message : String(err);
       this.logFailure(err);
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -211,6 +211,15 @@ export interface HealthSnapshot {
   eventLoopLagMs: number;
   uptimeSeconds: number;
   kvConnectivity?: { status: string; latencyMs?: number; error?: string };
+  /** Freshness of the persisted BM25/vector index, see getIndexPersistenceStatus(). */
+  indexPersistence?: {
+    bm25Docs: number;
+    vectors: number;
+    lastSavedAt: string | null;
+    lastError: string | null;
+    dirtySince: number | null;
+    stale: boolean;
+  };
   status: "healthy" | "degraded" | "critical";
   alerts: string[];
   notes?: string[];

--- a/test/index-freshness.test.ts
+++ b/test/index-freshness.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../src/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { evaluateHealth } from "../src/health/thresholds.js";
+import type { HealthSnapshot } from "../src/types.js";
+
+function snapshot(
+  indexPersistence?: HealthSnapshot["indexPersistence"],
+): HealthSnapshot {
+  return {
+    connectionState: "connected",
+    workers: [],
+    memory: { heapUsed: 10, heapTotal: 100, rss: 10 * 1024 * 1024, external: 0 },
+    cpu: { userMicros: 0, systemMicros: 0, percent: 1 },
+    eventLoopLagMs: 1,
+    uptimeSeconds: 100,
+    kvConnectivity: { status: "ok", latencyMs: 1 },
+    indexPersistence,
+    status: "healthy",
+    alerts: [],
+  };
+}
+
+describe("search-index freshness in health", () => {
+  it("reports docs, vectors and save age as a note when the index is being written", () => {
+    const res = evaluateHealth(
+      snapshot({
+        bm25Docs: 12400,
+        vectors: 12400,
+        lastSavedAt: new Date(Date.now() - 5 * 60_000).toISOString(),
+        lastError: null,
+        dirtySince: null,
+        stale: false,
+      }),
+    );
+    expect(res.status).toBe("healthy");
+    expect(res.notes.join(" ")).toContain("index_docs_12400_vec_12400_saved_5m_ago");
+  });
+
+  it("degrades when the index has been dirty past the stale window", () => {
+    const res = evaluateHealth(
+      snapshot({
+        bm25Docs: 12400,
+        vectors: 12400,
+        lastSavedAt: new Date(Date.now() - 20 * 24 * 3600_000).toISOString(),
+        lastError: null,
+        dirtySince: Date.now() - 3 * 3600_000,
+        stale: true,
+      }),
+    );
+    expect(res.status).toBe("degraded");
+    expect(res.alerts.some((a) => a.startsWith("index_persist_stale_"))).toBe(true);
+  });
+
+  it("degrades when the last save failed", () => {
+    const res = evaluateHealth(
+      snapshot({
+        bm25Docs: 100,
+        vectors: 0,
+        lastSavedAt: null,
+        lastError: "TIMEOUT: invocation timed out after 180000ms",
+        dirtySince: Date.now(),
+        stale: false,
+      }),
+    );
+    expect(res.status).toBe("degraded");
+    expect(res.alerts).toContain("index_persist_error");
+  });
+
+  it("says nothing when the snapshot carries no index information", () => {
+    const res = evaluateHealth(snapshot(undefined));
+    expect(res.status).toBe("healthy");
+    expect(res.notes.join(" ")).not.toContain("index_");
+  });
+});
+
+describe("index persistence status tracking", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("starts clean, marks dirty on scheduleSave and reports stale only past the window", async () => {
+    const { getIndexPersistenceStatus, resetIndexPersistenceStatus, IndexPersistence } =
+      await import("../src/state/index-persistence.js");
+    const { SearchIndex } = await import("../src/state/search-index.js");
+    resetIndexPersistenceStatus();
+
+    expect(getIndexPersistenceStatus().dirtySince).toBeNull();
+    expect(getIndexPersistenceStatus().stale).toBe(false);
+
+    const kv = {
+      get: async () => null,
+      set: async () => {},
+      delete: async () => {},
+      list: async () => [],
+    };
+    const persistence = new IndexPersistence(kv as never, new SearchIndex(), null);
+    persistence.scheduleSave();
+
+    const dirty = getIndexPersistenceStatus();
+    expect(dirty.dirtySince).not.toBeNull();
+    expect(dirty.stale).toBe(false); // just went dirty, well inside the window
+
+    persistence.stop();
+  });
+});


### PR DESCRIPTION
## Problem

When index persistence stops working, nothing says so.

- search keeps answering, because the in-memory index is fine
- `/agentmemory/health` keeps returning `healthy`
- the only trace is a `warn` line that `FAILURE_LOG_THROTTLE_MS` emits at most once a minute
- the loss materialises on the **next restart**, when the server loads whatever snapshot last succeeded

On an install here, `state::set` had been timing out for **20 days**. Every restart reloaded a snapshot of 4944 docs against a real corpus of 12 801 — 61% of memory silently unsearchable — and the install reported itself healthy the whole time. I only found it by comparing a file mtime against `kv.list` counts.

(That specific timeout is what the sharded manifest work in 0.9.25 addresses. This PR is about the class of failure being *visible*, whatever the cause: a shard write that fails, a KV that goes read-only, a disk that fills.)

## Change

`IndexPersistence` tracks its own outcome and exposes it:

```ts
getIndexPersistenceStatus(): {
  bm25Docs, vectors,
  lastSavedAt, lastError,
  dirtySince,   // when the index first went dirty with no save since
  stale,        // dirty for over an hour
}
```

`scheduleSave()` marks dirty, a successful `save()` clears it and records counts, a failed one records the error. The health snapshot carries the status and `evaluateHealth` reports it:

- note: `index_docs_12400_vec_12400_saved_5m_ago`
- alert (degrades): `index_persist_error`
- alert (degrades): `index_persist_stale_<n>m`

A snapshot without `indexPersistence` produces exactly today's output, so anything constructing `HealthSnapshot` itself is unaffected.

## Verification

`test/index-freshness.test.ts` (new, 5 cases): the note with counts and save age; degrade + `index_persist_stale_` past the window; degrade + `index_persist_error` on a failed save; silence when the snapshot carries no index info; and the dirty-tracking transition on `scheduleSave()`.

Full suite green (1601 passed, 1 skipped), `npm run build` clean. The three strict-mode `tsc` errors touching these files are pre-existing on `main`.

Run the suite with an isolated `HOME` — a real `~/.agentmemory/.env` on the machine leaks into 14 unrelated tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Health monitoring now reports search-index persistence status, including document counts, save times, errors, and freshness.
  * Healthy indexes provide informational metrics, while stale or failed persistence is surfaced as degraded health.
  * Indexes are tracked as pending during saves and marked current after successful persistence.

* **Tests**
  * Added coverage for healthy, stale, failed, unavailable, and pending index states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->