### PR TITLE
fix(test): point USERPROFILE at the temp home on Windows

### DIFF
--- a/test/slots-flag-gate.test.ts
+++ b/test/slots-flag-gate.test.ts
@@ -13,20 +13,27 @@ import { join } from "node:path";
 describe("isSlotsEnabled — reads merged env (#678)", () => {
   let home: string;
   let ORIG_HOME: string | undefined;
+  let ORIG_USERPROFILE: string | undefined;
   let ORIG_FLAG: string | undefined;
 
   beforeEach(() => {
     home = mkdtempSync(join(tmpdir(), "am-slots-flag-"));
     mkdirSync(join(home, ".agentmemory"), { recursive: true });
     ORIG_HOME = process.env["HOME"];
+    ORIG_USERPROFILE = process.env["USERPROFILE"];
     ORIG_FLAG = process.env["AGENTMEMORY_SLOTS"];
     process.env["HOME"] = home;
+    // os.homedir() ignores HOME on Windows and reads USERPROFILE, so without
+    // this the flag is read from the developer's real ~/.agentmemory/.env.
+    process.env["USERPROFILE"] = home;
     delete process.env["AGENTMEMORY_SLOTS"];
     vi.resetModules();
   });
 
   afterEach(() => {
     if (ORIG_HOME !== undefined) process.env["HOME"] = ORIG_HOME;
+    if (ORIG_USERPROFILE !== undefined) process.env["USERPROFILE"] = ORIG_USERPROFILE;
+    else delete process.env["USERPROFILE"];
     if (ORIG_FLAG !== undefined) process.env["AGENTMEMORY_SLOTS"] = ORIG_FLAG;
     else delete process.env["AGENTMEMORY_SLOTS"];
     rmSync(home, { recursive: true, force: true });
@@ -60,20 +67,25 @@ describe("isSlotsEnabled — reads merged env (#678)", () => {
 describe("isReflectEnabled — reads merged env (#678)", () => {
   let home: string;
   let ORIG_HOME: string | undefined;
+  let ORIG_USERPROFILE: string | undefined;
   let ORIG_FLAG: string | undefined;
 
   beforeEach(() => {
     home = mkdtempSync(join(tmpdir(), "am-reflect-flag-"));
     mkdirSync(join(home, ".agentmemory"), { recursive: true });
     ORIG_HOME = process.env["HOME"];
+    ORIG_USERPROFILE = process.env["USERPROFILE"];
     ORIG_FLAG = process.env["AGENTMEMORY_REFLECT"];
     process.env["HOME"] = home;
+    process.env["USERPROFILE"] = home;
     delete process.env["AGENTMEMORY_REFLECT"];
     vi.resetModules();
   });
 
   afterEach(() => {
     if (ORIG_HOME !== undefined) process.env["HOME"] = ORIG_HOME;
+    if (ORIG_USERPROFILE !== undefined) process.env["USERPROFILE"] = ORIG_USERPROFILE;
+    else delete process.env["USERPROFILE"];
     if (ORIG_FLAG !== undefined) process.env["AGENTMEMORY_REFLECT"] = ORIG_FLAG;
     else delete process.env["AGENTMEMORY_REFLECT"];
     rmSync(home, { recursive: true, force: true });


### PR DESCRIPTION
Two tests in `test/slots-flag-gate.test.ts` fail on Windows for anyone whose own `~/.agentmemory/.env` sets `AGENTMEMORY_SLOTS` or `AGENTMEMORY_REFLECT` to `false`.

## Cause

`beforeEach` creates a temp home and points `HOME` at it, but `src/functions/slots.js` resolves the config path through `os.homedir()` — and on Windows that reads `USERPROFILE`, ignoring `HOME` entirely:

```
> process.env.HOME = 'C:/tmp/fake-home'
> os.homedir()
'C:\Users\Administrator'
```

So the flag is read from the developer's real `.env` rather than the temp file the test just wrote. CI is green because `HOME` and `USERPROFILE` agree on Linux.

## Fix

Set `USERPROFILE` alongside `HOME` in both `describe` blocks and restore it in `afterEach`.

## Verification

On a clean checkout of `main`, Windows:

```
before: Tests  2 failed | 2 passed (4)
after:  Tests  4 passed (4)
```

`slots-flag-gate` is the only test file that overrides `HOME` without `USERPROFILE` — the other nine already set both, so this brings it in line with them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved cross-platform test reliability by ensuring temporary home-directory settings work correctly on Windows.
  * Added cleanup to restore the original environment after each test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->