### PR TITLE
fix(api): forward agentId on POST /agentmemory/remember

### DIFF
--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -1002,6 +1002,7 @@ export function registerApiTriggers(
         ttlDays?: number;
         sourceObservationIds?: string[];
         project?: string;
+        agentId?: string;
       }>,
     ): Promise<Response> => {
       const authErr = checkAuth(req, secret);
@@ -1019,6 +1020,13 @@ export function registerApiTriggers(
       ) {
         return { status_code: 400, body: { error: "project must be a non-empty string" } };
       }
+      // agentId is optional here on purpose: env AGENT_ID fallback is
+      // handled once, downstream, by mem::remember (remember.ts). Doing
+      // it here too would let the two fallbacks disagree.
+      const agentId =
+        typeof req.body.agentId === "string" && req.body.agentId.trim().length > 0
+          ? req.body.agentId.trim().slice(0, 128)
+          : undefined;
       const result = await sdk.trigger({
         function_id: "mem::remember",
         payload: {
@@ -1029,6 +1037,7 @@ export function registerApiTriggers(
           ...(req.body.ttlDays !== undefined && { ttlDays: req.body.ttlDays }),
           ...(req.body.sourceObservationIds !== undefined && { sourceObservationIds: req.body.sourceObservationIds }),
           ...(req.body.project !== undefined && { project: req.body.project }),
+          ...(agentId !== undefined && { agentId }),
         },
       });
       return { status_code: 201, body: result };

--- a/test/api-remember-agent-id.test.ts
+++ b/test/api-remember-agent-id.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../src/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { registerApiTriggers } from "../src/triggers/api.js";
+
+// Mock scaffolding mirrors test/mcp-resources.test.ts:10-66.
+
+function mockKV() {
+  const store = new Map<string, Map<string, unknown>>();
+  return {
+    get: async <T>(scope: string, key: string): Promise<T | null> => {
+      return (store.get(scope)?.get(key) as T) ?? null;
+    },
+    set: async <T>(scope: string, key: string, data: T): Promise<T> => {
+      if (!store.has(scope)) store.set(scope, new Map());
+      store.get(scope)!.set(key, data);
+      return data;
+    },
+    delete: async (scope: string, key: string): Promise<void> => {
+      store.get(scope)?.delete(key);
+    },
+    list: async <T>(scope: string): Promise<T[]> => {
+      const entries = store.get(scope);
+      return entries ? (Array.from(entries.values()) as T[]) : [];
+    },
+  };
+}
+
+function mockSdk() {
+  const functions = new Map<string, Function>();
+  const triggerOverrides = new Map<string, Function>();
+  return {
+    registerFunction: (idOrOpts: string | { id: string }, handler: Function) => {
+      const id = typeof idOrOpts === "string" ? idOrOpts : idOrOpts.id;
+      functions.set(id, handler);
+    },
+    registerTrigger: () => {},
+    trigger: async (
+      idOrInput: string | { function_id: string; payload: unknown },
+      data?: unknown,
+    ) => {
+      const id = typeof idOrInput === "string" ? idOrInput : idOrInput.function_id;
+      const payload = typeof idOrInput === "string" ? data : idOrInput.payload;
+      if (triggerOverrides.has(id)) {
+        return triggerOverrides.get(id)!(payload);
+      }
+      const fn = functions.get(id);
+      if (!fn) throw new Error(`No function: ${id}`);
+      return fn(payload);
+    },
+    overrideTrigger: (id: string, handler: Function) => {
+      triggerOverrides.set(id, handler);
+    },
+    getFunction: (id: string) => functions.get(id),
+  };
+}
+
+function makeReq(body?: unknown, headers?: Record<string, string>) {
+  return {
+    body,
+    headers: headers || {},
+    query_params: {},
+  };
+}
+
+describe("api::remember forwards agentId", () => {
+  let sdk: ReturnType<typeof mockSdk>;
+  let kv: ReturnType<typeof mockKV>;
+
+  beforeEach(() => {
+    sdk = mockSdk();
+    kv = mockKV();
+    registerApiTriggers(sdk as never, kv as never);
+  });
+
+  it("passes a normal-length agentId through to mem::remember", async () => {
+    let capturedPayload: unknown;
+    sdk.overrideTrigger("mem::remember", async (payload: unknown) => {
+      capturedPayload = payload;
+      return { id: "mem_1" };
+    });
+    const fn = sdk.getFunction("api::remember")!;
+    const res = await fn(makeReq({ content: "hello", agentId: "pm-agent" }));
+    expect(res.status_code).toBe(201);
+    expect((capturedPayload as { agentId?: string }).agentId).toBe("pm-agent");
+  });
+
+  it("truncates an agentId over 128 chars to exactly 128", async () => {
+    let capturedPayload: unknown;
+    sdk.overrideTrigger("mem::remember", async (payload: unknown) => {
+      capturedPayload = payload;
+      return { id: "mem_1" };
+    });
+    const fn = sdk.getFunction("api::remember")!;
+    const longAgentId = "a".repeat(150);
+    const res = await fn(makeReq({ content: "hello", agentId: longAgentId }));
+    expect(res.status_code).toBe(201);
+    const sentAgentId = (capturedPayload as { agentId?: string }).agentId;
+    expect(sentAgentId).toBe("a".repeat(128));
+    expect(sentAgentId?.length).toBe(128);
+  });
+
+  it("leaves agentId out of the payload when missing or empty, without erroring", async () => {
+    let capturedMissing: unknown;
+    let capturedEmpty: unknown;
+    sdk.overrideTrigger("mem::remember", async (payload: unknown) => {
+      capturedMissing = payload;
+      return { id: "mem_1" };
+    });
+    const fn = sdk.getFunction("api::remember")!;
+    const resMissing = await fn(makeReq({ content: "hello" }));
+    expect(resMissing.status_code).toBe(201);
+    expect((capturedMissing as { agentId?: string }).agentId).toBeUndefined();
+    expect("agentId" in (capturedMissing as object)).toBe(false);
+
+    sdk.overrideTrigger("mem::remember", async (payload: unknown) => {
+      capturedEmpty = payload;
+      return { id: "mem_1" };
+    });
+    const resEmpty = await fn(makeReq({ content: "hello", agentId: "   " }));
+    expect(resEmpty.status_code).toBe(201);
+    expect((capturedEmpty as { agentId?: string }).agentId).toBeUndefined();
+    expect("agentId" in (capturedEmpty as object)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

`api::remember` (`POST /agentmemory/remember` in `src/triggers/api.ts`) now accepts and forwards `body.agentId` to `mem::remember`, trimmed and capped at 128 chars.

## Why

`mem::remember` and `mem::observe` both accept a per-call `agentId`, and `mem::smart-search` filters on it, but the HTTP shim built its `mem::remember` payload from a fixed field allowlist (`content`, `tags`, `concepts`, `files`, `type`, `ttlDays`, `sourceObservationIds`, `project`) that omitted `agentId`. The field was silently discarded — every memory stored over REST fell back to the env identity (`getAgentId()`), or unscoped when `AGENT_ID` is unset. With `AGENTMEMORY_AGENT_SCOPE=isolated` this breaks scoping invisibly: writes report success (`201`) but rows carry the wrong identity, and scoped recalls return `0` results with no error anywhere.

This REST endpoint is also what the `@agentmemory/mcp` standalone stdio proxy's `memory_save` handler posts to (see the companion PR for `standalone.ts`, part of #1197) — so this fix is also the piece that makes that proxy's forwarding actually reach the server.

Fixes #1159

## How to verify

```
npm test -- test/api-remember-agent-id.test.ts
```

Three cases pass: normal-length `agentId` passed through, over-128-char `agentId` truncated to exactly 128 (mirroring the existing `api::session::start` convention at `api.ts:605-609`), and missing/empty `agentId` left out of the payload without erroring. Full suite: 1599 passed / 1 skipped (was 1596 on main; +3 from this PR).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional agent ID support to the memory-saving API.
  * Agent IDs are trimmed, validated, and limited to 128 characters.
  * Missing or blank agent IDs continue to work without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->