### PR TITLE
fix(providers): replace retired Anthropic default model identifiers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,7 @@
 # OPENAI_BASE_URL=https://api.openai.com         # Override for OpenAI-compatible providers
 
 # ANTHROPIC_API_KEY=sk-ant-...
-# ANTHROPIC_MODEL=claude-sonnet-4-20250514       # Default Anthropic model
+# ANTHROPIC_MODEL=claude-sonnet-4-6              # Default Anthropic model
 # ANTHROPIC_BASE_URL=https://api.anthropic.com   # Override for Anthropic-compatible proxies / Azure AI Foundry
 
 # GEMINI_API_KEY=...                             # Either env name works; GEMINI_API_KEY takes precedence
@@ -38,7 +38,7 @@
 # GEMINI_MODEL=gemini-2.5-flash                  # Default Gemini model (auto-detected GA model)
 
 # OPENROUTER_API_KEY=sk-or-...
-# OPENROUTER_MODEL=anthropic/claude-sonnet-4-20250514
+# OPENROUTER_MODEL=anthropic/claude-sonnet-4.6
 
 # MINIMAX_API_KEY=...
 # MINIMAX_MODEL=MiniMax-M2.7

--- a/src/config.ts
+++ b/src/config.ts
@@ -108,7 +108,7 @@ function detectProvider(env: Record<string, string>): ProviderConfig {
   if (hasRealValue(env["ANTHROPIC_API_KEY"])) {
     return {
       provider: "anthropic",
-      model: env["ANTHROPIC_MODEL"] || "claude-sonnet-4-20250514",
+      model: env["ANTHROPIC_MODEL"] || "claude-sonnet-4-6",
       maxTokens,
       baseURL: env["ANTHROPIC_BASE_URL"],
     };
@@ -128,7 +128,7 @@ function detectProvider(env: Record<string, string>): ProviderConfig {
   }
   if (hasRealValue(env["OPENROUTER_API_KEY"])) {
     const model =
-      env["OPENROUTER_MODEL"] || "anthropic/claude-sonnet-4-20250514";
+      env["OPENROUTER_MODEL"] || "anthropic/claude-sonnet-4.6";
     // warn when the configured OpenRouter model is in the
     // premium tier and likely to burn money on background compression.
     // Captured workload data shows ~$5/35h on claude-sonnet-4 vs
@@ -181,7 +181,7 @@ function detectProvider(env: Record<string, string>): ProviderConfig {
   );
   return {
     provider: "agent-sdk",
-    model: "claude-sonnet-4-20250514",
+    model: "claude-sonnet-4-6",
     maxTokens,
   };
 }

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -37,17 +37,17 @@ function defaultModelFor(providerType: ProviderConfig["provider"]): string {
     case "openai":
       return getEnvVar("OPENAI_MODEL") || "gpt-4o-mini";
     case "anthropic":
-      return getEnvVar("ANTHROPIC_MODEL") || "claude-sonnet-4-20250514";
+      return getEnvVar("ANTHROPIC_MODEL") || "claude-sonnet-4-6";
     case "gemini":
       return getEnvVar("GEMINI_MODEL") || "gemini-2.5-flash";
     case "openrouter":
       return (
-        getEnvVar("OPENROUTER_MODEL") || "anthropic/claude-sonnet-4-20250514"
+        getEnvVar("OPENROUTER_MODEL") || "anthropic/claude-sonnet-4.6"
       );
     case "minimax":
       return getEnvVar("MINIMAX_MODEL") || "MiniMax-M2.7";
     case "agent-sdk":
-      return "claude-sonnet-4-20250514";
+      return "claude-sonnet-4-6";
     case "noop":
     default:
       return "noop";


### PR DESCRIPTION
## What

Replaces `claude-sonnet-4-20250514`, retired on the Claude API on 15 June 2026, in the six places it is used as a fallback default, plus the two matching lines in `.env.example`.

The replacements are not the same string everywhere, which is the main thing worth reviewing:

| Provider | Was | Now |
| --- | --- | --- |
| `anthropic`, `agent-sdk` | `claude-sonnet-4-20250514` | `claude-sonnet-4-6` |
| `openrouter` | `anthropic/claude-sonnet-4-20250514` | `anthropic/claude-sonnet-4.6` |

OpenRouter uses dotted slugs, not the Anthropic dated form. I checked their live model list: `anthropic/claude-sonnet-4.6` is there, `anthropic/claude-sonnet-4-6` is not — and neither is the current `anthropic/claude-sonnet-4-20250514`, so that fallback has been pointing at a slug OpenRouter does not serve. A single find-and-replace across both providers would have swapped one broken identifier for another.

## Why

`detectProvider()` in `src/config.ts` and `defaultModelFor()` in `src/providers/index.ts` supply these when the matching `*_MODEL` env var is unset, which is the out-of-the-box path for anyone who sets only an API key.

## On `.env.example`

I included it, though the lines are commented. `npm run build` copies `.env.example` into `dist/`, so it ships to users and is what a new install is copied from — a dead default propagates from there. Happy to drop those two lines if you would rather keep the PR to executable code.

## Not touched

`test/fallback-model-resolution.test.ts` also contains the string, but it passes the model in explicitly and asserts the OpenAI and Minimax fallbacks do not inherit it. The literal is arbitrary there and the test does not read the defaults, so changing it would only churn the fixture.

## Verification

Clean clone, isolated environment, `npm install` then `npm test`:

- before: 142 test files passed, 1 skipped; 1596 tests passed, 1 skipped
- after: 142 test files passed, 1 skipped; 1596 tests passed, 1 skipped

`tsc --noEmit` reports 25 errors, identical before and after, all in files this PR does not touch (`src/triggers/`, `src/functions/`, `src/cli.ts`). Pre-existing, and not part of the workflow `CONTRIBUTING.md` describes — noting it so the number is not a surprise if you run it.

## Scope

3 files, identifiers only. No refactoring, no other models updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the default Claude model to `claude-sonnet-4-6` across supported Anthropic, OpenRouter, and Agent SDK providers.
  * Updated example configuration values to reflect the new default model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->