### PR TITLE
fix(mcp): expose agentId in memory_save tool schema

### DIFF
--- a/src/mcp/tools-registry.ts
+++ b/src/mcp/tools-registry.ts
@@ -83,6 +83,10 @@ export const CORE_TOOLS: McpToolDef[] = [
             "started. Do not use filesystem paths or ad-hoc display names — those " +
             "change across machines and will silently break project scoping.",
         },
+        agentId: {
+          type: "string",
+          description: "Agent role this memory belongs to (e.g. backend-dev)",
+        },
       },
       required: ["content"],
     },

--- a/test/tools-registry-memory-save-agent-id-schema.test.ts
+++ b/test/tools-registry-memory-save-agent-id-schema.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+
+import { getAllTools } from "../src/mcp/tools-registry.js";
+
+describe("memory_save tool schema exposes agentId", () => {
+  it("declares a string agentId property", () => {
+    const tool = getAllTools().find((t) => t.name === "memory_save");
+    expect(tool).toBeDefined();
+    expect(tool!.inputSchema.properties["agentId"]?.type).toBe("string");
+  });
+
+  it("keeps required as [content] and does not change the total tool count", () => {
+    const tool = getAllTools().find((t) => t.name === "memory_save");
+    expect(tool!.inputSchema.required).toEqual(["content"]);
+    expect(getAllTools().length).toBe(54);
+  });
+});


### PR DESCRIPTION
## What

Adds an `agentId` string property to the `memory_save` tool's `inputSchema` in `src/mcp/tools-registry.ts`. Schema-only change.

## Why

`memory_save`'s schema declares `content`/`type`/`concepts`/`files`/`project` but never `agentId`, so MCP clients (Claude Code, other hosts) have no schema-legal way to pass it at all. This is upstream of every other `agentId` drop on the `memory_save` path — the mcp/call switch in `server.ts`, the standalone stdio proxy in `standalone.ts`, and the REST shim in `api.ts` — since fixing any of those doesn't help a well-behaved client that only sends properties the schema advertises.

This PR by itself doesn't change any runtime behavior beyond what `tools/list` reports (required stays `[content]`, tool count unchanged) — it's the schema half of a 3-part MCP-path gap tracked in #1197, alongside PRs for `server.ts` and `standalone.ts`. Landing this one without the others is harmless; landing the others without this one means well-behaved clients still can't send the parameter in the first place.

## How to verify

```
npm test -- test/tools-registry-memory-save-agent-id-schema.test.ts
```

Both cases pass: `agentId` is a declared string property, and `required`/total tool count are unchanged. Full suite unaffected: 1598 passed / 1 skipped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional agent identifier field to saved memories, allowing memories to be associated with a specific agent role.

* **Tests**
  * Added validation to ensure the new field is supported while preserving existing required fields and tool availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->