### PR TITLE
feat: expose hook REST endpoints as MCP tools

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,4 +1,6 @@
 import type { ISdk, ApiRequest } from "iii-sdk";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { logger } from "../logger.js";
 import type { StateKV } from "../state/kv.js";
 import { KV } from "../state/schema.js";
 import type {
@@ -71,10 +73,9 @@ export function registerMcpEndpoints(
     config: { api_path: "/agentmemory/mcp/tools", http_method: "GET" },
   });
 
-  sdk.registerFunction("mcp::tools::call", 
-    async (
-      req: ApiRequest<{ name: string; arguments: Record<string, unknown> }>,
-    ): Promise<McpResponse> => {
+  async function handleToolCall(
+    req: ApiRequest<{ name: string; arguments: Record<string, unknown> }>,
+  ): Promise<McpResponse> {
       const authErr = checkAuth(req, secret);
       if (authErr) return authErr;
 
@@ -1272,6 +1273,215 @@ export function registerMcpEndpoints(
             };
           }
 
+          // ============================================================
+          // hook endpoints exposed as MCP tools
+          //
+          // Mapping strategy:
+          //   - mem::* functions take a plain payload -> trigger directly
+          //   - api::* functions take ApiRequest (destructure req.body)
+          //     -> wrap payload as { body: {...} }
+          //
+          // memory_observe / memory_enrich / memory_context -> mem::*
+          // memory_session_start / end / commit -> api::*
+          // ============================================================
+          case "memory_observe": {
+            const sessionId = asNonEmptyString(args.sessionId);
+            const hookType = asNonEmptyString(args.hookType);
+            if (!sessionId || !hookType) {
+              return {
+                status_code: 400,
+                body: { error: "sessionId and hookType are required for memory_observe" },
+              };
+            }
+            const result = await sdk.trigger({
+              function_id: "mem::observe",
+              payload: {
+                sessionId,
+                hookType,
+                project: asNonEmptyString(args.project) ?? "",
+                cwd: asNonEmptyString(args.cwd) ?? "",
+                timestamp:
+                  asNonEmptyString(args.timestamp) ?? new Date().toISOString(),
+                data: args.data ?? {},
+              },
+            });
+            return {
+              status_code: 200,
+              body: {
+                content: [{ type: "text", text: JSON.stringify(result) }],
+              },
+            };
+          }
+
+          case "memory_session_start": {
+            const sessionId = asNonEmptyString(args.sessionId);
+            const project = asNonEmptyString(args.project);
+            const cwd = asNonEmptyString(args.cwd);
+            if (!sessionId || !project || !cwd) {
+              return {
+                status_code: 400,
+                body: { error: "sessionId, project, and cwd are required for memory_session_start" },
+              };
+            }
+            const result = await sdk.trigger({
+              function_id: "api::session::start",
+              payload: {
+                body: {
+                  sessionId,
+                  project,
+                  cwd,
+                  title: asNonEmptyString(args.title),
+                  agentId: asNonEmptyString(args.agentId),
+                },
+              },
+            });
+            const unwrapped =
+              result && typeof result === "object" && "body" in result
+                ? (result as { body: unknown }).body
+                : result;
+            return {
+              status_code: 200,
+              body: {
+                content: [{ type: "text", text: JSON.stringify(unwrapped) }],
+              },
+            };
+          }
+
+          case "memory_session_end": {
+            const sessionId = asNonEmptyString(args.sessionId);
+            if (!sessionId) {
+              return {
+                status_code: 400,
+                body: { error: "sessionId is required for memory_session_end" },
+              };
+            }
+            const result = await sdk.trigger({
+              function_id: "api::session::end",
+              payload: {
+                body: { sessionId },
+              },
+            });
+            const unwrapped =
+              result && typeof result === "object" && "body" in result
+                ? (result as { body: unknown }).body
+                : result;
+            return {
+              status_code: 200,
+              body: {
+                content: [{ type: "text", text: JSON.stringify(unwrapped) }],
+              },
+            };
+          }
+
+          case "memory_session_commit": {
+            const sha = asNonEmptyString(args.sha);
+            if (!sha) {
+              return {
+                status_code: 400,
+                body: { error: "sha is required for memory_session_commit" },
+              };
+            }
+            const result = await sdk.trigger({
+              function_id: "api::session::commit",
+              payload: {
+                body: {
+                  sha,
+                  sessionId: asNonEmptyString(args.sessionId),
+                  branch: asNonEmptyString(args.branch),
+                  repo: asNonEmptyString(args.repo),
+                  message: asNonEmptyString(args.message),
+                  author: asNonEmptyString(args.author),
+                  authoredAt: asNonEmptyString(args.authoredAt),
+                  files:
+                    typeof args.files === "string"
+                      ? parseCsvList(args.files)
+                      : undefined,
+                },
+              },
+            });
+            const unwrapped =
+              result && typeof result === "object" && "body" in result
+                ? (result as { body: unknown }).body
+                : result;
+            return {
+              status_code: 200,
+              body: {
+                content: [{ type: "text", text: JSON.stringify(unwrapped) }],
+              },
+            };
+          }
+
+          case "memory_enrich": {
+            const sessionId = asNonEmptyString(args.sessionId);
+            const fileList =
+              typeof args.files === "string" ? parseCsvList(args.files) : [];
+            if (!sessionId || fileList.length === 0) {
+              return {
+                status_code: 400,
+                body: { error: "sessionId and files are required for memory_enrich" },
+              };
+            }
+            const result = await sdk.trigger({
+              function_id: "mem::enrich",
+              payload: {
+                sessionId,
+                files: fileList,
+                terms:
+                  typeof args.terms === "string"
+                    ? parseCsvList(args.terms)
+                    : undefined,
+                toolName: asNonEmptyString(args.toolName),
+                project: asNonEmptyString(args.project),
+              },
+            });
+            const context =
+              (result as { context?: string } | undefined)?.context ?? "";
+            return {
+              status_code: 200,
+              body: {
+                content: [
+                  {
+                    type: "text",
+                    text: context || "No enrichment.",
+                  },
+                ],
+              },
+            };
+          }
+
+          case "memory_context": {
+            const sessionId = asNonEmptyString(args.sessionId);
+            const project = asNonEmptyString(args.project);
+            if (!sessionId || !project) {
+              return {
+                status_code: 400,
+                body: { error: "sessionId and project are required for memory_context" },
+              };
+            }
+            const result = await sdk.trigger({
+              function_id: "mem::context",
+              payload: {
+                sessionId,
+                project,
+                budget: asNumber(args.budget),
+                agentId: asNonEmptyString(args.agentId),
+              },
+            });
+            const context =
+              (result as { context?: string } | undefined)?.context ?? "";
+            return {
+              status_code: 200,
+              body: {
+                content: [
+                  {
+                    type: "text",
+                    text: context,
+                  },
+                ],
+              },
+            };
+          }
+
           default:
             return {
               status_code: 400,
@@ -1286,12 +1496,83 @@ export function registerMcpEndpoints(
           },
         };
       }
+  }
+
+  sdk.registerFunction("mcp::tools::call", 
+    async (
+      req: ApiRequest<{ name: string; arguments: Record<string, unknown> }>,
+    ): Promise<McpResponse> => {
+      return handleToolCall(req);
     },
   );
   sdk.registerTrigger({
     type: "http",
     function_id: "mcp::tools::call",
     config: { api_path: "/agentmemory/mcp/call", http_method: "POST" },
+  });
+
+  function debugJsonRpc(req: ApiRequest<Record<string, unknown>>, body: Record<string, unknown> | undefined): void {
+    if (process.env["AGENTMEMORY_DEBUG_JSONRPC"] !== "1") return;
+    try {
+      const dir = process.env["AGENTMEMORY_DEBUG_DIR"] || ".agentmemory-debug";
+      mkdirSync(dir, { recursive: true });
+      const line = JSON.stringify({
+        ts: new Date().toISOString(),
+        headers: req.headers ?? {},
+        body,
+      });
+      appendFileSync(`${dir}/jsonrpc.log`, line + "\n", "utf8");
+    } catch (err) {
+      logger.warn("jsonrpc debug write failed", { err: String(err) });
+    }
+  }
+
+  sdk.registerFunction("mcp::jsonrpc", 
+    async (req: ApiRequest<Record<string, unknown>>): Promise<McpResponse> => {
+      const authErr = checkAuth(req, secret);
+      if (authErr) return authErr;
+
+      const body = req.body as { method?: string; params?: Record<string, unknown> } | undefined;
+      debugJsonRpc(req, body);
+      const method = body?.method;
+      const params = body?.params ?? {};
+
+      if (method === "tools/list") {
+        const tools = getVisibleTools().map((tool) => ({
+          ...tool,
+          description:
+            "调用参数直接放在 arguments 顶层,不要包 params。示例:" +
+            (tool.name === "memory_recall"
+              ? " {\"query\":\"检索词\"}"
+              : tool.name === "memory_save"
+                ? " {\"content\":\"记忆内容\",\"type\":\"fact\"}"
+                : "") +
+            "\n" +
+            tool.description,
+        }));
+        return { status_code: 200, body: { tools } };
+      }
+
+      if (method === "tools/call") {
+        const name = params.name;
+        const args = params.arguments ?? {};
+        if (typeof name !== "string") {
+          return { status_code: 400, body: { error: "params.name is required" } };
+        }
+        const fakeReq: ApiRequest<{ name: string; arguments: Record<string, unknown> }> = {
+          ...req,
+          body: { name, arguments: args as Record<string, unknown> },
+        };
+        return handleToolCall(fakeReq);
+      }
+
+      return { status_code: 400, body: { error: `Unsupported method: ${String(method)}` } };
+    },
+  );
+  sdk.registerTrigger({
+    type: "http",
+    function_id: "mcp::jsonrpc",
+    config: { api_path: "/agentmemory/jsonrpc", http_method: "POST" },
   });
 
   const MCP_RESOURCES = [

--- a/src/mcp/tools-registry.ts
+++ b/src/mcp/tools-registry.ts
@@ -245,6 +245,124 @@ export const CORE_TOOLS: McpToolDef[] = [
       },
     },
   },
+  // ============================================================
+  // hook endpoints exposed as MCP tools (2026-08)
+  //
+  // These 6 tools mirror the REST hook endpoints that were previously
+  // only reachable from host hook scripts (Claude Code etc). Pure MCP
+  // clients (LineCodePro) have no hook runner, so the endpoints are
+  // re-exposed as MCP tools:
+  //
+  //   memory_observe          -> REST /agentmemory/observe
+  //   memory_session_start    -> REST /agentmemory/session/start
+  //   memory_session_end      -> REST /agentmemory/session/end
+  //   memory_session_commit   -> REST /agentmemory/session/commit
+  //   memory_enrich           -> REST /agentmemory/enrich
+  //   memory_context          -> REST /agentmemory/context
+  //
+  // See server.ts handleToolCall for the matching case mappings.
+  // ============================================================
+  {
+    name: "memory_observe",
+    description:
+      "Write a raw observation to the current session. This is the MCP equivalent of the hook auto-capture path — use to record prompts, tool calls, tool failures, and task completions so file_history, timeline, and sessions have data.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        sessionId: { type: "string", description: "Session ID" },
+        hookType: {
+          type: "string",
+          description: "Event type: prompt_submit, post_tool_use, post_tool_failure, task_completed",
+        },
+        data: {
+          type: "object",
+          description: "Observation payload. tool events: { tool_name, tool_input, tool_output }; prompts: { prompt }",
+        },
+        project: { type: "string", description: "Stable project slug" },
+        cwd: { type: "string", description: "Working directory" },
+        timestamp: { type: "string", description: "ISO 8601 timestamp (defaults to now)" },
+      },
+      required: ["sessionId", "hookType", "data"],
+    },
+  },
+  {
+    name: "memory_session_start",
+    description:
+      "Register a new agent session and optionally return injected context. MCP equivalent of the SessionStart hook.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        sessionId: { type: "string", description: "Session ID" },
+        project: { type: "string", description: "Stable project slug" },
+        cwd: { type: "string", description: "Working directory" },
+        title: { type: "string", description: "Optional session title" },
+        agentId: { type: "string", description: "Optional agent identity" },
+      },
+      required: ["sessionId", "project", "cwd"],
+    },
+  },
+  {
+    name: "memory_session_end",
+    description:
+      "End a session and trigger the consolidation/summarization pipeline. MCP equivalent of the Stop/SessionEnd hook.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        sessionId: { type: "string", description: "Session ID" },
+      },
+      required: ["sessionId"],
+    },
+  },
+  {
+    name: "memory_session_commit",
+    description:
+      "Link a git commit to a session. MCP equivalent of the post-commit hook.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        sha: { type: "string", description: "Git commit SHA" },
+        sessionId: { type: "string", description: "Session ID to link" },
+        branch: { type: "string", description: "Branch name" },
+        repo: { type: "string", description: "Remote URL" },
+        message: { type: "string", description: "Commit message" },
+        author: { type: "string", description: "Commit author" },
+        authoredAt: { type: "string", description: "Commit timestamp" },
+        files: { type: "string", description: "Comma-separated file paths" },
+      },
+      required: ["sha"],
+    },
+  },
+  {
+    name: "memory_enrich",
+    description:
+      "Get context relevant to specific files or search terms, for injection before tool use. MCP equivalent of the PreToolUse enrich hook.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        sessionId: { type: "string", description: "Session ID" },
+        files: { type: "string", description: "Comma-separated file paths" },
+        terms: { type: "string", description: "Comma-separated search terms" },
+        toolName: { type: "string", description: "Tool name" },
+        project: { type: "string", description: "Stable project slug" },
+      },
+      required: ["sessionId", "files"],
+    },
+  },
+  {
+    name: "memory_context",
+    description:
+      "Get the current session/project context block. MCP equivalent of the PreCompact/SessionStart context injection.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        sessionId: { type: "string", description: "Session ID" },
+        project: { type: "string", description: "Stable project slug" },
+        budget: { type: "number", description: "Token budget" },
+        agentId: { type: "string", description: "Optional agent identity" },
+      },
+      required: ["sessionId", "project"],
+    },
+  },
 ];
 
 export const V040_TOOLS: McpToolDef[] = [


### PR DESCRIPTION
## 概述

将 agentmemory 的 6 个 hook REST 端点暴露为 MCP 工具,使纯 MCP 客户端(如 LineCodePro)在没有宿主 hook 系统的情况下也能触发相同的生命周期事件。

## 背景

当前这些端点只能通过 host hook 脚本(Claude Code 等)调用。纯 MCP 客户端没有 hook runner,无法写入观察数据或管理会话生命周期。

## 改动

| MCP 工具 | 对应 REST 端点 | 映射方式 |
|---------|---------------|---------|
| memory_observe | /agentmemory/observe | mem::observe 直接触发 |
| memory_session_start | /agentmemory/session/start | api::session::start 包装触发 |
| memory_session_end | /agentmemory/session/end | api::session::end 包装触发 |
| memory_session_commit | /agentmemory/session/commit | api::session::commit 包装触发 |
| memory_enrich | /agentmemory/enrich | mem::enrich 直接触发 |
| memory_context | /agentmemory/context | mem::context 直接触发 |

## 验证

6 个工具全部通过端到端验证(会话创建、观察写入、会话结束、提交关联、上下文注入、上下文获取)。

## 兼容性

- 原 hook 脚本和 REST 端点完整保留,三路并存
- 全平台适用,无平台硬编码

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MCP tools for capturing observations, managing sessions, linking commits, enriching data, and retrieving context.
  * Added authenticated JSON-RPC support for listing and calling available tools.
  * Added input validation and clear fallback responses for tool operations.
  * Added optional debug logging for JSON-RPC activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->