### PR TITLE
fix(mcp): standalone stdio proxy forwards agentId and project on memory_save

### DIFF
--- a/src/mcp/standalone.ts
+++ b/src/mcp/standalone.ts
@@ -105,6 +105,8 @@ interface Validated {
   tokenBudget?: number;
   memoryIds?: string[];
   reason?: string;
+  agentId?: string;
+  project?: string;
 }
 
 function validate(toolName: string, args: Record<string, unknown>): Validated {
@@ -122,6 +124,14 @@ function validate(toolName: string, args: Record<string, unknown>): Validated {
       v.type = (args["type"] as string) || "fact";
       v.concepts = normalizeList(args["concepts"]);
       v.files = normalizeList(args["files"]);
+      const agentId = args["agentId"];
+      if (typeof agentId === "string" && agentId.trim().length > 0) {
+        v.agentId = agentId;
+      }
+      const project = args["project"];
+      if (typeof project === "string" && project.trim().length > 0) {
+        v.project = project;
+      }
       return v;
     }
     case "memory_recall":
@@ -180,6 +190,8 @@ async function handleProxy(
           type: v.type,
           concepts: v.concepts,
           files: v.files,
+          agentId: v.agentId,
+          project: v.project,
         }),
       });
       return textResponse(result);

--- a/test/mcp-standalone-proxy.test.ts
+++ b/test/mcp-standalone-proxy.test.ts
@@ -365,6 +365,46 @@ describe("@agentmemory/mcp standalone — server proxy (issue #159)", () => {
     delete process.env["AGENTMEMORY_TOOLS"];
   });
 
+  it("FR-2 forwards agentId/project in the memory_save proxy body when provided", async () => {
+    let rememberBody: Record<string, unknown> | undefined;
+    installFetch((url, init) => {
+      if (url.endsWith("/agentmemory/livez")) return new Response("ok", { status: 200 });
+      if (url.endsWith("/agentmemory/remember")) {
+        rememberBody = init?.body ? JSON.parse(init.body as string) : undefined;
+        return new Response(JSON.stringify({ id: "m-1", action: "created" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    });
+    await handleToolCall("memory_save", {
+      content: "scoped entry",
+      agentId: "a1",
+      project: "p1",
+    });
+    expect(rememberBody?.["agentId"]).toBe("a1");
+    expect(rememberBody?.["project"]).toBe("p1");
+  });
+
+  it("FR-2 omits agentId/project from the memory_save proxy body when not provided", async () => {
+    let rememberBody: Record<string, unknown> | undefined;
+    installFetch((url, init) => {
+      if (url.endsWith("/agentmemory/livez")) return new Response("ok", { status: 200 });
+      if (url.endsWith("/agentmemory/remember")) {
+        rememberBody = init?.body ? JSON.parse(init.body as string) : undefined;
+        return new Response(JSON.stringify({ id: "m-1", action: "created" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    });
+    await handleToolCall("memory_save", { content: "unscoped entry" });
+    expect(rememberBody).not.toHaveProperty("agentId");
+    expect(rememberBody).not.toHaveProperty("project");
+  });
+
   it("AGENTMEMORY_PROBE_TIMEOUT_MS overrides the default probe timeout", async () => {
     process.env["AGENTMEMORY_PROBE_TIMEOUT_MS"] = "50";
     let probeStarted = 0;


### PR DESCRIPTION
## What

`src/mcp/standalone.ts` (the `@agentmemory/mcp` stdio bridge) now parses and forwards `agentId` and `project` for the `memory_save` tool: added to the `Validated` interface, `validate()`'s `memory_save` case, and `handleProxy()`'s `memory_save` case.

## Why

Most MCP hosts (Claude Code and others) run this standalone stdio package directly rather than talking to `server.ts`'s HTTP endpoint. Its `memory_save` handling only parsed/forwarded `content`/`type`/`concepts`/`files` — `agentId` was dropped entirely, and `project` silently too, even though the tool schema already advertises `project`. So no matter what a caller passed, scoping never reached the server through this path.

**This PR alone does not make agentId reach the server** — `handleProxy()`'s `memory_save` case POSTs to `/agentmemory/remember`, which is `api::remember` in `src/triggers/api.ts`. That endpoint currently drops `agentId` too (tracked as #1159); a companion PR fixing it is coming. This PR and that one are independent code-wise (neither's diff depends on the other, both compile and test standalone), but the end-to-end symptom (agent-scoped memories vanishing from scoped search) only clears once both are merged. Full picture, including two more independent legs of the same MCP `memory_save` path, tracked in #1197.

## How to verify

```
npm test -- test/mcp-standalone-proxy.test.ts
```

The two new cases (forwards `agentId`/`project` when provided, omits both when not provided) pass. Full suite unaffected: 1598 passed / 1 skipped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Memory save requests can now include optional agent and project information.
  - Provided values are forwarded when valid; omitted values remain excluded from requests.

- **Bug Fixes**
  - Improved handling of optional memory metadata during proxied saves.

- **Tests**
  - Added coverage for forwarding and omitting optional agent and project fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->