### PR TITLE
fix(build): copy assets from tsdown so the build works on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "agentmemory": "dist/cli.mjs"
   },
   "scripts": {
-    "build": "tsdown && (cp iii-config.yaml dist/ 2>/dev/null || true) && (cp iii-config.docker.yaml dist/ 2>/dev/null || true) && (cp docker-compose.yml dist/ 2>/dev/null || true) && (cp .env.example dist/ 2>/dev/null || true) && mkdir -p dist/viewer && cp src/viewer/index.html dist/viewer/ && cp src/viewer/favicon.svg dist/viewer/",
+    "build": "tsdown",
     "dev": "tsx src/index.ts",
     "start": "node dist/cli.mjs",
     "migrate": "node dist/functions/migrate.js",

--- a/test/build-asset-copy.test.ts
+++ b/test/build-asset-copy.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import config from "../tsdown.config.js";
+
+// The build used to copy assets with a POSIX `cp` tail on the npm script,
+// which npm runs through cmd.exe on Windows: the copies failed, dist/viewer
+// was never created, and `npm run build` exited 1 after printing success.
+// Assets now ride on tsdown's own `copy`, which these guard.
+
+const ROOT = join(import.meta.dirname, "..");
+
+type CopyEntry = { from: string; to: string };
+type Block = { copy?: CopyEntry[]; outDir?: string; clean?: boolean };
+
+const blocks = config as unknown as Block[];
+const copyBlocks = blocks.filter((b) => Array.isArray(b.copy) && b.copy.length > 0);
+const allCopies = copyBlocks.flatMap((b) => b.copy ?? []);
+
+describe("build asset copying", () => {
+  it("declares the copies on exactly one block", () => {
+    // hookEntries.map() expands one block into 14. A `copy` on the mapped
+    // block runs every copy 14x in parallel, and they race: EBUSY on Windows.
+    expect(copyBlocks).toHaveLength(1);
+  });
+
+  it("ships every asset the published package lists", () => {
+    const pkg = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf-8"));
+    const packagedRootAssets: string[] = pkg.files.filter((f: string) => !f.endsWith("/"));
+    const copiedNames = allCopies.map((c) => c.from.split("/").pop());
+
+    for (const asset of packagedRootAssets) {
+      if (asset === "LICENSE" || asset === "README.md" || asset === "AGENTS.md") continue;
+      expect(copiedNames).toContain(asset);
+    }
+  });
+
+  it("puts the viewer files under dist/viewer", () => {
+    const viewer = allCopies.filter((c) => c.from.startsWith("src/viewer/"));
+
+    expect(viewer.map((c) => c.from.split("/").pop()).sort()).toEqual([
+      "favicon.svg",
+      "index.html",
+    ]);
+    for (const entry of viewer) expect(entry.to).toBe("dist/viewer");
+  });
+
+  it("copies every source that actually exists in the repo", () => {
+    for (const entry of allCopies) {
+      expect(() => readFileSync(join(ROOT, entry.from))).not.toThrow();
+    }
+  });
+
+  it("keeps the build script free of POSIX shell utilities", () => {
+    const pkg = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf-8"));
+
+    // cmd.exe has no cp/mkdir -p; a reintroduced tail breaks Windows again.
+    expect(pkg.scripts.build).not.toMatch(/\bcp\b|\bmkdir\b/);
+  });
+
+  it("cleans dist on the first block only", () => {
+    // tsdown clears outDir per block, so a later clean would delete the
+    // artifacts the earlier blocks just wrote.
+    expect(blocks[0]?.clean).toBe(true);
+    expect(blocks.slice(1).some((b) => b.clean === true)).toBe(false);
+  });
+});

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -82,5 +82,22 @@ export default defineConfig([
     ...shared,
     clean: false,
     sourcemap: false,
+    // Assets ride on the last mapped block only. Setting `copy` on every
+    // block would run these copies once per entry, and the parallel copies
+    // race each other (EBUSY on Windows). Copying from tsdown rather than a
+    // shell `cp` in the npm script keeps the build working where npm runs
+    // scripts through cmd.exe and POSIX file utilities do not exist.
+    ...(entry === hookEntries[hookEntries.length - 1]
+      ? {
+          copy: [
+            { from: "iii-config.yaml", to: "dist" },
+            { from: "iii-config.docker.yaml", to: "dist" },
+            { from: "docker-compose.yml", to: "dist" },
+            { from: ".env.example", to: "dist" },
+            { from: "src/viewer/index.html", to: "dist/viewer" },
+            { from: "src/viewer/favicon.svg", to: "dist/viewer" },
+          ],
+        }
+      : {}),
   })),
 ]);


### PR DESCRIPTION
`npm run build` exits **1** on Windows, and `dist/viewer/` never gets created — so the viewer assets are silently missing from the built package.

The script chains POSIX file utilities after `tsdown`:

```json
"build": "tsdown && (cp iii-config.yaml dist/ 2>/dev/null || true) && ... && mkdir -p dist/viewer && cp src/viewer/index.html dist/viewer/ && cp src/viewer/favicon.svg dist/viewer/"
```

npm runs scripts through `cmd.exe` on Windows, which has neither `cp` nor `mkdir -p`:

```console
$ npm run build
...
✔ Build complete in 4245ms
The system cannot find the path specified.
The system cannot find the path specified.
The system cannot find the path specified.
The system cannot find the path specified.
The syntax of the command is incorrect.

$ echo $?
1
$ ls dist/viewer
ls: cannot access 'dist/viewer/': No such file or directory
```

The four leading copies survive because of their `|| true` guards, so `iii-config.yaml` and friends do land. `mkdir -p dist/viewer` and the two copies after it have no guard, so the chain dies there and takes the exit code with it.

Easy to miss two ways: `✔ Build complete` is printed *before* the failure, and piping the build through `tail`/`grep` reports the pipeline's last exit status rather than npm's.

## What this does

Moves the copies into tsdown's own `copy` option, which runs in Node and needs no shell. No new dependency — tsdown 0.21.10 already supports it.

The copy rides on the **last** hook entry rather than every mapped block. Setting it on all of them runs the copies once per entry, and the parallel copies race:

```console
ERROR  Error: EBUSY: resource busy or locked, unlink 'dist\iii-config.yaml'
    at async mayCopyFile (node:internal/fs/cp/cp:247:5)
    at async copy (tsdown/dist/watch-D6EGzM6P.mjs:19:2)
```

`clean: true` only runs on the first config block, so assets copied from the last one are not wiped.

## Verification

Windows 11, Node v24.19.0, starting from an empty `dist/`:

```console
$ rm -rf dist && npm run build >/dev/null 2>&1; echo $?
0

$ for each of the six assets: sha256 dist/... == sha256 source
  MATCH  dist/iii-config.yaml
  MATCH  dist/iii-config.docker.yaml
  MATCH  dist/docker-compose.yml
  MATCH  dist/.env.example
  MATCH  dist/viewer/index.html
  MATCH  dist/viewer/favicon.svg
```

Byte-identical to source, not merely present. Three consecutive builds without cleaning also stay at exit 0, and the outputs are unchanged: 12 bundles in `dist/`, 14 in `dist/hooks/`, 15 in `plugin/scripts/`. `package.json` `files` already ships `dist/`, so packaging is unaffected.

Test suite is **30 failed | 1665 passed**, identical to `main` at e04ba88 on this machine — the pre-existing failures are unrelated and unaffected.

This should be a no-op on Linux and macOS, where the old chain already worked. Worth a CI check on a Windows runner if you want it guarded, though I did not want to add a workflow uninvited.

Found while working on #1249; unrelated to it, so it is a separate PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build reliability by preventing duplicate asset-copy operations.
  * Ensured runtime, Docker, environment, and viewer assets are included in the build output.
  * Verified viewer files are placed in the expected location and packaged assets are available.

* **Chores**
  * Simplified the build process and centralized asset handling.
  * Added automated validation for build asset packaging and output structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->