### PR TITLE
fix(mcp): forward args.agentId in memory_save's mcp/call branch

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -187,12 +187,18 @@ export function registerMcpEndpoints(
                 ? args.project.trim()
                 : undefined;
 
+            const agentId =
+              typeof args.agentId === "string" && args.agentId.trim().length > 0
+                ? args.agentId.trim()
+                : undefined;
+
             const result = await sdk.trigger({ function_id: "mem::remember", payload: {
               content: args.content,
               type,
               concepts,
               files,
               ...(project !== undefined && { project }),
+              ...(agentId !== undefined && { agentId }),
             } });
             return {
               status_code: 200,

--- a/test/mcp-call-memory-save-agent-id.test.ts
+++ b/test/mcp-call-memory-save-agent-id.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../src/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { registerMcpEndpoints } from "../src/mcp/server.js";
+
+// Mock scaffolding mirrors test/mcp-resources.test.ts:10-66.
+
+function mockKV() {
+  const store = new Map<string, Map<string, unknown>>();
+  return {
+    get: async <T>(scope: string, key: string): Promise<T | null> => {
+      return (store.get(scope)?.get(key) as T) ?? null;
+    },
+    set: async <T>(scope: string, key: string, data: T): Promise<T> => {
+      if (!store.has(scope)) store.set(scope, new Map());
+      store.get(scope)!.set(key, data);
+      return data;
+    },
+    delete: async (scope: string, key: string): Promise<void> => {
+      store.get(scope)?.delete(key);
+    },
+    list: async <T>(scope: string): Promise<T[]> => {
+      const entries = store.get(scope);
+      return entries ? (Array.from(entries.values()) as T[]) : [];
+    },
+  };
+}
+
+function mockSdk() {
+  const functions = new Map<string, Function>();
+  const triggerOverrides = new Map<string, Function>();
+  return {
+    registerFunction: (idOrOpts: string | { id: string }, handler: Function) => {
+      const id = typeof idOrOpts === "string" ? idOrOpts : idOrOpts.id;
+      functions.set(id, handler);
+    },
+    registerTrigger: () => {},
+    trigger: async (
+      idOrInput: string | { function_id: string; payload: unknown },
+      data?: unknown,
+    ) => {
+      const id = typeof idOrInput === "string" ? idOrInput : idOrInput.function_id;
+      const payload = typeof idOrInput === "string" ? data : idOrInput.payload;
+      if (triggerOverrides.has(id)) {
+        return triggerOverrides.get(id)!(payload);
+      }
+      const fn = functions.get(id);
+      if (!fn) throw new Error(`No function: ${id}`);
+      return fn(payload);
+    },
+    overrideTrigger: (id: string, handler: Function) => {
+      triggerOverrides.set(id, handler);
+    },
+    getFunction: (id: string) => functions.get(id),
+  };
+}
+
+function makeReq(body?: unknown, headers?: Record<string, string>) {
+  return {
+    body,
+    headers: headers || {},
+    query_params: {},
+  };
+}
+
+describe("POST /agentmemory/mcp/call memory_save forwards agentId", () => {
+  let sdk: ReturnType<typeof mockSdk>;
+  let kv: ReturnType<typeof mockKV>;
+
+  beforeEach(() => {
+    sdk = mockSdk();
+    kv = mockKV();
+    registerMcpEndpoints(sdk as never, kv as never);
+  });
+
+  it("forwards args.agentId into the mem::remember payload", async () => {
+    let capturedPayload: unknown;
+    sdk.overrideTrigger("mem::remember", (payload: unknown) => {
+      capturedPayload = payload;
+      return { id: "mem_1" };
+    });
+    const fn = sdk.getFunction("mcp::tools::call")!;
+    const res = await fn(
+      makeReq({
+        name: "memory_save",
+        arguments: { content: "hello", agentId: "a1", project: "worker-config" },
+      }),
+    );
+    expect(res.status_code).toBe(200);
+    expect((capturedPayload as { agentId?: string }).agentId).toBe("a1");
+    expect((capturedPayload as { project?: string }).project).toBe(
+      "worker-config",
+    );
+  });
+
+  it("omits agentId from the payload when not provided, leaving project transparency unaffected", async () => {
+    let capturedPayload: unknown;
+    sdk.overrideTrigger("mem::remember", (payload: unknown) => {
+      capturedPayload = payload;
+      return { id: "mem_1" };
+    });
+    const fn = sdk.getFunction("mcp::tools::call")!;
+    const res = await fn(
+      makeReq({
+        name: "memory_save",
+        arguments: { content: "hello", project: "worker-config" },
+      }),
+    );
+    expect(res.status_code).toBe(200);
+    expect("agentId" in (capturedPayload as object)).toBe(false);
+    expect((capturedPayload as { project?: string }).project).toBe(
+      "worker-config",
+    );
+  });
+});


### PR DESCRIPTION
## What

`POST /agentmemory/mcp/call`'s `memory_save` switch branch in `src/mcp/server.ts` now forwards `args.agentId` into the `mem::remember` payload, mirroring how the same branch already forwards `project`.

## Why

The same file's `memory_recall` branch already forwards `agentId` (per #817), but the `memory_save` branch didn't — it built the payload from `content`/`type`/`concepts`/`files`/`project` only. This is a distinct code path from `api::remember` (the REST shim tracked in #1159) and from the standalone stdio proxy (#1197's third leg) — it's the direct HTTP MCP-call endpoint.

For a well-behaved MCP client, this fix takes effect once the companion schema PR (`tools-registry.ts`, exposing `agentId` on `memory_save`) also lands — without it, clients have no schema-legal reason to send the field on this path in the first place. Both PRs are independent code-wise; full picture in #1197.

## How to verify

```
npm test -- test/mcp-call-memory-save-agent-id.test.ts
```

Both cases pass: `agentId` is forwarded when provided, omitted (not `undefined`-valued) when absent, `project` transparency unaffected either way. Full suite unaffected: 1598 passed / 1 skipped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional agent identification when saving memories, allowing saved data to be associated with a specific agent.
  * Existing memory-saving behavior remains unchanged when no agent ID is provided.

* **Tests**
  * Added coverage verifying agent IDs are forwarded correctly and existing project data is preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->