### PR TITLE
fix(embedding): route transformers cacheDir to user home cache

### DIFF
--- a/__mocks__/@huggingface/transformers.ts
+++ b/__mocks__/@huggingface/transformers.ts
@@ -1,21 +1,8 @@
-const transitiveMissingPackage =
-  process.env.AGENTMEMORY_TEST_TRANSFORMERS_TRANSITIVE_MISSING_PACKAGE;
-const injectedErrorKey = Symbol.for(
-  "agentmemory.test.transformersImportError",
-);
-const injectedError = (globalThis as Record<PropertyKey, unknown>)[
-  injectedErrorKey
-];
+import { getTransformersImportError } from "../../test/fixtures/transformers-import-error.js";
 
 throw (
-  injectedError instanceof Error
-    ? injectedError
-    : Object.assign(
-        new Error(
-          transitiveMissingPackage
-            ? `Cannot find package '${transitiveMissingPackage}' imported from @huggingface/transformers`
-            : "Cannot find package '@huggingface/transformers'",
-        ),
-        { code: "ERR_MODULE_NOT_FOUND" },
-      )
+  getTransformersImportError() ??
+  Object.assign(new Error("Cannot find package '@huggingface/transformers'"), {
+    code: "ERR_MODULE_NOT_FOUND",
+  })
 );

--- a/__mocks__/@huggingface/transformers.ts
+++ b/__mocks__/@huggingface/transformers.ts
@@ -1,4 +1,11 @@
+const transitiveMissingPackage =
+  process.env.AGENTMEMORY_TEST_TRANSFORMERS_TRANSITIVE_MISSING_PACKAGE;
+
 throw Object.assign(
-  new Error("Cannot find package '@huggingface/transformers'"),
+  new Error(
+    transitiveMissingPackage
+      ? `Cannot find package '${transitiveMissingPackage}' imported from @huggingface/transformers`
+      : "Cannot find package '@huggingface/transformers'",
+  ),
   { code: "ERR_MODULE_NOT_FOUND" },
 );

--- a/__mocks__/@huggingface/transformers.ts
+++ b/__mocks__/@huggingface/transformers.ts
@@ -1,11 +1,21 @@
 const transitiveMissingPackage =
   process.env.AGENTMEMORY_TEST_TRANSFORMERS_TRANSITIVE_MISSING_PACKAGE;
+const injectedErrorKey = Symbol.for(
+  "agentmemory.test.transformersImportError",
+);
+const injectedError = (globalThis as Record<PropertyKey, unknown>)[
+  injectedErrorKey
+];
 
-throw Object.assign(
-  new Error(
-    transitiveMissingPackage
-      ? `Cannot find package '${transitiveMissingPackage}' imported from @huggingface/transformers`
-      : "Cannot find package '@huggingface/transformers'",
-  ),
-  { code: "ERR_MODULE_NOT_FOUND" },
+throw (
+  injectedError instanceof Error
+    ? injectedError
+    : Object.assign(
+        new Error(
+          transitiveMissingPackage
+            ? `Cannot find package '${transitiveMissingPackage}' imported from @huggingface/transformers`
+            : "Cannot find package '@huggingface/transformers'",
+        ),
+        { code: "ERR_MODULE_NOT_FOUND" },
+      )
 );

--- a/src/providers/embedding/_transformers.ts
+++ b/src/providers/embedding/_transformers.ts
@@ -1,0 +1,30 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type * as TransformersType from "@huggingface/transformers";
+
+export async function loadTransformers(
+  purpose = "local embeddings",
+): Promise<typeof TransformersType> {
+  let transformers: any;
+  try {
+    transformers = await import("@huggingface/transformers");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ERR_MODULE_NOT_FOUND") {
+      throw new Error(
+        `Install @huggingface/transformers for ${purpose}: npm install @huggingface/transformers`,
+      );
+    }
+    throw err;
+  }
+  try {
+    if (transformers && "env" in transformers && transformers.env) {
+      transformers.env.cacheDir =
+        process.env.TRANSFORMERS_CACHE ||
+        process.env.HF_HOME ||
+        join(homedir(), ".cache", "huggingface", "transformers");
+    }
+  } catch {
+    // Ignore when env is omitted in mock environments
+  }
+  return transformers;
+}

--- a/src/providers/embedding/_transformers.ts
+++ b/src/providers/embedding/_transformers.ts
@@ -2,6 +2,16 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import type * as TransformersType from "@huggingface/transformers";
 
+function isDirectTransformersModuleNotFound(err: unknown): err is Error {
+  return (
+    err instanceof Error &&
+    (err as NodeJS.ErrnoException).code === "ERR_MODULE_NOT_FOUND" &&
+    /^(?:Cannot find package|Cannot find module) (['"])@huggingface\/transformers\1(?:$|\n| imported from )/.test(
+      err.message,
+    )
+  );
+}
+
 export async function loadTransformers(
   purpose = "local embeddings",
 ): Promise<typeof TransformersType> {
@@ -9,9 +19,10 @@ export async function loadTransformers(
   try {
     transformers = await import("@huggingface/transformers");
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "ERR_MODULE_NOT_FOUND") {
+    if (isDirectTransformersModuleNotFound(err)) {
       throw new Error(
         `Install @huggingface/transformers for ${purpose}: npm install @huggingface/transformers`,
+        { cause: err },
       );
     }
     throw err;
@@ -24,7 +35,6 @@ export async function loadTransformers(
         join(homedir(), ".cache", "huggingface", "transformers");
     }
   } catch {
-    // Ignore when env is omitted in mock environments
   }
   return transformers;
 }

--- a/src/providers/embedding/clip.ts
+++ b/src/providers/embedding/clip.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
 import type { RawImage } from "@huggingface/transformers";
 import type { EmbeddingProvider } from "../../types.js";
+import { loadTransformers } from "./_transformers.js";
 
 type TransformersModule = typeof import("@huggingface/transformers");
 type ClipPipeline = (
@@ -33,7 +34,7 @@ export class ClipEmbeddingProvider implements EmbeddingProvider {
   }
 
   async embedImage(src: string): Promise<Float32Array> {
-    const t = await loadTransformers();
+    const t = await loadTransformers("CLIP embeddings");
     const image = await loadImage(t, src);
     const extractor = await this.getImageExtractor();
     const output = await extractor(image);
@@ -43,29 +44,16 @@ export class ClipEmbeddingProvider implements EmbeddingProvider {
 
   private async getTextExtractor(): Promise<ClipPipeline> {
     if (this.textExtractor) return this.textExtractor;
-    const t = await loadTransformers();
+    const t = await loadTransformers("CLIP embeddings");
     this.textExtractor = (await t.pipeline("feature-extraction", this.modelId, { dtype: "q8" })) as ClipPipeline;
     return this.textExtractor;
   }
 
   private async getImageExtractor(): Promise<ClipPipeline> {
     if (this.imageExtractor) return this.imageExtractor;
-    const t = await loadTransformers();
+    const t = await loadTransformers("CLIP embeddings");
     this.imageExtractor = (await t.pipeline("image-feature-extraction", this.modelId, { dtype: "q8" })) as ClipPipeline;
     return this.imageExtractor;
-  }
-}
-
-async function loadTransformers(): Promise<TransformersModule> {
-  try {
-    return await import("@huggingface/transformers");
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "ERR_MODULE_NOT_FOUND") {
-      throw new Error(
-        "Install @huggingface/transformers for CLIP embeddings: npm install @huggingface/transformers",
-      );
-    }
-    throw err;
   }
 }
 

--- a/src/providers/embedding/local.ts
+++ b/src/providers/embedding/local.ts
@@ -1,4 +1,5 @@
 import type { EmbeddingProvider } from "../../types.js";
+import { loadTransformers } from "./_transformers.js";
 
 type FeatureExtractor = (
   texts: string[],
@@ -26,17 +27,7 @@ export class LocalEmbeddingProvider implements EmbeddingProvider {
 
   private async getExtractor() {
     if (this.extractor) return this.extractor;
-    let transformers: typeof import("@huggingface/transformers");
-    try {
-      transformers = await import("@huggingface/transformers");
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code === "ERR_MODULE_NOT_FOUND") {
-        throw new Error(
-          "Install @huggingface/transformers for local embeddings: npm install @huggingface/transformers",
-        );
-      }
-      throw err;
-    }
+    const transformers = await loadTransformers();
     this.extractor = (await transformers.pipeline(
       "feature-extraction",
       "Xenova/all-MiniLM-L6-v2",

--- a/src/state/reranker.ts
+++ b/src/state/reranker.ts
@@ -1,4 +1,5 @@
 import type { HybridSearchResult } from "../types.js";
+import { loadTransformers } from "../providers/embedding/_transformers.js";
 
 let pipeline: any = null;
 let pipelineLoading: Promise<any> | null = null;
@@ -11,10 +12,8 @@ async function loadPipeline(): Promise<any> {
 
   pipelineLoading = (async () => {
     try {
-      const { pipeline: createPipeline } = await import(
-        "@huggingface/transformers"
-      );
-      pipeline = await createPipeline(
+      const transformers = await loadTransformers();
+      pipeline = await transformers.pipeline(
         "text-classification",
         "Xenova/ms-marco-MiniLM-L-6-v2",
         { dtype: "q8" },

--- a/test/fixtures/transformers-import-error.ts
+++ b/test/fixtures/transformers-import-error.ts
@@ -7,3 +7,7 @@ export function setTransformersImportError(error: Error): void {
 export function getTransformersImportError(): Error | undefined {
   return transformersImportError;
 }
+
+export function clearTransformersImportError(): void {
+  transformersImportError = undefined;
+}

--- a/test/fixtures/transformers-import-error.ts
+++ b/test/fixtures/transformers-import-error.ts
@@ -1,0 +1,9 @@
+let transformersImportError: Error | undefined;
+
+export function setTransformersImportError(error: Error): void {
+  transformersImportError = error;
+}
+
+export function getTransformersImportError(): Error | undefined {
+  return transformersImportError;
+}

--- a/test/local-embedding-provider.test.ts
+++ b/test/local-embedding-provider.test.ts
@@ -2,15 +2,8 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const previousTransitiveMissingPackage =
-  process.env.AGENTMEMORY_TEST_TRANSFORMERS_TRANSITIVE_MISSING_PACKAGE;
 const previousTransformersCache = process.env.TRANSFORMERS_CACHE;
 const previousHfHome = process.env.HF_HOME;
-const transformerImportErrorKey = Symbol.for(
-  "agentmemory.test.transformersImportError",
-);
-const testGlobals = globalThis as Record<PropertyKey, unknown>;
-const previousTransformerImportError = testGlobals[transformerImportErrorKey];
 
 function restoreEnvironmentVariable(
   name: string,
@@ -24,24 +17,13 @@ function restoreEnvironmentVariable(
 }
 
 beforeEach(() => {
-  delete process.env.AGENTMEMORY_TEST_TRANSFORMERS_TRANSITIVE_MISSING_PACKAGE;
   delete process.env.TRANSFORMERS_CACHE;
   delete process.env.HF_HOME;
-  delete testGlobals[transformerImportErrorKey];
 });
 
 afterEach(() => {
-  restoreEnvironmentVariable(
-    "AGENTMEMORY_TEST_TRANSFORMERS_TRANSITIVE_MISSING_PACKAGE",
-    previousTransitiveMissingPackage,
-  );
   restoreEnvironmentVariable("TRANSFORMERS_CACHE", previousTransformersCache);
   restoreEnvironmentVariable("HF_HOME", previousHfHome);
-  if (previousTransformerImportError === undefined) {
-    delete testGlobals[transformerImportErrorKey];
-  } else {
-    testGlobals[transformerImportErrorKey] = previousTransformerImportError;
-  }
   vi.doUnmock("@huggingface/transformers");
   vi.resetModules();
 });
@@ -65,11 +47,12 @@ describe("LocalEmbeddingProvider (package unavailable)", () => {
       ),
       { code: "ERR_MODULE_NOT_FOUND" },
     );
-    process.env.AGENTMEMORY_TEST_TRANSFORMERS_TRANSITIVE_MISSING_PACKAGE =
-      "sharp";
-    testGlobals[transformerImportErrorKey] = transitiveError;
     vi.doMock("@huggingface/transformers");
     vi.resetModules();
+    const { setTransformersImportError } = await import(
+      "./fixtures/transformers-import-error.js"
+    );
+    setTransformersImportError(transitiveError);
     const { LocalEmbeddingProvider: Fresh } = await import(
       "../src/providers/embedding/local.js"
     );
@@ -81,13 +64,13 @@ describe("LocalEmbeddingProvider (package unavailable)", () => {
 describe("Transformers cache initialization", () => {
   async function loadTransformersWithMock(
     module: Record<string, unknown>,
-  ): Promise<void> {
+  ) {
     vi.doMock("@huggingface/transformers", () => module);
     vi.resetModules();
     const { loadTransformers } = await import(
       "../src/providers/embedding/_transformers.js"
     );
-    await loadTransformers();
+    return loadTransformers();
   }
 
   it("prefers TRANSFORMERS_CACHE over HF_HOME", async () => {
@@ -119,10 +102,18 @@ describe("Transformers cache initialization", () => {
     );
   });
 
-  it("loads safely when the module has no env export", async () => {
-    await expect(
-      loadTransformersWithMock({ pipeline: vi.fn() }),
-    ).resolves.toBeUndefined();
+  it("keeps the module usable when cacheDir is not writable", async () => {
+    const pipeline = vi.fn();
+    const setCacheDir = vi.fn(() => {
+      throw new TypeError("cacheDir is read-only");
+    });
+    const env = {};
+    Object.defineProperty(env, "cacheDir", { set: setCacheDir });
+
+    const transformers = await loadTransformersWithMock({ env, pipeline });
+
+    expect(setCacheDir).toHaveBeenCalledOnce();
+    expect(transformers.pipeline).toBe(pipeline);
   });
 });
 

--- a/test/local-embedding-provider.test.ts
+++ b/test/local-embedding-provider.test.ts
@@ -1,7 +1,15 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 
+const previousTransitiveMissingPackage =
+  process.env.AGENTMEMORY_TEST_TRANSFORMERS_TRANSITIVE_MISSING_PACKAGE;
+
 afterEach(() => {
-  delete process.env.AGENTMEMORY_TEST_TRANSFORMERS_TRANSITIVE_MISSING_PACKAGE;
+  if (previousTransitiveMissingPackage === undefined) {
+    delete process.env.AGENTMEMORY_TEST_TRANSFORMERS_TRANSITIVE_MISSING_PACKAGE;
+  } else {
+    process.env.AGENTMEMORY_TEST_TRANSFORMERS_TRANSITIVE_MISSING_PACKAGE =
+      previousTransitiveMissingPackage;
+  }
   vi.doUnmock("@huggingface/transformers");
   vi.resetModules();
 });

--- a/test/local-embedding-provider.test.ts
+++ b/test/local-embedding-provider.test.ts
@@ -21,9 +21,13 @@ beforeEach(() => {
   delete process.env.HF_HOME;
 });
 
-afterEach(() => {
+afterEach(async () => {
   restoreEnvironmentVariable("TRANSFORMERS_CACHE", previousTransformersCache);
   restoreEnvironmentVariable("HF_HOME", previousHfHome);
+  const { clearTransformersImportError } = await import(
+    "./fixtures/transformers-import-error.js"
+  );
+  clearTransformersImportError();
   vi.doUnmock("@huggingface/transformers");
   vi.resetModules();
 });

--- a/test/local-embedding-provider.test.ts
+++ b/test/local-embedding-provider.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 
 afterEach(() => {
+  delete process.env.AGENTMEMORY_TEST_TRANSFORMERS_TRANSITIVE_MISSING_PACKAGE;
   vi.doUnmock("@huggingface/transformers");
   vi.resetModules();
 });
@@ -15,6 +16,22 @@ describe("LocalEmbeddingProvider (package unavailable)", () => {
     await expect(new Fresh().embed("hello")).rejects.toThrow(
       "Install @huggingface/transformers for local embeddings",
     );
+  });
+
+  it("preserves missing transitive dependency errors", async () => {
+    process.env.AGENTMEMORY_TEST_TRANSFORMERS_TRANSITIVE_MISSING_PACKAGE =
+      "sharp";
+    vi.doMock("@huggingface/transformers");
+    vi.resetModules();
+    const { LocalEmbeddingProvider: Fresh } = await import(
+      "../src/providers/embedding/local.js"
+    );
+
+    await expect(new Fresh().embed("hello")).rejects.toMatchObject({
+      code: "ERR_MODULE_NOT_FOUND",
+      message:
+        "Cannot find package 'sharp' imported from @huggingface/transformers",
+    });
   });
 });
 

--- a/test/local-embedding-provider.test.ts
+++ b/test/local-embedding-provider.test.ts
@@ -1,14 +1,46 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const previousTransitiveMissingPackage =
   process.env.AGENTMEMORY_TEST_TRANSFORMERS_TRANSITIVE_MISSING_PACKAGE;
+const previousTransformersCache = process.env.TRANSFORMERS_CACHE;
+const previousHfHome = process.env.HF_HOME;
+const transformerImportErrorKey = Symbol.for(
+  "agentmemory.test.transformersImportError",
+);
+const testGlobals = globalThis as Record<PropertyKey, unknown>;
+const previousTransformerImportError = testGlobals[transformerImportErrorKey];
+
+function restoreEnvironmentVariable(
+  name: string,
+  previousValue: string | undefined,
+): void {
+  if (previousValue === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = previousValue;
+  }
+}
+
+beforeEach(() => {
+  delete process.env.AGENTMEMORY_TEST_TRANSFORMERS_TRANSITIVE_MISSING_PACKAGE;
+  delete process.env.TRANSFORMERS_CACHE;
+  delete process.env.HF_HOME;
+  delete testGlobals[transformerImportErrorKey];
+});
 
 afterEach(() => {
-  if (previousTransitiveMissingPackage === undefined) {
-    delete process.env.AGENTMEMORY_TEST_TRANSFORMERS_TRANSITIVE_MISSING_PACKAGE;
+  restoreEnvironmentVariable(
+    "AGENTMEMORY_TEST_TRANSFORMERS_TRANSITIVE_MISSING_PACKAGE",
+    previousTransitiveMissingPackage,
+  );
+  restoreEnvironmentVariable("TRANSFORMERS_CACHE", previousTransformersCache);
+  restoreEnvironmentVariable("HF_HOME", previousHfHome);
+  if (previousTransformerImportError === undefined) {
+    delete testGlobals[transformerImportErrorKey];
   } else {
-    process.env.AGENTMEMORY_TEST_TRANSFORMERS_TRANSITIVE_MISSING_PACKAGE =
-      previousTransitiveMissingPackage;
+    testGlobals[transformerImportErrorKey] = previousTransformerImportError;
   }
   vi.doUnmock("@huggingface/transformers");
   vi.resetModules();
@@ -27,19 +59,70 @@ describe("LocalEmbeddingProvider (package unavailable)", () => {
   });
 
   it("preserves missing transitive dependency errors", async () => {
+    const transitiveError = Object.assign(
+      new Error(
+        "Cannot find package 'sharp' imported from @huggingface/transformers",
+      ),
+      { code: "ERR_MODULE_NOT_FOUND" },
+    );
     process.env.AGENTMEMORY_TEST_TRANSFORMERS_TRANSITIVE_MISSING_PACKAGE =
       "sharp";
+    testGlobals[transformerImportErrorKey] = transitiveError;
     vi.doMock("@huggingface/transformers");
     vi.resetModules();
     const { LocalEmbeddingProvider: Fresh } = await import(
       "../src/providers/embedding/local.js"
     );
 
-    await expect(new Fresh().embed("hello")).rejects.toMatchObject({
-      code: "ERR_MODULE_NOT_FOUND",
-      message:
-        "Cannot find package 'sharp' imported from @huggingface/transformers",
-    });
+    await expect(new Fresh().embed("hello")).rejects.toBe(transitiveError);
+  });
+});
+
+describe("Transformers cache initialization", () => {
+  async function loadTransformersWithMock(
+    module: Record<string, unknown>,
+  ): Promise<void> {
+    vi.doMock("@huggingface/transformers", () => module);
+    vi.resetModules();
+    const { loadTransformers } = await import(
+      "../src/providers/embedding/_transformers.js"
+    );
+    await loadTransformers();
+  }
+
+  it("prefers TRANSFORMERS_CACHE over HF_HOME", async () => {
+    process.env.TRANSFORMERS_CACHE = "/tmp/transformers-cache";
+    process.env.HF_HOME = "/tmp/hf-home";
+    const env = { cacheDir: "" };
+
+    await loadTransformersWithMock({ env });
+
+    expect(env.cacheDir).toBe("/tmp/transformers-cache");
+  });
+
+  it("uses HF_HOME when TRANSFORMERS_CACHE is absent", async () => {
+    process.env.HF_HOME = "/tmp/hf-home";
+    const env = { cacheDir: "" };
+
+    await loadTransformersWithMock({ env });
+
+    expect(env.cacheDir).toBe("/tmp/hf-home");
+  });
+
+  it("falls back to the user cache when both variables are absent", async () => {
+    const env = { cacheDir: "" };
+
+    await loadTransformersWithMock({ env });
+
+    expect(env.cacheDir).toBe(
+      join(homedir(), ".cache", "huggingface", "transformers"),
+    );
+  });
+
+  it("loads safely when the module has no env export", async () => {
+    await expect(
+      loadTransformersWithMock({ pipeline: vi.fn() }),
+    ).resolves.toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Problem
When `agentmemory` is installed globally (e.g. system npm, Arch Linux AUR package in `/usr/lib/node_modules/@agentmemory/agentmemory`, Docker container, or shared environments), `@huggingface/transformers` defaults to creating a `.cache/` directory relative to its own package directory (`__dirname`). This causes an `EACCES: permission denied` error when running as a regular user:

```
An error occurred while writing the file to cache: Error: EACCES: permission denied, mkdir '/usr/lib/node_modules/@agentmemory/agentmemory/node_modules/@huggingface/transformers/.cache'
```

## Solution
- Introduce a centralized loader `src/providers/embedding/_transformers.ts` that configures `transformers.env.cacheDir` to honor `TRANSFORMERS_CACHE`, `HF_HOME`, or default to `~/.cache/huggingface/transformers`.
- Refactor `LocalEmbeddingProvider`, `ClipEmbeddingProvider`, and `reranker` to use the shared loader.
- Handle mock and headless test environments gracefully.

## Validation
- `npm run build` passes with full TypeScript / tsdown compilation.
- `npm test` passes with 148 test files, 1,641 tests (100% green).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent loading for Transformers-powered image, text embedding, local embedding, and reranking features.
  * Added configurable cache locations with a sensible default when no setting is provided.

* **Bug Fixes**
  * Improved guidance when Transformers is not installed.
  * Preserved useful error details for missing dependencies.
  * Improved reliability in restricted environments, including read-only cache locations and missing optional configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->