### PR TITLE
fix: ignore unknown session end events

### DIFF
--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -665,10 +665,28 @@ export function registerApiTriggers(
           body: { error: "sessionId is required and must be a non-empty string" },
         };
       }
-      await kv.update(KV.sessions, sessionId, [
-        { type: "set", path: "endedAt", value: new Date().toISOString() },
-        { type: "set", path: "status", value: "completed" },
-      ]);
+      // state::update has upsert semantics. A lifecycle adapter can emit an
+      // end event before its first observation has created the corresponding
+      // agentmemory session (for example, OpenClaw's /new command). Updating
+      // that missing key would create a partial row with only status/endedAt,
+      // which later breaks consumers that require Session.id.
+      const endResult = await withKeyedLock(`obs:${sessionId}`, async () => {
+        const session = await kv.get<Session>(KV.sessions, sessionId);
+        if (!session || session.id !== sessionId) return "not_found" as const;
+        if (session.status === "completed") return "already_completed" as const;
+
+        await kv.update(KV.sessions, sessionId, [
+          { type: "set", path: "endedAt", value: new Date().toISOString() },
+          { type: "set", path: "status", value: "completed" },
+        ]);
+        return "ended" as const;
+      });
+      if (endResult !== "ended") {
+        return {
+          status_code: 200,
+          body: { success: true, ended: false, reason: endResult },
+        };
+      }
       // Fan out session-stopped lifecycle (non-blocking).
       try {
         sdk.trigger({
@@ -682,7 +700,7 @@ export function registerApiTriggers(
           error: err instanceof Error ? err.message : String(err),
         });
       }
-      return { status_code: 200, body: { success: true } };
+      return { status_code: 200, body: { success: true, ended: true } };
     },
   );
   sdk.registerTrigger({
@@ -851,6 +869,17 @@ export function registerApiTriggers(
       const authErr = checkAuth(req, secret);
       if (authErr) return authErr;
       const sessions = await kv.list<Session>(KV.sessions);
+      // Be tolerant of legacy partial rows created by state::update before
+      // the session existed. In particular, never issue state::get with an
+      // undefined summary key: iii-engine can leave that invocation pending
+      // until the caller times out, making the viewer look empty.
+      const validSessions = sessions.filter(
+        (session): session is Session =>
+          !!session &&
+          typeof session === "object" &&
+          typeof session.id === "string" &&
+          session.id.length > 0,
+      );
       const normalizedAgentId =
         typeof req.query_params?.["agentId"] === "string"
           ? req.query_params["agentId"].trim()
@@ -863,8 +892,8 @@ export function registerApiTriggers(
         : explicitAgentId ??
           (isAgentScopeIsolated() ? getAgentId() : undefined);
       const filtered = filterAgentId
-        ? sessions.filter((s) => s.agentId === filterAgentId)
-        : sessions;
+        ? validSessions.filter((s) => s.agentId === filterAgentId)
+        : validSessions;
       // Bounded fan-out: each kv.get is a full engine invocation, so
       // Promise.all over hundreds of sessions saturates the invocation
       // pool. Batch in chunks of 10 (parallel within a chunk, sequential

--- a/test/session-lifecycle-api.test.ts
+++ b/test/session-lifecycle-api.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { registerApiTriggers } from "../src/triggers/api.js";
+import { KV } from "../src/state/schema.js";
+import type { Session } from "../src/types.js";
+
+type ApiResponse = {
+  status_code: number;
+  body: Record<string, unknown>;
+};
+
+function makeHarness(sessionRows: Array<[string, unknown]> = []) {
+  const store = new Map<string, Map<string, unknown>>([
+    [KV.sessions, new Map(sessionRows)],
+    [KV.summaries, new Map()],
+  ]);
+  const functions = new Map<string, Function>();
+  const trigger = vi.fn(async () => undefined);
+  const update = vi.fn(
+    async (
+      scope: string,
+      key: string,
+      ops: Array<{ type: "set" | "remove"; path: string; value?: unknown }>,
+    ) => {
+      const values = store.get(scope) ?? new Map<string, unknown>();
+      store.set(scope, values);
+      const existing = values.get(key);
+      const next =
+        existing && typeof existing === "object"
+          ? { ...(existing as Record<string, unknown>) }
+          : {};
+      for (const op of ops) {
+        if (op.type === "remove") delete next[op.path];
+        else next[op.path] = op.value;
+      }
+      values.set(key, next);
+      return next;
+    },
+  );
+  const kv = {
+    get: vi.fn(async (scope: string, key: string) => {
+      if (typeof key !== "string" || key.length === 0) {
+        throw new Error("state::get requires a non-empty key");
+      }
+      return store.get(scope)?.get(key) ?? null;
+    }),
+    set: vi.fn(),
+    update,
+    delete: vi.fn(),
+    list: vi.fn(async (scope: string) =>
+      Array.from(store.get(scope)?.values() ?? []),
+    ),
+  };
+  const sdk = {
+    registerFunction: (id: string, handler: Function) => functions.set(id, handler),
+    registerTrigger: vi.fn(),
+    trigger,
+  };
+
+  registerApiTriggers(sdk as never, kv as never);
+
+  return { functions, kv, store, trigger, update };
+}
+
+function session(id: string, status: Session["status"] = "active"): Session {
+  return {
+    id,
+    project: "test-project",
+    cwd: "/tmp/test-project",
+    startedAt: "2026-08-26T00:00:00.000Z",
+    status,
+    observationCount: 1,
+  };
+}
+
+describe("session lifecycle API", () => {
+  it("treats ending an unknown session as a no-op without creating a partial row", async () => {
+    const harness = makeHarness();
+    const handler = harness.functions.get("api::session::end")!;
+
+    const response = (await handler({
+      body: { sessionId: "agent:dmp-pm:direct:test" },
+    })) as ApiResponse;
+
+    expect(response).toEqual({
+      status_code: 200,
+      body: { success: true, ended: false, reason: "not_found" },
+    });
+    expect(harness.update).not.toHaveBeenCalled();
+    expect(harness.store.get(KV.sessions)).toEqual(new Map());
+    expect(harness.trigger).not.toHaveBeenCalledWith(
+      expect.objectContaining({ function_id: "event::session::stopped" }),
+    );
+  });
+
+  it("does not treat an existing partial row as a valid session", async () => {
+    const sessionId = "agent:dmp-pm:direct:partial";
+    const harness = makeHarness([
+      [sessionId, { status: "completed", endedAt: "2026-08-26T00:00:00.000Z" }],
+    ]);
+    const handler = harness.functions.get("api::session::end")!;
+
+    const response = (await handler({ body: { sessionId } })) as ApiResponse;
+
+    expect(response.body).toEqual({
+      success: true,
+      ended: false,
+      reason: "not_found",
+    });
+    expect(harness.update).not.toHaveBeenCalled();
+  });
+
+  it("ends an existing session and publishes the stopped lifecycle once", async () => {
+    const sessionId = "agent:dmp-pm:direct:existing";
+    const harness = makeHarness([[sessionId, session(sessionId)]]);
+    const handler = harness.functions.get("api::session::end")!;
+
+    const response = (await handler({ body: { sessionId } })) as ApiResponse;
+
+    expect(response.body).toEqual({ success: true, ended: true });
+    expect(harness.store.get(KV.sessions)?.get(sessionId)).toMatchObject({
+      id: sessionId,
+      status: "completed",
+      endedAt: expect.any(String),
+    });
+    expect(harness.trigger).toHaveBeenCalledTimes(1);
+    expect(harness.trigger).toHaveBeenCalledWith(
+      expect.objectContaining({
+        function_id: "event::session::stopped",
+        payload: { sessionId },
+      }),
+    );
+  });
+
+  it("skips malformed rows when listing sessions and never reads an undefined summary key", async () => {
+    const valid = session("ses_valid", "completed");
+    const harness = makeHarness([
+      [valid.id, valid],
+      ["agent:dmp-pm:direct:partial", { status: "completed", endedAt: "2026-08-26T00:00:00.000Z" }],
+    ]);
+    const handler = harness.functions.get("api::sessions")!;
+
+    const response = (await handler({
+      headers: {},
+      query_params: { agentId: "*" },
+    })) as ApiResponse;
+
+    expect(response.status_code).toBe(200);
+    expect(response.body.sessions).toEqual([valid]);
+    expect(harness.kv.get).toHaveBeenCalledWith(KV.summaries, valid.id);
+    expect(harness.kv.get).not.toHaveBeenCalledWith(KV.summaries, undefined);
+  });
+});

--- a/test/session-lifecycle-api.test.ts
+++ b/test/session-lifecycle-api.test.ts
@@ -1,5 +1,16 @@
 import { describe, expect, it, vi } from "vitest";
 
+vi.mock("iii-sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("iii-sdk")>();
+  return {
+    ...actual,
+    TriggerAction: {
+      ...actual.TriggerAction,
+      Void: vi.fn(() => ({ type: "void" })),
+    },
+  };
+});
+
 import { registerApiTriggers } from "../src/triggers/api.js";
 import { KV } from "../src/state/schema.js";
 import type { Session } from "../src/types.js";
@@ -108,6 +119,21 @@ describe("session lifecycle API", () => {
       reason: "not_found",
     });
     expect(harness.update).not.toHaveBeenCalled();
+  });
+
+  it("treats ending an already-completed session as a no-op", async () => {
+    const sessionId = "agent:dmp-pm:direct:completed";
+    const harness = makeHarness([[sessionId, session(sessionId, "completed")]]);
+    const handler = harness.functions.get("api::session::end")!;
+
+    const response = (await handler({ body: { sessionId } })) as ApiResponse;
+
+    expect(response).toEqual({
+      status_code: 200,
+      body: { success: true, ended: false, reason: "already_completed" },
+    });
+    expect(harness.update).not.toHaveBeenCalled();
+    expect(harness.trigger).not.toHaveBeenCalled();
   });
 
   it("ends an existing session and publishes the stopped lifecycle once", async () => {


### PR DESCRIPTION
## Summary

- make `POST /agentmemory/session/end` an idempotent no-op for missing, malformed, or already-completed sessions
- serialize session-end updates with observation capture using the existing per-session lock
- only publish `event::session::stopped` after a real active-to-completed transition
- skip legacy session rows without a valid `id` before looking up summaries
- add behavioral regression coverage for unknown sessions, partial rows, valid session completion, and resilient session listing

## Root cause

iii-engine's `state::update` has upsert semantics. Calling `/agentmemory/session/end` for a session that had not yet been created therefore wrote a partial row containing only `status` and `endedAt`.

`api::sessions` later attempted `kv.get(KV.summaries, s.id)` for that row, where `s.id` was undefined. That invocation could remain pending until timeout, making the dashboard and MCP surface appear to contain zero sessions even though the valid rows were still present.

OpenClaw exposes this race when `/new` emits `session_end(reason: "new")` before the conversation has produced its first successful observation, but the server endpoint should be safe for every integration.

## Verification

- `npm test`: 1,715 passed, 1 skipped
- `npm run build`: passed
- live regression against iii-engine 0.11.2:
  - ending an unknown session returns HTTP 200 with `ended: false`
  - no session row is created
  - `/agentmemory/sessions` continues to return all valid sessions

Fixes #1251

Related: #1058, #466, #729, #1100


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session ending behavior for unknown, incomplete, or already completed sessions.
  - Prevented malformed session records from appearing in session listings.
  - Ensured session completion events are published only once.
  - Prevented session summaries from being requested for invalid records.

- **Tests**
  - Added coverage for session lifecycle and listing edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->