### PR TITLE
fix: serialize and deduplicate dashboard loading

### DIFF
--- a/src/viewer/index.html
+++ b/src/viewer/index.html
@@ -1471,15 +1471,17 @@
     var dashboardRefreshPending = false;
     async function loadDashboard() {
       if (dashboardLoadPromise) return dashboardLoadPromise;
-      do {
-        dashboardRefreshPending = false;
-        dashboardLoadPromise = loadDashboardOnce();
-        try {
-          await dashboardLoadPromise;
-        } finally {
-          dashboardLoadPromise = null;
-        }
-      } while (dashboardRefreshPending);
+      dashboardLoadPromise = (async function() {
+        do {
+          dashboardRefreshPending = false;
+          await loadDashboardOnce();
+        } while (dashboardRefreshPending);
+      })();
+      try {
+        await dashboardLoadPromise;
+      } finally {
+        dashboardLoadPromise = null;
+      }
     }
 
     async function loadDashboardOnce() {

--- a/src/viewer/index.html
+++ b/src/viewer/index.html
@@ -1550,10 +1550,8 @@
       html += '<div class="stats-grid">';
       html += '<div class="stat-card" data-action="goto-tab" data-tab="sessions" role="link" tabindex="0"><div class="label">Sessions</div><div class="value">' + d.sessions.length + '</div><div class="sub">' + activeSessions + ' active</div></div>';
       html += '<div class="stat-card" data-action="goto-tab" data-tab="memories" role="link" tabindex="0"><div class="label">Memories</div><div class="value">' + d.memories.length + '</div><div class="sub">latest versions</div></div>';
-      var lessonCount = (d.lessons || []).length;
-      var crystalCount = (d.crystals || []).length;
-      html += '<div class="stat-card" data-action="goto-tab" data-tab="lessons" role="link" tabindex="0"><div class="label">Lessons</div><div class="value">' + lessonCount + '</div><div class="sub">confidence-scored</div></div>';
-      html += '<div class="stat-card" data-action="goto-tab" data-tab="crystals" role="link" tabindex="0"><div class="label">Crystals</div><div class="value">' + crystalCount + '</div><div class="sub">action digests</div></div>';
+      html += '<div class="stat-card" data-action="goto-tab" data-tab="lessons" role="link" tabindex="0"><div class="label">Lessons</div><div class="value">&mdash;</div><div class="sub">load tab to view</div></div>';
+      html += '<div class="stat-card" data-action="goto-tab" data-tab="crystals" role="link" tabindex="0"><div class="label">Crystals</div><div class="value">&mdash;</div><div class="sub">load tab to view</div></div>';
       html += '<div class="stat-card" data-action="goto-tab" data-tab="graph" role="link" tabindex="0"><div class="label">Graph Nodes</div><div class="value">' + nodeCount + '</div><div class="sub">' + edgeCount + ' edges</div></div>';
       html += '<div class="stat-card"><div class="label">Health</div><div class="value"><div class="health-bar"><span class="health-dot ' + dotClass + '"></span> ' + esc(healthStatus) + '</div></div>';
       html += '<div class="sub">' + esc(snap.connectionState || 'unknown') + '</div></div>';

--- a/src/viewer/index.html
+++ b/src/viewer/index.html
@@ -1491,23 +1491,13 @@
           await apiGet('sessions'),
           await apiGet('memories?latest=true&limit=500'),
           await apiGet('graph/stats'),
-          await apiGet('audit?limit=5'),
-          await apiGet('semantic'),
-          await apiGet('procedural'),
-          await apiGet('relations'),
-          await apiGet('lessons'),
-          await apiGet('crystals')
+          await apiGet('audit?limit=5')
         ];
         state.dashboard.health = results[0];
         state.dashboard.sessions = (results[1] && results[1].sessions) || [];
         state.dashboard.memories = (results[2] && results[2].memories) || [];
         state.dashboard.graphStats = results[3];
         state.dashboard.recentAudit = (results[4] && results[4].entries) || [];
-        state.dashboard.semantic = (results[5] && results[5].facts) || (results[5] && results[5].semantic) || [];
-        state.dashboard.procedural = (results[6] && results[6].procedures) || (results[6] && results[6].procedural) || [];
-        state.dashboard.lessons = (results[8] && results[8].lessons) || [];
-        state.dashboard.crystals = (results[9] && results[9].crystals) || [];
-        state.dashboard.relations = (results[7] && results[7].relations) || [];
         state.dashboard.loaded = true;
         renderDashboard();
       } catch (err) {
@@ -1721,12 +1711,15 @@
       var semFacts = d.semantic || [];
       var procItems = d.procedural || [];
       var relItems = d.relations || [];
+      var consolidationDeferred = d.semantic === undefined;
 
       html += '<hr class="section-rule">';
       html += '<div class="two-col">';
 
       html += '<div class="card"><div class="card-title">Semantic Memory</div>';
-      if (semFacts.length === 0) {
+      if (consolidationDeferred) {
+        html += '<div style="font-size:13px;color:var(--ink-faint);font-style:italic;">Not loaded on the dashboard to keep large memory stores responsive.</div>';
+      } else if (semFacts.length === 0) {
         html += '<div style="font-size:13px;color:var(--ink-faint);font-style:italic;">No semantic facts yet. Observations will be consolidated into semantic memories over time.</div>';
       } else {
           semFacts.slice(0, 5).forEach(function(f) {
@@ -1744,7 +1737,9 @@
         html += '</div>';
 
         html += '<div class="card"><div class="card-title">Procedural Memory</div>';
-      if (procItems.length === 0) {
+      if (consolidationDeferred) {
+        html += '<div style="font-size:13px;color:var(--ink-faint);font-style:italic;">Not loaded on the dashboard to keep large memory stores responsive.</div>';
+      } else if (procItems.length === 0) {
         html += '<div style="font-size:13px;color:var(--ink-faint);font-style:italic;">No procedures yet. Repeated patterns will be extracted as procedures.</div>';
       } else {
           procItems.slice(0, 5).forEach(function(p) {
@@ -1766,10 +1761,10 @@
       html += '</div>';
 
       html += '<div class="card" style="margin-top:16px;"><div class="card-title">Consolidation Status</div>';
-      html += '<div class="consolidation-row"><span class="cl">Semantic facts</span><span class="cv">' + semFacts.length + '</span></div>';
-      html += '<div class="consolidation-row"><span class="cl">Procedures</span><span class="cv">' + procItems.length + '</span></div>';
-      html += '<div class="consolidation-row"><span class="cl">Relations</span><span class="cv">' + relItems.length + '</span></div>';
-      if (semFacts.length === 0 && procItems.length === 0 && relItems.length === 0) {
+      html += '<div class="consolidation-row"><span class="cl">Semantic facts</span><span class="cv">' + (consolidationDeferred ? '&mdash;' : semFacts.length) + '</span></div>';
+      html += '<div class="consolidation-row"><span class="cl">Procedures</span><span class="cv">' + (consolidationDeferred ? '&mdash;' : procItems.length) + '</span></div>';
+      html += '<div class="consolidation-row"><span class="cl">Relations</span><span class="cv">' + (consolidationDeferred ? '&mdash;' : relItems.length) + '</span></div>';
+      if (!consolidationDeferred && semFacts.length === 0 && procItems.length === 0 && relItems.length === 0) {
         html += '<div style="font-size:12px;color:var(--ink-faint);margin-top:8px;line-height:1.5;">Consolidation distills session observations into durable facts and repeatable procedures. It runs on a schedule when <code>CONSOLIDATION_ENABLED=true</code> and an LLM provider key are set, or on demand via <code>memory_consolidate</code>.</div>';
       }
       html += '</div>';

--- a/src/viewer/index.html
+++ b/src/viewer/index.html
@@ -1467,22 +1467,33 @@
       }
     }
 
+    var dashboardLoadPromise = null;
     async function loadDashboard() {
+      if (dashboardLoadPromise) return dashboardLoadPromise;
+      dashboardLoadPromise = loadDashboardOnce();
+      try {
+        return await dashboardLoadPromise;
+      } finally {
+        dashboardLoadPromise = null;
+      }
+    }
+
+    async function loadDashboardOnce() {
       var el = document.getElementById('view-dashboard');
       if (!state.dashboard.loaded) el.innerHTML = '<div class="loading">Loading dashboard...</div>';
       try {
-        var results = await Promise.all([
-          api('health', { readErrorBody: true }),
-          apiGet('sessions'),
-          apiGet('memories?latest=true&limit=500'),
-          apiGet('graph/stats'),
-          apiGet('audit?limit=5'),
-          apiGet('semantic'),
-          apiGet('procedural'),
-          apiGet('relations'),
-          apiGet('lessons'),
-          apiGet('crystals')
-        ]);
+        var results = [
+          await api('health', { readErrorBody: true }),
+          await apiGet('sessions'),
+          await apiGet('memories?latest=true&limit=500'),
+          await apiGet('graph/stats'),
+          await apiGet('audit?limit=5'),
+          await apiGet('semantic'),
+          await apiGet('procedural'),
+          await apiGet('relations'),
+          await apiGet('lessons'),
+          await apiGet('crystals')
+        ];
         state.dashboard.health = results[0];
         state.dashboard.sessions = (results[1] && results[1].sessions) || [];
         state.dashboard.memories = (results[2] && results[2].memories) || [];
@@ -1496,8 +1507,8 @@
         state.dashboard.loaded = true;
         renderDashboard();
       } catch (err) {
-        // Without this catch, any uncaught error in the await Promise.all
-        // or the renderDashboard call leaves the dashboard stuck on
+        // Without this catch, an uncaught request or render error leaves
+        // the dashboard stuck on
         // "Loading dashboard..." forever with no indication to the user
         // (#323). apiGet() already swallows network/HTTP errors and
         // returns null, but renderDashboard can still throw on shape

--- a/src/viewer/index.html
+++ b/src/viewer/index.html
@@ -1468,14 +1468,18 @@
     }
 
     var dashboardLoadPromise = null;
+    var dashboardRefreshPending = false;
     async function loadDashboard() {
       if (dashboardLoadPromise) return dashboardLoadPromise;
-      dashboardLoadPromise = loadDashboardOnce();
-      try {
-        return await dashboardLoadPromise;
-      } finally {
-        dashboardLoadPromise = null;
-      }
+      do {
+        dashboardRefreshPending = false;
+        dashboardLoadPromise = loadDashboardOnce();
+        try {
+          await dashboardLoadPromise;
+        } finally {
+          dashboardLoadPromise = null;
+        }
+      } while (dashboardRefreshPending);
     }
 
     async function loadDashboardOnce() {
@@ -1793,7 +1797,8 @@
     var dashboardTimer = null;
     function refreshDashboard() {
       state.dashboard.loaded = false;
-      loadDashboard();
+      if (dashboardLoadPromise) dashboardRefreshPending = true;
+      return loadDashboard();
     }
     function startDashboardAutoRefresh() {
       if (dashboardTimer) clearInterval(dashboardTimer);
@@ -3810,8 +3815,7 @@
       pollTimer = setInterval(function() {
         tick++;
         if (state.activeTab === 'dashboard') {
-          state.dashboard.loaded = false;
-          loadDashboard();
+          refreshDashboard();
         } else if (state.activeTab === 'memories') {
           state.memories.loaded = false;
           loadMemories();
@@ -3975,8 +3979,7 @@
         }
       }
       if (state.activeTab === 'dashboard') {
-        state.dashboard.loaded = false;
-        loadDashboard();
+        refreshDashboard();
       }
       if (state.activeTab === 'activity' && msg.observation) {
         state.activity.observations.unshift(msg.observation);

--- a/test/viewer-session-id.test.ts
+++ b/test/viewer-session-id.test.ts
@@ -1,5 +1,5 @@
 import * as vm from "node:vm";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { renderViewerDocument } from "../src/viewer/document.js";
 
 function htmlEscape(value: string): string {
@@ -169,12 +169,21 @@ function loadViewerSandbox() {
     /\n    switchTab\(tabFromRoute\(\), \{ replaceRoute: true \}\);\n    \/\/ Resolve[\s\S]*?\n    startDashboardAutoRefresh\(\);/,
     "\n",
   );
+  expect(scriptWithoutAutoStart).not.toBe(scriptMatch[1]);
 
   vm.createContext(sandbox);
   vm.runInContext(scriptWithoutAutoStart, sandbox);
 
   return { sandbox, getElement };
 }
+
+const DASHBOARD_PATHS = [
+  "/agentmemory/health",
+  "/agentmemory/sessions",
+  "/agentmemory/memories",
+  "/agentmemory/graph/stats",
+  "/agentmemory/audit",
+] as const;
 
 describe("viewer session rendering", () => {
   it("deduplicates dashboard loads and fetches every endpoint serially", async () => {
@@ -194,36 +203,61 @@ describe("viewer session rendering", () => {
     await Promise.all([sandbox.loadDashboard(), sandbox.loadDashboard()]);
 
     expect(maxActive).toBe(1);
-    expect(paths).toEqual([
-      "/agentmemory/health",
-      "/agentmemory/sessions",
-      "/agentmemory/memories",
-      "/agentmemory/graph/stats",
-      "/agentmemory/audit",
-    ]);
+    expect(paths).toEqual(DASHBOARD_PATHS);
   });
 
   it("runs one pending refresh after an in-flight dashboard load", async () => {
     const { sandbox } = loadViewerSandbox();
     const paths: string[] = [];
-    let releaseSessions: (() => void) | undefined;
+    let active = 0;
+    let maxActive = 0;
+    let releaseSessions = () => {
+      throw new Error("sessions request did not start");
+    };
+    let sessionsStarted = false;
     sandbox.fetch = async (url: string) => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
       paths.push(new URL(url).pathname);
       if (paths.length === 2) {
         await new Promise<void>((resolve) => {
           releaseSessions = resolve;
+          sessionsStarted = true;
         });
       }
+      active -= 1;
       return { ok: true, json: async () => ({}) };
     };
 
     const initialLoad = sandbox.loadDashboard();
-    while (!releaseSessions) await Promise.resolve();
+    await vi.waitFor(() => expect(sessionsStarted).toBe(true), { timeout: 1000 });
     const pendingRefresh = sandbox.refreshDashboard();
     releaseSessions();
-    await Promise.all([initialLoad, pendingRefresh]);
+    await pendingRefresh;
+    const pathsWhenRefreshResolved = paths.slice();
+    await initialLoad;
 
-    expect(paths).toHaveLength(10);
+    expect(maxActive).toBe(1);
+    expect(pathsWhenRefreshResolved).toEqual([...DASHBOARD_PATHS, ...DASHBOARD_PATHS]);
+    expect(paths).toEqual([...DASHBOARD_PATHS, ...DASHBOARD_PATHS]);
+  });
+
+  it("starts a fresh dashboard cycle after a failed load", async () => {
+    const { sandbox } = loadViewerSandbox();
+    const getElementById = sandbox.document.getElementById;
+    sandbox.document.getElementById = () => null;
+
+    await expect(sandbox.loadDashboard()).rejects.toThrow();
+
+    sandbox.document.getElementById = getElementById;
+    const paths: string[] = [];
+    sandbox.fetch = async (url: string) => {
+      paths.push(new URL(url).pathname);
+      return { ok: true, json: async () => ({}) };
+    };
+    await sandbox.loadDashboard();
+
+    expect(paths).toEqual(DASHBOARD_PATHS);
   });
 
   it("marks lesson and crystal counts as deferred", () => {
@@ -232,8 +266,12 @@ describe("viewer session rendering", () => {
     sandbox.renderDashboard();
 
     const html = getElement("view-dashboard").innerHTML;
-    expect(html).toContain('<div class="label">Lessons</div><div class="value">&mdash;</div>');
-    expect(html).toContain('<div class="label">Crystals</div><div class="value">&mdash;</div>');
+    expect(html).toContain(
+      '<div class="label">Lessons</div><div class="value">&mdash;</div><div class="sub">load tab to view</div>',
+    );
+    expect(html).toContain(
+      '<div class="label">Crystals</div><div class="value">&mdash;</div><div class="sub">load tab to view</div>',
+    );
   });
 
   it("attaches the saved viewer bearer to API calls", async () => {

--- a/test/viewer-session-id.test.ts
+++ b/test/viewer-session-id.test.ts
@@ -226,6 +226,16 @@ describe("viewer session rendering", () => {
     expect(paths).toHaveLength(10);
   });
 
+  it("marks lesson and crystal counts as deferred", () => {
+    const { sandbox, getElement } = loadViewerSandbox();
+
+    sandbox.renderDashboard();
+
+    const html = getElement("view-dashboard").innerHTML;
+    expect(html).toContain('<div class="label">Lessons</div><div class="value">&mdash;</div>');
+    expect(html).toContain('<div class="label">Crystals</div><div class="value">&mdash;</div>');
+  });
+
   it("attaches the saved viewer bearer to API calls", async () => {
     const { sandbox } = loadViewerSandbox();
     const requests: Array<{ url: string; opts: { headers?: Record<string, string> } }> = [];

--- a/test/viewer-session-id.test.ts
+++ b/test/viewer-session-id.test.ts
@@ -166,7 +166,7 @@ function loadViewerSandbox() {
   };
 
   const scriptWithoutAutoStart = scriptMatch[1].replace(
-    /\n\s*loadTab\('dashboard'\);\n\s*connectWs\(\);\n\s*startDashboardAutoRefresh\(\);\s*$/,
+    /\n    switchTab\(tabFromRoute\(\), \{ replaceRoute: true \}\);\n    \/\/ Resolve[\s\S]*?\n    startDashboardAutoRefresh\(\);/,
     "\n",
   );
 
@@ -177,6 +177,37 @@ function loadViewerSandbox() {
 }
 
 describe("viewer session rendering", () => {
+  it("deduplicates dashboard loads and fetches every endpoint serially", async () => {
+    const { sandbox } = loadViewerSandbox();
+    let active = 0;
+    let maxActive = 0;
+    const paths: string[] = [];
+    sandbox.fetch = async (url: string) => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      paths.push(new URL(url).pathname);
+      await Promise.resolve();
+      active -= 1;
+      return { ok: true, json: async () => ({}) };
+    };
+
+    await Promise.all([sandbox.loadDashboard(), sandbox.loadDashboard()]);
+
+    expect(maxActive).toBe(1);
+    expect(paths).toEqual([
+      "/agentmemory/health",
+      "/agentmemory/sessions",
+      "/agentmemory/memories",
+      "/agentmemory/graph/stats",
+      "/agentmemory/audit",
+      "/agentmemory/semantic",
+      "/agentmemory/procedural",
+      "/agentmemory/relations",
+      "/agentmemory/lessons",
+      "/agentmemory/crystals",
+    ]);
+  });
+
   it("attaches the saved viewer bearer to API calls", async () => {
     const { sandbox } = loadViewerSandbox();
     const requests: Array<{ url: string; opts: { headers?: Record<string, string> } }> = [];

--- a/test/viewer-session-id.test.ts
+++ b/test/viewer-session-id.test.ts
@@ -200,11 +200,6 @@ describe("viewer session rendering", () => {
       "/agentmemory/memories",
       "/agentmemory/graph/stats",
       "/agentmemory/audit",
-      "/agentmemory/semantic",
-      "/agentmemory/procedural",
-      "/agentmemory/relations",
-      "/agentmemory/lessons",
-      "/agentmemory/crystals",
     ]);
   });
 
@@ -228,7 +223,7 @@ describe("viewer session rendering", () => {
     releaseSessions();
     await Promise.all([initialLoad, pendingRefresh]);
 
-    expect(paths).toHaveLength(20);
+    expect(paths).toHaveLength(10);
   });
 
   it("attaches the saved viewer bearer to API calls", async () => {

--- a/test/viewer-session-id.test.ts
+++ b/test/viewer-session-id.test.ts
@@ -208,6 +208,29 @@ describe("viewer session rendering", () => {
     ]);
   });
 
+  it("runs one pending refresh after an in-flight dashboard load", async () => {
+    const { sandbox } = loadViewerSandbox();
+    const paths: string[] = [];
+    let releaseSessions: (() => void) | undefined;
+    sandbox.fetch = async (url: string) => {
+      paths.push(new URL(url).pathname);
+      if (paths.length === 2) {
+        await new Promise<void>((resolve) => {
+          releaseSessions = resolve;
+        });
+      }
+      return { ok: true, json: async () => ({}) };
+    };
+
+    const initialLoad = sandbox.loadDashboard();
+    while (!releaseSessions) await Promise.resolve();
+    const pendingRefresh = sandbox.refreshDashboard();
+    releaseSessions();
+    await Promise.all([initialLoad, pendingRefresh]);
+
+    expect(paths).toHaveLength(20);
+  });
+
   it("attaches the saved viewer bearer to API calls", async () => {
     const { sandbox } = loadViewerSandbox();
     const requests: Array<{ url: string; opts: { headers?: Record<string, string> } }> = [];


### PR DESCRIPTION
## Summary

- load the five bounded dashboard endpoints one at a time to avoid saturating the worker invocation pool
- stop auto-loading full semantic, procedural, relation, lesson, and crystal collections; oversized state responses can unregister the whole iii worker (#1142, #1168)
- coalesce overlapping loads while preserving one pending refresh after mid-load events
- show consolidation details as deferred instead of falsely reporting zero

## Verification

- focused viewer tests pass, including serial loading, deduplication, and pending-refresh coverage
- build passes
- 1,643 unit tests pass (one skipped); live-service integration and macOS filesystem watcher timing tests are separate
- reproduced the original failure with a ~17 MB semantic state file, then verified the live dashboard keeps accurate session, memory, graph, and health values without dropping the worker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard loading reliability when multiple refresh requests occur simultaneously.
  * Prevented duplicate dashboard requests while a load is in progress.
  * Ensured polling and live updates trigger a single follow-up refresh when needed.
  * Reduced initial dashboard loading by deferring secondary data sections until available.
  * Deferred sections now display clear loading messages and placeholders.
  * Lesson and crystal dashboard cards now direct you to load their respective tabs.

* **Tests**
  * Added coverage for serialized loads, queued refreshes, deferred sections, recovery after failed loads, and expected request ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->