### PR TITLE
fix(mcp): read graph stats from the snapshot instead of enumerating the graph

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1478,13 +1478,6 @@ export function registerMcpEndpoints(
 
         if (uri === "agentmemory://graph/stats") {
           try {
-            // Read the precomputed snapshot rather than enumerating the graph.
-            // KV.graphSnapshot exists for exactly this (#814, state/schema.ts):
-            // it carries the same aggregate counts in one small key. Listing
-            // the scopes instead pulled every node and edge over the engine
-            // transport — on a real corpus that is a multi-hundred-MB frame
-            // against a 16 MiB limit (state/frame-guard.ts), which kills the
-            // worker connection every time this resource is read.
             const snapshot = await kv.get<GraphSnapshot>(
               KV.graphSnapshot,
               "current",
@@ -1502,8 +1495,6 @@ export function registerMcpEndpoints(
                       totalEdges: stats?.totalEdges ?? 0,
                       nodesByType: stats?.nodesByType ?? {},
                       edgesByType: stats?.edgesByType ?? {},
-                      // Absent snapshot reports zeros rather than falling back
-                      // to a scope enumeration: the fallback is the failure.
                       ...(snapshot ? {} : { pending: true }),
                     }),
                   },

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,12 +1,7 @@
 import type { ISdk, ApiRequest } from "iii-sdk";
 import type { StateKV } from "../state/kv.js";
 import { KV } from "../state/schema.js";
-import type {
-  SessionSummary,
-  Memory,
-  Session,
-  GraphSnapshot,
-} from "../types.js";
+import type { SessionSummary, Memory, Session } from "../types.js";
 import { getVisibleTools } from "./tools-registry.js";
 import { timingSafeCompare } from "../auth.js";
 import { getAgentId, isAgentScopeIsolated } from "../config.js";
@@ -1478,11 +1473,10 @@ export function registerMcpEndpoints(
 
         if (uri === "agentmemory://graph/stats") {
           try {
-            const snapshot = await kv.get<GraphSnapshot>(
-              KV.graphSnapshot,
-              "current",
-            );
-            const stats = snapshot?.stats;
+            const stats = await sdk.trigger({
+              function_id: "mem::graph-stats",
+              payload: {},
+            });
             return {
               status_code: 200,
               body: {
@@ -1490,13 +1484,7 @@ export function registerMcpEndpoints(
                   {
                     uri,
                     mimeType: "application/json",
-                    text: JSON.stringify({
-                      totalNodes: stats?.totalNodes ?? 0,
-                      totalEdges: stats?.totalEdges ?? 0,
-                      nodesByType: stats?.nodesByType ?? {},
-                      edgesByType: stats?.edgesByType ?? {},
-                      ...(snapshot ? {} : { pending: true }),
-                    }),
+                    text: JSON.stringify(stats),
                   },
                 ],
               },

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -5,8 +5,7 @@ import type {
   SessionSummary,
   Memory,
   Session,
-  GraphNode,
-  GraphEdge,
+  GraphSnapshot,
 } from "../types.js";
 import { getVisibleTools } from "./tools-registry.js";
 import { timingSafeCompare } from "../auth.js";
@@ -1479,14 +1478,18 @@ export function registerMcpEndpoints(
 
         if (uri === "agentmemory://graph/stats") {
           try {
-            const nodes = await kv.list<GraphNode>(KV.graphNodes);
-            const edges = await kv.list<GraphEdge>(KV.graphEdges);
-            const nodesByType: Record<string, number> = {};
-            for (const n of nodes)
-              nodesByType[n.type] = (nodesByType[n.type] || 0) + 1;
-            const edgesByType: Record<string, number> = {};
-            for (const e of edges)
-              edgesByType[e.type] = (edgesByType[e.type] || 0) + 1;
+            // Read the precomputed snapshot rather than enumerating the graph.
+            // KV.graphSnapshot exists for exactly this (#814, state/schema.ts):
+            // it carries the same aggregate counts in one small key. Listing
+            // the scopes instead pulled every node and edge over the engine
+            // transport — on a real corpus that is a multi-hundred-MB frame
+            // against a 16 MiB limit (state/frame-guard.ts), which kills the
+            // worker connection every time this resource is read.
+            const snapshot = await kv.get<GraphSnapshot>(
+              KV.graphSnapshot,
+              "current",
+            );
+            const stats = snapshot?.stats;
             return {
               status_code: 200,
               body: {
@@ -1495,10 +1498,13 @@ export function registerMcpEndpoints(
                     uri,
                     mimeType: "application/json",
                     text: JSON.stringify({
-                      totalNodes: nodes.length,
-                      totalEdges: edges.length,
-                      nodesByType,
-                      edgesByType,
+                      totalNodes: stats?.totalNodes ?? 0,
+                      totalEdges: stats?.totalEdges ?? 0,
+                      nodesByType: stats?.nodesByType ?? {},
+                      edgesByType: stats?.edgesByType ?? {},
+                      // Absent snapshot reports zeros rather than falling back
+                      // to a scope enumeration: the fallback is the failure.
+                      ...(snapshot ? {} : { pending: true }),
                     }),
                   },
                 ],

--- a/test/mcp-resources.test.ts
+++ b/test/mcp-resources.test.ts
@@ -231,6 +231,35 @@ describe("MCP Resources", () => {
     expect(data[0].title).toBe("Latest pattern");
   });
 
+  it("reads agentmemory://graph/stats from mem::graph-stats", async () => {
+    sdk.overrideTrigger("mem::graph-stats", async () => ({
+      totalNodes: 3,
+      totalEdges: 2,
+      nodesByType: { file: 3 },
+      edgesByType: { imports: 2 },
+      fromSnapshot: false,
+      warning:
+        "No graph snapshot available. Run POST /agentmemory/graph/snapshot-rebuild",
+    }));
+
+    const fn = sdk.getFunction("mcp::resources::read")!;
+    const result = (await fn(
+      makeReq({ uri: "agentmemory://graph/stats" }),
+    )) as {
+      status_code: number;
+      body: { contents: Array<{ text: string }> };
+    };
+
+    expect(result.status_code).toBe(200);
+    const data = JSON.parse(result.body.contents[0].text);
+    expect(data.totalNodes).toBe(3);
+    expect(data.totalEdges).toBe(2);
+    expect(data.nodesByType).toEqual({ file: 3 });
+    expect(data.edgesByType).toEqual({ imports: 2 });
+    expect(data.warning).toContain("snapshot-rebuild");
+    expect(data.pending).toBeUndefined();
+  });
+
   it("returns 404 for unknown URI", async () => {
     const fn = sdk.getFunction("mcp::resources::read")!;
     const result = (await fn(


### PR DESCRIPTION
## The bug

`agentmemory://graph/stats` lists every node and every edge in order to produce four aggregate numbers:

```ts
const nodes = await kv.list<GraphNode>(KV.graphNodes);
const edges = await kv.list<GraphEdge>(KV.graphEdges);
// ...returns totalNodes, totalEdges, nodesByType, edgesByType
```

`kv.list` returns every *value* in a scope (`state/kv.ts:41-46`), so this is a full materialisation of the graph over the engine transport — to compute a histogram.

## Real behavior proof

Measured on a deployed instance, read-only:

| scope | size | vs the 16 MiB limit |
|---|---|---|
| `mem:graph:nodes` | **111 MB** | 7× over |
| `mem:graph:edges` | **84 MB** | 5× over |

The limit is not incidental — this repo defines it itself, in `state/frame-guard.ts:5`:

```ts
const FRAME_LIMIT_BYTES = 16 * 1024 * 1024;
```

So this read cannot succeed. It closes the worker connection with `1009 Message Too Big` every time it is served. In the logs:

```
[iii] WebSocket error RangeError: Max payload size exceeded
  code: 'WS_ERR_UNSUPPORTED_MESSAGE_LENGTH', [Symbol(status-code)]: 1009
[iii] Reconnecting in 1014ms (attempt 1)...
[iii] Worker registered with ID: <new uuid>
```

Measured rate across three separate containers: **3.8 to 5.1 kills per minute**, each followed by a reconnect that registers a fresh worker id. Roughly 150 new registrations accumulate per 40 minutes.

## The fix

The counts were already precomputed. `KV.graphSnapshot` carries `totalNodes`, `totalEdges`, `nodesByType`, and `edgesByType` in a single key, and the comment introducing it in `state/schema.ts` names this exact caller:

> *"precomputed snapshot of the top-degree subgraph and aggregate type counts. Saves /graph/query and /graph/stats from a full kv.list enumeration over 75K+ node corpora, which exceeds the iii invocation timeout"*

This resource simply never adopted it.

An absent snapshot now reports zeros with `pending: true` rather than falling back to enumeration. The fallback is the failure mode, so there is no version of it worth keeping.

## Limitations, stated up front

**This does not fully bound the read.** The snapshot key is currently 15 MB on the measured instance, right at `SAFE_PAYLOAD_BYTES`. It is a single `kv.get` rather than an enumeration, and 15 MB against 195 MB is a 13× reduction, but the `stats` block would be better split into its own small key so it is not carried behind `topNodes`/`topEdges`. That is a schema change and belongs in its own PR.

**This is not the only enumerating caller.** Also outstanding, and deliberately not bundled here:

- `mcp/server.ts` `agentmemory://status` lists all sessions and the entire 36 MB `mem:memories` scope to return three integers. It is a status endpoint, so it is polled — this is almost certainly the higher-frequency offender, and it needs maintained counters rather than a swap.
- `cascade.ts:27,44` needs a `sourceObservationId → nodeIds` index before it can stop scanning.
- `api.ts:2801` calls `checkPayloadFrameSize` on its response but not on the inbound read that has already happened.

## Testing

`npm test`: 1710 passing; the single failure is `test/cli-lifecycle-safety.test.ts`, which spawns real subprocesses, passes 14/14 in isolation, and imports none of the changed modules.

`tsc --noEmit` unchanged from base (same 30 pre-existing errors, confirmed by stashing).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the graph statistics resource to retrieve current statistics directly, providing more accurate node and edge counts.
  * Removed the pending-status response from graph statistics, ensuring results consistently include the available totals, type breakdowns, and warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->