### PR TITLE
fix(mcp): pin matching core package version

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/rohitg00/agentmemory#readme",
   "bugs": "https://github.com/rohitg00/agentmemory/issues",
   "dependencies": {
-    "@agentmemory/agentmemory": "~0.9.0"
+    "@agentmemory/agentmemory": "0.9.29"
   },
   "publishConfig": {
     "access": "public",

--- a/test/consistency.test.ts
+++ b/test/consistency.test.ts
@@ -35,13 +35,14 @@ describe("Consistency checks", () => {
     expect(plugin.version).toBe(pkg.version);
   });
 
-  it("packages/mcp version matches package.json", () => {
+  it("packages/mcp version and core dependency match package.json", () => {
     // The mcp package publishes in lockstep with the main package but its
     // version lives in its own manifest; without this guard a release bump
     // can silently ship a stale @agentmemory/mcp (it slipped in 0.9.29).
     const pkg = JSON.parse(readText("package.json"));
     const mcp = JSON.parse(readText("packages/mcp/package.json"));
     expect(mcp.version).toBe(pkg.version);
+    expect(mcp.dependencies["@agentmemory/agentmemory"]).toBe(pkg.version);
   });
 
   it("export-import.ts supports current version", () => {


### PR DESCRIPTION
## Summary

- pin `@agentmemory/mcp@0.9.29` to the exact matching `@agentmemory/agentmemory@0.9.29` core package
- extend the existing package consistency test so future release bumps fail unless the shim version, root version, and core dependency stay synchronized

Closes #668

## Testing

- `node_modules/.bin/vitest run test/consistency.test.ts` — 9 tests passed
- `node_modules/.bin/vitest run --exclude test/integration.test.ts` — 151 test files passed, 1 skipped; 1,657 tests passed, 1 skipped
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package version consistency by pinning the MCP package dependency to the exact matching release.
* **Tests**
  * Added validation to ensure the MCP dependency version stays aligned with the root package version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->