### PR TITLE
fix(reflect): continue past visited graph seeds

### DIFF
--- a/src/functions/reflect.ts
+++ b/src/functions/reflect.ts
@@ -66,10 +66,11 @@ function buildGraphClusters(
 
   const visited = new Set<string>();
   const clusters: string[][] = [];
-  const conceptNodeIds = new Set(conceptNodes.map((n) => n.id));
+  const nodeById = new Map(conceptNodes.map((n) => [n.id, n]));
 
   for (const seed of sorted) {
-    if (visited.has(seed.id) || clusters.length >= maxClusters) break;
+    if (clusters.length >= maxClusters) break;
+    if (visited.has(seed.id)) continue;
 
     const cluster: string[] = [];
     const queue = [seed.id];
@@ -83,9 +84,9 @@ function buildGraphClusters(
         if (seen.has(current)) continue;
         seen.add(current);
 
-        if (conceptNodeIds.has(current)) {
-          const node = conceptNodes.find((n) => n.id === current);
-          if (node) cluster.push(node.name);
+        const node = nodeById.get(current);
+        if (node) {
+          cluster.push(node.name);
           visited.add(current);
         }
 

--- a/test/reflect.test.ts
+++ b/test/reflect.test.ts
@@ -218,6 +218,60 @@ describe("Reflect", () => {
       expect(after[0].reinforcements).toBe(1);
     });
 
+    it("clusters every disconnected concept group instead of stopping at a visited seed", async () => {
+      await kv.set("mem:graph:nodes", "node_alpha", makeConceptNode("alpha"));
+      await kv.set("mem:graph:nodes", "node_beta", makeConceptNode("beta"));
+      await kv.set("mem:graph:nodes", "node_gamma", makeConceptNode("gamma"));
+      await kv.set("mem:graph:nodes", "node_delta", makeConceptNode("delta"));
+      await kv.set("mem:graph:nodes", "node_epsilon", makeConceptNode("epsilon"));
+      await kv.set("mem:graph:edges", "edge_ab", makeEdge("alpha", "beta"));
+      await kv.set("mem:graph:edges", "edge_bg", makeEdge("beta", "gamma"));
+      await kv.set("mem:graph:edges", "edge_ga", makeEdge("gamma", "alpha"));
+      await kv.set("mem:graph:edges", "edge_de", makeEdge("delta", "epsilon"));
+
+      await kv.set("mem:semantic", "sem_a1", makeSemantic("alpha beta gamma pipeline"));
+      await kv.set("mem:semantic", "sem_a2", makeSemantic("alpha caching layer"));
+      await kv.set("mem:semantic", "sem_a3", makeSemantic("beta gamma queue"));
+      await kv.set("mem:semantic", "sem_b1", makeSemantic("delta epsilon storage"));
+      await kv.set("mem:semantic", "sem_b2", makeSemantic("delta epsilon index"));
+      await kv.set("mem:semantic", "sem_b3", makeSemantic("epsilon delta flush"));
+
+      const result = (await sdk.trigger("mem::reflect", {})) as {
+        clustersProcessed: number;
+        newInsights: number;
+      };
+
+      expect(result.clustersProcessed).toBe(2);
+      expect(result.newInsights).toBe(2);
+      expect(provider.summarize).toHaveBeenCalledTimes(2);
+    });
+
+    it("stops at the maxClusters bound even when more groups exist", async () => {
+      await kv.set("mem:graph:nodes", "node_alpha", makeConceptNode("alpha"));
+      await kv.set("mem:graph:nodes", "node_beta", makeConceptNode("beta"));
+      await kv.set("mem:graph:nodes", "node_gamma", makeConceptNode("gamma"));
+      await kv.set("mem:graph:nodes", "node_delta", makeConceptNode("delta"));
+      await kv.set("mem:graph:nodes", "node_epsilon", makeConceptNode("epsilon"));
+      await kv.set("mem:graph:edges", "edge_ab", makeEdge("alpha", "beta"));
+      await kv.set("mem:graph:edges", "edge_bg", makeEdge("beta", "gamma"));
+      await kv.set("mem:graph:edges", "edge_ga", makeEdge("gamma", "alpha"));
+      await kv.set("mem:graph:edges", "edge_de", makeEdge("delta", "epsilon"));
+
+      await kv.set("mem:semantic", "sem_a1", makeSemantic("alpha beta gamma pipeline"));
+      await kv.set("mem:semantic", "sem_a2", makeSemantic("alpha caching layer"));
+      await kv.set("mem:semantic", "sem_a3", makeSemantic("beta gamma queue"));
+      await kv.set("mem:semantic", "sem_b1", makeSemantic("delta epsilon storage"));
+      await kv.set("mem:semantic", "sem_b2", makeSemantic("delta epsilon index"));
+      await kv.set("mem:semantic", "sem_b3", makeSemantic("epsilon delta flush"));
+
+      const result = (await sdk.trigger("mem::reflect", { maxClusters: 1 })) as {
+        clustersProcessed: number;
+      };
+
+      expect(result.clustersProcessed).toBe(1);
+      expect(provider.summarize).toHaveBeenCalledTimes(1);
+    });
+
     it("falls back to Jaccard grouping when graph is empty", async () => {
       await kv.set("mem:semantic", "sem_1", makeSemantic("security validation is important"));
       await kv.set("mem:semantic", "sem_2", makeSemantic("security testing prevents bugs"));


### PR DESCRIPTION
## Summary

`mem::reflect` stopped clustering when it reached a seed that had already been visited, so disconnected groups could be skipped.

This changes that case from `break` to `continue` and uses a map for node lookups instead of scanning the node list each time. In the issue reporter's 5,128-node benchmark, cluster construction was **2.8x faster**.

This PR only covers the seed-loop and node-lookup fixes from #1133. The other follow-up ideas in that issue are separate changes.

## Testing

- Added tests for disconnected graph groups and the `maxClusters` limit
- 1,713 tests passed
- Build and skill checks passed

Addresses #1133
