### PR TITLE
fix: reject state reads without keys

### DIFF
--- a/src/state/kv.ts
+++ b/src/state/kv.ts
@@ -4,6 +4,9 @@ export class StateKV {
   constructor(private sdk: ISdk) {}
 
   async get<T = unknown>(scope: string, key: string): Promise<T | null> {
+    if (typeof key !== "string" || !key.trim()) {
+      throw new Error("key must be a non-empty string");
+    }
     return this.sdk.trigger<{ scope: string; key: string }, T | null>({
       function_id: 'state::get',
       payload: { scope, key },

--- a/test/state-kv.test.ts
+++ b/test/state-kv.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from "vitest";
+import { StateKV } from "../src/state/kv.js";
+
+describe("StateKV", () => {
+  it("rejects missing and blank get keys before serializing state::get", async () => {
+    const trigger = vi.fn();
+    const kv = new StateKV({ trigger } as never);
+
+    await expect(kv.get("mem:sessions", undefined as never)).rejects.toThrow(
+      "key must be a non-empty string",
+    );
+    await expect(kv.get("mem:sessions", "")).rejects.toThrow(
+      "key must be a non-empty string",
+    );
+    await expect(kv.get("mem:sessions", " ")).rejects.toThrow(
+      "key must be a non-empty string",
+    );
+    expect(trigger).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- reject missing, non-string, empty, and whitespace-only StateKV keys before calling the iii engine
- cover the shared boundary so malformed callers cannot emit state::get payloads without key

## Verification

- focused StateKV test passes
- build passes
- 1,642 unit tests pass; the live-service integration suite and macOS filesystem watcher timing tests were validated separately
- live local service no longer emits missing-field-key warnings after restart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent state lookups with missing, empty, or whitespace-only keys.
  * Invalid lookups now fail with a clear error before triggering state-related actions.

* **Tests**
  * Added coverage for invalid key scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->