### PR TITLE
ci: run the matrix on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,11 +47,7 @@ jobs:
       # whether a flake is platform-specific or universal).
       fail-fast: false
       matrix:
-        # Windows held back: test/obsidian-export.test.ts has hardcoded
-        # POSIX paths (`/tmp/...`) that fail on D:\ drive runners.
-        # src/functions/obsidian-export.ts needs os.tmpdir() + path.join
-        # rework before Windows can be added back. Tracked as follow-up.
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         node-version: [20, 22, 24, 26]
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
The matrix comment says Windows is held back because `test/obsidian-export.test.ts` has hardcoded POSIX paths and `src/functions/obsidian-export.ts` "needs os.tmpdir() + path.join rework".

Half of that is no longer true. The production file already builds paths correctly:

```ts
const DEFAULT_EXPORT_ROOT = join(homedir(), ".agentmemory");
const resolved = resolve(vaultDir || join(root, "vault"));
```

The POSIX literals were in the test's `fs` mock, not the source — fixed in #1262. So the stated blocker is a test issue that has since been addressed, and the note has been steering readers at the wrong file since #556 (May).

## What this PR does

Adds `windows-latest` to the matrix, and adds a `.gitattributes` pinning checkouts to LF.

The `.gitattributes` is not cosmetic — without it `npm run skills:check` fails on Windows before a single test runs. `core.autocrlf` rewrites files on checkout, `scripts/skills/generate.ts` compares its LF output against the CRLF on disk with `existing !== next`, and every `REFERENCE.md` is reported as drifted:

```
DRIFT: plugin/skills/agentmemory-mcp-tools/REFERENCE.md (AUTOGEN:tools out of date)
DRIFT: plugin/skills/agentmemory-rest-api/REFERENCE.md  (AUTOGEN:rest out of date)
... 5 total
```

It is also the underlying cause of two of the test failures in #1263, where source files read for string matching came back with CRLF.

## Verified locally

Windows 11, Node 24.19.0, with #1253 and #1261–#1265 applied:

```
npm run build         exit 0    (fails without #1253 — cp/mkdir are not cmd.exe builtins)
npm run skills:check  exit 0    (fails without .gitattributes)
npm test              2 failed | 1716 passed (1735)
```

The 2 remaining are the `cli-lifecycle-safety` cases described in #1265: `spawnSync` cannot execute a `.cmd` without `shell: true`, which is a production decision I did not want to make unilaterally.

## Merge order

This one should land last. On its own it turns the matrix red — #1253 (build) and #1261–#1265 (tests) are what make Windows green, and #1265 leaves 2 known failures until the `spawnSync` question is settled.

Happy to hold this until the others are merged, or to gate the Windows cell with `continue-on-error: true` in the interim if you would rather see the signal without blocking merges.

Context: #1264.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized text file line endings across the repository.
  * Expanded automated testing to include Windows alongside macOS and Linux.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->