### PR TITLE
fix(consolidate): index consolidated memories into BM25/vector search

### DIFF
--- a/src/functions/consolidate.ts
+++ b/src/functions/consolidate.ts
@@ -204,10 +204,6 @@ export function registerConsolidateFunction(
               newId: evolved.id,
               concept,
             });
-            // The newest version must be searchable immediately, mirroring
-            // mem::remember. Without this the BM25/vector index keeps pointing
-            // at the superseded version (or nothing on first creation) until a
-            // full rebuild — memories are invisible to smart-search in between.
             try {
               getSearchIndex().add(memoryToObservation(evolved));
             } catch (err) {
@@ -240,9 +236,6 @@ export function registerConsolidateFunction(
               action: "create_memory",
               concept,
             });
-            // Same indexing as mem::remember: without this, consolidated
-            // memories are written to KV but never enter the BM25/vector
-            // index, so smart-search cannot recall them until a full rebuild.
             try {
               getSearchIndex().add(memoryToObservation(memory));
             } catch (err) {

--- a/src/functions/consolidate.ts
+++ b/src/functions/consolidate.ts
@@ -8,6 +8,8 @@ import type {
 import { KV, generateId } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
 import { recordAudit } from "./audit.js";
+import { getSearchIndex, vectorIndexAddGuarded } from "./search.js";
+import { memoryToObservation } from "../state/memory-utils.js";
 
 const CONSOLIDATION_SYSTEM = `You are a memory consolidation engine. Given a set of related observations from coding sessions, synthesize them into a single long-term memory.
 
@@ -202,6 +204,24 @@ export function registerConsolidateFunction(
               newId: evolved.id,
               concept,
             });
+            // The newest version must be searchable immediately, mirroring
+            // mem::remember. Without this the BM25/vector index keeps pointing
+            // at the superseded version (or nothing on first creation) until a
+            // full rebuild — memories are invisible to smart-search in between.
+            try {
+              getSearchIndex().add(memoryToObservation(evolved));
+            } catch (err) {
+              logger.warn("Failed to index evolved memory into BM25", {
+                memId: evolved.id,
+                error: err instanceof Error ? err.message : String(err),
+              });
+            }
+            await vectorIndexAddGuarded(
+              evolved.id,
+              evolved.sessionIds?.[0] ?? "memory",
+              evolved.title + " " + evolved.content,
+              { kind: "memory", logId: evolved.id },
+            );
             existingTitles.add(evolved.title.toLowerCase());
             consolidated++;
           } else {
@@ -220,6 +240,23 @@ export function registerConsolidateFunction(
               action: "create_memory",
               concept,
             });
+            // Same indexing as mem::remember: without this, consolidated
+            // memories are written to KV but never enter the BM25/vector
+            // index, so smart-search cannot recall them until a full rebuild.
+            try {
+              getSearchIndex().add(memoryToObservation(memory));
+            } catch (err) {
+              logger.warn("Failed to index consolidated memory into BM25", {
+                memId: memory.id,
+                error: err instanceof Error ? err.message : String(err),
+              });
+            }
+            await vectorIndexAddGuarded(
+              memory.id,
+              memory.sessionIds?.[0] ?? "memory",
+              memory.title + " " + memory.content,
+              { kind: "memory", logId: memory.id },
+            );
             existingTitles.add(memory.title.toLowerCase());
             consolidated++;
           }

--- a/src/functions/smart-search.ts
+++ b/src/functions/smart-search.ts
@@ -191,9 +191,7 @@ export function registerSmartSearchFunction(
       // searcher for more hits than we need and trim post-filter. 3×
       // is a defensible middle ground: enough headroom for a small
       // workload, capped at 300 so a 100-limit request never asks for
-      // thousands of hits. The project filter trims even harder
-      // (observations only carry their project via the session row),
-      // so it over-fetches the same way.
+      // thousands of hits.
       const projectFilter =
         typeof data.project === "string" && data.project.trim().length > 0
           ? data.project.trim()
@@ -210,31 +208,36 @@ export function registerSmartSearchFunction(
           : Promise.resolve([]),
       ]);
 
-      // Observations are only searchable via their compressed form,
-      // which has no project — the project lives on the session row.
-      // Resolve it per hit (falling back to KV.memories for hits that
-      // are memories, whose sessionId is synthetic), treating null or
-      // unknown projects as unscoped so they stay visible.
-      const sessionProjects = new Map<string, string | undefined>();
-      const memoryProjects = new Map<string, string | undefined>();
+      const sessionProjects = new Map<string, Promise<string | undefined>>();
+      const memoryProjects = new Map<string, Promise<string | undefined>>();
+      const getSessionProject = (sessionId: string): Promise<string | undefined> => {
+        let project = sessionProjects.get(sessionId);
+        if (!project) {
+          project = kv
+            .get<{ project?: string }>(KV.sessions, sessionId)
+            .catch(() => null)
+            .then((session) => session?.project);
+          sessionProjects.set(sessionId, project);
+        }
+        return project;
+      };
+      const getMemoryProject = (obsId: string): Promise<string | undefined> => {
+        let project = memoryProjects.get(obsId);
+        if (!project) {
+          project = kv
+            .get<{ project?: string }>(KV.memories, obsId)
+            .catch(() => null)
+            .then((memory) => memory?.project);
+          memoryProjects.set(obsId, project);
+        }
+        return project;
+      };
       const resolveHitProject = async (r: HybridSearchResult): Promise<string | undefined> => {
         if (r.sessionId) {
-          if (!sessionProjects.has(r.sessionId)) {
-            const s = await kv
-              .get<{ project?: string }>(KV.sessions, r.sessionId)
-              .catch(() => null);
-            sessionProjects.set(r.sessionId, s?.project);
-          }
-          const p = sessionProjects.get(r.sessionId);
+          const p = await getSessionProject(r.sessionId);
           if (p) return p;
         }
-        if (!memoryProjects.has(r.observation.id)) {
-          const m = await kv
-            .get<{ project?: string }>(KV.memories, r.observation.id)
-            .catch(() => null);
-          memoryProjects.set(r.observation.id, m?.project);
-        }
-        return memoryProjects.get(r.observation.id);
+        return getMemoryProject(r.observation.id);
       };
 
       let projectScoped = hybridResults;

--- a/src/functions/smart-search.ts
+++ b/src/functions/smart-search.ts
@@ -191,10 +191,17 @@ export function registerSmartSearchFunction(
       // searcher for more hits than we need and trim post-filter. 3×
       // is a defensible middle ground: enough headroom for a small
       // workload, capped at 300 so a 100-limit request never asks for
-      // thousands of hits.
-      const overFetchLimit = filterAgentId
-        ? Math.min(limit * 3, 300)
-        : limit;
+      // thousands of hits. The project filter trims even harder
+      // (observations only carry their project via the session row),
+      // so it over-fetches the same way.
+      const projectFilter =
+        typeof data.project === "string" && data.project.trim().length > 0
+          ? data.project.trim()
+          : undefined;
+      const overFetchLimit =
+        filterAgentId || projectFilter
+          ? Math.min(limit * 3, 300)
+          : limit;
 
       const [hybridResults, lessons] = await Promise.all([
         searchFn(data.query, overFetchLimit),
@@ -203,11 +210,48 @@ export function registerSmartSearchFunction(
           : Promise.resolve([]),
       ]);
 
+      // Observations are only searchable via their compressed form,
+      // which has no project — the project lives on the session row.
+      // Resolve it per hit (falling back to KV.memories for hits that
+      // are memories, whose sessionId is synthetic), treating null or
+      // unknown projects as unscoped so they stay visible.
+      const sessionProjects = new Map<string, string | undefined>();
+      const memoryProjects = new Map<string, string | undefined>();
+      const resolveHitProject = async (r: HybridSearchResult): Promise<string | undefined> => {
+        if (r.sessionId) {
+          if (!sessionProjects.has(r.sessionId)) {
+            const s = await kv
+              .get<{ project?: string }>(KV.sessions, r.sessionId)
+              .catch(() => null);
+            sessionProjects.set(r.sessionId, s?.project);
+          }
+          const p = sessionProjects.get(r.sessionId);
+          if (p) return p;
+        }
+        if (!memoryProjects.has(r.observation.id)) {
+          const m = await kv
+            .get<{ project?: string }>(KV.memories, r.observation.id)
+            .catch(() => null);
+          memoryProjects.set(r.observation.id, m?.project);
+        }
+        return memoryProjects.get(r.observation.id);
+      };
+
+      let projectScoped = hybridResults;
+      if (projectFilter) {
+        const resolved = await Promise.all(
+          hybridResults.map(async (r) => ({ r, project: await resolveHitProject(r) })),
+        );
+        projectScoped = resolved
+          .filter(({ project }) => !project || project === projectFilter)
+          .map(({ r }) => r);
+      }
+
       const filteredHybrid = filterAgentId
-        ? hybridResults
+        ? projectScoped
             .filter((r) => r.observation.agentId === filterAgentId)
             .slice(0, limit)
-        : hybridResults.slice(0, limit);
+        : projectScoped.slice(0, limit);
 
       const compact: CompactSearchResult[] = filteredHybrid.map((r) => ({
         obsId: r.observation.id,


### PR DESCRIPTION
mem::consolidate writes memories to KV but never adds them to the search index, while mem::remember does. So memories created or evolved by consolidation are invisible to smart-search (and agent recall) until a full index rebuild — the index either keeps pointing at the superseded version (evolve) or never sees the memory at all (create). This is the same class of hole as #257 (remember) and the open #1160/#1163.

Mirror the remember.ts pattern in both branches: add the memory to the BM25 index via memoryToObservation and enqueue a vector add, each guarded so an indexing failure cannot roll back the KV write.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Memories created or evolved through consolidation are now indexed for improved keyword and semantic search.
  * Smart Search now provides more accurate project and agent filtering, including broader result retrieval when filters are applied.

* **Bug Fixes**
  * Indexing issues no longer interrupt the consolidation process.
  * Search results now correctly exclude items outside the selected project or agent scope while retaining relevant unassigned items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->