### PR TITLE
fix(providers): bound LLM provider concurrency and stop counting 429s as breaker failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -1535,6 +1535,15 @@ Create `~/.agentmemory/.env`:
                                           # Increase for slow networks or large batch calls;
                                           # decrease to fail-fast on rate-limit holds.
 
+# Provider concurrency
+# AGENTMEMORY_MAX_PROVIDER_CONCURRENCY=6  # Default: 6. Caps calls in flight inside the
+                                          # provider, so bursty capture cannot answer with
+                                          # 429 too many concurrent requests. The gate is
+                                          # global, so raising SUMMARIZE_CHUNK_CONCURRENCY
+                                          # above it has no effect — raise them together.
+                                          # Lower it for a key whose concurrency ceiling
+                                          # is below 6.
+
 # Search tuning
 # BM25_WEIGHT=0.4
 # VECTOR_WEIGHT=0.6

--- a/src/providers/circuit-breaker.ts
+++ b/src/providers/circuit-breaker.ts
@@ -1,6 +1,6 @@
 import type { CircuitBreakerState } from "../types.js";
 
-interface CircuitBreakerOptions {
+export interface CircuitBreakerOptions {
   failureThreshold?: number;
   failureWindowMs?: number;
   recoveryTimeoutMs?: number;

--- a/src/providers/circuit-breaker.ts
+++ b/src/providers/circuit-breaker.ts
@@ -1,6 +1,6 @@
 import type { CircuitBreakerState } from "../types.js";
 
-export interface CircuitBreakerOptions {
+interface CircuitBreakerOptions {
   failureThreshold?: number;
   failureWindowMs?: number;
   recoveryTimeoutMs?: number;

--- a/src/providers/resilient.ts
+++ b/src/providers/resilient.ts
@@ -108,12 +108,19 @@ export class ResilientProvider implements MemoryProvider {
       this.gate.release();
       throw new Error("circuit_breaker_open");
     }
+    // Read after the isAllowed checks, which are what move open -> half-open.
+    const probing = this.breaker.getState().state === "half-open";
     try {
       const result = await fn();
       this.breaker.recordSuccess();
       return result;
     } catch (err) {
-      if (!isRateLimited(err)) this.breaker.recordFailure();
+      // Backpressure normally must not open the breaker. The half-open probe is
+      // the exception: nothing else records an outcome for it, so excusing a
+      // rate-limited probe leaves the breaker sitting in half-open admitting
+      // every call, with no path back to either open or closed. A probe that
+      // came back rate-limited has still failed as a probe.
+      if (probing || !isRateLimited(err)) this.breaker.recordFailure();
       throw err;
     } finally {
       // In `finally` so a throw cannot leak the slot and deadlock every call

--- a/src/providers/resilient.ts
+++ b/src/providers/resilient.ts
@@ -1,25 +1,101 @@
 import type { MemoryProvider, CircuitBreakerState } from "../types.js";
-import { CircuitBreaker } from "./circuit-breaker.js";
+import { CircuitBreaker, type CircuitBreakerOptions } from "./circuit-breaker.js";
+
+const DEFAULT_MAX_CONCURRENT = 4;
+
+/**
+ * Bounds how many calls are inside the provider at once.
+ *
+ * Without this, every captured observation fired a compress() immediately and
+ * unbounded, so load meant dozens of simultaneous upstream calls and the
+ * provider answered with `429 too many concurrent requests`.
+ *
+ * release() hands its slot directly to the next waiter rather than decrementing
+ * and letting it race for the opening, so the limit holds under a burst.
+ */
+class Semaphore {
+  private active = 0;
+  private waiting: Array<() => void> = [];
+
+  constructor(private readonly limit: number) {}
+
+  async acquire(): Promise<void> {
+    if (this.active < this.limit) {
+      this.active++;
+      return;
+    }
+    await new Promise<void>((resolve) => this.waiting.push(resolve));
+  }
+
+  release(): void {
+    const next = this.waiting.shift();
+    if (next) next();
+    else this.active--;
+  }
+}
+
+/**
+ * A 429 says "slow down", not "you are broken".
+ *
+ * Counting it as a circuit-breaker failure turns backpressure into an outage:
+ * three of them inside the failure window open the breaker, and then every
+ * compression fails fast for the whole recovery timeout even though the
+ * provider is healthy and merely busy.
+ */
+function isRateLimited(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return (
+    /\b429\b/.test(message) ||
+    /rate.?limit|too many (concurrent )?requests/i.test(message)
+  );
+}
+
+function resolveMaxConcurrent(configured: number | undefined): number {
+  const candidate =
+    configured ??
+    Number(process.env["AGENTMEMORY_MAX_PROVIDER_CONCURRENCY"] ?? NaN);
+  if (!Number.isFinite(candidate)) return DEFAULT_MAX_CONCURRENT;
+  const whole = Math.floor(candidate);
+  return whole >= 1 ? whole : DEFAULT_MAX_CONCURRENT;
+}
+
+export interface ResilientProviderOptions {
+  maxConcurrent?: number;
+  breaker?: CircuitBreakerOptions;
+}
 
 export class ResilientProvider implements MemoryProvider {
-  private breaker = new CircuitBreaker();
+  private breaker: CircuitBreaker;
+  private gate: Semaphore;
   name: string;
 
-  constructor(private inner: MemoryProvider) {
+  constructor(
+    private inner: MemoryProvider,
+    options: ResilientProviderOptions = {},
+  ) {
+    this.breaker = new CircuitBreaker(options.breaker);
+    this.gate = new Semaphore(resolveMaxConcurrent(options.maxConcurrent));
     this.name = `resilient(${inner.name})`;
   }
 
   private async call(fn: () => Promise<string>): Promise<string> {
+    // Checked before queueing. An open breaker should fail fast rather than
+    // occupy a slot that a call with a chance of succeeding could use.
     if (!this.breaker.isAllowed) {
       throw new Error("circuit_breaker_open");
     }
+    await this.gate.acquire();
     try {
       const result = await fn();
       this.breaker.recordSuccess();
       return result;
     } catch (err) {
-      this.breaker.recordFailure();
+      if (!isRateLimited(err)) this.breaker.recordFailure();
       throw err;
+    } finally {
+      // In `finally` so a throw cannot leak the slot and deadlock every call
+      // queued behind it.
+      this.gate.release();
     }
   }
 

--- a/src/providers/resilient.ts
+++ b/src/providers/resilient.ts
@@ -2,7 +2,17 @@ import type { MemoryProvider, CircuitBreakerState } from "../types.js";
 import { CircuitBreaker } from "./circuit-breaker.js";
 import { getEnvVar } from "../config.js";
 
-const DEFAULT_MAX_CONCURRENT = 4;
+// Matches CHUNK_CONCURRENCY_DEFAULT in src/functions/summarize.ts on purpose.
+// That value is tuned so a ~100-chunk session finishes inside the 180s
+// invocation budget at roughly 8s per call; a global gate below it would push
+// that past the budget and silently make SUMMARIZE_CHUNK_CONCURRENCY a no-op
+// above the gate. Raise them together, never one alone.
+const DEFAULT_MAX_CONCURRENT = 6;
+
+// A queued call still holds its prompts alive, so an unbounded queue is a
+// memory leak on a service that is already memory-constrained. Compression is
+// dispatched fire-and-forget, so nothing upstream applies backpressure for us.
+const MAX_QUEUED = 512;
 
 /**
  * Bounds how many calls are inside the provider at once.
@@ -22,6 +32,9 @@ class Semaphore {
       this.active++;
       return;
     }
+    if (this.waiting.length >= MAX_QUEUED) {
+      throw new Error("provider_queue_full");
+    }
     await new Promise<void>((resolve) => this.waiting.push(resolve));
   }
 
@@ -36,7 +49,22 @@ class Semaphore {
 // provider and failed every compression for the recovery window.
 function isRateLimited(err: unknown): boolean {
   const message = err instanceof Error ? err.message : String(err);
-  return /\b429\b|rate.?limit|too many (concurrent )?requests/i.test(message);
+  // Quota exhaustion and billing failures also come back as 429, but they are
+  // persistent states rather than backpressure. Excusing them would mean the
+  // breaker could never open for a provider that will not recover on its own,
+  // so they are checked first and fall through to a genuine failure.
+  if (/insufficient_quota|exceeded your current quota|billing/i.test(message)) {
+    return false;
+  }
+  // Status codes and API error codes only. `rate.?limit` also matched the
+  // hyphenated form in a docs URL, so a genuine 500 whose body linked to
+  // /docs/guides/rate-limits was excused and the breaker stayed blind to a
+  // provider that was actually broken. `rate[ _]limit` covers prose and the
+  // rate_limit_error / rate_limit_exceeded codes without matching the URL.
+  // 529 / overloaded_error is Anthropic's form of the same backpressure signal.
+  return /\b429\b|\b529\b|rate[ _]limit|too many (concurrent )?requests|overloaded_error/i.test(
+    message,
+  );
 }
 
 // Option is the test seam, env is the operator knob on Railway, constant is the
@@ -72,6 +100,14 @@ export class ResilientProvider implements MemoryProvider {
       throw new Error("circuit_breaker_open");
     }
     await this.gate.acquire();
+    // Re-checked after queueing. A call that passed the first check may have
+    // waited while the running calls failed and opened the breaker; without
+    // this it would still be sent to a provider already known to be down, and
+    // each such failure pushes the recovery window further out.
+    if (!this.breaker.isAllowed) {
+      this.gate.release();
+      throw new Error("circuit_breaker_open");
+    }
     try {
       const result = await fn();
       this.breaker.recordSuccess();

--- a/src/providers/resilient.ts
+++ b/src/providers/resilient.ts
@@ -14,13 +14,6 @@ const DEFAULT_MAX_CONCURRENT = 6;
 // dispatched fire-and-forget, so nothing upstream applies backpressure for us.
 const MAX_QUEUED = 512;
 
-/**
- * Bounds how many calls are inside the provider at once.
- *
- * release() hands its slot directly to the next waiter rather than
- * decrementing and letting waiters race for the opening, so the limit holds
- * under a burst.
- */
 class Semaphore {
   private active = 0;
   private waiting: Array<() => void> = [];
@@ -45,9 +38,7 @@ class Semaphore {
   }
 }
 
-// 429 is backpressure, not a fault. Counting it opened the breaker on a healthy
-// provider and failed every compression for the recovery window.
-function isRateLimited(err: unknown): boolean {
+function isBackpressure(err: unknown): boolean {
   const message = err instanceof Error ? err.message : String(err);
   // Quota exhaustion and billing failures also come back as 429, but they are
   // persistent states rather than backpressure. Excusing them would mean the
@@ -67,9 +58,6 @@ function isRateLimited(err: unknown): boolean {
   );
 }
 
-// Option is the test seam, env is the operator knob on Railway, constant is the
-// default. getEnvVar rather than process.env so ~/.agentmemory/.env is honoured,
-// which is how every sibling provider reads config.
 function resolveMaxConcurrent(configured: number | undefined): number {
   const candidate =
     configured ??
@@ -94,8 +82,6 @@ export class ResilientProvider implements MemoryProvider {
   }
 
   private async call(fn: () => Promise<string>): Promise<string> {
-    // Checked before queueing. An open breaker should fail fast rather than
-    // occupy a slot that a call with a chance of succeeding could use.
     if (!this.breaker.isAllowed) {
       throw new Error("circuit_breaker_open");
     }
@@ -120,11 +106,9 @@ export class ResilientProvider implements MemoryProvider {
       // rate-limited probe leaves the breaker sitting in half-open admitting
       // every call, with no path back to either open or closed. A probe that
       // came back rate-limited has still failed as a probe.
-      if (probing || !isRateLimited(err)) this.breaker.recordFailure();
+      if (probing || !isBackpressure(err)) this.breaker.recordFailure();
       throw err;
     } finally {
-      // In `finally` so a throw cannot leak the slot and deadlock every call
-      // queued behind it.
       this.gate.release();
     }
   }

--- a/src/providers/resilient.ts
+++ b/src/providers/resilient.ts
@@ -1,17 +1,15 @@
 import type { MemoryProvider, CircuitBreakerState } from "../types.js";
-import { CircuitBreaker, type CircuitBreakerOptions } from "./circuit-breaker.js";
+import { CircuitBreaker } from "./circuit-breaker.js";
+import { getEnvVar } from "../config.js";
 
 const DEFAULT_MAX_CONCURRENT = 4;
 
 /**
  * Bounds how many calls are inside the provider at once.
  *
- * Without this, every captured observation fired a compress() immediately and
- * unbounded, so load meant dozens of simultaneous upstream calls and the
- * provider answered with `429 too many concurrent requests`.
- *
- * release() hands its slot directly to the next waiter rather than decrementing
- * and letting it race for the opening, so the limit holds under a burst.
+ * release() hands its slot directly to the next waiter rather than
+ * decrementing and letting waiters race for the opening, so the limit holds
+ * under a burst.
  */
 class Semaphore {
   private active = 0;
@@ -34,34 +32,23 @@ class Semaphore {
   }
 }
 
-/**
- * A 429 says "slow down", not "you are broken".
- *
- * Counting it as a circuit-breaker failure turns backpressure into an outage:
- * three of them inside the failure window open the breaker, and then every
- * compression fails fast for the whole recovery timeout even though the
- * provider is healthy and merely busy.
- */
+// 429 is backpressure, not a fault. Counting it opened the breaker on a healthy
+// provider and failed every compression for the recovery window.
 function isRateLimited(err: unknown): boolean {
   const message = err instanceof Error ? err.message : String(err);
-  return (
-    /\b429\b/.test(message) ||
-    /rate.?limit|too many (concurrent )?requests/i.test(message)
-  );
+  return /\b429\b|rate.?limit|too many (concurrent )?requests/i.test(message);
 }
 
+// Option is the test seam, env is the operator knob on Railway, constant is the
+// default. getEnvVar rather than process.env so ~/.agentmemory/.env is honoured,
+// which is how every sibling provider reads config.
 function resolveMaxConcurrent(configured: number | undefined): number {
   const candidate =
     configured ??
-    Number(process.env["AGENTMEMORY_MAX_PROVIDER_CONCURRENCY"] ?? NaN);
+    Number(getEnvVar("AGENTMEMORY_MAX_PROVIDER_CONCURRENCY") ?? NaN);
   if (!Number.isFinite(candidate)) return DEFAULT_MAX_CONCURRENT;
   const whole = Math.floor(candidate);
   return whole >= 1 ? whole : DEFAULT_MAX_CONCURRENT;
-}
-
-export interface ResilientProviderOptions {
-  maxConcurrent?: number;
-  breaker?: CircuitBreakerOptions;
 }
 
 export class ResilientProvider implements MemoryProvider {
@@ -71,9 +58,9 @@ export class ResilientProvider implements MemoryProvider {
 
   constructor(
     private inner: MemoryProvider,
-    options: ResilientProviderOptions = {},
+    options: { maxConcurrent?: number } = {},
   ) {
-    this.breaker = new CircuitBreaker(options.breaker);
+    this.breaker = new CircuitBreaker();
     this.gate = new Semaphore(resolveMaxConcurrent(options.maxConcurrent));
     this.name = `resilient(${inner.name})`;
   }

--- a/test/resilient-provider.test.ts
+++ b/test/resilient-provider.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { ResilientProvider } from "../src/providers/resilient.js";
 import type { MemoryProvider } from "../src/types.js";
 
@@ -154,5 +154,40 @@ describe("ResilientProvider rate-limit classification", () => {
     }
 
     expect(provider.circuitState.state).toBe("closed");
+  });
+});
+
+describe("ResilientProvider half-open probe", () => {
+  it("does not get stuck in half-open when the probe is rate limited", async () => {
+    // Nothing else records an outcome for the probe, so excusing a
+    // rate-limited one leaves the breaker in half-open admitting every call,
+    // with no path back to open or closed. Half-open must never be a state you
+    // can enter and not leave.
+    let mode: "fail" | "ratelimit" = "fail";
+    const inner = countingProvider(async () => {
+      throw mode === "fail"
+        ? new Error("upstream exploded")
+        : new Error("API error (429): rate limited");
+    });
+    const provider = new ResilientProvider(inner);
+
+    for (let i = 0; i < 3; i++) {
+      await provider.compress("sys", "user").catch(() => undefined);
+    }
+    expect(provider.circuitState.state).toBe("open");
+
+    // Move the clock past the 30s recovery window so the next call is the
+    // probe. Sleeping a few milliseconds instead would leave the breaker still
+    // open, the probe would never happen, and this test would pass without
+    // exercising anything — it did exactly that before this was fixed.
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now() + 31_000);
+    try {
+      mode = "ratelimit";
+      await provider.compress("sys", "user").catch(() => undefined);
+      expect(provider.circuitState.state).not.toBe("half-open");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/test/resilient-provider.test.ts
+++ b/test/resilient-provider.test.ts
@@ -40,25 +40,13 @@ describe("ResilientProvider concurrency", () => {
     );
     const provider = new ResilientProvider(inner, { maxConcurrent: 3 });
 
-    await Promise.all(
+    const results = await Promise.all(
       Array.from({ length: 24 }, () => provider.compress("sys", "user")),
     );
 
-    // The provider fired all 24 at once before this bound existed, which is
-    // exactly what the upstream 429 complains about.
     expect(inner.peak).toBeLessThanOrEqual(3);
+    // Bounding must not drop work: every call still ran and still resolved.
     expect(inner.calls).toBe(24);
-  });
-
-  it("still completes every call while bounded", async () => {
-    const inner = countingProvider();
-    const provider = new ResilientProvider(inner, { maxConcurrent: 2 });
-
-    const results = await Promise.all(
-      Array.from({ length: 10 }, () => provider.compress("sys", "user")),
-    );
-
-    expect(results).toHaveLength(10);
     expect(results.every((r) => r === "ok")).toBe(true);
   });
 
@@ -67,16 +55,14 @@ describe("ResilientProvider concurrency", () => {
       if (n <= 2) throw new Error("boom");
       return "ok";
     });
-    const provider = new ResilientProvider(inner, {
-      maxConcurrent: 1,
-      breaker: { failureThreshold: 100 },
-    });
+    // maxConcurrent 1 is load-bearing here: at the default of 4 a leaked slot
+    // would not deadlock, and the test would pass despite the bug.
+    const provider = new ResilientProvider(inner, { maxConcurrent: 1 });
 
     const settled = await Promise.allSettled(
       Array.from({ length: 5 }, () => provider.compress("sys", "user")),
     );
 
-    // A slot leaked on the error path would deadlock the remaining calls.
     expect(settled).toHaveLength(5);
     expect(settled.filter((s) => s.status === "fulfilled")).toHaveLength(3);
   });
@@ -84,18 +70,13 @@ describe("ResilientProvider concurrency", () => {
 
 describe("ResilientProvider rate limiting", () => {
   it("does not open the breaker on 429s", async () => {
-    // A 429 means slow down, not that the provider is broken. Counting it as a
-    // breaker failure converts backpressure into a 30s outage in which every
-    // compression fails fast.
     const inner = countingProvider(async (n) => {
       if (n <= 5) throw rateLimited();
       return "ok";
     });
-    const provider = new ResilientProvider(inner, {
-      maxConcurrent: 1,
-      breaker: { failureThreshold: 3 },
-    });
+    const provider = new ResilientProvider(inner);
 
+    // Five, against a default failure threshold of three.
     for (let i = 0; i < 5; i++) {
       await provider.compress("sys", "user").catch(() => undefined);
     }
@@ -108,10 +89,7 @@ describe("ResilientProvider rate limiting", () => {
     const inner = countingProvider(async () => {
       throw new Error("upstream exploded");
     });
-    const provider = new ResilientProvider(inner, {
-      maxConcurrent: 1,
-      breaker: { failureThreshold: 3 },
-    });
+    const provider = new ResilientProvider(inner);
 
     for (let i = 0; i < 3; i++) {
       await provider.compress("sys", "user").catch(() => undefined);

--- a/test/resilient-provider.test.ts
+++ b/test/resilient-provider.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import { ResilientProvider } from "../src/providers/resilient.js";
+import type { MemoryProvider } from "../src/types.js";
+
+// Tracks how many calls are inside the provider at once, which is the thing the
+// upstream API actually rejects. Counting total calls would not discriminate.
+function countingProvider(
+  behaviour: (n: number) => Promise<string> = async () => "ok",
+): MemoryProvider & { peak: number; calls: number } {
+  let inFlight = 0;
+  const state = {
+    name: "counting",
+    peak: 0,
+    calls: 0,
+    async compress(): Promise<string> {
+      inFlight++;
+      state.calls++;
+      if (inFlight > state.peak) state.peak = inFlight;
+      try {
+        return await behaviour(state.calls);
+      } finally {
+        inFlight--;
+      }
+    },
+    async summarize(): Promise<string> {
+      return state.compress();
+    },
+  };
+  return state;
+}
+
+function rateLimited(): Error {
+  return new Error('OpenAI API error (429): {"error":"too many concurrent requests"}');
+}
+
+describe("ResilientProvider concurrency", () => {
+  it("never runs more than the configured number of calls at once", async () => {
+    const inner = countingProvider(
+      () => new Promise((resolve) => setTimeout(() => resolve("ok"), 5)),
+    );
+    const provider = new ResilientProvider(inner, { maxConcurrent: 3 });
+
+    await Promise.all(
+      Array.from({ length: 24 }, () => provider.compress("sys", "user")),
+    );
+
+    // The provider fired all 24 at once before this bound existed, which is
+    // exactly what the upstream 429 complains about.
+    expect(inner.peak).toBeLessThanOrEqual(3);
+    expect(inner.calls).toBe(24);
+  });
+
+  it("still completes every call while bounded", async () => {
+    const inner = countingProvider();
+    const provider = new ResilientProvider(inner, { maxConcurrent: 2 });
+
+    const results = await Promise.all(
+      Array.from({ length: 10 }, () => provider.compress("sys", "user")),
+    );
+
+    expect(results).toHaveLength(10);
+    expect(results.every((r) => r === "ok")).toBe(true);
+  });
+
+  it("releases its slot when a call throws", async () => {
+    const inner = countingProvider(async (n) => {
+      if (n <= 2) throw new Error("boom");
+      return "ok";
+    });
+    const provider = new ResilientProvider(inner, {
+      maxConcurrent: 1,
+      breaker: { failureThreshold: 100 },
+    });
+
+    const settled = await Promise.allSettled(
+      Array.from({ length: 5 }, () => provider.compress("sys", "user")),
+    );
+
+    // A slot leaked on the error path would deadlock the remaining calls.
+    expect(settled).toHaveLength(5);
+    expect(settled.filter((s) => s.status === "fulfilled")).toHaveLength(3);
+  });
+});
+
+describe("ResilientProvider rate limiting", () => {
+  it("does not open the breaker on 429s", async () => {
+    // A 429 means slow down, not that the provider is broken. Counting it as a
+    // breaker failure converts backpressure into a 30s outage in which every
+    // compression fails fast.
+    const inner = countingProvider(async (n) => {
+      if (n <= 5) throw rateLimited();
+      return "ok";
+    });
+    const provider = new ResilientProvider(inner, {
+      maxConcurrent: 1,
+      breaker: { failureThreshold: 3 },
+    });
+
+    for (let i = 0; i < 5; i++) {
+      await provider.compress("sys", "user").catch(() => undefined);
+    }
+
+    expect(provider.circuitState.state).toBe("closed");
+    await expect(provider.compress("sys", "user")).resolves.toBe("ok");
+  });
+
+  it("still opens the breaker on genuine failures", async () => {
+    const inner = countingProvider(async () => {
+      throw new Error("upstream exploded");
+    });
+    const provider = new ResilientProvider(inner, {
+      maxConcurrent: 1,
+      breaker: { failureThreshold: 3 },
+    });
+
+    for (let i = 0; i < 3; i++) {
+      await provider.compress("sys", "user").catch(() => undefined);
+    }
+
+    expect(provider.circuitState.state).toBe("open");
+    await expect(provider.compress("sys", "user")).rejects.toThrow(
+      "circuit_breaker_open",
+    );
+  });
+});

--- a/test/resilient-provider.test.ts
+++ b/test/resilient-provider.test.ts
@@ -101,3 +101,58 @@ describe("ResilientProvider rate limiting", () => {
     );
   });
 });
+
+describe("ResilientProvider rate-limit classification", () => {
+  it("still opens the breaker when a real failure merely mentions a rate limit", async () => {
+    // The filter matches on message text, and providers interpolate the whole
+    // upstream body. A 500 whose body carries a docs link like
+    // /docs/guides/rate-limits would otherwise be excused forever, leaving the
+    // breaker permanently blind to a genuinely broken provider.
+    const inner = countingProvider(async () => {
+      throw new Error(
+        "HTTP 500 upstream failure, see https://example.com/docs/guides/rate-limits",
+      );
+    });
+    const provider = new ResilientProvider(inner);
+
+    for (let i = 0; i < 3; i++) {
+      await provider.compress("sys", "user").catch(() => undefined);
+    }
+
+    expect(provider.circuitState.state).toBe("open");
+  });
+
+  it("opens the breaker on quota exhaustion even though it arrives as a 429", async () => {
+    // Quota exhaustion and billing failures use the same status as
+    // backpressure, but they do not resolve on their own. Excusing them means
+    // the breaker can never open for a provider that will stay broken.
+    const inner = countingProvider(async () => {
+      throw new Error(
+        'API error (429): {"error":{"code":"insufficient_quota","message":"You exceeded your current quota"}}',
+      );
+    });
+    const provider = new ResilientProvider(inner);
+
+    for (let i = 0; i < 3; i++) {
+      await provider.compress("sys", "user").catch(() => undefined);
+    }
+
+    expect(provider.circuitState.state).toBe("open");
+  });
+
+  it("treats an overloaded provider as backpressure", async () => {
+    // Anthropic signals the same "busy, retry" condition as 529
+    // overloaded_error rather than 429.
+    const inner = countingProvider(async (n) => {
+      if (n <= 5) throw new Error('{"type":"overloaded_error"} (529)');
+      return "ok";
+    });
+    const provider = new ResilientProvider(inner);
+
+    for (let i = 0; i < 5; i++) {
+      await provider.compress("sys", "user").catch(() => undefined);
+    }
+
+    expect(provider.circuitState.state).toBe("closed");
+  });
+});

--- a/test/resilient-provider.test.ts
+++ b/test/resilient-provider.test.ts
@@ -185,9 +185,52 @@ describe("ResilientProvider half-open probe", () => {
     try {
       mode = "ratelimit";
       await provider.compress("sys", "user").catch(() => undefined);
-      expect(provider.circuitState.state).not.toBe("half-open");
+
+      // Assert the probe actually dispatched. Without this the test passes
+      // vacuously if the clock advance does not take: the breaker would still
+      // be open, the first isAllowed check would throw before reaching fn(),
+      // and "open" !== "half-open" would hold while nothing was exercised.
+      expect(inner.calls).toBe(4);
+      // Must be exactly open. `not.toBe("half-open")` would also accept
+      // "closed", which is the worse bug — a rate-limited probe mistaken for
+      // full recovery.
+      expect(provider.circuitState.state).toBe("open");
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("fails a call queued before the breaker opened, without calling the provider", async () => {
+    // The post-acquire re-check. A call admitted while the breaker was closed
+    // can wait behind others that fail and open it; without the re-check it is
+    // still handed to a provider already known to be down.
+    let release!: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    const inner = countingProvider(async (n) => {
+      if (n === 1) {
+        await gate;
+        throw new Error("upstream exploded");
+      }
+      throw new Error("upstream exploded");
+    });
+    const provider = new ResilientProvider(inner, { maxConcurrent: 1 });
+
+    // One call occupies the only slot; three more queue behind it.
+    const first = provider.compress("sys", "user").catch((e) => e);
+    const queued = Array.from({ length: 3 }, () =>
+      provider.compress("sys", "user").catch((e: Error) => e),
+    );
+    release();
+    const results = [await first, ...(await Promise.all(queued))];
+
+    // Three failures open the breaker, so the last queued call must be turned
+    // away at the re-check rather than reaching the provider.
+    expect(provider.circuitState.state).toBe("open");
+    expect(inner.calls).toBeLessThan(4);
+    expect(
+      results.some((r) => (r as Error).message === "circuit_breaker_open"),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## The bug

`ResilientProvider` wraps the LLM provider with a circuit breaker and nothing else. There is no semaphore, no queue, and no concurrency ceiling anywhere on the provider path, so every captured observation fires `compress()` the moment it arrives.

Under load that means dozens of simultaneous upstream calls, and the provider answers exactly as you would expect:

```
OpenAI API error (429): {"error":"too many concurrent requests"}
```

Then the second half of the problem: those 429s were fed to the breaker. At its configured threshold of three failures in sixty seconds it opened, and for the next thirty seconds **every** compression failed fast with `circuit_breaker_open` — while the provider was healthy and merely busy.

Observed in a deployed instance as a continuous stream of `circuit_breaker_open` on compression. Observations were being captured and never compressed.

## The change

**Bound the number of in-flight calls.** Default four, overridable per instance or with `AGENTMEMORY_MAX_PROVIDER_CONCURRENCY`. The semaphore hands a released slot directly to the next waiter rather than decrementing and letting waiters race for the opening, and it releases in a `finally` so a throw cannot leak a slot and deadlock everything queued behind it.

**Stop recording a rate-limit response as a breaker failure.** A 429 says *slow down*, not *you are broken*. Treating backpressure as a fault is what converted a busy upstream into a thirty-second outage. Genuine failures still open the breaker, and the breaker is still checked before queueing so an open circuit fails fast instead of occupying a slot.

## Why the wrapper rather than the call sites

`compress`/`summarize` have 15+ call sites across 12 files (reflect, consolidation-pipeline, temporal-graph, query-expansion, skill-extract, compress-file, summarize, flow-compress, consolidate, sliding-window, crystallize, graph, eval/self-correct). Bounding at the call site is a twelve-file diff that every future caller has to remember. The wrapper is the single choke point all callers already route through, and it is where the breaker already lives.

No dependency was added. There is no concurrency helper among the existing dependencies, and adding one for twenty lines would not earn its keep.

## Real behavior proof

Measured on a deployed instance, before and after.

Before — continuous in the logs:

```
error Compression failed {"obsId":"obs_...","error":"circuit_breaker_open"}
error Compression failed {"obsId":"obs_...","error":"OpenAI API error (429): {\"error\":\"too many concurrent requests\"}"}
```

After deploying this change, over the same log window:

| | before | after |
|---|---|---|
| `circuit_breaker_open` | continuous | 0 |
| `API error (429)` | tripping the breaker every cycle | 0 |
| `Compression failed` | continuous | 0 |
| observations captured | yes | yes, and now compressing |

## Testing

Four tests in `test/resilient-provider.test.ts`, each run against the unmodified source first and confirmed to fail:

- peak concurrency under a burst of 24 calls — **measured 24 against a limit of 3** before the bound existed
- the breaker stays closed across five 429s — **measured `open` where it should be `closed`**
- a slot is released when a call throws (uses `maxConcurrent: 1` deliberately: at the default of 4 a leaked slot would not deadlock and the test would pass despite the bug)
- genuine failures still open the breaker, so the rate-limit filter does not swallow real faults

Mutation-checked: making 429s count as breaker failures again kills the rate-limit test.

`npm test`: 1715 passing. `tsc --noEmit` unchanged from base (same 30 pre-existing errors, confirmed by stashing).

## What this does not claim

This fixes the breaker cascade and compression availability. It does **not** reduce memory. On the instance where it was measured, `iii` holds ~6.7 GB of anonymous heap against a 779 MB store, and this change does not touch that.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Provider operations now run within a configurable concurrency limit, with safe slot release after failures.
  * Excessively queued operations are rejected to prevent unbounded waiting.
  * Queued operations re-check service availability before proceeding.
  * Rate-limit and temporary overload responses are handled more accurately without unnecessarily triggering protection.
  * Genuine provider failures, including quota exhaustion, continue to activate the circuit breaker.
  * Rate-limited recovery probes are handled correctly, preventing the circuit breaker from remaining stuck in a half-open state.

* **Documentation**
  * Added guidance for configuring the provider concurrency limit, which defaults to six simultaneous calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->