### PR TITLE
fix(pi): attribute sessions to Pi cwd

### DIFF
--- a/integrations/pi/index.ts
+++ b/integrations/pi/index.ts
@@ -289,7 +289,7 @@ export default function agentmemoryExtension(pi: ExtensionAPI) {
   pi.on("session_start", async (_event, ctx) => {
     const sessionFile = ctx.sessionManager.getSessionFile();
     sessionId = sessionFile ? path.basename(sessionFile).replace(/\.[^.]+$/, "") : `ephemeral-${crypto.randomUUID().slice(0, 8)}`;
-    currentCwd = process.cwd();
+    currentCwd = ctx.cwd;
     currentProject = resolveProjectName(currentCwd);
     await refreshStatus(ctx);
     // After refreshStatus: that is where lastHealthOk is first populated.
@@ -301,7 +301,7 @@ export default function agentmemoryExtension(pi: ExtensionAPI) {
   });
 
   pi.on("before_agent_start", async (event, ctx) => {
-    currentCwd = event.systemPromptOptions.cwd || process.cwd();
+    currentCwd = event.systemPromptOptions.cwd || ctx.cwd;
     currentProject = resolveProjectName(currentCwd);
     lastPrompt = event.prompt?.trim() || "";
     if (!lastPrompt) return;

--- a/test/connect-pi.test.ts
+++ b/test/connect-pi.test.ts
@@ -130,4 +130,15 @@ describe("integrations/pi is a valid pi package", () => {
     expect(index).toContain("@earendil-works/pi-coding-agent");
     expect(index).not.toContain("@mariozechner/pi-coding-agent");
   });
+
+  it("uses Pi's session cwd for session and prompt attribution", () => {
+    const index = readFileSync("integrations/pi/index.ts", "utf-8");
+    const sessionStart = index.slice(
+      index.indexOf('pi.on("session_start"'),
+      index.indexOf('pi.on("before_agent_start"'),
+    );
+    expect(sessionStart).toContain("currentCwd = ctx.cwd;");
+    expect(sessionStart).not.toContain("process.cwd()");
+    expect(index).toContain("currentCwd = event.systemPromptOptions.cwd || ctx.cwd;");
+  });
 });


### PR DESCRIPTION
## Summary
- use `ctx.cwd` when Pi starts an agentmemory session
- use the same fallback for prompt attribution
- add a regression test for session and prompt attribution

## Test
- `npm test -- test/connect-pi.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pi integration now correctly uses the session and prompt working directories when attributing activity and managing project context.
  * Prompt-specific working directory overrides are applied when provided.
  * Prevented incorrect attribution caused by relying on the process’s working directory.

* **Tests**
  * Added coverage to verify working-directory handling across Pi sessions and prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->