### PR TITLE
fix(pi): scope memory_save memories to the current project

### DIFF
--- a/integrations/pi/index.ts
+++ b/integrations/pi/index.ts
@@ -234,7 +234,7 @@ export default function agentmemoryExtension(pi: ExtensionAPI) {
     }),
     async execute(_toolCallId, params) {
       const result = await callAgentMemory<Record<string, unknown>>("remember", {
-        body: { content: params.content, type: params.type || "fact" },
+        body: { content: params.content, type: params.type || "fact", project: currentProject },
       });
       if (!result) {
         return {


### PR DESCRIPTION
The server's mem::remember only stamps a memory with a project when project is passed explicitly; otherwise the memory is stored as global (project: null). Every other official integration passes its project, so pi was the odd one out: all memories saved from pi landed in the global bucket while observations from the same session were project-scoped.

Pass currentProject so memory_save results are queryable under the same project bucket as the session's observations. Search stays global either way (smart-search is not project-filtered), so cross-project recall is unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Memory saves now include the currently selected project, improving project-specific memory handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->