### PR TITLE
fix: restore memory_smart_search expandIds flow

### DIFF
--- a/src/functions/smart-search.ts
+++ b/src/functions/smart-search.ts
@@ -382,5 +382,5 @@ async function findObservation(
     const found = results.find((r) => r !== null);
     if (found) return found;
   }
-  return null;
+  return kv.get<CompressedObservation>(KV.memories, obsId).catch(() => null);
 }

--- a/src/functions/smart-search.ts
+++ b/src/functions/smart-search.ts
@@ -5,9 +5,11 @@ import type {
   CompressedObservation,
   HybridSearchResult,
   Lesson,
+  Memory,
 } from "../types.js";
 import { KV } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
+import { memoryToObservation } from "../state/memory-utils.js";
 import { withKeyedLock } from "../state/keyed-mutex.js";
 import { recordAccessBatch } from "./access-tracker.js";
 import {
@@ -382,5 +384,6 @@ async function findObservation(
     const found = results.find((r) => r !== null);
     if (found) return found;
   }
-  return kv.get<CompressedObservation>(KV.memories, obsId).catch(() => null);
+  const memory = await kv.get<Memory>(KV.memories, obsId).catch(() => null);
+  return memory ? memoryToObservation(memory) : null;
 }

--- a/src/mcp/standalone.ts
+++ b/src/mcp/standalone.ts
@@ -111,6 +111,7 @@ interface Validated {
   limit?: number;
   format?: string;
   tokenBudget?: number;
+  expandIds?: string[];
   memoryIds?: string[];
   reason?: string;
 }
@@ -159,6 +160,9 @@ function validate(toolName: string, args: Record<string, unknown>): Validated {
       } else if (typeof budget === "string" && budget.trim()) {
         const n = Number(budget);
         if (Number.isFinite(n) && n > 0) v.tokenBudget = Math.floor(n);
+      }
+      if (toolName === "memory_smart_search") {
+        v.expandIds = normalizeList(args["expandIds"]).slice(0, 20);
       }
       return v;
     }
@@ -220,6 +224,7 @@ async function handleProxy(
       const body: Record<string, unknown> = { query: v.query, limit: v.limit };
       if (v.format != null) body["format"] = v.format;
       if (v.tokenBudget != null) body["token_budget"] = v.tokenBudget;
+      if (v.expandIds && v.expandIds.length > 0) body["expandIds"] = v.expandIds;
       const result = await handle.call("/agentmemory/smart-search", {
         method: "POST",
         body: JSON.stringify(body),

--- a/src/mcp/standalone.ts
+++ b/src/mcp/standalone.ts
@@ -6,6 +6,8 @@ import { getAllTools } from "./tools-registry.js";
 import { getStandalonePersistPath } from "../config.js";
 import { VERSION } from "../version.js";
 import { generateId } from "../state/schema.js";
+import { memoryToObservation } from "../state/memory-utils.js";
+import type { Memory } from "../types.js";
 import {
   resolveHandle,
   invalidateHandle,
@@ -142,8 +144,7 @@ function validate(toolName: string, args: Record<string, unknown>): Validated {
       }
       return v;
     }
-    case "memory_recall":
-    case "memory_smart_search": {
+    case "memory_recall": {
       const query = args["query"];
       if (typeof query !== "string" || !query.trim()) {
         throw new Error("query is required");
@@ -161,8 +162,27 @@ function validate(toolName: string, args: Record<string, unknown>): Validated {
         const n = Number(budget);
         if (Number.isFinite(n) && n > 0) v.tokenBudget = Math.floor(n);
       }
-      if (toolName === "memory_smart_search") {
-        v.expandIds = normalizeList(args["expandIds"]).slice(0, 20);
+      return v;
+    }
+    case "memory_smart_search": {
+      const query = args["query"];
+      const expandIds = normalizeList(args["expandIds"]).slice(0, 20);
+      if ((typeof query !== "string" || !query.trim()) && expandIds.length === 0) {
+        throw new Error("query or expandIds is required");
+      }
+      if (typeof query === "string" && query.trim()) v.query = query.trim();
+      v.expandIds = expandIds;
+      v.limit = parseLimit(args["limit"]);
+      const fmt = args["format"];
+      if (typeof fmt === "string" && fmt.trim()) {
+        v.format = fmt.trim().toLowerCase();
+      }
+      const budget = args["token_budget"];
+      if (typeof budget === "number" && Number.isFinite(budget) && budget > 0) {
+        v.tokenBudget = Math.floor(budget);
+      } else if (typeof budget === "string" && budget.trim()) {
+        const n = Number(budget);
+        if (Number.isFinite(n) && n > 0) v.tokenBudget = Math.floor(n);
       }
       return v;
     }
@@ -221,7 +241,8 @@ async function handleProxy(
       return textResponse(result, true);
     }
     case "memory_smart_search": {
-      const body: Record<string, unknown> = { query: v.query, limit: v.limit };
+      const body: Record<string, unknown> = { limit: v.limit };
+      if (v.query != null) body["query"] = v.query;
       if (v.format != null) body["format"] = v.format;
       if (v.tokenBudget != null) body["token_budget"] = v.tokenBudget;
       if (v.expandIds && v.expandIds.length > 0) body["expandIds"] = v.expandIds;
@@ -287,12 +308,49 @@ async function handleLocal(
       return textResponse({ saved: id });
     }
 
-    case "memory_recall":
-    case "memory_smart_search": {
+    case "memory_recall": {
       const query = (v.query || "").toLowerCase();
       const limit = v.limit ?? DEFAULT_LIMIT;
       const all =
         await kvInstance.list<Record<string, unknown>>("mem:memories");
+      const results = all
+        .filter((m) => {
+          const text = [
+            typeof m["title"] === "string" ? m["title"] : "",
+            typeof m["content"] === "string" ? m["content"] : "",
+            Array.isArray(m["files"]) ? m["files"].join(" ") : "",
+            Array.isArray(m["concepts"]) ? m["concepts"].join(" ") : "",
+            Array.isArray(m["sessionIds"]) ? m["sessionIds"].join(" ") : "",
+            typeof m["id"] === "string" ? m["id"] : "",
+          ]
+            .join(" ")
+            .toLowerCase();
+          return query.split(/\s+/).every((word) => text.includes(word));
+        })
+        .slice(0, limit);
+      return textResponse({ mode: "compact", results }, true);
+    }
+
+    case "memory_smart_search": {
+      if (v.expandIds && v.expandIds.length > 0) {
+        const memories = await Promise.all(
+          v.expandIds.map((id) => kvInstance.get<Memory>("mem:memories", id)),
+        );
+        const results = memories.flatMap((memory, index) =>
+          memory
+            ? [{
+                obsId: v.expandIds![index],
+                sessionId: memory.sessionIds?.[0] ?? "memory",
+                observation: memoryToObservation(memory),
+              }]
+            : [],
+        );
+        return textResponse({ mode: "expanded", results }, true);
+      }
+
+      const query = (v.query || "").toLowerCase();
+      const limit = v.limit ?? DEFAULT_LIMIT;
+      const all = await kvInstance.list<Record<string, unknown>>("mem:memories");
       const results = all
         .filter((m) => {
           const text = [

--- a/test/mcp-standalone-proxy.test.ts
+++ b/test/mcp-standalone-proxy.test.ts
@@ -75,6 +75,28 @@ describe("@agentmemory/mcp standalone — server proxy (issue #159)", () => {
     expect(body.results[0].id).toBe("m1");
   });
 
+  it("forwards CSV expandIds to memory_smart_search as an array", async () => {
+    let smartSearchBody: Record<string, unknown> | undefined;
+    installFetch((url, init) => {
+      if (url.endsWith("/agentmemory/livez")) return new Response("ok", { status: 200 });
+      if (url.endsWith("/agentmemory/smart-search")) {
+        smartSearchBody = init?.body ? JSON.parse(init.body as string) : undefined;
+        return new Response(JSON.stringify({ mode: "expanded", results: [] }), { status: 200 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    await handleToolCall("memory_smart_search", {
+      query: "auth bug",
+      expandIds: "mem_one, mem_two",
+    });
+
+    expect(smartSearchBody).toMatchObject({
+      query: "auth bug",
+      expandIds: ["mem_one", "mem_two"],
+    });
+  });
+
   it("proxies memory_recall to POST /agentmemory/search and forwards format/token_budget (#507)", async () => {
     const calls: Array<{ url: string; body?: unknown }> = [];
     installFetch((url, init) => {

--- a/test/mcp-standalone-proxy.test.ts
+++ b/test/mcp-standalone-proxy.test.ts
@@ -97,6 +97,25 @@ describe("@agentmemory/mcp standalone — server proxy (issue #159)", () => {
     });
   });
 
+  it("allows memory_smart_search expansion without a query", async () => {
+    let smartSearchBody: Record<string, unknown> | undefined;
+    installFetch((url, init) => {
+      if (url.endsWith("/agentmemory/livez")) return new Response("ok", { status: 200 });
+      if (url.endsWith("/agentmemory/smart-search")) {
+        smartSearchBody = init?.body ? JSON.parse(init.body as string) : undefined;
+        return new Response(JSON.stringify({ mode: "expanded", results: [] }), { status: 200 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    await handleToolCall("memory_smart_search", { expandIds: "mem_one, mem_two" });
+
+    expect(smartSearchBody).toEqual({
+      limit: 10,
+      expandIds: ["mem_one", "mem_two"],
+    });
+  });
+
   it("proxies memory_recall to POST /agentmemory/search and forwards format/token_budget (#507)", async () => {
     const calls: Array<{ url: string; body?: unknown }> = [];
     installFetch((url, init) => {

--- a/test/mcp-standalone.test.ts
+++ b/test/mcp-standalone.test.ts
@@ -285,18 +285,47 @@ describe("handleToolCall", () => {
     expect(parsed.results[0].content).toBe("Use bcrypt for password hashing");
   });
 
-  it("memory_smart_search rejects empty query to prevent match-all in forget flow (#139)", async () => {
+  it("memory_smart_search rejects requests without a query or expandIds", async () => {
     const kv = new InMemoryKV();
     await handleToolCall("memory_save", { content: "anything" }, kv);
     await expect(
       handleToolCall("memory_smart_search", {}, kv),
-    ).rejects.toThrow("query is required");
+    ).rejects.toThrow("query or expandIds is required");
     await expect(
       handleToolCall("memory_smart_search", { query: "" }, kv),
-    ).rejects.toThrow("query is required");
+    ).rejects.toThrow("query or expandIds is required");
     await expect(
       handleToolCall("memory_smart_search", { query: "   " }, kv),
-    ).rejects.toThrow("query is required");
+    ).rejects.toThrow("query or expandIds is required");
+  });
+
+  it("memory_smart_search expands saved memory IDs without a query", async () => {
+    const kv = new InMemoryKV();
+    const saved = await handleToolCall(
+      "memory_save",
+      { content: "Use argon2id", concepts: ["auth"] },
+      kv,
+    );
+    const id = JSON.parse(saved.content[0].text).saved as string;
+
+    const result = await handleToolCall(
+      "memory_smart_search",
+      { expandIds: [id] },
+      kv,
+    );
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.mode).toBe("expanded");
+    expect(parsed.results).toHaveLength(1);
+    expect(parsed.results[0]).toMatchObject({
+      obsId: id,
+      sessionId: "memory",
+      observation: {
+        id,
+        narrative: "Use argon2id",
+        concepts: ["auth"],
+      },
+    });
   });
 
   it("memory_smart_search searches files and concepts, not just title/content (#139)", async () => {

--- a/test/smart-search.test.ts
+++ b/test/smart-search.test.ts
@@ -9,6 +9,7 @@ import type {
   CompressedObservation,
   HybridSearchResult,
   CompactSearchResult,
+  Memory,
   Session,
 } from "../src/types.js";
 
@@ -140,12 +141,20 @@ describe("Smart Search Function", () => {
   });
 
   it("expand mode resolves long-term memory IDs from KV.memories", async () => {
-    const memory = makeObs({
+    const memory: Memory = {
       id: "mem_long_term",
-      sessionId: "memory",
+      createdAt: "2026-08-20T10:00:00.000Z",
+      updatedAt: "2026-08-20T11:00:00.000Z",
+      type: "fact",
       title: "Long-term auth memory",
-      narrative: "Remembered auth detail",
-    });
+      content: "Remembered auth detail",
+      concepts: ["auth"],
+      files: ["src/auth.ts"],
+      sessionIds: [],
+      strength: 8,
+      version: 1,
+      isLatest: true,
+    };
     await kv.set("mem:memories", memory.id, memory);
 
     const result = (await sdk.trigger("mem::smart-search", {
@@ -157,7 +166,18 @@ describe("Smart Search Function", () => {
     expect(result.results[0]).toMatchObject({
       obsId: memory.id,
       sessionId: "memory",
-      observation: memory,
+      observation: {
+        id: memory.id,
+        sessionId: "memory",
+        timestamp: memory.createdAt,
+        type: "decision",
+        title: memory.title,
+        facts: [memory.content],
+        narrative: memory.content,
+        concepts: memory.concepts,
+        files: memory.files,
+        importance: memory.strength,
+      },
     });
   });
 

--- a/test/smart-search.test.ts
+++ b/test/smart-search.test.ts
@@ -139,6 +139,28 @@ describe("Smart Search Function", () => {
     expect(result.results[0].observation.title).toBe("Auth handler");
   });
 
+  it("expand mode resolves long-term memory IDs from KV.memories", async () => {
+    const memory = makeObs({
+      id: "mem_long_term",
+      sessionId: "memory",
+      title: "Long-term auth memory",
+      narrative: "Remembered auth detail",
+    });
+    await kv.set("mem:memories", memory.id, memory);
+
+    const result = (await sdk.trigger("mem::smart-search", {
+      expandIds: [memory.id],
+    })) as { mode: string; results: Array<{ obsId: string; sessionId: string; observation: CompressedObservation }> };
+
+    expect(result.mode).toBe("expanded");
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0]).toMatchObject({
+      obsId: memory.id,
+      sessionId: "memory",
+      observation: memory,
+    });
+  });
+
   it("returns error when query is missing and no expandIds", async () => {
     const result = (await sdk.trigger("mem::smart-search", {})) as {
       mode: string;


### PR DESCRIPTION
## Summary

- parse and forward `expandIds` through the standalone MCP proxy
- fall back to `KV.memories` when expanding long-term `mem_*` IDs
- add regression coverage for both paths

Fixes #889

## Related work

PR #837 already forwards `expandIds` through the standalone proxy. This PR includes the same shim-side flow because #889 also requires the separate engine fix: compact smart-search results expose long-term `mem_*` IDs, while expansion previously searched only session observations. The `KV.memories` fallback and its regression test are the additional end-to-end behavior covered here.

## Testing

- `npm test -- --run test/mcp-standalone-proxy.test.ts test/smart-search.test.ts`
- 2 test files passed
- 31 tests passed
- `git diff --check` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for expanding saved memory IDs in smart search results.
  * Smart search can now run using memory IDs without requiring a text query.
  * Multiple IDs can be provided, with normalized input and support for up to 20 IDs.
* **Bug Fixes**
  * Improved observation retrieval when session-based lookup is unavailable by falling back to saved memories.
* **Tests**
  * Added coverage for ID expansion, query-free searches, and proxy request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->