### PR TITLE
fix(health): normalize process CPU percent by core count

### DIFF
--- a/src/health/monitor.ts
+++ b/src/health/monitor.ts
@@ -5,15 +5,6 @@ import type { StateKV } from "../state/kv.js";
 import { KV } from "../state/schema.js";
 import { evaluateHealth } from "./thresholds.js";
 
-/**
- * Process CPU usage as a percentage of total machine capacity (all cores).
- *
- * `process.cpuUsage()` deltas scale with single-core time: saturating one
- * core yields 100, so an N-core host can reach N * 100. The health
- * thresholds in thresholds.ts express a share of the whole machine, so the
- * raw value is normalized by core count — otherwise any burst past ~0.9
- * cores reports `cpu_critical` on wide, mostly-idle hosts (#1235).
- */
 export function computeProcessCpuPercent(
   userDeltaMicros: number,
   systemDeltaMicros: number,

--- a/src/health/monitor.ts
+++ b/src/health/monitor.ts
@@ -1,8 +1,28 @@
+import { cpus } from "node:os";
 import type { ISdk } from "iii-sdk";
 import type { HealthSnapshot } from "../types.js";
 import type { StateKV } from "../state/kv.js";
 import { KV } from "../state/schema.js";
 import { evaluateHealth } from "./thresholds.js";
+
+/**
+ * Process CPU usage as a percentage of total machine capacity (all cores).
+ *
+ * `process.cpuUsage()` deltas scale with single-core time: saturating one
+ * core yields 100, so an N-core host can reach N * 100. The health
+ * thresholds in thresholds.ts express a share of the whole machine, so the
+ * raw value is normalized by core count — otherwise any burst past ~0.9
+ * cores reports `cpu_critical` on wide, mostly-idle hosts (#1235).
+ */
+export function computeProcessCpuPercent(
+  userDeltaMicros: number,
+  systemDeltaMicros: number,
+  elapsedMs: number,
+  coreCount: number = cpus().length,
+): number {
+  if (elapsedMs <= 0 || coreCount <= 0) return 0;
+  return ((userDeltaMicros + systemDeltaMicros) / 1000 / elapsedMs) * 100 / coreCount;
+}
 
 export function registerHealthMonitor(
   sdk: ISdk,
@@ -27,8 +47,7 @@ export function registerHealthMonitor(
     const elapsedMs = now - prevCpuTime;
     const userDelta = currentCpu.user - prevCpuUsage.user;
     const systemDelta = currentCpu.system - prevCpuUsage.system;
-    const cpuPercent =
-      elapsedMs > 0 ? ((userDelta + systemDelta) / 1000 / elapsedMs) * 100 : 0;
+    const cpuPercent = computeProcessCpuPercent(userDelta, systemDelta, elapsedMs);
     prevCpuUsage = currentCpu;
     prevCpuTime = now;
 

--- a/test/health-monitor-cpu.test.ts
+++ b/test/health-monitor-cpu.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { computeProcessCpuPercent } from "../src/health/monitor.js";
+import { evaluateHealth } from "../src/health/thresholds.js";
+import type { HealthSnapshot } from "../src/types.js";
+
+function snap(over: Partial<HealthSnapshot> = {}): HealthSnapshot {
+  return {
+    connectionState: "connected",
+    workers: [],
+    memory: { heapUsed: 0, heapTotal: 1, rss: 0, external: 0 },
+    cpu: { userMicros: 0, systemMicros: 0, percent: 0 },
+    eventLoopLagMs: 0,
+    uptimeSeconds: 1,
+    kvConnectivity: { status: "ok", latencyMs: 1 },
+    status: "healthy",
+    alerts: [],
+    ...over,
+  };
+}
+
+describe("computeProcessCpuPercent (issue #1235)", () => {
+  it("normalizes single-core-scale deltas by core count", () => {
+    // One fully busy core over 1s of wall time on a 16-core host.
+    const percent = computeProcessCpuPercent(1_000_000, 0, 1000, 16);
+    expect(percent).toBeCloseTo(6.25, 5);
+  });
+
+  it("reaches 100 only when every core is saturated", () => {
+    // 16 cores busy over 1s on a 16-core host.
+    const percent = computeProcessCpuPercent(16_000_000, 0, 1000, 16);
+    expect(percent).toBeCloseTo(100, 5);
+  });
+
+  it("preserves single-core-host behaviour", () => {
+    // One core busy on a single-core host is still 100%.
+    const percent = computeProcessCpuPercent(1_000_000, 0, 1000, 1);
+    expect(percent).toBeCloseTo(100, 5);
+  });
+
+  it("returns 0 for non-positive elapsed time or core count", () => {
+    expect(computeProcessCpuPercent(1_000_000, 0, 0, 16)).toBe(0);
+    expect(computeProcessCpuPercent(1_000_000, 0, -5, 16)).toBe(0);
+    expect(computeProcessCpuPercent(1_000_000, 0, 1000, 0)).toBe(0);
+  });
+});
+
+describe("evaluateHealth cpu severity on multi-core hosts (issue #1235)", () => {
+  it("stays healthy when the process uses about one of sixteen cores", () => {
+    const percent = computeProcessCpuPercent(1_160_000, 0, 1000, 16);
+    const { status, alerts } = evaluateHealth(snap({ cpu: { userMicros: 0, systemMicros: 0, percent } }));
+    expect(status).toBe("healthy");
+    expect(alerts.find((a) => a.startsWith("cpu_"))).toBeUndefined();
+  });
+
+  it("goes critical only near full machine saturation", () => {
+    const percent = computeProcessCpuPercent(15_000_000, 0, 1000, 16);
+    expect(percent).toBeGreaterThan(90);
+    const { status, alerts } = evaluateHealth(snap({ cpu: { userMicros: 0, systemMicros: 0, percent } }));
+    expect(status).toBe("critical");
+    expect(alerts.some((a) => a.startsWith("cpu_critical_"))).toBe(true);
+  });
+});

--- a/test/health-monitor-cpu.test.ts
+++ b/test/health-monitor-cpu.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("iii-sdk", () => ({}));
+
 import { computeProcessCpuPercent } from "../src/health/monitor.js";
 import { evaluateHealth } from "../src/health/thresholds.js";
 import type { HealthSnapshot } from "../src/types.js";

--- a/test/health-monitor-cpu.test.ts
+++ b/test/health-monitor-cpu.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("iii-sdk", () => ({}));
+vi.mock("iii-sdk", () => ({
+  sdk: { trigger: vi.fn() },
+  kv: { get: vi.fn(), set: vi.fn(), list: vi.fn() },
+}));
 
 import { computeProcessCpuPercent } from "../src/health/monitor.js";
 import { evaluateHealth } from "../src/health/thresholds.js";


### PR DESCRIPTION
## What

`process.cpuUsage()` deltas are single-core scale (one fully busy core = 100), but the CPU thresholds in `thresholds.ts` (`cpuWarnPercent: 80` / `cpuCriticalPercent: 90`) express a share of the whole machine. This extracts the calculation into `computeProcessCpuPercent()` and normalizes by core count, so `cpu.percent` means **percent of total machine capacity**.

## Why

On multi-core hosts, any burst past ~0.9 cores flipped `/agentmemory/health` to `status: "critical"` (`cpu_critical_116%`) even when the machine was almost idle overall. Observed on a 16-core Linux host running 0.9.29: the process idles at ~7% of capacity and bursts to ~120% (1.2 of 16 cores) during compress/summarize waves — normal background work reported as critical. Health consumers that gate on `ok/healthy` then treat a healthy server as down.

Single-core hosts are unaffected (divide by 1).

## How to verify

```bash
npx vitest run test/health-monitor-cpu.test.ts   # new: normalization + severity mapping
npm test                                          # full suite: 152 files / 1663 tests pass
npm run build                                     # clean
```

New tests cover: one busy core on 16 cores → ~6.25% (healthy), all cores saturated → 100% (critical), single-core back-compat, and degenerate inputs.

Related: #1223 (health critical noise), #226 (configurable thresholds — complementary; this fixes the scale mismatch itself).

Fixes #1235

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CPU health reporting on multi-core machines by normalizing process usage against available CPU cores.
  * Prevented invalid elapsed-time or core-count values from producing incorrect CPU percentages.
  * Updated health severity detection to better reflect near-total machine CPU saturation.

* **Tests**
  * Added coverage for CPU percentage calculations and health status thresholds across single- and multi-core systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->