### PR TITLE
feat(pi): summarize and end the session on quit

### DIFF
--- a/integrations/pi/index.ts
+++ b/integrations/pi/index.ts
@@ -157,7 +157,11 @@ export default function agentmemoryExtension(pi: ExtensionAPI) {
 
   async function refreshStatus(ctx: { ui: { setStatus: (key: string, text: string) => void } }) {
     const health = await getHealth();
-    lastHealthOk = !!health && (health.status === "healthy" || health.health?.status === "healthy");
+    lastHealthOk =
+      !!health &&
+      (health.status === "ok" ||
+        health.status === "healthy" ||
+        health.health?.status === "healthy");
     ctx.ui.setStatus("agentmemory", lastHealthOk ? "🧠 agentmemory" : "🧠 agentmemory off");
   }
 
@@ -311,7 +315,11 @@ export default function agentmemoryExtension(pi: ExtensionAPI) {
     // Mirrors the Claude Code Stop hook (plugin/scripts/stop.mjs): summarize the
     // session before marking it ended so the summary is persisted, with an
     // explicit timeout so a slow LLM cannot hang the exit.
-    await callAgentMemory("summarize", { body: { sessionId }, timeoutMs: 120_000 });
+    const summary = await callAgentMemory("summarize", {
+      body: { sessionId },
+      timeoutMs: 120_000,
+    });
+    if (!summary) return;
     await callAgentMemory("session/end", { body: { sessionId }, timeoutMs: 5_000 });
     // mem::consolidate has no scheduler and is not invoked by
     // consolidate-pipeline, so fold one run into the exit path: it clusters

--- a/integrations/pi/index.ts
+++ b/integrations/pi/index.ts
@@ -89,6 +89,7 @@ async function callAgentMemory<T>(
     method?: "GET" | "POST";
     body?: unknown;
     baseUrl?: string;
+    timeoutMs?: number;
   },
 ): Promise<T | null> {
   const baseUrl = normalizeBaseUrl(options?.baseUrl || process.env.AGENTMEMORY_URL || DEFAULT_URL);
@@ -105,6 +106,7 @@ async function callAgentMemory<T>(
       method,
       headers,
       body: options?.body !== undefined ? JSON.stringify(options.body) : undefined,
+      signal: options?.timeoutMs ? AbortSignal.timeout(options.timeoutMs) : undefined,
     });
     if (!response.ok) return null;
     return (await response.json()) as T;
@@ -298,5 +300,23 @@ export default function agentmemoryExtension(pi: ExtensionAPI) {
         },
       },
     });
+  });
+
+  pi.on("session_shutdown", async (event) => {
+    // Only on a real quit: /new, /resume, /fork and extension reloads all fire
+    // this hook too, but the session continues. Ending it early would orphan the
+    // observations of the session that keeps running.
+    if (event.reason !== "quit") return;
+    if (!lastHealthOk || !sessionId) return;
+    // Mirrors the Claude Code Stop hook (plugin/scripts/stop.mjs): summarize the
+    // session before marking it ended so the summary is persisted, with an
+    // explicit timeout so a slow LLM cannot hang the exit.
+    await callAgentMemory("summarize", { body: { sessionId }, timeoutMs: 120_000 });
+    await callAgentMemory("session/end", { body: { sessionId }, timeoutMs: 5_000 });
+    // mem::consolidate has no scheduler and is not invoked by
+    // consolidate-pipeline, so fold one run into the exit path: it clusters
+    // observations (importance >= 5, same concept >= 3) into cross-session
+    // memories. Fire-and-forget — the server runs it in the background.
+    void callAgentMemory("consolidate", { body: {} });
   });
 }


### PR DESCRIPTION
pi sessions were never closed on the server: the extension only fired agent_end observes, so every session stayed active forever, never got a summary, and accumulated as zombies. This mirrors the Claude Code Stop hook (plugin/scripts/stop.mjs), which calls /agentmemory/summarize (120s timeout) then /agentmemory/session/end before exiting.

Only act on a real quit — /new, /resume, /fork and extension reloads fire session_shutdown too, but the session keeps running, and ending it early would orphan its observations.

callAgentMemory gains an optional timeoutMs so the exit path cannot hang on a slow summarize.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic session summaries when an active session is actually closed.
  * Added bounded timeouts for session shutdown requests.
  * Session consolidation now continues in the background after shutdown.

* **Bug Fixes**
  * Prevented shutdown handling for non-quit events and unavailable or unhealthy sessions.
  * Improved recognition of healthy session statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->