### PR TITLE
fix(clip): use CLIP text tower for text embeddings

### DIFF
--- a/src/providers/embedding/clip.ts
+++ b/src/providers/embedding/clip.ts
@@ -7,13 +7,14 @@ type ClipPipeline = (
   input: string[] | RawImage | RawImage[],
   options?: { pooling?: string; normalize?: boolean },
 ) => Promise<{ tolist: () => number[][]; data: Float32Array }>;
+type ClipTextEncoder = (texts: string[]) => Promise<Float32Array[]>;
 
 const DEFAULT_MODEL = "Xenova/clip-vit-base-patch32";
 
 export class ClipEmbeddingProvider implements EmbeddingProvider {
   readonly name = "clip";
   readonly dimensions = 512;
-  private textExtractor: ClipPipeline | null = null;
+  private textExtractor: ClipTextEncoder | null = null;
   private imageExtractor: ClipPipeline | null = null;
   private readonly modelId: string;
 
@@ -27,9 +28,8 @@ export class ClipEmbeddingProvider implements EmbeddingProvider {
   }
 
   async embedBatch(texts: string[]): Promise<Float32Array[]> {
-    const extractor = await this.getTextExtractor();
-    const output = await extractor(texts, { pooling: "mean", normalize: true });
-    return output.tolist().map((v) => new Float32Array(v));
+    const encode = await this.getTextExtractor();
+    return encode(texts);
   }
 
   async embedImage(src: string): Promise<Float32Array> {
@@ -41,10 +41,24 @@ export class ClipEmbeddingProvider implements EmbeddingProvider {
     return normalize(vec);
   }
 
-  private async getTextExtractor(): Promise<ClipPipeline> {
+  private async getTextExtractor(): Promise<ClipTextEncoder> {
     if (this.textExtractor) return this.textExtractor;
     const t = await loadTransformers();
-    this.textExtractor = (await t.pipeline("feature-extraction", this.modelId, { dtype: "q8" })) as ClipPipeline;
+    // CLIP repos expose a dual-encoder. The generic "feature-extraction"
+    // pipeline instantiates the full CLIPModel, whose forward pass requires
+    // both input_ids and pixel_values, so a text-only call fails with
+    // "Missing the following inputs: pixel_values". Load the text tower with
+    // its projection head instead: that is the encoder whose output shares
+    // the 512-d contrastive space with the image embeddings.
+    const tokenizer = await t.AutoTokenizer.from_pretrained(this.modelId);
+    const model = await t.CLIPTextModelWithProjection.from_pretrained(this.modelId, {
+      dtype: "q8",
+    });
+    this.textExtractor = async (texts: string[]) => {
+      const inputs = tokenizer(texts, { padding: true, truncation: true });
+      const { text_embeds } = await model(inputs);
+      return text_embeds.tolist().map((v: number[]) => normalize(new Float32Array(v)));
+    };
     return this.textExtractor;
   }
 

--- a/src/providers/embedding/clip.ts
+++ b/src/providers/embedding/clip.ts
@@ -44,12 +44,9 @@ export class ClipEmbeddingProvider implements EmbeddingProvider {
   private async getTextExtractor(): Promise<ClipTextEncoder> {
     if (this.textExtractor) return this.textExtractor;
     const t = await loadTransformers();
-    // CLIP repos expose a dual-encoder. The generic "feature-extraction"
-    // pipeline instantiates the full CLIPModel, whose forward pass requires
-    // both input_ids and pixel_values, so a text-only call fails with
-    // "Missing the following inputs: pixel_values". Load the text tower with
-    // its projection head instead: that is the encoder whose output shares
-    // the 512-d contrastive space with the image embeddings.
+    // The generic "feature-extraction" pipeline loads the full dual-encoder,
+    // which demands pixel_values and breaks text-only calls (#1249). The
+    // projection head is also what puts text in the image vectors' 512-d space.
     const tokenizer = await t.AutoTokenizer.from_pretrained(this.modelId);
     const model = await t.CLIPTextModelWithProjection.from_pretrained(this.modelId, {
       dtype: "q8",

--- a/test/clip-embedding-provider.test.ts
+++ b/test/clip-embedding-provider.test.ts
@@ -119,4 +119,83 @@ describe("ClipEmbeddingProvider (with loaded pipeline)", () => {
       dtype: "q8",
     });
   });
+
+  it("caches the text tower across calls instead of reloading it", async () => {
+    const { fromPretrainedText, fromPretrainedTokenizer } = mockSuccessModule();
+    const { ClipEmbeddingProvider: Fresh } = await import(
+      "../src/providers/embedding/clip.js"
+    );
+    const provider = new Fresh();
+    await provider.embed("hello");
+    await provider.embed("world");
+    await provider.embedBatch(["a", "b"]);
+
+    expect(fromPretrainedTokenizer).toHaveBeenCalledTimes(1);
+    expect(fromPretrainedText).toHaveBeenCalledTimes(1);
+  });
+
+  it("tokenizes with padding so a batch of uneven texts stays one tensor", async () => {
+    const { tokenizer } = mockSuccessModule();
+    const { ClipEmbeddingProvider: Fresh } = await import(
+      "../src/providers/embedding/clip.js"
+    );
+    await new Fresh().embedBatch(["hi", "a much longer caption"]);
+
+    expect(tokenizer).toHaveBeenCalledWith(
+      ["hi", "a much longer caption"],
+      expect.objectContaining({ padding: true, truncation: true }),
+    );
+  });
+
+  it("keeps text and image vectors in the same space via the projection head", async () => {
+    const { fromPretrainedText, pipeline } = mockSuccessModule();
+    const { ClipEmbeddingProvider: Fresh } = await import(
+      "../src/providers/embedding/clip.js"
+    );
+    const provider = new Fresh();
+    const text = await provider.embed("a red square");
+    const image = await provider.embedImage("data:image/png;base64,AAAA");
+
+    // Text goes through CLIPTextModelWithProjection, images through the
+    // image-feature-extraction pipeline; both must land normalized in the
+    // same dimensionality or cross-modal search compares nothing (#1249).
+    expect(fromPretrainedText).toHaveBeenCalled();
+    expect(pipeline).toHaveBeenCalledWith(
+      "image-feature-extraction",
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(text.length).toBe(image.length);
+    const norm = (v: Float32Array) => Math.sqrt(v.reduce((s, x) => s + x * x, 0));
+    expect(norm(text)).toBeCloseTo(1, 6);
+    expect(norm(image)).toBeCloseTo(1, 6);
+  });
+
+  it("propagates a non-missing-module load failure untouched", async () => {
+    const boom = Object.assign(new Error("wasm backend unavailable"), {
+      code: "ERR_DLOPEN_FAILED",
+    });
+    vi.doMock("@huggingface/transformers", () => ({
+      get pipeline() {
+        throw boom;
+      },
+      get AutoTokenizer() {
+        throw boom;
+      },
+      get CLIPTextModelWithProjection() {
+        throw boom;
+      },
+      RawImage: { fromBlob: vi.fn() },
+    }));
+    vi.resetModules();
+    const { ClipEmbeddingProvider: Fresh } = await import(
+      "../src/providers/embedding/clip.js"
+    );
+
+    // Only ERR_MODULE_NOT_FOUND becomes the install hint; anything else must
+    // surface as itself or a real runtime fault reads as a missing package.
+    await expect(new Fresh().embed("hello")).rejects.toThrow(
+      "wasm backend unavailable",
+    );
+  });
 });

--- a/test/clip-embedding-provider.test.ts
+++ b/test/clip-embedding-provider.test.ts
@@ -20,41 +20,64 @@ describe("ClipEmbeddingProvider (package unavailable)", () => {
 
 describe("ClipEmbeddingProvider (with loaded pipeline)", () => {
   function mockSuccessModule() {
-    const textExtractor = vi.fn(async (texts: string[]) => ({
-      tolist: () => texts.map(() => [0.1, 0.2]),
+    let lastBatchSize = 1;
+    const textModel = vi.fn(async () => ({
+      text_embeds: { tolist: () => Array.from({ length: lastBatchSize }, () => [0.1, 0.2]) },
     }));
+    const tokenizer = vi.fn((texts: string[]) => {
+      lastBatchSize = texts.length;
+      return { input_ids: texts.map(() => [1, 2, 3]) };
+    });
+    const fromPretrainedText = vi.fn(async () => textModel);
+    const fromPretrainedTokenizer = vi.fn(async () => tokenizer);
     const imageExtractor = vi.fn(async () => ({
       tolist: () => [[0.3, 0.4]],
       data: new Float32Array([0.3, 0.4]),
     }));
     const fromBlob = vi.fn(async () => ({}));
     const pipeline = vi.fn((task: string) => {
-      if (task === "feature-extraction") return Promise.resolve(textExtractor);
       if (task === "image-feature-extraction") return Promise.resolve(imageExtractor);
       return Promise.reject(new Error(`unmocked task: ${task}`));
     });
     vi.doMock("@huggingface/transformers", () => ({
       pipeline,
+      AutoTokenizer: { from_pretrained: fromPretrainedTokenizer },
+      CLIPTextModelWithProjection: { from_pretrained: fromPretrainedText },
       RawImage: { fromBlob },
     }));
     vi.resetModules();
-    return { pipeline, textExtractor, imageExtractor, fromBlob };
+    return {
+      pipeline,
+      textModel,
+      tokenizer,
+      fromPretrainedText,
+      fromPretrainedTokenizer,
+      imageExtractor,
+      fromBlob,
+    };
   }
 
-  it("loads text pipeline with dtype: q8 and returns mapped Float32Array", async () => {
-    const { pipeline } = mockSuccessModule();
+  it("loads the CLIP text tower with dtype: q8 and returns a normalized Float32Array", async () => {
+    const { pipeline, fromPretrainedText, fromPretrainedTokenizer } = mockSuccessModule();
     const { ClipEmbeddingProvider: Fresh } = await import(
       "../src/providers/embedding/clip.js"
     );
     const vec = await new Fresh().embed("hello");
 
-    expect(pipeline).toHaveBeenCalledWith(
+    expect(fromPretrainedTokenizer).toHaveBeenCalledWith("Xenova/clip-vit-base-patch32");
+    expect(fromPretrainedText).toHaveBeenCalledWith("Xenova/clip-vit-base-patch32", {
+      dtype: "q8",
+    });
+    // Regression guard for #1249: the generic feature-extraction pipeline
+    // instantiates the full dual-encoder and demands pixel_values.
+    expect(pipeline).not.toHaveBeenCalledWith(
       "feature-extraction",
-      "Xenova/clip-vit-base-patch32",
-      { dtype: "q8" },
+      expect.anything(),
+      expect.anything(),
     );
     expect(vec).toBeInstanceOf(Float32Array);
-    expect(vec).toEqual(new Float32Array([0.1, 0.2]));
+    const norm = Math.sqrt(vec.reduce((s, v) => s + v * v, 0));
+    expect(norm).toBeCloseTo(1, 6);
   });
 
   it("embedBatch returns one Float32Array per input", async () => {
@@ -85,16 +108,15 @@ describe("ClipEmbeddingProvider (with loaded pipeline)", () => {
   });
 
   it("accepts custom model ID via constructor", async () => {
-    const { pipeline } = mockSuccessModule();
+    const { fromPretrainedText, fromPretrainedTokenizer } = mockSuccessModule();
     const { ClipEmbeddingProvider: Fresh } = await import(
       "../src/providers/embedding/clip.js"
     );
     await new Fresh("Xenova/clip-vit-large-patch14").embed("hello");
 
-    expect(pipeline).toHaveBeenCalledWith(
-      "feature-extraction",
-      "Xenova/clip-vit-large-patch14",
-      { dtype: "q8" },
-    );
+    expect(fromPretrainedTokenizer).toHaveBeenCalledWith("Xenova/clip-vit-large-patch14");
+    expect(fromPretrainedText).toHaveBeenCalledWith("Xenova/clip-vit-large-patch14", {
+      dtype: "q8",
+    });
   });
 });


### PR DESCRIPTION
Fixes #1249.

`ClipEmbeddingProvider.getTextExtractor()` builds the text encoder from the generic `feature-extraction` pipeline. On a CLIP repo that instantiates the **full dual-encoder** `CLIPModel`, whose forward pass requires `input_ids` *and* `pixel_values`. The text-only call supplies just `input_ids`, so ONNX rejects it and every text entry point into the provider fails:

```console
$ curl -s -X POST -H 'Content-Type: application/json' \
    -d '{"queryText":"docker compose diagram","limit":3}' \
    http://127.0.0.1:3111/agentmemory/vision-search
{"error":"query embed failed: An error occurred during model execution: \"Missing the following inputs: pixel_values.","success":false}
```

Image-to-image search on the same store works, because `image-feature-extraction` maps to the vision tower alone — so the feature looks half-broken rather than obviously broken.

## What this does

Loads the text tower with its projection head (`AutoTokenizer` + `CLIPTextModelWithProjection`) instead of the generic pipeline. That is the encoder whose 512-d output shares the contrastive space with the image embeddings already written by `mem::vision-embed`, so **stored vectors stay comparable and no re-embedding is needed**.

Worth recording why the obvious smaller fix is wrong: `pooling: "mean"` over the last hidden state would not be equivalent even if it ran. CLIP's joint space is defined by the projection head, so mean-pooled hidden states embed into a *different* space and would return meaningless cosine scores against the image vectors — silently, with no error.

## How to verify

Against `Xenova/clip-vit-base-patch32` (dtype `q8`), embedding text and one image fixture through the patched provider:

```console
provider: clip dims: 512

[text] embedBatch -> 3 vectors, dim = 512
[text] L2 norm = 1.000000 (want ~1.0)

[image] embedImage -> dim = 512 | dims match: true

[cross-modal cosine] text vs that image:
   0.3229  "a red square"
   0.2539  "a blue circle"
   0.2364  "a docker compose diagram"
```

The fixture is a red square, and it ranks the three captions in the right order — the text and image vectors are in the same space, not merely the same length.

## Tests

`test/clip-embedding-provider.test.ts` mocked `pipeline("feature-extraction")`, so it asserted exactly the call that cannot work at runtime. Updated to mock the text tower, plus a regression guard:

```js
// Regression guard for #1249: the generic feature-extraction pipeline
// instantiates the full dual-encoder and demands pixel_values.
expect(pipeline).not.toHaveBeenCalledWith(
  "feature-extraction", expect.anything(), expect.anything(),
);
```

The batch test now also exercises a real 2-item batch, which the previous fixed-length mock would have passed regardless.

```console
$ npx vitest run test/clip-embedding-provider.test.ts
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

`npm run build` is clean. On the full suite this branch is **30 failed | 1665 passed**, identical to `main` at e04ba88 on the same machine — the pre-existing failures (`cli-lifecycle-safety`, `obsidian-export`, `compress-file`, and friends) are unrelated to this change and are unaffected by it.

Environment: Node v24.19.0, `@huggingface/transformers` 4.2.0, Windows 11.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLIP text embedding generation for more reliable text-only processing.
  * Text embeddings are now consistently normalized and returned in a predictable format.
  * Improved support for batched text inputs, including uneven batch sizes.
  * Enhanced compatibility between text and image embeddings in the shared vector space.
  * Improved handling of custom model configurations and model-loading errors.
  * Reused loaded text-embedding resources for more efficient repeated requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->