### PR TITLE
fix(test): normalise fs mock paths so they match on Windows

### DIFF
--- a/test/compress-file.test.ts
+++ b/test/compress-file.test.ts
@@ -8,12 +8,19 @@ const fileStore = new Map<string, string>();
 const symlinkPaths = new Set<string>();
 const openEloopPaths = new Set<string>();
 
+// The function resolves filePath before touching the fs, and resolve() turns
+// a POSIX fixture path into a drive-rooted one on Windows ("/tmp/notes.md" ->
+// "C:\tmp\notes.md"), so raw-path keys never match there.
+function key(path: string): string {
+  return path.replace(/\\/g, "/").replace(/^[A-Za-z]:/, "");
+}
+
 vi.mock("node:fs/promises", () => ({
   lstat: vi.fn(async (path: string) => {
-    if (symlinkPaths.has(path)) {
+    if (symlinkPaths.has(key(path))) {
       return { isSymbolicLink: () => true };
     }
-    if (!fileStore.has(path)) {
+    if (!fileStore.has(key(path))) {
       throw Object.assign(new Error(`ENOENT: no such file or directory, lstat '${path}'`), {
         code: "ENOENT",
       });
@@ -21,25 +28,25 @@ vi.mock("node:fs/promises", () => ({
     return { isSymbolicLink: () => false };
   }),
   open: vi.fn(async (path: string) => {
-    if (openEloopPaths.has(path)) {
+    if (openEloopPaths.has(key(path))) {
       throw Object.assign(new Error("ELOOP: too many levels of symbolic links"), {
         code: "ELOOP",
       });
     }
     return {
       writeFile: vi.fn(async (content: string) => {
-        fileStore.set(path, content);
+        fileStore.set(key(path), content);
       }),
       close: vi.fn(async () => {}),
     };
   }),
   readFile: vi.fn(async (path: string) => {
-    const value = fileStore.get(path);
+    const value = fileStore.get(key(path));
     if (value === undefined) throw new Error("ENOENT");
     return value;
   }),
   writeFile: vi.fn(async (path: string, content: string) => {
-    fileStore.set(path, content);
+    fileStore.set(key(path), content);
   }),
 }));
 
@@ -172,7 +179,7 @@ describe("mem::compress-file", () => {
     };
 
     expect(result.success).toBe(true);
-    expect(result.backupPath).toBe("/tmp/notes.original.md");
+    expect(key(result.backupPath)).toBe("/tmp/notes.original.md");
     expect(fileStore.get("/tmp/notes.original.md")).toContain("Some long explanation.");
     expect(fileStore.get(path)).toContain("Short explanation.");
     expect(result.compressedChars).toBeLessThan(result.originalChars);
@@ -203,7 +210,7 @@ describe("mem::compress-file", () => {
     })) as { success: boolean; backupPath: string };
 
     expect(result.success).toBe(true);
-    expect(result.backupPath).toBe("/tmp/notes.original.backup.md");
+    expect(key(result.backupPath)).toBe("/tmp/notes.original.backup.md");
     expect(fileStore.get("/tmp/notes.original.backup.md")).toBe(
       "# Title\n\nLong original body.",
     );

--- a/test/obsidian-export.test.ts
+++ b/test/obsidian-export.test.ts
@@ -7,12 +7,18 @@ vi.mock("../src/logger.js", () => ({
 const writtenFiles = new Map<string, string>();
 const createdDirs = new Set<string>();
 
+// resolve()/join() produce drive-rooted Windows paths from the POSIX fixture
+// paths these tests use, so keys are normalised before they go in the maps.
+function key(path: string): string {
+  return path.replace(/\\/g, "/").replace(/^[A-Za-z]:/, "");
+}
+
 vi.mock("node:fs/promises", () => ({
   mkdir: vi.fn(async (dir: string) => {
-    createdDirs.add(dir);
+    createdDirs.add(key(dir));
   }),
   writeFile: vi.fn(async (path: string, content: string) => {
-    writtenFiles.set(path, content);
+    writtenFiles.set(key(path), content);
   }),
 }));
 
@@ -238,7 +244,7 @@ describe("Obsidian Export", () => {
     })) as { success: boolean; error: string };
 
     expect(result.success).toBe(false);
-    expect(result.error).toContain(exportRoot);
+    expect(key(result.error)).toContain(exportRoot);
   });
 
   it("skips deleted lessons", async () => {


### PR DESCRIPTION
`test/compress-file.test.ts` and `test/obsidian-export.test.ts` fail on Windows — 13 tests between them — because their in-memory `node:fs/promises` mocks are keyed on the raw path string while the functions under test resolve the path first.

## Cause

```js
resolve("/tmp/notes.md")   // Linux:   /tmp/notes.md
                           // Windows: C:\tmp\notes.md
```

`compress-file` calls `resolve(data.filePath)` before its first `lstat`. The mock's `fileStore` has `/tmp/notes.md`, the lookup asks for `C:\tmp\notes.md`, `lstat` throws ENOENT, and the function returns `file not found` — for a fixture the test wrote two lines earlier. `obsidian-export` has the same mismatch through `join()`.

That is why the failures read like unrelated assertion noise (`expected 'file not found' to contain 'symlink'`, `expected undefined to be defined`) rather than a path problem.

## Fix

A small `key()` normaliser applied where paths enter the mock maps, plus three assertions that compare a returned path or error message against a POSIX literal. No production code changes.

## Verification

Windows, clean checkout of `main`:

```
compress-file    before: 5 failed | 2 passed (7)     after: 7 passed (7)
obsidian-export  before: 8 failed | 8 passed (16)    after: 16 passed (16)

full suite       before: 30 failed | 1682 passed     after: 17 failed | 1695 passed
```

Linux is unaffected: `key()` is an identity transform on paths that are already POSIX.

The remaining 17 are separate Windows issues (process spawning, file locking, `cli-lifecycle-safety` fixtures) — happy to look at those in follow-ups if useful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved cross-platform test coverage for file compression and export workflows.
  * Added consistent path handling across Windows and POSIX-style environments.
  * Strengthened verification of backup paths, generated files and directories, and export-related error messages.
  * Reduced false failures caused by differences in path separators and drive-letter formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->