### PR TITLE
fix(test): drop POSIX-only assumptions from six suites

### DIFF
--- a/test/cli-engine-startup.test.ts
+++ b/test/cli-engine-startup.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 describe("fresh native engine startup", () => {
-  const source = readFileSync("src/cli.ts", "utf8");
+  const source = readFileSync("src/cli.ts", "utf8").replace(/\r\n/g, "\n");
 
   it("routes existing and newly installed engines through one runtime config", () => {
     const prepareStart = source.indexOf("function prepareEngineLaunch");

--- a/test/cli-remove.test.ts
+++ b/test/cli-remove.test.ts
@@ -17,6 +17,10 @@ import { join } from "node:path";
 
 let sandbox: string;
 
+// remove-plan looks for iii.exe on Windows, so the fixtures have to use the
+// same name or the plan items never become applicable.
+const III_BIN = process.platform === "win32" ? "iii.exe" : "iii";
+
 function ctx(overrides: Partial<RemoveContext> = {}): RemoveContext {
   return {
     home: sandbox,
@@ -112,7 +116,7 @@ describe("buildRemovePlan", () => {
   });
 
   it("local-bin/iii is alwaysAsk when version does not match", () => {
-    touch(".local/bin/iii", "fakebin");
+    touch(`.local/bin/${III_BIN}`, "fakebin");
     const plan = buildRemovePlan(
       ctx({ localBinIiiVersion: "9.9.9" }),
       { force: false, keepData: false },
@@ -123,7 +127,7 @@ describe("buildRemovePlan", () => {
   });
 
   it("local-bin/iii is auto-fixable when version matches pinned", () => {
-    touch(".local/bin/iii", "fakebin");
+    touch(`.local/bin/${III_BIN}`, "fakebin");
     const plan = buildRemovePlan(
       ctx({ localBinIiiVersion: "0.11.2" }),
       { force: false, keepData: false },
@@ -141,7 +145,7 @@ describe("buildRemovePlan", () => {
   });
 
   it("private ~/.agentmemory/bin/iii is removed without prompt", () => {
-    touch(".agentmemory/bin/iii", "fakebin");
+    touch(`.agentmemory/bin/${III_BIN}`, "fakebin");
     const plan = buildRemovePlan(ctx(), { force: false, keepData: false });
     const item = plan.find((p) => p.id === "private-bin-iii")!;
     expect(item).toBeDefined();

--- a/test/copilot-plugin.test.ts
+++ b/test/copilot-plugin.test.ts
@@ -295,7 +295,9 @@ describe("Copilot hook scripts", () => {
     expect(result.requests[0]?.path).toBe("/agentmemory/session/start");
     expect(result.requests[0]?.body).toMatchObject({
       sessionId: "copilot-session",
-      project: "C:\\repo",
+      // basename() only treats a backslash as a separator on Windows,
+      // so this cwd resolves to "repo" there and stays whole on POSIX.
+      project: process.platform === "win32" ? "repo" : "C:\\repo",
       cwd: "C:\\repo",
     });
   });

--- a/test/engine-config.test.ts
+++ b/test/engine-config.test.ts
@@ -8,7 +8,7 @@ describe("renderEngineConfig", () => {
     const source = readFileSync(
       join(import.meta.dirname, "..", "iii-config.yaml"),
       "utf8",
-    );
+    ).replace(/\r\n/g, "\n");
     const dataDir = join("/var", "lib", "agentmemory");
 
     const rendered = renderEngineConfig(source, { dataDir });
@@ -26,7 +26,7 @@ describe("renderEngineConfig", () => {
     const source = readFileSync(
       join(import.meta.dirname, "..", "iii-config.yaml"),
       "utf8",
-    );
+    ).replace(/\r\n/g, "\n");
 
     const rendered = renderEngineConfig(source, {
       dataDir: "/tmp/agentmemory",

--- a/test/engine-launch.test.ts
+++ b/test/engine-launch.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import {
   agentmemoryHome,
   dockerComposeArgs,
@@ -32,12 +32,12 @@ describe("engine-launch path resolution", () => {
   });
 
   it("resolveEngineCwd keeps the invocation cwd for repo-local configs", () => {
-    const repo = "/work/agentmemory";
+    const repo = resolve("/work/agentmemory");
     expect(resolveEngineCwd(join(repo, "iii-config.yaml"), repo, HOME)).toBe(repo);
   });
 
   it("resolveEngineCwd anchors bundled configs and preserves custom config roots", () => {
-    const repo = "/work/some-project";
+    const repo = resolve("/work/some-project");
     expect(resolveEngineCwd("/opt/pkg/dist/iii-config.yaml", repo, HOME, true)).toBe(
       join(HOME, ".agentmemory"),
     );

--- a/test/runtime-paths.test.ts
+++ b/test/runtime-paths.test.ts
@@ -1,4 +1,4 @@
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { runtimeMetadataPath } from "../src/runtime-paths.js";
 
@@ -6,10 +6,10 @@ describe("runtime metadata paths", () => {
   it("uses an explicit runtime directory so instances do not share metadata", () => {
     expect(
       runtimeMetadataPath("engine-state.json", {
-        env: { AGENTMEMORY_RUNTIME_DIR: "/var/lib/agentmemory/instance-2" },
+        env: { AGENTMEMORY_RUNTIME_DIR: resolve("/var/lib/agentmemory/instance-2") },
         home: "/home/test",
       }),
-    ).toBe(join("/var/lib/agentmemory/instance-2", "engine-state.json"));
+    ).toBe(join(resolve("/var/lib/agentmemory/instance-2"), "engine-state.json"));
   });
 
   it("keeps instance-zero lifecycle state canonical across data-dir changes", () => {

--- a/test/runtime-paths.test.ts
+++ b/test/runtime-paths.test.ts
@@ -6,7 +6,7 @@ describe("runtime metadata paths", () => {
   it("uses an explicit runtime directory so instances do not share metadata", () => {
     expect(
       runtimeMetadataPath("engine-state.json", {
-        env: { AGENTMEMORY_RUNTIME_DIR: resolve("/var/lib/agentmemory/instance-2") },
+        env: { AGENTMEMORY_RUNTIME_DIR: "/var/lib/agentmemory/instance-2" },
         home: "/home/test",
       }),
     ).toBe(join(resolve("/var/lib/agentmemory/instance-2"), "engine-state.json"));


### PR DESCRIPTION
Six test suites fail on Windows because of platform assumptions in the tests themselves. No production code is involved — each one is a fixture or an assertion that only holds where paths are POSIX and line endings are LF.

## What each one was

| Suite | Assumption |
|---|---|
| `cli-remove` (3) | fixtures named `iii`, but `remove-plan` looks for `iii.exe` on Windows via `iiiBinFile()`, so no plan item was ever `applicable` |
| `cli-engine-startup` (1) | matches a multi-line `\n` literal against `src/cli.ts`, which git checks out with CRLF |
| `engine-config` (1) | same, against `iii-config.yaml` |
| `engine-launch` (2) | compares `resolveEngineCwd()` output to `"/work/agentmemory"` |
| `runtime-paths` (1) | compares `runtimeMetadataPath()` output to a POSIX literal |
| `copilot-plugin` (1) | expects `basename("C:\\repo")` to be the whole string — true only where `\` is not a separator |

The `cli-remove` one is worth calling out: the production code is correct and platform-aware, and the test is what hard-codes the POSIX name. The failure surfaces as `TypeError: Cannot read properties of undefined`, which reads like a broken fixture rather than a platform issue.

## Fix

Fixtures use the same `iii.exe`/`iii` rule as the source, CRLF is normalised where a test reads a file to match source text, and path comparisons go through `resolve()`.

## Verification

Windows:

```
before: Tests  30 failed | 1682 passed (1729)
after:  Tests   6 failed | 1706 passed (1729)
```

The six suites here go from 13 failed to 56 passed. Linux is unaffected — every change is either an identity transform there or already-matching behaviour.

## Not covered

`cli-lifecycle-safety` still fails 6. It writes a shebang script named `docker` onto PATH and drives it through `spawnSync`; a `.cmd` shim plus `path.delimiter` fixes one of the six, but the rest depend on POSIX process semantics (SIGTERM delivery, exit-code propagation through the shim). That needs a different approach than a fixture tweak, so I have left it out of this PR rather than half-fix it.

Related: #1261 (USERPROFILE), #1262 (fs mock path keys).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved cross-platform test reliability across Windows and POSIX environments.
  * Normalized line endings and file paths for consistent configuration and startup checks.
  * Updated executable and project path expectations to reflect platform-specific behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->