### PR TITLE
fix(cli): run a .cmd docker wrapper through cmd.exe

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -826,7 +826,7 @@ function inspectDockerContainer(
   state: DockerEngineState,
   ownerPort: number,
 ): DockerEngineInspection {
-  const result = spawnSync(dockerBin, ["inspect", containerId], {
+  const result = spawnBinary(dockerBin, ["inspect", containerId], {
     encoding: "utf-8",
     stdio: ["ignore", "pipe", "ignore"],
     maxBuffer: 1024 * 1024,
@@ -991,7 +991,7 @@ function inspectOwnedDockerEngine(state: EngineState): DockerEngineInspection {
           reason: `${composeFile} does not define iii-engine`,
         };
       }
-      const psResult = spawnSync(
+      const psResult = spawnBinary(
         dockerBin,
         dockerComposeArgs(composeFile, state.projectName, [
           "ps",
@@ -1023,7 +1023,7 @@ function inspectOwnedDockerEngine(state: EngineState): DockerEngineInspection {
         ? ["--filter", `label=com.docker.compose.project=${state.projectName}`]
         : []),
     ];
-    const scanResult = spawnSync(
+    const scanResult = spawnBinary(
       dockerBin,
       scanArgs,
       { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] },
@@ -1442,7 +1442,7 @@ function printDockerStartupLogs(): void {
   if (inspection.status !== "running" && inspection.status !== "stopped") return;
   const dockerBin = whichBinary("docker");
   if (!dockerBin) return;
-  const result = spawnSync(
+  const result = spawnBinary(
     dockerBin,
     [
       "logs",
@@ -3118,6 +3118,23 @@ async function runDemoBody(base: string) {
   p.log.success("agentmemory is working. Point your agent at it and get back to coding.");
 }
 
+// CreateProcess cannot run a .cmd/.bat directly — spawn fails with EINVAL —
+// and `shell: true` would concatenate the arguments into a command line
+// where a container id containing shell metacharacters is interpreted.
+// Routing through cmd.exe with the arguments still passed as a real argv
+// keeps them opaque to the interpreter.
+function spawnBinary(
+  binary: string,
+  binaryArgs: string[],
+  options: Parameters<typeof spawnSync>[2],
+): ReturnType<typeof spawnSync> {
+  if (IS_WINDOWS && /\.(cmd|bat)$/i.test(binary)) {
+    const comspec = process.env["ComSpec"] || "cmd.exe";
+    return spawnSync(comspec, ["/d", "/s", "/c", binary, ...binaryArgs], options);
+  }
+  return spawnSync(binary, binaryArgs, options);
+}
+
 function runCommand(
   command: string,
   commandArgs: string[],
@@ -3125,7 +3142,7 @@ function runCommand(
 ): boolean {
   const spinner = p.spinner();
   spinner.start(options.label);
-  const result = spawnSync(command, commandArgs, {
+  const result = spawnBinary(command, commandArgs, {
     cwd: options.cwd || process.cwd(),
     stdio: "pipe",
     encoding: "utf-8",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3122,13 +3122,25 @@ async function runDemoBody(base: string) {
 // and `shell: true` would concatenate the arguments into a command line
 // where a container id containing shell metacharacters is interpreted.
 // Routing through cmd.exe with the arguments still passed as a real argv
-// keeps them opaque to the interpreter.
+// keeps most metacharacters opaque, but cmd.exe still expands %VAR% and a
+// literal " can close the quoting cmd.exe wraps each argv entry in — reject
+// both rather than trying to escape them. Every caller here passes Docker
+// container ids ([0-9a-f]{12,64}) or compose project names ([\w-]+), so a
+// real value never trips this.
+const CMD_UNSAFE = /["%]/;
+
 function spawnBinary(
   binary: string,
   binaryArgs: string[],
   options: Parameters<typeof spawnSync>[2],
 ): ReturnType<typeof spawnSync> {
   if (IS_WINDOWS && /\.(cmd|bat)$/i.test(binary)) {
+    const unsafe = binaryArgs.find((arg) => CMD_UNSAFE.test(arg));
+    if (unsafe !== undefined) {
+      throw new Error(
+        `refusing to spawn ${JSON.stringify(binary)}: argument ${JSON.stringify(unsafe)} contains a character (" or %) that is not safe to pass through cmd.exe`,
+      );
+    }
     const comspec = process.env["ComSpec"] || "cmd.exe";
     return spawnSync(comspec, ["/d", "/s", "/c", binary, ...binaryArgs], options);
   }

--- a/test/cli-lifecycle-safety.test.ts
+++ b/test/cli-lifecycle-safety.test.ts
@@ -1,4 +1,9 @@
 import { spawnSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+const IS_WIN = process.platform === "win32";
+// The CLI removes iii.exe on Windows, so fixtures must use that name.
+const III_BIN = IS_WIN ? "iii.exe" : "iii";
 import {
   chmodSync,
   existsSync,
@@ -9,7 +14,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, delimiter } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 const sandboxes: string[] = [];
@@ -24,7 +29,10 @@ function sandbox(): string {
 
 function installFakeDocker(binDir: string): void {
   mkdirSync(binDir, { recursive: true });
-  const dockerPath = join(binDir, "docker");
+  // `where docker` reports a bare file before any .cmd, and CreateProcess
+  // cannot run a shebang script, so the fake lives under a .js name and a
+  // .cmd shim carries the "docker" name.
+  const dockerPath = join(binDir, IS_WIN ? "docker-fake.js" : "docker");
   writeFileSync(
     dockerPath,
     `#!/usr/bin/env node
@@ -67,6 +75,12 @@ process.exit(0);
 `,
   );
   chmodSync(dockerPath, 0o755);
+  if (IS_WIN) {
+    writeFileSync(
+      join(binDir, "docker.cmd"),
+      `@echo off\r\n"${process.execPath}" "${dockerPath}" %*\r\n`,
+    );
+  }
 }
 
 function runDockerStop(
@@ -80,7 +94,7 @@ function runDockerStop(
   const binDir = join(root, "bin");
   const composeFile = join(root, "docker-compose.yml");
   const dockerLog = join(root, "docker.log");
-  const privateBin = join(runtimeDir, "bin", "iii");
+  const privateBin = join(runtimeDir, "bin", III_BIN);
   mkdirSync(runtimeDir, { recursive: true });
   mkdirSync(dataDir, { recursive: true });
   if (command === "remove") {
@@ -129,7 +143,7 @@ function runDockerStop(
         HOME: home,
         USERPROFILE: home,
         CI: "1",
-        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        PATH: `${binDir}${delimiter}${process.env.PATH ?? ""}`,
         DOCKER_LOG: dockerLog,
         DOCKER_FAILURE_MODE: failureMode,
         DOCKER_DATA_DIR: dataDir,
@@ -149,7 +163,7 @@ function runDockerStop(
 function runInstanceRemove(instanceArgs = ["--instance", "1"]) {
   const root = sandbox();
   const home = join(root, "home");
-  const privateBin = join(home, ".agentmemory", "bin", "iii");
+  const privateBin = join(home, ".agentmemory", "bin", III_BIN);
   const dataBase = join(root, "data");
   mkdirSync(join(home, ".agentmemory", "bin"), { recursive: true });
   writeFileSync(privateBin, "shared binary");
@@ -185,7 +199,7 @@ function runNativeRemoveWithWorkerFailure() {
   const root = sandbox();
   const home = join(root, "home");
   const runtimeDir = join(home, ".agentmemory");
-  const privateBin = join(runtimeDir, "bin", "iii");
+  const privateBin = join(runtimeDir, "bin", III_BIN);
   const engineState = join(runtimeDir, "engine-state.json");
   const enginePidfile = join(runtimeDir, "iii.pid");
   const workerPidfile = join(runtimeDir, "worker.pid");
@@ -223,7 +237,8 @@ process.kill = (pid, signal) => {
     process.execPath,
     [
       "--import",
-      preload,
+      // A bare Windows path is not a valid ESM specifier; --import needs a URL.
+      pathToFileURL(preload).href,
       "--import",
       "tsx",
       "src/cli.ts",

--- a/test/cli-lifecycle-safety.test.ts
+++ b/test/cli-lifecycle-safety.test.ts
@@ -399,7 +399,8 @@ describe.runIf(IS_WIN)("cmd.exe argument safety (#1264)", () => {
       }),
     );
 
-    spawnSync(
+    const tempSentinel = join(root, "cmd-expansion-sentinel");
+    const result = spawnSync(
       process.execPath,
       ["--import", "tsx", "src/cli.ts", "stop", "--data-dir", dataDir],
       {
@@ -409,6 +410,7 @@ describe.runIf(IS_WIN)("cmd.exe argument safety (#1264)", () => {
           ...process.env,
           HOME: home,
           USERPROFILE: home,
+          TEMP: tempSentinel,
           CI: "1",
           PATH: `${binDir}${delimiter}${process.env.PATH ?? ""}`,
           DOCKER_LOG: dockerLog,
@@ -419,10 +421,7 @@ describe.runIf(IS_WIN)("cmd.exe argument safety (#1264)", () => {
       },
     );
 
-    const log = existsSync(dockerLog) ? readFileSync(dockerLog, "utf-8") : "";
-    // The fake docker echoes whatever argv it actually received. If
-    // cmd.exe expanded the variable before docker saw it, the log
-    // carries a real filesystem path instead of the literal token.
-    expect(log).not.toContain("AppData");
+    expect(result.status).not.toBe(0);
+    expect(existsSync(dockerLog)).toBe(false);
   });
 });

--- a/test/cli-lifecycle-safety.test.ts
+++ b/test/cli-lifecycle-safety.test.ts
@@ -369,3 +369,60 @@ describe("native removal shutdown", () => {
     expect(`${result.stdout}\n${result.stderr}`).toContain("stop --instance 1");
   });
 });
+
+describe.runIf(IS_WIN)("cmd.exe argument safety (#1264)", () => {
+  it("does not let cmd.exe expand a %VAR% hiding inside a container id", () => {
+    const root = sandbox();
+    const home = join(root, "home");
+    const runtimeDir = join(home, ".agentmemory");
+    const dataDir = join(root, "data");
+    const binDir = join(root, "bin");
+    const dockerLog = join(root, "docker.log");
+    mkdirSync(runtimeDir, { recursive: true });
+    mkdirSync(dataDir, { recursive: true });
+    installFakeDocker(binDir);
+    const statePath = join(runtimeDir, "engine-state.json");
+    writeFileSync(
+      statePath,
+      JSON.stringify({
+        kind: "docker",
+        schemaVersion: 2,
+        composeFile: join(root, "docker-compose.yml"),
+        projectName: "agentmemory-3111",
+        engineVersion: "0.11.2",
+        restPort: 3111,
+        dataDir,
+        containerId: "candidate-%TEMP%",
+        dataMountType: "bind",
+        dataMountSource: dataDir,
+        preserveContainer: false,
+      }),
+    );
+
+    spawnSync(
+      process.execPath,
+      ["--import", "tsx", "src/cli.ts", "stop", "--data-dir", dataDir],
+      {
+        cwd: process.cwd(),
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          HOME: home,
+          USERPROFILE: home,
+          CI: "1",
+          PATH: `${binDir}${delimiter}${process.env.PATH ?? ""}`,
+          DOCKER_LOG: dockerLog,
+          DOCKER_FAILURE_MODE: "none",
+          DOCKER_DATA_DIR: dataDir,
+          FULL_CONTAINER_ID,
+        },
+      },
+    );
+
+    const log = existsSync(dockerLog) ? readFileSync(dockerLog, "utf-8") : "";
+    // The fake docker echoes whatever argv it actually received. If
+    // cmd.exe expanded the variable before docker saw it, the log
+    // carries a real filesystem path instead of the literal token.
+    expect(log).not.toContain("AppData");
+  });
+});

--- a/test/windows-cmd-spawn.test.ts
+++ b/test/windows-cmd-spawn.test.ts
@@ -1,0 +1,75 @@
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const IS_WIN = process.platform === "win32";
+
+// A .cmd wrapper is the shape that fails: CreateProcess rejects it with
+// EINVAL, and the obvious remedy (shell: true) reintroduces interpretation
+// of whatever ends up on the command line.
+describe.runIf(IS_WIN)("spawning a .cmd wrapper (#1264)", () => {
+  let root: string;
+  let binDir: string;
+  let wrapper: string;
+
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), "am-cmd-"));
+    binDir = join(root, "bin");
+    mkdirSync(binDir, { recursive: true });
+    const script = join(binDir, "echo-argv.js");
+    writeFileSync(script, `console.log("ARGV:" + JSON.stringify(process.argv.slice(2)));\n`);
+    chmodSync(script, 0o755);
+    wrapper = join(binDir, "faketool.cmd");
+    writeFileSync(wrapper, `@echo off\r\n"${process.execPath}" "${script}" %*\r\n`);
+  });
+
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  const viaComSpec = (args: string[]) =>
+    spawnSync(process.env["ComSpec"] || "cmd.exe", ["/d", "/s", "/c", wrapper, ...args], {
+      encoding: "utf-8",
+    });
+
+  it("cannot spawn a .cmd directly", () => {
+    const direct = spawnSync(wrapper, ["inspect"], { encoding: "utf-8" });
+
+    expect(direct.status).toBeNull();
+    expect((direct.error as NodeJS.ErrnoException | undefined)?.code).toBe("EINVAL");
+  });
+
+  it("runs the wrapper when routed through cmd.exe", () => {
+    const result = viaComSpec(["inspect", "abc123def456"]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe(`ARGV:["inspect","abc123def456"]`);
+  });
+
+  it("keeps shell metacharacters in a container id opaque", () => {
+    const hostile = "abc123 & echo PWNED";
+
+    const result = viaComSpec(["inspect", hostile]);
+
+    expect(result.stdout).not.toContain("PWNED\r\n");
+    expect(JSON.parse(result.stdout.trim().slice("ARGV:".length))).toEqual(["inspect", hostile]);
+  });
+
+  it("keeps a pipe in a container id opaque", () => {
+    const hostile = "abc123 | echo PWNED";
+
+    const result = viaComSpec(["inspect", hostile]);
+
+    expect(JSON.parse(result.stdout.trim().slice("ARGV:".length))).toEqual(["inspect", hostile]);
+  });
+
+  it("shows why shell: true is not the fix", () => {
+    const hostile = "abc123 & echo PWNED";
+
+    const shell = spawnSync(wrapper, ["inspect", hostile], { encoding: "utf-8", shell: true });
+
+    expect(shell.stdout).toContain("PWNED");
+  });
+});


### PR DESCRIPTION
Closes the last 2 Windows failures from #1264. With this, the suite is fully green on Windows: **1723 passed, 0 failed**.

## The bug

`whichBinary("docker")` resolves correctly, but `CreateProcess` cannot execute a `.cmd` or `.bat`. Every lifecycle command that shells out to Docker fails with `EINVAL` and reports the engine as unverifiable:

```js
spawnSync("C:\\...\\docker.cmd", ["inspect", id])   // status=null, EINVAL
```

Invisible with Docker Desktop, which ships `docker.exe`. It surfaces with wrapper-style installs — Chocolatey shims, Scoop shims, corporate wrappers — and with the test fixtures, which is why `cli-lifecycle-safety` could not pass.

## Why not `shell: true`

It is the obvious fix and it is unsafe. `shell: true` concatenates the arguments into a command line, so anything in a container id is interpreted:

```js
spawnSync(wrapper, ["inspect", "abc123 & echo PWNED"], { shell: true })
// -> ARGV:["inspect","abc123","b"]  +  PWNED
```

I also tried preferring the `.exe` in the `where` output. That fixes production but is worse overall: it silently skips a wrapper the user deliberately put first on PATH, and it took the lifecycle suite from 2 failures to 3 by making the CLI find the real Docker instead of the fixture.

## The fix

Route `.cmd`/`.bat` through `cmd.exe /d /s /c` with the arguments still passed as a real argv, so the interpreter never sees them as syntax:

```ts
if (IS_WINDOWS && /\.(cmd|bat)$/i.test(binary)) {
  return spawnSync(comspec, ["/d", "/s", "/c", binary, ...binaryArgs], options);
}
return spawnSync(binary, binaryArgs, options);
```

Applied to the four `dockerBin` call sites and `runCommand`. On POSIX `spawnBinary` delegates straight to `spawnSync`, so nothing changes there.

`test/windows-cmd-spawn.test.ts` adds 5 tests: the direct spawn really does return `EINVAL`, the routed call works, metacharacters and pipes stay opaque — and one test pins that `shell: true` *is* exploitable, so the tempting fix is not reintroduced later.

Verified by removing the fix: `cli-lifecycle-safety` goes back to 2 failed, restored 14 passed.

## Full Windows pipeline

Windows 11, Node 24.19.0, with #1253 and #1261–#1266 applied:

```
npm run build         exit 0
npm run skills:check  exit 0
npm test              1723 passed | 1 skipped (1740)
```

## Note on the stacking

This branches off #1265, which supplies the `.cmd` fixture the new behaviour is tested against. If you would rather have it standalone I can rebase once #1265 lands, or squash the two together — your call.

One caveat worth stating plainly: `cmd.exe` still expands `%VAR%` in arguments, and a literal `"` can break out. Neither is reachable here — Docker container ids are `[0-9a-f]{12,64}` and project names are `[a-zA-Z0-9_-]` — but if `spawnBinary` is ever reused for user-supplied strings, that assumption needs revisiting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows compatibility when running `.cmd` and `.bat` command-line tools.
  * Preserved command arguments safely, including shell metacharacters and environment-variable tokens.
  * Improved Docker command execution, startup logs, container inspection, and lifecycle handling on Windows.
  * Prevented command arguments from being unexpectedly expanded or misinterpreted by the Windows command shell.

* **Tests**
  * Added Windows coverage for command wrappers, argument handling, and cross-platform CLI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->