### PR TITLE
fix(state): memoryToObservation transparently passes through agentId and project

### DIFF
--- a/src/state/memory-utils.ts
+++ b/src/state/memory-utils.ts
@@ -20,5 +20,7 @@ export function memoryToObservation(memory: Memory): CompressedObservation {
     concepts: memory.concepts,
     files: memory.files,
     importance: memory.strength,
+    agentId: memory.agentId,
+    project: memory.project,
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,6 +61,7 @@ export interface CompressedObservation {
   imageDescription?: string;
   modality?: "text" | "image" | "mixed";
   agentId?: string;
+  project?: string;
 }
 
 export type ObservationType =

--- a/test/memory-to-observation-agent-scope.test.ts
+++ b/test/memory-to-observation-agent-scope.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+
+import { memoryToObservation } from "../src/state/memory-utils.js";
+import type { Memory } from "../src/types.js";
+
+function makeMemory(overrides: Partial<Memory> = {}): Memory {
+  return {
+    id: "mem_test_1",
+    createdAt: "2026-08-14T00:00:00.000Z",
+    updatedAt: "2026-08-14T00:00:00.000Z",
+    type: "fact",
+    title: "test memory",
+    content: "test content",
+    concepts: [],
+    files: [],
+    sessionIds: [],
+    strength: 1,
+    version: 1,
+    isLatest: true,
+    ...overrides,
+  };
+}
+
+describe("memoryToObservation agentId/project passthrough", () => {
+  it("transparently passes through agentId and project", () => {
+    const memory = makeMemory({ agentId: "pm-agent", project: "worker-config" });
+    const observation = memoryToObservation(memory);
+    expect(observation.agentId).toBe("pm-agent");
+    expect(observation.project).toBe("worker-config");
+  });
+
+  it("leaves agentId/project undefined without defaults or errors", () => {
+    const memory = makeMemory();
+    expect(() => memoryToObservation(memory)).not.toThrow();
+    const observation = memoryToObservation(memory);
+    expect(observation.agentId).toBeUndefined();
+    expect(observation.project).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

`memoryToObservation()` (`src/state/memory-utils.ts`) now copies `agentId` and `project` from the underlying `Memory` record onto the `Observation` it returns. Also adds the (previously missing) `project` field to `CompressedObservation` in `src/types.ts` so the type accepts what this fix now sets.

## Why

Scoped search filters apply strict equality on the hydrated result (`obs.agentId !== filterAgentId`), but memories reach that filter through `memoryToObservation()` — used both at index time and in the KV-fallback hydration path for `mem_*` ids — and that converter dropped `agentId` even though `remember()` already stores it on the `Memory` record. Net effect: a memory stored with `agentId: "X"` could never be found by a search filtered to `agentId: "X"`, only unfiltered/wildcard searches saw it. Combined with `AGENTMEMORY_AGENT_SCOPE=isolated`, memories effectively vanished for the very agents that owned them.

This is a small, standalone fix on the read side only — it doesn't touch or depend on any of the write-side gaps (#1159, #1197) also open right now. It closes the "written with a scope tag but unfindable by that tag" symptom for any memory that already has `agentId`/`project` set on it (e.g. rows written directly against `mem::remember`, or once the write-side issues land).

Fixes #1160

## How to verify

```
npm test -- test/memory-to-observation-agent-scope.test.ts
```

Both new cases pass: the passthrough case (`agentId`/`project` set → preserved) and the boundary case (both `undefined` → stays `undefined`, no throw, no default fill-in). Full suite (`npm test`) passes unchanged otherwise — 1598 passed / 1 skipped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Compressed observations now retain project information and agent context when available.
  - Missing project or agent details remain optional without causing errors.

- **Tests**
  - Added coverage to verify context is preserved and undefined values are handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->