### PR TITLE
feat(pi): observe per-tool results (PostToolUse parity)

### DIFF
--- a/integrations/pi/index.ts
+++ b/integrations/pi/index.ts
@@ -149,6 +149,13 @@ export default function agentmemoryExtension(pi: ExtensionAPI) {
   let lastPrompt = "";
   let lastHealthOk = false;
 
+  // PostToolUse parity: observe each tool call as its own observation.
+  // The server's inferType classifies by tool name (command_run, file_edit,
+  // file_read, ...) and, with AUTO_COMPRESS=true, the LLM compression
+  // extracts title/concepts/importance per call. Set AGENTMEMORY_TOOL_OBSERVE=0
+  // to fall back to conversation-level observations only.
+  const toolObserveEnabled = process.env.AGENTMEMORY_TOOL_OBSERVE !== "0";
+
   async function getHealth() {
     return await callAgentMemory<HealthResponse>("health", { method: "GET" });
   }
@@ -278,6 +285,40 @@ export default function agentmemoryExtension(pi: ExtensionAPI) {
     return {
       systemPrompt: [event.systemPrompt, TOOL_GUIDANCE, recallBlock].filter(Boolean).join("\n\n"),
     };
+  });
+
+  pi.on("tool_result", (event) => {
+    if (!toolObserveEnabled) return;
+    if (!lastHealthOk || !sessionId) return;
+    const toolName = event.toolName;
+    if (!toolName) return;
+    let input: string;
+    try {
+      input = typeof event.input === "string" ? event.input : JSON.stringify(event.input ?? {});
+    } catch {
+      input = "";
+    }
+    let output: string;
+    try {
+      output = typeof event.content === "string" ? event.content : JSON.stringify(event.content ?? "");
+    } catch {
+      output = "";
+    }
+    void callAgentMemory("observe", {
+      body: {
+        hookType: "post_tool_use",
+        sessionId,
+        project: currentProject,
+        cwd: currentCwd,
+        timestamp: new Date().toISOString(),
+        data: {
+          tool_name: toolName,
+          tool_input: input.slice(0, 8000),
+          tool_output: output.slice(0, 8000),
+          ...(event.isError ? { tool_error: true } : {}),
+        },
+      },
+    });
   });
 
   pi.on("agent_end", async (event) => {


### PR DESCRIPTION
## What

Adds per-tool observations to the pi integration via the `tool_result` event, matching Claude Code's PostToolUse hook. Currently pi only observes conversation turns (agent_end), so tool-level detail — which command ran, which file was edited, its output — never reaches the memory system.

## Why

The server's `inferType` classifies observations by tool name (`command_run`, `file_edit`, `file_read`, ...) and, with `AGENTMEMORY_AUTO_COMPRESS=true`, the LLM compression extracts per-call title/concepts/importance. Per-tool observations let consolidation cluster operational patterns alongside topic-level insights, and give smart-search the ability to recall individual tool calls.

## How to verify

1. Set `AGENTMEMORY_AUTO_COMPRESS=true` (default off)
2. Run pi, execute a few tool calls, then check the server:
   ```bash
   curl -s localhost:3111/agentmemory/sessions | jq '.sessions[0].id'
   curl -s "localhost:3111/agentmemory/observations?sessionId=<id>" | jq '.type'
   ```
   Expect `command_run` / `file_edit` / `file_read` entries per tool call.

## Details

- New `tool_result` handler: observes each tool call with `hookType: post_tool_use`, input/output truncated to 8000 chars (matching `plugin/scripts/post-tool-use.mjs`), `tool_error: true` marker on failures.
- Gated by `AGENTMEMORY_TOOL_OBSERVE` (default on; set to `0` to fall back to conversation-level only).
- Fire-and-forget via `callAgentMemory` like the existing agent_end observe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional per-tool observation for sending tool results to agentmemory.
  * Captured observations include tool details, project and session context, timestamps, and error status.
  * Tool inputs and outputs are safely truncated, with graceful handling of serialization failures.
  * Per-tool observation can be disabled through configuration; existing conversation-level observation is unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->