### PR TITLE
fix(test): make the lifecycle fixtures runnable on Windows

### DIFF
--- a/test/cli-lifecycle-safety.test.ts
+++ b/test/cli-lifecycle-safety.test.ts
@@ -1,4 +1,9 @@
 import { spawnSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+const IS_WIN = process.platform === "win32";
+// The CLI removes iii.exe on Windows, so fixtures must use that name.
+const III_BIN = IS_WIN ? "iii.exe" : "iii";
 import {
   chmodSync,
   existsSync,
@@ -9,7 +14,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, delimiter } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 const sandboxes: string[] = [];
@@ -24,7 +29,10 @@ function sandbox(): string {
 
 function installFakeDocker(binDir: string): void {
   mkdirSync(binDir, { recursive: true });
-  const dockerPath = join(binDir, "docker");
+  // `where docker` reports a bare file before any .cmd, and CreateProcess
+  // cannot run a shebang script, so the fake lives under a .js name and a
+  // .cmd shim carries the "docker" name.
+  const dockerPath = join(binDir, IS_WIN ? "docker-fake.js" : "docker");
   writeFileSync(
     dockerPath,
     `#!/usr/bin/env node
@@ -67,6 +75,12 @@ process.exit(0);
 `,
   );
   chmodSync(dockerPath, 0o755);
+  if (IS_WIN) {
+    writeFileSync(
+      join(binDir, "docker.cmd"),
+      `@echo off\r\n"${process.execPath}" "${dockerPath}" %*\r\n`,
+    );
+  }
 }
 
 function runDockerStop(
@@ -80,7 +94,7 @@ function runDockerStop(
   const binDir = join(root, "bin");
   const composeFile = join(root, "docker-compose.yml");
   const dockerLog = join(root, "docker.log");
-  const privateBin = join(runtimeDir, "bin", "iii");
+  const privateBin = join(runtimeDir, "bin", III_BIN);
   mkdirSync(runtimeDir, { recursive: true });
   mkdirSync(dataDir, { recursive: true });
   if (command === "remove") {
@@ -129,7 +143,7 @@ function runDockerStop(
         HOME: home,
         USERPROFILE: home,
         CI: "1",
-        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        PATH: `${binDir}${delimiter}${process.env.PATH ?? ""}`,
         DOCKER_LOG: dockerLog,
         DOCKER_FAILURE_MODE: failureMode,
         DOCKER_DATA_DIR: dataDir,
@@ -149,7 +163,7 @@ function runDockerStop(
 function runInstanceRemove(instanceArgs = ["--instance", "1"]) {
   const root = sandbox();
   const home = join(root, "home");
-  const privateBin = join(home, ".agentmemory", "bin", "iii");
+  const privateBin = join(home, ".agentmemory", "bin", III_BIN);
   const dataBase = join(root, "data");
   mkdirSync(join(home, ".agentmemory", "bin"), { recursive: true });
   writeFileSync(privateBin, "shared binary");
@@ -185,7 +199,7 @@ function runNativeRemoveWithWorkerFailure() {
   const root = sandbox();
   const home = join(root, "home");
   const runtimeDir = join(home, ".agentmemory");
-  const privateBin = join(runtimeDir, "bin", "iii");
+  const privateBin = join(runtimeDir, "bin", III_BIN);
   const engineState = join(runtimeDir, "engine-state.json");
   const enginePidfile = join(runtimeDir, "iii.pid");
   const workerPidfile = join(runtimeDir, "worker.pid");
@@ -223,7 +237,8 @@ process.kill = (pid, signal) => {
     process.execPath,
     [
       "--import",
-      preload,
+      // A bare Windows path is not a valid ESM specifier; --import needs a URL.
+      pathToFileURL(preload).href,
       "--import",
       "tsx",
       "src/cli.ts",


### PR DESCRIPTION
`test/cli-lifecycle-safety.test.ts` fails 6 tests on Windows. Four separate fixture assumptions are responsible; this PR fixes those and takes the suite to 2 failures. The last two need a production decision, described below.

## What was wrong

**The fake docker never ran.** The suite writes a `#!/usr/bin/env node` script named `docker` onto PATH. Windows resolves a bare `docker` through PATHEXT and `CreateProcess` ignores shebang lines, so the CLI's `whichBinary("docker")` either missed it or found something unrunnable. The fake now lives under `docker-fake.js` with a `.cmd` shim carrying the `docker` name.

**PATH was joined with `":"`.** On Windows the separator is `;`, so `binDir` was never a real PATH entry — now `path.delimiter`.

**`--import` got a bare Windows path.** `--import C:\...\deny-worker-signal.mjs` is not a valid ESM specifier and the child aborted before the preload could patch `process.kill`, which is why the SIGTERM assertion saw an empty log. Now `pathToFileURL(preload).href`.

**Private-bin fixtures were named `iii`.** The CLI removes `iii.exe` on Windows, so the deletion assertions could never pass. Same root cause as #1263's `cli-remove` fix.

## Result

```
before: Tests  6 failed | 8 passed (14)
after:  Tests  2 failed | 12 passed (14)
```

Linux unchanged — every branch is `process.platform === "win32"` guarded or an identity transform.

## The remaining 2

`deduplicates short and full IDs` and `removes shared assets while preserving validated Docker recovery state` still fail, and it is not a fixture problem:

`whichBinary()` correctly returns the `.cmd` shim — I verified `where docker` reports it first. But `spawnSync(dockerBin, ["inspect", id])` then fails with `EINVAL`, because Node cannot execute a `.cmd` without `shell: true`:

```js
spawnSync(cmd, ["inspect", "x"])                 // status=null, EINVAL
spawnSync(cmd, ["inspect", "x"], {shell: true})  // status=0
```

So on Windows the CLI cannot invoke any Docker CLI that is a `.cmd` wrapper. Real Docker Desktop ships `docker.exe`, so this is invisible in normal use — but it does mean `src/cli.ts` has an untested constraint on how `docker` is installed.

Fixing it means adding `shell: true` (and quoting the arguments) at the four `spawnSync`/`execFileSync` call sites that take `dockerBin`. That is a production change with a real injection surface, so I did not want to bundle it into a test-only PR. Happy to do it as a follow-up if you want it.

Related: #1264 (Windows test audit), #1263, #1262, #1261.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI lifecycle test compatibility on Windows.
  * Added support for Windows executable naming, command shims, PATH formatting, and ESM preload URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->