### PR TITLE
fix(search): preserve top result under token budget

### DIFF
--- a/src/functions/search.ts
+++ b/src/functions/search.ts
@@ -638,12 +638,9 @@ export function registerSearchFunction(sdk: ISdk, kv: StateKV): void {
           if (selected.length === 0) {
             const clipped = clipToBudget(item, tokenBudget)
             if (clipped) {
-              return {
-                items: [clipped],
-                used: estimateTokens(clipped),
-                truncated: items.length > 1,
-                excluded: items.length - 1,
-              }
+              selected.push(clipped)
+              used += estimateTokens(clipped)
+              continue
             }
           }
           return {

--- a/src/functions/search.ts
+++ b/src/functions/search.ts
@@ -609,23 +609,128 @@ export function registerSearchFunction(sdk: ISdk, kv: StateKV): void {
       const estimateTokens = (value: unknown): number =>
         Math.max(1, Math.ceil(JSON.stringify(value).length / 3))
 
-      const applyTokenBudget = <T>(items: T[]): {
+      const applyTokenBudget = <T>(
+        items: T[],
+        clipToBudget: (item: T, budget: number) => T | null,
+      ): {
         items: T[]
         used: number
         truncated: boolean
+        excluded: number
       } => {
-        if (!tokenBudget) return { items, used: items.reduce((sum, item) => sum + estimateTokens(item), 0), truncated: false }
+        if (!tokenBudget) {
+          return {
+            items,
+            used: items.reduce((sum, item) => sum + estimateTokens(item), 0),
+            truncated: false,
+            excluded: 0,
+          }
+        }
         const selected: T[] = []
         let used = 0
         for (const item of items) {
           const itemTokens = estimateTokens(item)
-          if (used + itemTokens > tokenBudget) {
-            return { items: selected, used, truncated: selected.length < items.length }
+          if (used + itemTokens <= tokenBudget) {
+            selected.push(item)
+            used += itemTokens
+            continue
           }
-          selected.push(item)
-          used += itemTokens
+          if (selected.length === 0) {
+            const clipped = clipToBudget(item, tokenBudget)
+            if (clipped) {
+              return {
+                items: [clipped],
+                used: estimateTokens(clipped),
+                truncated: items.length > 1,
+                excluded: items.length - 1,
+              }
+            }
+          }
+          return {
+            items: selected,
+            used,
+            truncated: selected.length < items.length,
+            excluded: items.length - selected.length,
+          }
         }
-        return { items: selected, used, truncated: false }
+        return { items: selected, used, truncated: false, excluded: 0 }
+      }
+
+      const clipTextFields = <T>(
+        item: T,
+        budget: number,
+        textFields: string[],
+      ): T | null => {
+        const shrink = (scale: number): T => {
+          const clipped: Record<string, unknown> = {
+            ...(item as Record<string, unknown>),
+          }
+          for (const field of textFields) {
+            const value = clipped[field]
+            if (typeof value === 'string') {
+              clipped[field] = value.slice(0, Math.floor(value.length * scale))
+            }
+          }
+          clipped.content_truncated = true
+          return clipped as T
+        }
+        let scale = 0.5
+        for (let pass = 0; pass < 12; pass++) {
+          const candidate = shrink(scale)
+          if (estimateTokens(candidate) <= budget) return candidate
+          scale *= 0.5
+        }
+        const candidate = shrink(0)
+        return estimateTokens(candidate) <= budget ? candidate : null
+      }
+
+      const clipFullResult = (
+        result: SearchResult,
+        budget: number,
+      ): SearchResult | null => {
+        const clipAt = (
+          narrativeScale: number,
+          factsScale: number,
+        ): SearchResult => ({
+          ...result,
+          observation: {
+            ...result.observation,
+            narrative: result.observation.narrative.slice(
+              0,
+              Math.floor(
+                result.observation.narrative.length * narrativeScale,
+              ),
+            ),
+            facts: result.observation.facts.map((fact) =>
+              fact.slice(0, Math.floor(fact.length * factsScale)),
+            ),
+          },
+          content_truncated: true,
+        })
+
+        let scale = 0.5
+        const factsFit = clipAt(0, 1)
+        if (estimateTokens(factsFit) <= budget) {
+          for (let pass = 0; pass < 12; pass++) {
+            const candidate = clipAt(scale, 1)
+            if (estimateTokens(candidate) <= budget) return candidate
+            scale *= 0.5
+          }
+          return factsFit
+        }
+
+        scale = 0.5
+        for (let pass = 0; pass < 12; pass++) {
+          const candidate = clipAt(0, scale)
+          if (estimateTokens(candidate) <= budget) return candidate
+          scale *= 0.5
+        }
+        const candidate: SearchResult = {
+          ...result,
+          observation: { ...result.observation, narrative: '', facts: [] },
+          content_truncated: true,
+        }
+        return estimateTokens(candidate) <= budget ? candidate : null
       }
 
       if (format === 'compact') {
@@ -637,13 +742,17 @@ export function registerSearchFunction(sdk: ISdk, kv: StateKV): void {
           score: r.score,
           timestamp: r.observation.timestamp,
         }))
-        const packed = applyTokenBudget(compactResults)
+        const packed = applyTokenBudget(
+          compactResults,
+          (item, budget) => clipTextFields(item, budget, ['title']),
+        )
         return {
           format,
           results: packed.items,
           tokens_used: packed.used,
           tokens_budget: tokenBudget,
           truncated: packed.truncated,
+          ...(packed.excluded > 0 ? { excluded_by_budget: packed.excluded } : {}),
         }
       }
 
@@ -656,7 +765,10 @@ export function registerSearchFunction(sdk: ISdk, kv: StateKV): void {
           score: r.score,
           timestamp: r.observation.timestamp,
         }))
-        const packed = applyTokenBudget(narrativeResults)
+        const packed = applyTokenBudget(
+          narrativeResults,
+          (item, budget) => clipTextFields(item, budget, ['narrative']),
+        )
         const text = packed.items
           .map((r, index) => `${index + 1}. ${r.title}\n${r.narrative}`)
           .join('\n\n')
@@ -667,10 +779,13 @@ export function registerSearchFunction(sdk: ISdk, kv: StateKV): void {
           tokens_used: packed.used,
           tokens_budget: tokenBudget,
           truncated: packed.truncated,
+          ...(packed.excluded > 0 ? { excluded_by_budget: packed.excluded } : {}),
         }
       }
 
-      const packed = applyTokenBudget(enriched)
+      const packed = applyTokenBudget(enriched, (item, budget) =>
+        clipFullResult(item, budget),
+      )
 
       // Avoid logging raw cwd/project (host paths). Log only that filters were active.
       logger.info('Search completed', {
@@ -685,6 +800,7 @@ export function registerSearchFunction(sdk: ISdk, kv: StateKV): void {
         tokens_used: packed.used,
         tokens_budget: tokenBudget,
         truncated: packed.truncated,
+        ...(packed.excluded > 0 ? { excluded_by_budget: packed.excluded } : {}),
       }
     }
   )

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -128,14 +128,42 @@ export function registerMcpEndpoints(
               token_budget: tokenBudget,
               agentId: recallAgentId,
             } });
-            const text =
+            let text: string;
+            if (
               format === "narrative" &&
               result &&
               typeof result === "object" &&
               "text" in (result as Record<string, unknown>) &&
               typeof (result as { text?: unknown }).text === "string"
-                ? (result as { text: string }).text
-                : JSON.stringify(result, null, 2);
+            ) {
+              const narrativeResult = result as {
+                text: string;
+                results?: Array<{ content_truncated?: boolean }>;
+                excluded_by_budget?: number;
+              };
+              const budgetMetadata: Record<string, boolean | number> = {};
+              if (
+                narrativeResult.results?.some(
+                  (item) => item.content_truncated === true,
+                )
+              ) {
+                budgetMetadata.content_truncated = true;
+              }
+              if (
+                typeof narrativeResult.excluded_by_budget === "number" &&
+                narrativeResult.excluded_by_budget > 0
+              ) {
+                budgetMetadata.excluded_by_budget =
+                  narrativeResult.excluded_by_budget;
+              }
+              const notice =
+                Object.keys(budgetMetadata).length > 0
+                  ? `[Budget metadata: ${JSON.stringify(budgetMetadata)}]`
+                  : "";
+              text = [narrativeResult.text, notice].filter(Boolean).join("\n\n");
+            } else {
+              text = JSON.stringify(result, null, 2);
+            }
             return {
               status_code: 200,
               body: {

--- a/src/mcp/tools-registry.ts
+++ b/src/mcp/tools-registry.ts
@@ -30,7 +30,12 @@ export const CORE_TOOLS: McpToolDef[] = [
         },
         token_budget: {
           type: "number",
-          description: "Optional token budget to trim returned results",
+          description:
+            "Optional token budget: returned results are trimmed to fit it " +
+            "(tokens_used <= token_budget). Results that do not fit are " +
+            "dropped and reported via excluded_by_budget. If the top result " +
+            "alone exceeds the budget it is returned clipped with " +
+            "content_truncated: true instead of dropped.",
         },
       },
       required: ["query"],

--- a/src/types.ts
+++ b/src/types.ts
@@ -192,6 +192,7 @@ export interface SearchResult {
   observation: CompressedObservation;
   score: number;
   sessionId: string;
+  content_truncated?: boolean;
 }
 
 export interface ContextBlock {
@@ -289,6 +290,7 @@ export interface CompactSearchResult {
   type: ObservationType;
   score: number;
   timestamp: string;
+  content_truncated?: boolean;
 }
 
 export interface CompactLessonResult {

--- a/test/mcp-recall-budget.test.ts
+++ b/test/mcp-recall-budget.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { registerMcpEndpoints } from "../src/mcp/server.js";
+
+function mockSdk(searchResult: unknown) {
+  const functions = new Map<string, Function>();
+  return {
+    registerFunction: (idOrOpts: string | { id: string }, handler: Function) => {
+      const id = typeof idOrOpts === "string" ? idOrOpts : idOrOpts.id;
+      functions.set(id, handler);
+    },
+    registerTrigger: () => {},
+    trigger: async (
+      idOrInput: string | { function_id: string; payload: unknown },
+    ) => {
+      const id =
+        typeof idOrInput === "string" ? idOrInput : idOrInput.function_id;
+      if (id === "mem::search") return searchResult;
+      const fn = functions.get(id);
+      if (!fn) throw new Error(`No function: ${id}`);
+      return fn(
+        typeof idOrInput === "string" ? undefined : idOrInput.payload,
+      );
+    },
+    getFunction: (id: string) => functions.get(id),
+  };
+}
+
+function makeReq(arguments_: Record<string, unknown>) {
+  return {
+    body: { name: "memory_recall", arguments: arguments_ },
+    headers: {},
+    query_params: {},
+  };
+}
+
+describe("MCP memory_recall token budget reporting (#1232)", () => {
+  it("includes clipping and exclusion metadata in narrative output", async () => {
+    const sdk = mockSdk({
+      format: "narrative",
+      results: [
+        {
+          title: "Auth decision",
+          narrative: "Use rotating tokens.",
+          content_truncated: true,
+        },
+      ],
+      text: "1. Auth decision\nUse rotating tokens.",
+      truncated: true,
+      excluded_by_budget: 2,
+    });
+    registerMcpEndpoints(sdk as never, {} as never);
+
+    const result = (await sdk.getFunction("mcp::tools::call")!(
+      makeReq({ query: "auth", format: "narrative", token_budget: 200 }),
+    )) as {
+      status_code: number;
+      body: { content: Array<{ type: string; text: string }> };
+    };
+
+    expect(result.status_code).toBe(200);
+    expect(result.body.content[0]?.text).toContain("1. Auth decision");
+    expect(result.body.content[0]?.text).toContain(
+      '[Budget metadata: {"content_truncated":true,"excluded_by_budget":2}]',
+    );
+  });
+
+  it("leaves untruncated narrative output unchanged", async () => {
+    const text = "1. Auth decision\nUse rotating tokens.";
+    const sdk = mockSdk({
+      format: "narrative",
+      results: [{ title: "Auth decision", narrative: "Use rotating tokens." }],
+      text,
+      truncated: false,
+    });
+    registerMcpEndpoints(sdk as never, {} as never);
+
+    const result = (await sdk.getFunction("mcp::tools::call")!(
+      makeReq({ query: "auth", format: "narrative" }),
+    )) as {
+      body: { content: Array<{ type: string; text: string }> };
+    };
+
+    expect(result.body.content[0]?.text).toBe(text);
+  });
+});

--- a/test/search.test.ts
+++ b/test/search.test.ts
@@ -417,6 +417,45 @@ describe("mem::search token budget contract (#1232)", () => {
     expect(result.excluded_by_budget).toBeUndefined();
   });
 
+  it("uses the remaining budget after clipping the top result", async () => {
+    const stored = await kv.get<CompressedObservation>(
+      KV.observations("ses_1"),
+      "obs_long",
+    );
+    expect(stored).not.toBeNull();
+    await kv.set(KV.observations("ses_1"), "obs_long", {
+      ...stored!,
+      title: "record decision auth ".repeat(110),
+    });
+    getSearchIndex().clear();
+    await rebuildIndex(kv as never);
+
+    const result = (await sdk.trigger("mem::search", {
+      query: "record decision auth",
+      limit: 2,
+      format: "compact",
+      token_budget: 220,
+    })) as {
+      results: Array<{
+        obsId: string;
+        content_truncated?: boolean;
+      }>;
+      tokens_used: number;
+      truncated: boolean;
+      excluded_by_budget?: number;
+    };
+
+    expect(result.results.map((item) => item.obsId)).toEqual([
+      "obs_long",
+      "obs_short",
+    ]);
+    expect(result.results[0]?.content_truncated).toBe(true);
+    expect(result.results[1]?.content_truncated).toBeUndefined();
+    expect(result.tokens_used).toBeLessThanOrEqual(220);
+    expect(result.truncated).toBe(false);
+    expect(result.excluded_by_budget).toBeUndefined();
+  });
+
   it("clips memory-derived records whose content duplicates into facts", async () => {
     const memoryContent =
       "Deployed the gift card payments toggle fix to production. ".repeat(40);

--- a/test/search.test.ts
+++ b/test/search.test.ts
@@ -210,3 +210,252 @@ describe("mem::search", () => {
     setEmbeddingProvider(null);
   });
 });
+
+describe("mem::search token budget contract (#1232)", () => {
+  let sdk: ReturnType<typeof mockSdk>;
+  let kv: ReturnType<typeof mockKV>;
+
+  const LONG_PROSE =
+    "This is a deliberately authored decision record. ".repeat(60) +
+    "The decision is to adopt a rotating refresh token strategy for auth middleware.";
+
+  beforeEach(async () => {
+    sdk = mockSdk();
+    kv = mockKV();
+    registerSearchFunction(sdk as never, kv as never);
+
+    const session: Session = {
+      id: "ses_1",
+      project: "demo",
+      cwd: "/tmp/demo",
+      startedAt: "2026-01-01T00:00:00Z",
+      status: "completed",
+      observationCount: 2,
+    };
+    await kv.set(KV.sessions, session.id, session);
+
+    const longObs: CompressedObservation = {
+      id: "obs_long",
+      sessionId: "ses_1",
+      timestamp: "2026-01-01T00:00:00Z",
+      type: "decision",
+      title: "Auth refresh token strategy decision",
+      facts: ["Rotating refresh tokens adopted"],
+      narrative: LONG_PROSE,
+      concepts: ["auth", "jwt", "tokens"],
+      files: ["src/auth.ts"],
+      importance: 9,
+    };
+    const shortObs: CompressedObservation = {
+      id: "obs_short",
+      sessionId: "ses_1",
+      timestamp: "2026-01-02T00:00:00Z",
+      type: "file_edit",
+      title: "auth middleware bug",
+      facts: ["Fixed a null pointer in the auth middleware"],
+      narrative: "Fixed a null pointer in the auth middleware.",
+      concepts: ["auth"],
+      files: ["src/auth.ts"],
+      importance: 3,
+    };
+    await kv.set(KV.observations("ses_1"), longObs.id, longObs);
+    await kv.set(KV.observations("ses_1"), shortObs.id, shortObs);
+
+    getSearchIndex().clear();
+    await rebuildIndex(kv as never);
+  });
+
+  it("returns the top match clipped when it alone exceeds the budget (full)", async () => {
+    const result = (await sdk.trigger("mem::search", {
+      query: "record decision auth",
+      limit: 4,
+      token_budget: 200,
+    })) as {
+      results: Array<{
+        observation: CompressedObservation;
+        content_truncated?: boolean;
+      }>;
+      tokens_used: number;
+      truncated: boolean;
+      excluded_by_budget?: number;
+    };
+
+    expect(result.results.length).toBe(1);
+    expect(result.results[0]?.observation.id).toBe("obs_long");
+    expect(result.results[0]?.content_truncated).toBe(true);
+    expect(result.tokens_used).toBeGreaterThan(0);
+    expect(result.tokens_used).toBeLessThanOrEqual(200);
+    expect(result.truncated).toBe(true);
+    expect(result.excluded_by_budget).toBe(1);
+    expect(result.results[0]?.observation.narrative.length).toBeLessThan(
+      LONG_PROSE.length,
+    );
+    expect(result.results[0]?.observation.facts).toEqual([
+      "Rotating refresh tokens adopted",
+    ]);
+  });
+
+  it("keeps the top match intact and reports nothing excluded when the budget fits (full)", async () => {
+    const result = (await sdk.trigger("mem::search", {
+      query: "record decision auth",
+      limit: 4,
+      token_budget: 5000,
+    })) as {
+      results: Array<{ observation: CompressedObservation; content_truncated?: boolean }>;
+      tokens_used: number;
+      truncated: boolean;
+      excluded_by_budget?: number;
+    };
+
+    expect(result.results).toHaveLength(2);
+    expect(result.results[0]?.observation.id).toBe("obs_long");
+    expect(result.results[0]?.observation.narrative).toBe(LONG_PROSE);
+    expect(result.results[0]?.content_truncated).toBeUndefined();
+    expect(result.truncated).toBe(false);
+    expect(result.excluded_by_budget).toBeUndefined();
+  });
+
+  it("still returns an empty result with no drop report for a genuine miss", async () => {
+    const result = (await sdk.trigger("mem::search", {
+      query: "zzz qqq xqq",
+      limit: 4,
+      token_budget: 200,
+    })) as {
+      results: unknown[];
+      truncated: boolean;
+      excluded_by_budget?: number;
+    };
+
+    expect(result.results).toEqual([]);
+    expect(result.truncated).toBe(false);
+    expect(result.excluded_by_budget).toBeUndefined();
+  });
+
+  it("reports results excluded by the budget after the first item", async () => {
+    const result = (await sdk.trigger("mem::search", {
+      query: "auth middleware bug",
+      limit: 4,
+      token_budget: 150,
+    })) as {
+      results: Array<{
+        observation: CompressedObservation;
+        content_truncated?: boolean;
+      }>;
+      tokens_used: number;
+      truncated: boolean;
+      excluded_by_budget?: number;
+    };
+
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0]?.observation.id).toBe("obs_short");
+    expect(result.results[0]?.content_truncated).toBeUndefined();
+    expect(result.tokens_used).toBeLessThanOrEqual(150);
+    expect(result.truncated).toBe(true);
+    expect(result.excluded_by_budget).toBe(1);
+  });
+
+  it("clips the top match in narrative format and keeps text consistent", async () => {
+    const result = (await sdk.trigger("mem::search", {
+      query: "record decision auth",
+      limit: 4,
+      format: "narrative",
+      token_budget: 200,
+    })) as {
+      results: Array<{ obsId: string; narrative: string; content_truncated?: boolean }>;
+      text: string;
+      tokens_used: number;
+      truncated: boolean;
+      excluded_by_budget?: number;
+    };
+
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0]?.obsId).toBe("obs_long");
+    expect(result.results[0]?.content_truncated).toBe(true);
+    expect(result.tokens_used).toBeLessThanOrEqual(200);
+    expect(result.text).toContain(result.results[0]?.narrative);
+    expect(result.text).not.toContain(LONG_PROSE);
+    expect(result.excluded_by_budget).toBe(1);
+  });
+
+  it("reports the drop when even the text-free form cannot fit the budget", async () => {
+    const result = (await sdk.trigger("mem::search", {
+      query: "record decision auth",
+      limit: 4,
+      format: "compact",
+      token_budget: 10,
+    })) as {
+      results: unknown[];
+      truncated: boolean;
+      excluded_by_budget?: number;
+    };
+
+    expect(result.results).toEqual([]);
+    expect(result.truncated).toBe(true);
+    expect(result.excluded_by_budget).toBe(2);
+  });
+
+  it("clips a compact title when the metadata floor fits", async () => {
+    const result = (await sdk.trigger("mem::search", {
+      query: "record decision auth",
+      limit: 1,
+      format: "compact",
+      token_budget: 55,
+    })) as {
+      results: Array<{ title: string; content_truncated?: boolean }>;
+      tokens_used: number;
+      truncated: boolean;
+      excluded_by_budget?: number;
+    };
+
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0]?.content_truncated).toBe(true);
+    expect(result.results[0]?.title.length).toBeLessThan(
+      "Auth refresh token strategy decision".length,
+    );
+    expect(result.tokens_used).toBeLessThanOrEqual(55);
+    expect(result.truncated).toBe(false);
+    expect(result.excluded_by_budget).toBeUndefined();
+  });
+
+  it("clips memory-derived records whose content duplicates into facts", async () => {
+    const memoryContent =
+      "Deployed the gift card payments toggle fix to production. ".repeat(40);
+    await kv.set(KV.memories, "mem_gift", {
+      id: "mem_gift",
+      createdAt: "2026-02-01T00:00:00Z",
+      updatedAt: "2026-02-01T00:00:00Z",
+      type: "fact",
+      title: "Gift card payments toggle fix deployment",
+      content: memoryContent,
+      concepts: ["gift", "payments"],
+      files: [],
+      sessionIds: [],
+      strength: 7,
+      version: 1,
+      isLatest: true,
+    });
+    await rebuildIndex(kv as never);
+
+    const result = (await sdk.trigger("mem::search", {
+      query: "gift card payments toggle deployment",
+      limit: 4,
+      token_budget: 200,
+    })) as {
+      results: Array<{
+        observation: CompressedObservation;
+        content_truncated?: boolean;
+      }>;
+      tokens_used: number;
+      truncated: boolean;
+      excluded_by_budget?: number;
+    };
+
+    const hit = result.results.find((r) => r.observation.id === "mem_gift");
+    expect(hit).toBeDefined();
+    expect(hit?.content_truncated).toBe(true);
+    expect(result.tokens_used).toBeLessThanOrEqual(200);
+    expect(result.truncated).toBe(false);
+    expect(result.excluded_by_budget).toBeUndefined();
+    expect(hit?.observation.facts[0]?.length).toBeLessThan(memoryContent.length);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes `memory_recall` dropping the top result when it exceeds `token_budget`.

The top result is now clipped instead of removed, and excluded results are reported with `excluded_by_budget`.

## Testing

Added coverage for all result formats, small budgets, and MCP output.

- 1,722 tests passed
- Build passed

Fixes #1232