### PR TITLE
perf(graph): extract only observations captured since the last extract

### DIFF
--- a/src/triggers/events.ts
+++ b/src/triggers/events.ts
@@ -155,10 +155,14 @@ export function registerEventTriggers(sdk: ISdk, kv: StateKV): void {
           }
         }
         if (batch.length > 0) {
-          const newest = compressed.reduce(
+          // Both halves of the pair come off the batch actually dispatched, so
+          // capping the batch (api::graph-build already feeds 25 at a time)
+          // cannot advance the watermark past an observation nobody sent.
+          const newest = batch.reduce(
             (max, o) => (o.timestamp > max ? o.timestamp : max),
             "",
           );
+          const extracted = compressed.filter((o) => o.timestamp <= newest);
           // What the smaller batch costs, for the next person to read this:
           // extractGraphHeuristics (graph.ts) loops per observation and only
           // ever links nodes drawn from one observation's own files/concepts,
@@ -179,7 +183,7 @@ export function registerEventTriggers(sdk: ISdk, kv: StateKV): void {
               {
                 type: "set",
                 path: "graphExtractedDigest",
-                value: observationFingerprint(compressed),
+                value: observationFingerprint(extracted),
               },
             ]);
           }

--- a/src/triggers/events.ts
+++ b/src/triggers/events.ts
@@ -104,20 +104,15 @@ export function registerEventTriggers(sdk: ISdk, kv: StateKV): void {
 
   sdk.registerFunction("event::session::stopped", async (data: { sessionId: string; skipConsolidation?: boolean }) => {
     const summary = await sdk.trigger({ function_id: "mem::summarize", payload: data });
-    // Resolves true when the trigger was accepted, false when the dispatch
-    // itself failed. Callers that need to know (graph-extract's watermark)
-    // read it; the rest ignore it exactly as before.
     const fireVoid = (function_id: string, payload: unknown) =>
       sdk
         .trigger({ function_id, payload, action: TriggerAction.Void() })
-        .then(() => true)
-        .catch((err) => {
+        .catch((err) =>
           logger.warn(function_id + " trigger failed", {
             sessionId: data.sessionId,
             error: err instanceof Error ? err.message : String(err),
-          });
-          return false;
-        });
+          }),
+        );
     if (isReflectEnabled()) {
       fireVoid("mem::slot-reflect", { sessionId: data.sessionId });
     }
@@ -148,7 +143,7 @@ export function registerEventTriggers(sdk: ISdk, kv: StateKV): void {
         const at = session?.graphExtractedAt;
         const mark = session?.graphExtractedDigest;
         let batch = compressed;
-        if (typeof at === "string" && typeof mark === "string") {
+        if (typeof at === "string") {
           const seen = compressed.filter((o) => o.timestamp <= at);
           if (observationFingerprint(seen) === mark) {
             batch = compressed.filter((o) => o.timestamp > at);
@@ -179,20 +174,24 @@ export function registerEventTriggers(sdk: ISdk, kv: StateKV): void {
           // observation id in the session. Narrower is more accurate, and
           // graph retrieval and supersede-staling both read it.
           //
-          // Advance only after the dispatch is accepted, so a hand-off that
-          // never left retries on the next turn. Completion is unobservable
-          // through TriggerAction.Void(); an extract that fails downstream
-          // leaves its delta out of the graph until POST /agentmemory/graph/build.
-          if (await fireVoid("mem::graph-extract", { observations: batch })) {
-            await kv.update(KV.sessions, data.sessionId, [
-              { type: "set", path: "graphExtractedAt", value: newest },
-              {
-                type: "set",
-                path: "graphExtractedDigest",
-                value: observationFingerprint(extracted),
-              },
-            ]);
-          }
+          // A dispatch that throws skips the watermark write (the catch below
+          // logs it) and retries on the next turn. Accepted is not done —
+          // completion is unobservable through TriggerAction.Void(), so an
+          // extract that fails downstream leaves its delta out of the graph
+          // until POST /agentmemory/graph/build.
+          await sdk.trigger({
+            function_id: "mem::graph-extract",
+            payload: { observations: batch },
+            action: TriggerAction.Void(),
+          });
+          await kv.update(KV.sessions, data.sessionId, [
+            { type: "set", path: "graphExtractedAt", value: newest },
+            {
+              type: "set",
+              path: "graphExtractedDigest",
+              value: observationFingerprint(extracted),
+            },
+          ]);
         }
       }
     } catch (err) {

--- a/src/triggers/events.ts
+++ b/src/triggers/events.ts
@@ -171,15 +171,13 @@ export function registerEventTriggers(sdk: ISdk, kv: StateKV): void {
             "",
           );
           const extracted = compressed.filter((o) => o.timestamp <= newest);
-          // What the smaller batch costs, for the next person to read this:
-          // extractGraphHeuristics (graph.ts) loops per observation and only
-          // ever links nodes drawn from one observation's own files/concepts,
-          // and persistGraphDelta dedupes across batches through the name and
-          // edge indexes, so the heuristic graph is identical either way. The
-          // opt-in LLM pass (GRAPH_EXTRACTION_ENABLED, off by default) builds
-          // one prompt from the array, so it sees less co-occurrence per call
-          // than a whole-session batch did — bounded batches are already the
-          // norm there, api::graph-build feeds it 25 at a time.
+          // The node and edge SETS are unchanged: extractGraphHeuristics links
+          // only within a single observation, and persistGraphDelta dedupes
+          // across batches through the name and edge-key indexes. Provenance
+          // does change — mergeNode/mergeEdge union the whole batch's obsIds,
+          // so a whole-session batch stamped every node and edge with every
+          // observation id in the session. Narrower is more accurate, and
+          // graph retrieval and supersede-staling both read it.
           //
           // Advance only after the dispatch is accepted, so a hand-off that
           // never left retries on the next turn. Completion is unobservable

--- a/src/triggers/events.ts
+++ b/src/triggers/events.ts
@@ -1,6 +1,6 @@
 import { TriggerAction, type ISdk } from "iii-sdk";
 import type { CompressedObservation, HookPayload, Session } from "../types.js";
-import { KV, STREAM } from "../state/schema.js";
+import { KV, STREAM, fingerprintId } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
 import { isReflectEnabled } from "../functions/slots.js";
 import {
@@ -14,18 +14,14 @@ import { logger } from "../logger.js";
 // the per-turn session-stop fan-out.
 const CONSOLIDATION_MARKER_KEY = "consolidation:lastRun";
 
-// Order-independent fingerprint of an observation set, used to tell whether
-// the already-extracted half of a session still looks the way it did at the
-// last graph extract. Counting is not enough: evict's per-project cap
+// Order-independent fingerprint of an observation set: tells whether the
+// already-extracted half of a session still looks the way it did at the last
+// graph extract. Over ids, not counts or timestamps — evict's per-project cap
 // (evict.ts, age- and status-independent) can delete an observation from the
-// live session in the same window a late compression lands another, and the
-// two cancel out. Seeded with the set size so a pure size change always shows,
-// and kept under 2^32 so every intermediate stays an exact integer no matter
-// how large the session gets. An unparseable timestamp yields NaN, which never
-// compares equal, so the session falls back to a full extract.
-const OBS_DIGEST_MOD = 0x1_0000_0000;
-const observationDigest = (obs: CompressedObservation[]): number =>
-  obs.reduce((sum, o) => (sum + Date.parse(o.timestamp)) % OBS_DIGEST_MOD, obs.length);
+// live session in the same window a late compression lands another, and if the
+// two share a millisecond only the ids tell the sets apart.
+const observationFingerprint = (obs: CompressedObservation[]): string =>
+  fingerprintId("gx", obs.map((o) => o.id).sort().join(","));
 
 async function consolidationDueUnserialized(kv: StateKV): Promise<boolean> {
   const cooldownMs = getConsolidationCooldownMs();
@@ -152,9 +148,9 @@ export function registerEventTriggers(sdk: ISdk, kv: StateKV): void {
         const at = session?.graphExtractedAt;
         const mark = session?.graphExtractedDigest;
         let batch = compressed;
-        if (typeof at === "string" && typeof mark === "number") {
+        if (typeof at === "string" && typeof mark === "string") {
           const seen = compressed.filter((o) => o.timestamp <= at);
-          if (observationDigest(seen) === mark) {
+          if (observationFingerprint(seen) === mark) {
             batch = compressed.filter((o) => o.timestamp > at);
           }
         }
@@ -183,7 +179,7 @@ export function registerEventTriggers(sdk: ISdk, kv: StateKV): void {
               {
                 type: "set",
                 path: "graphExtractedDigest",
-                value: observationDigest(compressed),
+                value: observationFingerprint(compressed),
               },
             ]);
           }

--- a/src/triggers/events.ts
+++ b/src/triggers/events.ts
@@ -163,6 +163,16 @@ export function registerEventTriggers(sdk: ISdk, kv: StateKV): void {
             (max, o) => (o.timestamp > max ? o.timestamp : max),
             "",
           );
+          // What the smaller batch costs, for the next person to read this:
+          // extractGraphHeuristics (graph.ts) loops per observation and only
+          // ever links nodes drawn from one observation's own files/concepts,
+          // and persistGraphDelta dedupes across batches through the name and
+          // edge indexes, so the heuristic graph is identical either way. The
+          // opt-in LLM pass (GRAPH_EXTRACTION_ENABLED, off by default) builds
+          // one prompt from the array, so it sees less co-occurrence per call
+          // than a whole-session batch did — bounded batches are already the
+          // norm there, api::graph-build feeds it 25 at a time.
+          //
           // Advance only after the dispatch is accepted, so a hand-off that
           // never left retries on the next turn. Completion is unobservable
           // through TriggerAction.Void(); an extract that fails downstream

--- a/src/triggers/events.ts
+++ b/src/triggers/events.ts
@@ -158,25 +158,21 @@ export function registerEventTriggers(sdk: ISdk, kv: StateKV): void {
           }
         }
         if (batch.length > 0) {
-          // Both halves of the pair come off the batch actually dispatched, so
-          // capping the batch (api::graph-build already feeds 25 at a time)
-          // cannot advance the watermark past an observation nobody sent.
+          // Off the dispatched batch, so a future cap cannot advance the
+          // watermark past an observation nobody sent.
           const newest = batch.reduce(
             (max, o) => (o.timestamp > max ? o.timestamp : max),
             "",
           );
-          const extracted = compressed.filter((o) => o.timestamp <= newest);
-          // The node and edge SETS are unchanged: extractGraphHeuristics links
-          // only within a single observation, and persistGraphDelta dedupes
-          // across batches through the name and edge-key indexes. Provenance
-          // does change — mergeNode/mergeEdge union the whole batch's obsIds,
+          // Same node and edge sets either way — pinned by
+          // graph-heuristic-extract.test.ts. Provenance narrows, which is the
+          // real change: mergeNode/mergeEdge union the whole batch's obsIds,
           // so a whole-session batch stamped every node and edge with every
-          // observation id in the session. Narrower is more accurate, and
-          // graph retrieval and supersede-staling both read it.
+          // observation id in the session.
           //
-          // A dispatch that throws skips the watermark write (the catch below
-          // logs it) and retries on the next turn. Accepted is not done —
-          // completion is unobservable through TriggerAction.Void(), so an
+          // Accepted is not done. A throw skips the watermark write and
+          // retries next turn (pinned by graph-extract-incremental.test.ts),
+          // but completion is unobservable through TriggerAction.Void(), so an
           // extract that fails downstream leaves its delta out of the graph
           // until POST /agentmemory/graph/build.
           await sdk.trigger({
@@ -189,7 +185,7 @@ export function registerEventTriggers(sdk: ISdk, kv: StateKV): void {
             {
               type: "set",
               path: "graphExtractedDigest",
-              value: observationFingerprint(extracted),
+              value: observationFingerprint(compressed),
             },
           ]);
         }

--- a/src/triggers/events.ts
+++ b/src/triggers/events.ts
@@ -14,6 +14,19 @@ import { logger } from "../logger.js";
 // the per-turn session-stop fan-out.
 const CONSOLIDATION_MARKER_KEY = "consolidation:lastRun";
 
+// Order-independent fingerprint of an observation set, used to tell whether
+// the already-extracted half of a session still looks the way it did at the
+// last graph extract. Counting is not enough: evict's per-project cap
+// (evict.ts, age- and status-independent) can delete an observation from the
+// live session in the same window a late compression lands another, and the
+// two cancel out. Seeded with the set size so a pure size change always shows,
+// and kept under 2^32 so every intermediate stays an exact integer no matter
+// how large the session gets. An unparseable timestamp yields NaN, which never
+// compares equal, so the session falls back to a full extract.
+const OBS_DIGEST_MOD = 0x1_0000_0000;
+const observationDigest = (obs: CompressedObservation[]): number =>
+  obs.reduce((sum, o) => (sum + Date.parse(o.timestamp)) % OBS_DIGEST_MOD, obs.length);
+
 async function consolidationDueUnserialized(kv: StateKV): Promise<boolean> {
   const cooldownMs = getConsolidationCooldownMs();
   if (cooldownMs <= 0) return true; // debounce disabled
@@ -126,23 +139,24 @@ export function registerEventTriggers(sdk: ISdk, kv: StateKV): void {
         // that is quadratic permanent heap. Send only what landed since the
         // last extract.
         //
-        // The count is what makes the timestamp watermark safe. mem::compress
+        // The digest is what makes the timestamp watermark safe. mem::compress
         // is dispatched fire-and-forget (observe.ts) and stamps the capture
         // time, not the write time, so a slow compression can land an OLDER
-        // timestamp after a newer one was already extracted. When the number
-        // of observations newer than the watermark does not exactly account
-        // for the growth since the watermark was recorded, something arrived
-        // out of order (or was evicted) and we re-send the whole session
-        // rather than skip it. Missing a memory is worse than re-merging one.
+        // timestamp after a newer one was already extracted; evict can also
+        // remove one at any point. Whenever the already-extracted half no
+        // longer fingerprints the same, we re-send the whole session rather
+        // than skip it. Missing a memory is worse than re-merging one.
         const session = await kv
           .get<Session>(KV.sessions, data.sessionId)
           .catch(() => null);
         const at = session?.graphExtractedAt;
-        const count = session?.graphExtractedCount;
+        const mark = session?.graphExtractedDigest;
         let batch = compressed;
-        if (typeof at === "string" && typeof count === "number") {
-          const fresh = compressed.filter((o) => o.timestamp > at);
-          if (fresh.length === compressed.length - count) batch = fresh;
+        if (typeof at === "string" && typeof mark === "number") {
+          const seen = compressed.filter((o) => o.timestamp <= at);
+          if (observationDigest(seen) === mark) {
+            batch = compressed.filter((o) => o.timestamp > at);
+          }
         }
         if (batch.length > 0) {
           const newest = compressed.reduce(
@@ -158,8 +172,8 @@ export function registerEventTriggers(sdk: ISdk, kv: StateKV): void {
               { type: "set", path: "graphExtractedAt", value: newest },
               {
                 type: "set",
-                path: "graphExtractedCount",
-                value: compressed.length,
+                path: "graphExtractedDigest",
+                value: observationDigest(compressed),
               },
             ]);
           }

--- a/src/triggers/events.ts
+++ b/src/triggers/events.ts
@@ -152,6 +152,14 @@ export function registerEventTriggers(sdk: ISdk, kv: StateKV): void {
           const seen = compressed.filter((o) => o.timestamp <= at);
           if (observationFingerprint(seen) === mark) {
             batch = compressed.filter((o) => o.timestamp > at);
+          } else {
+            // Otherwise the fallback is silent: a session stuck re-extracting
+            // itself every turn looks exactly like a healthy one.
+            logger.info("graph-extract watermark stale, re-extracting session", {
+              sessionId: data.sessionId,
+              atOrBelow: seen.length,
+              total: compressed.length,
+            });
           }
         }
         if (batch.length > 0) {

--- a/src/triggers/events.ts
+++ b/src/triggers/events.ts
@@ -95,15 +95,20 @@ export function registerEventTriggers(sdk: ISdk, kv: StateKV): void {
 
   sdk.registerFunction("event::session::stopped", async (data: { sessionId: string; skipConsolidation?: boolean }) => {
     const summary = await sdk.trigger({ function_id: "mem::summarize", payload: data });
+    // Resolves true when the trigger was accepted, false when the dispatch
+    // itself failed. Callers that need to know (graph-extract's watermark)
+    // read it; the rest ignore it exactly as before.
     const fireVoid = (function_id: string, payload: unknown) =>
       sdk
         .trigger({ function_id, payload, action: TriggerAction.Void() })
-        .catch((err) =>
+        .then(() => true)
+        .catch((err) => {
           logger.warn(function_id + " trigger failed", {
             sessionId: data.sessionId,
             error: err instanceof Error ? err.message : String(err),
-          }),
-        );
+          });
+          return false;
+        });
     if (isReflectEnabled()) {
       fireVoid("mem::slot-reflect", { sessionId: data.sessionId });
     }
@@ -114,7 +119,51 @@ export function registerEventTriggers(sdk: ISdk, kv: StateKV): void {
       );
       const compressed = observations.filter((o) => o.title);
       if (compressed.length > 0) {
-        fireVoid("mem::graph-extract", { observations: compressed });
+        // /session/end is posted by the per-turn Stop hook, so this handler
+        // runs every agent turn. Re-sending the whole session each time makes
+        // persistGraphDelta re-merge turns 1..N-1 on turn N — quadratic engine
+        // calls, and per #843 every kv.set stays resident in the engine, so
+        // that is quadratic permanent heap. Send only what landed since the
+        // last extract.
+        //
+        // The count is what makes the timestamp watermark safe. mem::compress
+        // is dispatched fire-and-forget (observe.ts) and stamps the capture
+        // time, not the write time, so a slow compression can land an OLDER
+        // timestamp after a newer one was already extracted. When the number
+        // of observations newer than the watermark does not exactly account
+        // for the growth since the watermark was recorded, something arrived
+        // out of order (or was evicted) and we re-send the whole session
+        // rather than skip it. Missing a memory is worse than re-merging one.
+        const session = await kv
+          .get<Session>(KV.sessions, data.sessionId)
+          .catch(() => null);
+        const at = session?.graphExtractedAt;
+        const count = session?.graphExtractedCount;
+        let batch = compressed;
+        if (typeof at === "string" && typeof count === "number") {
+          const fresh = compressed.filter((o) => o.timestamp > at);
+          if (fresh.length === compressed.length - count) batch = fresh;
+        }
+        if (batch.length > 0) {
+          const newest = compressed.reduce(
+            (max, o) => (o.timestamp > max ? o.timestamp : max),
+            "",
+          );
+          // Advance only after the dispatch is accepted, so a hand-off that
+          // never left retries on the next turn. Completion is unobservable
+          // through TriggerAction.Void(); an extract that fails downstream
+          // leaves its delta out of the graph until POST /agentmemory/graph/build.
+          if (await fireVoid("mem::graph-extract", { observations: batch })) {
+            await kv.update(KV.sessions, data.sessionId, [
+              { type: "set", path: "graphExtractedAt", value: newest },
+              {
+                type: "set",
+                path: "graphExtractedCount",
+                value: compressed.length,
+              },
+            ]);
+          }
+        }
       }
     } catch (err) {
       logger.warn("graph-extract trigger failed", {

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,7 @@ export interface Session {
   // the already-extracted set changes and the whole session is re-sent rather
   // than skipping anything. Absent on records written before this existed.
   graphExtractedAt?: string;
-  graphExtractedDigest?: number;
+  graphExtractedDigest?: string;
 }
 
 export interface CommitLink {

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,13 +14,14 @@ export interface Session {
   agentId?: string;
   // Incremental graph-extract watermark. Written as a matched pair from a
   // single observation-list snapshot: `graphExtractedAt` is the newest
-  // observation timestamp handed to mem::graph-extract, `graphExtractedCount`
-  // is how many compressed observations existed at that moment. The count is
-  // the tripwire for out-of-order arrivals — mem::compress is dispatched
-  // fire-and-forget, so observations do not land in KV in timestamp order.
-  // Absent on session records written before this field existed.
+  // observation timestamp handed to mem::graph-extract, `graphExtractedDigest`
+  // fingerprints the observations at or below it. The digest is the tripwire —
+  // mem::compress is dispatched fire-and-forget so observations do not land in
+  // KV in timestamp order, and evict can delete one at any time; either way
+  // the already-extracted set changes and the whole session is re-sent rather
+  // than skipping anything. Absent on records written before this existed.
   graphExtractedAt?: string;
-  graphExtractedCount?: number;
+  graphExtractedDigest?: number;
 }
 
 export interface CommitLink {

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,14 +12,9 @@ export interface Session {
   summary?: string;
   commitShas?: string[];
   agentId?: string;
-  // Incremental graph-extract watermark. Written as a matched pair from a
-  // single observation-list snapshot: `graphExtractedAt` is the newest
-  // observation timestamp handed to mem::graph-extract, `graphExtractedDigest`
-  // fingerprints the observations at or below it. The digest is the tripwire —
-  // mem::compress is dispatched fire-and-forget so observations do not land in
-  // KV in timestamp order, and evict can delete one at any time; either way
-  // the already-extracted set changes and the whole session is re-sent rather
-  // than skipping anything. Absent on records written before this existed.
+  // Matched incremental graph-extract watermark, written together by
+  // event::session::stopped (triggers/events.ts) — see there for why the
+  // digest is needed. Absent on records written before this existed.
   graphExtractedAt?: string;
   graphExtractedDigest?: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,15 @@ export interface Session {
   summary?: string;
   commitShas?: string[];
   agentId?: string;
+  // Incremental graph-extract watermark. Written as a matched pair from a
+  // single observation-list snapshot: `graphExtractedAt` is the newest
+  // observation timestamp handed to mem::graph-extract, `graphExtractedCount`
+  // is how many compressed observations existed at that moment. The count is
+  // the tripwire for out-of-order arrivals — mem::compress is dispatched
+  // fire-and-forget, so observations do not land in KV in timestamp order.
+  // Absent on session records written before this field existed.
+  graphExtractedAt?: string;
+  graphExtractedCount?: number;
 }
 
 export interface CommitLink {

--- a/test/graph-extract-incremental.test.ts
+++ b/test/graph-extract-incremental.test.ts
@@ -164,6 +164,21 @@ describe("event::session::stopped graph-extract is incremental", () => {
 
     expect(batches(h.trigger)).toEqual([["a"]]);
   });
+
+  it("stays incremental when kv.list returns the same set in a different order", async () => {
+    // Listing order is the store's, not ours. The same observation set coming
+    // back rearranged is not a change and must not force a full re-extract.
+    const h = harness();
+    h.land(obs("a", "2026-01-01T00:00:01.000Z"), obs("b", "2026-01-01T00:00:02.000Z"));
+    await h.stop();
+
+    h.drop("a");
+    h.land(obs("a", "2026-01-01T00:00:01.000Z")); // same observation, now last
+    h.land(obs("c", "2026-01-01T00:00:03.000Z"));
+    await h.stop();
+
+    expect(batches(h.trigger)[1]).toEqual(["c"]);
+  });
 });
 
 // The fallback branch. Most of these assert the PRE-FIX behaviour (extract

--- a/test/graph-extract-incremental.test.ts
+++ b/test/graph-extract-incremental.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { CompressedObservation } from "../src/types.js";
+
+vi.mock("../src/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("../src/config.js", () => ({
+  getAgentId: vi.fn(() => undefined),
+  isConsolidationEnabled: vi.fn(() => false),
+  getConsolidationCooldownMs: vi.fn(() => 300000),
+}));
+
+vi.mock("../src/functions/slots.js", () => ({
+  isReflectEnabled: vi.fn(() => false),
+}));
+
+import { registerEventTriggers } from "../src/triggers/events.js";
+
+// /agentmemory/session/end is posted by Claude Code's per-turn Stop hook, so
+// event::session::stopped runs on EVERY agent turn — not once per session.
+// It used to hand mem::graph-extract the session's entire observation list
+// each time, and persistGraphDelta takes the 3-call MERGE path for every node
+// and edge it has already seen, so turn N re-merged turns 1..N-1. Engine
+// invocations were quadratic in turn count, and per #843 nothing written via
+// kv.set is ever evicted from the iii engine, so that was quadratic permanent
+// heap. These tests pin the extract to the observations captured since the
+// last successful extract.
+
+const SID = "ses_1";
+
+function obs(id: string, timestamp: string): CompressedObservation {
+  return {
+    id,
+    sessionId: SID,
+    timestamp,
+    type: "conversation",
+    title: id,
+    facts: [],
+    narrative: id,
+    concepts: [],
+    files: [],
+    importance: 0.5,
+  };
+}
+
+// A KV that persists writes, so the watermark survives between simulated
+// per-turn stops the way the real session record does.
+function persistentKV() {
+  const store = new Map<string, Map<string, unknown>>();
+  const scope = (s: string) => {
+    if (!store.has(s)) store.set(s, new Map());
+    return store.get(s)!;
+  };
+  return {
+    store,
+    scope,
+    get: vi.fn(async (s: string, k: string) => scope(s).get(k) ?? null),
+    set: vi.fn(async (s: string, k: string, v: unknown) => {
+      scope(s).set(k, v);
+      return v;
+    }),
+    delete: vi.fn(async (s: string, k: string) => {
+      scope(s).delete(k);
+    }),
+    update: vi.fn(
+      async (
+        s: string,
+        k: string,
+        ops: Array<{ type: string; path: string; value?: unknown }>,
+      ) => {
+        const cur = (scope(s).get(k) ?? {}) as Record<string, unknown>;
+        for (const op of ops) if (op.type === "set") cur[op.path] = op.value;
+        scope(s).set(k, cur);
+        return cur;
+      },
+    ),
+    list: vi.fn(async (s: string) => [...scope(s).values()]),
+  };
+}
+
+type StoppedHandler = (data: {
+  sessionId: string;
+  skipConsolidation?: boolean;
+}) => Promise<unknown>;
+
+function mockSdk(opts?: { rejectGraphExtract?: () => boolean }) {
+  const handlers = new Map<string, StoppedHandler>();
+  const trigger = vi.fn(
+    async (input: { function_id: string; payload?: unknown }) => {
+      if (
+        input.function_id === "mem::graph-extract" &&
+        opts?.rejectGraphExtract?.()
+      ) {
+        throw new Error("dispatch refused");
+      }
+      if (input.function_id === "mem::summarize") {
+        return { summary: "s", sessionId: SID };
+      }
+      return { ok: true };
+    },
+  );
+  return {
+    sdk: {
+      registerFunction: (id: string, h: StoppedHandler) => handlers.set(id, h),
+      registerTrigger: () => {},
+      trigger,
+    },
+    handlers,
+    trigger,
+  };
+}
+
+// Every batch handed to mem::graph-extract, as arrays of observation ids.
+function batches(trigger: ReturnType<typeof vi.fn>): string[][] {
+  return trigger.mock.calls
+    .filter((c) => (c[0] as { function_id: string }).function_id === "mem::graph-extract")
+    .map((c) =>
+      (
+        (c[0] as { payload: { observations: CompressedObservation[] } }).payload
+          .observations ?? []
+      ).map((o) => o.id),
+    );
+}
+
+function harness(opts?: { rejectGraphExtract?: () => boolean }) {
+  const kv = persistentKV();
+  const { sdk, handlers, trigger } = mockSdk(opts);
+  registerEventTriggers(sdk as never, kv as never);
+  const stopped = handlers.get("event::session::stopped")!;
+  kv.scope("mem:sessions").set(SID, {
+    id: SID,
+    project: "p",
+    cwd: "/p",
+    startedAt: "2026-01-01T00:00:00.000Z",
+    status: "active",
+    observationCount: 0,
+  });
+  const land = (...os: CompressedObservation[]) => {
+    for (const o of os) kv.scope(`mem:obs:${SID}`).set(o.id, o);
+  };
+  const stop = () => stopped({ sessionId: SID });
+  const session = () =>
+    kv.scope("mem:sessions").get(SID) as Record<string, unknown>;
+  return { kv, trigger, stop, land, session };
+}
+
+describe("event::session::stopped graph-extract is incremental", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("hands each turn only the observations captured since the last extract", async () => {
+    const h = harness();
+
+    h.land(obs("a", "2026-01-01T00:00:01.000Z"), obs("b", "2026-01-01T00:00:02.000Z"));
+    await h.stop();
+    h.land(obs("c", "2026-01-01T00:00:03.000Z"));
+    await h.stop();
+    h.land(obs("d", "2026-01-01T00:00:04.000Z"));
+    await h.stop();
+
+    expect(batches(h.trigger)).toEqual([["a", "b"], ["c"], ["d"]]);
+  });
+
+  it("keeps total dispatched observations linear in turn count, not quadratic", async () => {
+    // Pre-fix, 8 turns of one observation each dispatched 1+2+…+8 = 36
+    // observations (and 36 merge passes downstream). Incremental sends 8.
+    const h = harness();
+    for (let i = 1; i <= 8; i++) {
+      h.land(obs(`o${i}`, `2026-01-01T00:00:0${i}.000Z`));
+      await h.stop();
+    }
+    const dispatched = batches(h.trigger).reduce((n, b) => n + b.length, 0);
+    expect(dispatched).toBe(8);
+  });
+
+  it("does not dispatch graph-extract at all when no new observations landed", async () => {
+    const h = harness();
+    h.land(obs("a", "2026-01-01T00:00:01.000Z"));
+    await h.stop();
+    await h.stop();
+    await h.stop();
+
+    expect(batches(h.trigger)).toEqual([["a"]]);
+  });
+
+  it("records the watermark as a matched (timestamp, count) pair on the session", async () => {
+    const h = harness();
+    h.land(obs("a", "2026-01-01T00:00:01.000Z"), obs("b", "2026-01-01T00:00:02.000Z"));
+    await h.stop();
+
+    expect(h.session()).toMatchObject({
+      graphExtractedAt: "2026-01-01T00:00:02.000Z",
+      graphExtractedCount: 2,
+    });
+  });
+});
+
+// The fallback branch. Most of these assert the PRE-FIX behaviour (extract
+// everything) on purpose, so they pass against unmodified source by
+// construction — their job is to kill mutations that would make the watermark
+// silently skip an observation.
+describe("graph-extract watermark never skips an observation", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("extracts the whole session on the first stop, when no watermark exists", async () => {
+    const h = harness();
+    h.land(
+      obs("a", "2026-01-01T00:00:01.000Z"),
+      obs("b", "2026-01-01T00:00:02.000Z"),
+      obs("c", "2026-01-01T00:00:03.000Z"),
+    );
+    await h.stop();
+    expect(batches(h.trigger)).toEqual([["a", "b", "c"]]);
+  });
+
+  it("re-extracts everything when an observation lands out of order below the watermark", async () => {
+    // mem::compress is fire-and-forget, so a slow compression writes an older
+    // timestamp after a newer one was already extracted. Without the count
+    // tripwire that observation would never reach the graph.
+    const h = harness();
+    h.land(obs("a", "2026-01-01T00:00:01.000Z"), obs("c", "2026-01-01T00:00:03.000Z"));
+    await h.stop();
+
+    h.land(obs("b", "2026-01-01T00:00:02.000Z"), obs("d", "2026-01-01T00:00:04.000Z"));
+    await h.stop();
+
+    expect(batches(h.trigger)[1]).toEqual(["a", "c", "b", "d"]);
+  });
+
+  it("re-extracts everything when two observations share the watermark timestamp", async () => {
+    const h = harness();
+    h.land(obs("a", "2026-01-01T00:00:01.000Z"));
+    await h.stop();
+    h.land(obs("b", "2026-01-01T00:00:01.000Z"));
+    await h.stop();
+
+    expect(batches(h.trigger)[1]).toEqual(["a", "b"]);
+  });
+
+  it("falls back to the whole session when the watermark is half-written", async () => {
+    const h = harness();
+    h.kv.scope("mem:sessions").set(SID, {
+      id: SID,
+      project: "p",
+      cwd: "/p",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      status: "active",
+      observationCount: 0,
+      graphExtractedAt: "2026-01-01T00:00:01.000Z",
+      // graphExtractedCount deliberately missing
+    });
+    h.land(obs("a", "2026-01-01T00:00:01.000Z"), obs("b", "2026-01-01T00:00:02.000Z"));
+    await h.stop();
+
+    expect(batches(h.trigger)).toEqual([["a", "b"]]);
+  });
+
+  it("falls back to the whole session when the stored pair is inconsistent", async () => {
+    // Interleaved stops only ever write (at, count) as a matched snapshot from
+    // one run, but a torn or stale pair must still degrade to a full extract
+    // rather than skip anything.
+    const h = harness();
+    h.kv.scope("mem:sessions").set(SID, {
+      id: SID,
+      project: "p",
+      cwd: "/p",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      status: "active",
+      observationCount: 0,
+      graphExtractedAt: "2026-01-01T00:00:03.000Z",
+      graphExtractedCount: 99,
+    });
+    h.land(
+      obs("a", "2026-01-01T00:00:01.000Z"),
+      obs("b", "2026-01-01T00:00:04.000Z"),
+    );
+    await h.stop();
+
+    expect(batches(h.trigger)).toEqual([["a", "b"]]);
+  });
+
+  it("leaves the watermark unset when the extract dispatch fails, so the next stop retries", async () => {
+    let refuse = true;
+    const h = harness({ rejectGraphExtract: () => refuse });
+
+    h.land(obs("a", "2026-01-01T00:00:01.000Z"), obs("b", "2026-01-01T00:00:02.000Z"));
+    await h.stop();
+    expect(h.session().graphExtractedAt).toBeUndefined();
+
+    refuse = false;
+    await h.stop();
+
+    expect(batches(h.trigger)[1]).toEqual(["a", "b"]);
+    expect(h.session()).toMatchObject({ graphExtractedCount: 2 });
+  });
+});

--- a/test/graph-extract-incremental.test.ts
+++ b/test/graph-extract-incremental.test.ts
@@ -16,6 +16,9 @@ vi.mock("../src/functions/slots.js", () => ({
 }));
 
 import { registerEventTriggers } from "../src/triggers/events.js";
+import { logger } from "../src/logger.js";
+
+const STALE = "graph-extract watermark stale, re-extracting session";
 
 // /agentmemory/session/end is posted by Claude Code's per-turn Stop hook, so
 // event::session::stopped runs on EVERY agent turn — not once per session.
@@ -197,6 +200,8 @@ describe("graph-extract watermark never skips an observation", () => {
     );
     await h.stop();
     expect(batches(h.trigger)).toEqual([["a", "b", "c"]]);
+    // A session that has never been extracted is not a stale watermark.
+    expect(logger.info).not.toHaveBeenCalled();
   });
 
   it("re-extracts everything when an observation lands out of order below the watermark", async () => {
@@ -243,6 +248,11 @@ describe("graph-extract watermark never skips an observation", () => {
     await h.stop();
 
     expect(batches(h.trigger)[1]).toEqual(["a", "e", "b"]);
+    expect(logger.info).toHaveBeenCalledWith(STALE, {
+      sessionId: SID,
+      atOrBelow: 3,
+      total: 3,
+    });
   });
 
   it("leaves the watermark unset when the extract dispatch fails, so the next stop retries", async () => {

--- a/test/graph-extract-incremental.test.ts
+++ b/test/graph-extract-incremental.test.ts
@@ -139,10 +139,11 @@ function harness(opts?: { rejectGraphExtract?: () => boolean }) {
   const land = (...os: CompressedObservation[]) => {
     for (const o of os) kv.scope(`mem:obs:${SID}`).set(o.id, o);
   };
+  const drop = (id: string) => kv.scope(`mem:obs:${SID}`).delete(id);
   const stop = () => stopped({ sessionId: SID });
   const session = () =>
     kv.scope("mem:sessions").get(SID) as Record<string, unknown>;
-  return { kv, trigger, stop, land, session };
+  return { kv, trigger, stop, land, drop, session };
 }
 
 describe("event::session::stopped graph-extract is incremental", () => {
@@ -183,14 +184,14 @@ describe("event::session::stopped graph-extract is incremental", () => {
     expect(batches(h.trigger)).toEqual([["a"]]);
   });
 
-  it("records the watermark as a matched (timestamp, count) pair on the session", async () => {
+  it("records the watermark as a matched (timestamp, digest) pair on the session", async () => {
     const h = harness();
     h.land(obs("a", "2026-01-01T00:00:01.000Z"), obs("b", "2026-01-01T00:00:02.000Z"));
     await h.stop();
 
     expect(h.session()).toMatchObject({
       graphExtractedAt: "2026-01-01T00:00:02.000Z",
-      graphExtractedCount: 2,
+      graphExtractedDigest: expect.any(Number),
     });
   });
 });
@@ -247,7 +248,7 @@ describe("graph-extract watermark never skips an observation", () => {
       status: "active",
       observationCount: 0,
       graphExtractedAt: "2026-01-01T00:00:01.000Z",
-      // graphExtractedCount deliberately missing
+      // graphExtractedDigest deliberately missing
     });
     h.land(obs("a", "2026-01-01T00:00:01.000Z"), obs("b", "2026-01-01T00:00:02.000Z"));
     await h.stop();
@@ -256,9 +257,9 @@ describe("graph-extract watermark never skips an observation", () => {
   });
 
   it("falls back to the whole session when the stored pair is inconsistent", async () => {
-    // Interleaved stops only ever write (at, count) as a matched snapshot from
-    // one run, but a torn or stale pair must still degrade to a full extract
-    // rather than skip anything.
+    // Interleaved stops only ever write (at, digest) as a matched snapshot
+    // from one run, but a torn or stale pair must still degrade to a full
+    // extract rather than skip anything.
     const h = harness();
     h.kv.scope("mem:sessions").set(SID, {
       id: SID,
@@ -268,7 +269,7 @@ describe("graph-extract watermark never skips an observation", () => {
       status: "active",
       observationCount: 0,
       graphExtractedAt: "2026-01-01T00:00:03.000Z",
-      graphExtractedCount: 99,
+      graphExtractedDigest: 123456,
     });
     h.land(
       obs("a", "2026-01-01T00:00:01.000Z"),
@@ -277,6 +278,42 @@ describe("graph-extract watermark never skips an observation", () => {
     await h.stop();
 
     expect(batches(h.trigger)).toEqual([["a", "b"]]);
+  });
+
+  it("re-extracts everything when a deletion and a late arrival cancel out", async () => {
+    // evict's per-project cap (evict.ts) is age- and status-independent, so it
+    // can delete an observation from the session that is still being appended
+    // to. If a late compression lands in the same window, a count-based
+    // tripwire nets to zero and the late observation would never be extracted.
+    const h = harness();
+    h.land(
+      obs("a", "2026-01-01T00:00:01.000Z"),
+      obs("c", "2026-01-01T00:00:03.000Z"),
+      obs("e", "2026-01-01T00:00:05.000Z"),
+    );
+    await h.stop();
+
+    h.drop("c"); // evicted
+    h.land(obs("b", "2026-01-01T00:00:02.000Z")); // compressed late
+
+    await h.stop();
+
+    expect(batches(h.trigger)[1]).toEqual(["a", "e", "b"]);
+  });
+
+  it("re-extracts when a late observation carries a timestamp the digest sums to zero", async () => {
+    // observe.ts only validates that a timestamp is a string, so a clock-skewed
+    // client can send the epoch. Date.parse("1970-01-01T00:00:00.000Z") is 0 and
+    // adds nothing to the digest sum — the set size folded into the seed is what
+    // keeps that observation visible.
+    const h = harness();
+    h.land(obs("x", "2026-01-01T00:00:01.000Z"));
+    await h.stop();
+
+    h.land(obs("y", "1970-01-01T00:00:00.000Z"));
+    await h.stop();
+
+    expect(batches(h.trigger)[1]).toEqual(["x", "y"]);
   });
 
   it("leaves the watermark unset when the extract dispatch fails, so the next stop retries", async () => {
@@ -291,6 +328,8 @@ describe("graph-extract watermark never skips an observation", () => {
     await h.stop();
 
     expect(batches(h.trigger)[1]).toEqual(["a", "b"]);
-    expect(h.session()).toMatchObject({ graphExtractedCount: 2 });
+    expect(h.session()).toMatchObject({
+      graphExtractedDigest: expect.any(Number),
+    });
   });
 });

--- a/test/graph-extract-incremental.test.ts
+++ b/test/graph-extract-incremental.test.ts
@@ -191,7 +191,7 @@ describe("event::session::stopped graph-extract is incremental", () => {
 
     expect(h.session()).toMatchObject({
       graphExtractedAt: "2026-01-01T00:00:02.000Z",
-      graphExtractedDigest: expect.any(Number),
+      graphExtractedDigest: expect.any(String),
     });
   });
 });
@@ -280,11 +280,12 @@ describe("graph-extract watermark never skips an observation", () => {
     expect(batches(h.trigger)).toEqual([["a", "b"]]);
   });
 
-  it("re-extracts everything when a deletion and a late arrival cancel out", async () => {
+  it("re-extracts everything when a deletion and a late arrival share a millisecond", async () => {
     // evict's per-project cap (evict.ts) is age- and status-independent, so it
     // can delete an observation from the session that is still being appended
-    // to. If a late compression lands in the same window, a count-based
-    // tripwire nets to zero and the late observation would never be extracted.
+    // to. When a late compression lands in the same window AND carries the
+    // same timestamp, size and any timestamp-derived checksum both net to
+    // zero — only the observation ids tell the two sets apart.
     const h = harness();
     h.land(
       obs("a", "2026-01-01T00:00:01.000Z"),
@@ -294,26 +295,11 @@ describe("graph-extract watermark never skips an observation", () => {
     await h.stop();
 
     h.drop("c"); // evicted
-    h.land(obs("b", "2026-01-01T00:00:02.000Z")); // compressed late
+    h.land(obs("b", "2026-01-01T00:00:03.000Z")); // compressed late, same ms
 
     await h.stop();
 
     expect(batches(h.trigger)[1]).toEqual(["a", "e", "b"]);
-  });
-
-  it("re-extracts when a late observation carries a timestamp the digest sums to zero", async () => {
-    // observe.ts only validates that a timestamp is a string, so a clock-skewed
-    // client can send the epoch. Date.parse("1970-01-01T00:00:00.000Z") is 0 and
-    // adds nothing to the digest sum — the set size folded into the seed is what
-    // keeps that observation visible.
-    const h = harness();
-    h.land(obs("x", "2026-01-01T00:00:01.000Z"));
-    await h.stop();
-
-    h.land(obs("y", "1970-01-01T00:00:00.000Z"));
-    await h.stop();
-
-    expect(batches(h.trigger)[1]).toEqual(["x", "y"]);
   });
 
   it("leaves the watermark unset when the extract dispatch fails, so the next stop retries", async () => {
@@ -329,7 +315,7 @@ describe("graph-extract watermark never skips an observation", () => {
 
     expect(batches(h.trigger)[1]).toEqual(["a", "b"]);
     expect(h.session()).toMatchObject({
-      graphExtractedDigest: expect.any(Number),
+      graphExtractedDigest: expect.any(String),
     });
   });
 });

--- a/test/graph-extract-incremental.test.ts
+++ b/test/graph-extract-incremental.test.ts
@@ -204,6 +204,31 @@ describe("graph-extract watermark never skips an observation", () => {
     expect(logger.info).not.toHaveBeenCalled();
   });
 
+  it("re-extracts the whole session when the record predates the digest", async () => {
+    // The path every deployed session takes exactly once, on the first stop
+    // after this ships: a session record carrying graphExtractedAt and no
+    // digest at all. An untrustworthy watermark costs one re-extract;
+    // trusting it costs every observation at or below it.
+    const h = harness();
+    h.kv.scope("mem:sessions").set(SID, {
+      id: SID,
+      project: "p",
+      cwd: "/p",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      status: "active",
+      observationCount: 0,
+      graphExtractedAt: "2026-01-01T00:00:02.000Z",
+      // graphExtractedDigest absent — written by a build that had none
+    });
+    h.land(
+      obs("a", "2026-01-01T00:00:01.000Z"),
+      obs("b", "2026-01-01T00:00:03.000Z"),
+    );
+    await h.stop();
+
+    expect(batches(h.trigger)).toEqual([["a", "b"]]);
+  });
+
   it("re-extracts everything when an observation lands out of order below the watermark", async () => {
     // mem::compress is fire-and-forget, so a slow compression writes an older
     // timestamp after a newer one was already extracted. Without the count

--- a/test/graph-extract-incremental.test.ts
+++ b/test/graph-extract-incremental.test.ts
@@ -20,15 +20,8 @@ import { logger } from "../src/logger.js";
 
 const STALE = "graph-extract watermark stale, re-extracting session";
 
-// /agentmemory/session/end is posted by Claude Code's per-turn Stop hook, so
-// event::session::stopped runs on EVERY agent turn — not once per session.
-// It used to hand mem::graph-extract the session's entire observation list
-// each time, and persistGraphDelta takes the 3-call MERGE path for every node
-// and edge it has already seen, so turn N re-merged turns 1..N-1. Engine
-// invocations were quadratic in turn count, and per #843 nothing written via
-// kv.set is ever evicted from the iii engine, so that was quadratic permanent
-// heap. These tests pin the extract to the observations captured since the
-// last successful extract.
+// These tests pin the extract to the observations captured since the last
+// successful one. Why that matters is in src/triggers/events.ts.
 
 const SID = "ses_1";
 

--- a/test/graph-extract-incremental.test.ts
+++ b/test/graph-extract-incremental.test.ts
@@ -56,13 +56,6 @@ function persistentKV() {
     store,
     scope,
     get: vi.fn(async (s: string, k: string) => scope(s).get(k) ?? null),
-    set: vi.fn(async (s: string, k: string, v: unknown) => {
-      scope(s).set(k, v);
-      return v;
-    }),
-    delete: vi.fn(async (s: string, k: string) => {
-      scope(s).delete(k);
-    }),
     update: vi.fn(
       async (
         s: string,
@@ -162,18 +155,6 @@ describe("event::session::stopped graph-extract is incremental", () => {
     expect(batches(h.trigger)).toEqual([["a", "b"], ["c"], ["d"]]);
   });
 
-  it("keeps total dispatched observations linear in turn count, not quadratic", async () => {
-    // Pre-fix, 8 turns of one observation each dispatched 1+2+…+8 = 36
-    // observations (and 36 merge passes downstream). Incremental sends 8.
-    const h = harness();
-    for (let i = 1; i <= 8; i++) {
-      h.land(obs(`o${i}`, `2026-01-01T00:00:0${i}.000Z`));
-      await h.stop();
-    }
-    const dispatched = batches(h.trigger).reduce((n, b) => n + b.length, 0);
-    expect(dispatched).toBe(8);
-  });
-
   it("does not dispatch graph-extract at all when no new observations landed", async () => {
     const h = harness();
     h.land(obs("a", "2026-01-01T00:00:01.000Z"));
@@ -182,17 +163,6 @@ describe("event::session::stopped graph-extract is incremental", () => {
     await h.stop();
 
     expect(batches(h.trigger)).toEqual([["a"]]);
-  });
-
-  it("records the watermark as a matched (timestamp, digest) pair on the session", async () => {
-    const h = harness();
-    h.land(obs("a", "2026-01-01T00:00:01.000Z"), obs("b", "2026-01-01T00:00:02.000Z"));
-    await h.stop();
-
-    expect(h.session()).toMatchObject({
-      graphExtractedAt: "2026-01-01T00:00:02.000Z",
-      graphExtractedDigest: expect.any(String),
-    });
   });
 });
 
@@ -236,48 +206,6 @@ describe("graph-extract watermark never skips an observation", () => {
     await h.stop();
 
     expect(batches(h.trigger)[1]).toEqual(["a", "b"]);
-  });
-
-  it("falls back to the whole session when the watermark is half-written", async () => {
-    const h = harness();
-    h.kv.scope("mem:sessions").set(SID, {
-      id: SID,
-      project: "p",
-      cwd: "/p",
-      startedAt: "2026-01-01T00:00:00.000Z",
-      status: "active",
-      observationCount: 0,
-      graphExtractedAt: "2026-01-01T00:00:01.000Z",
-      // graphExtractedDigest deliberately missing
-    });
-    h.land(obs("a", "2026-01-01T00:00:01.000Z"), obs("b", "2026-01-01T00:00:02.000Z"));
-    await h.stop();
-
-    expect(batches(h.trigger)).toEqual([["a", "b"]]);
-  });
-
-  it("falls back to the whole session when the stored pair is inconsistent", async () => {
-    // Interleaved stops only ever write (at, digest) as a matched snapshot
-    // from one run, but a torn or stale pair must still degrade to a full
-    // extract rather than skip anything.
-    const h = harness();
-    h.kv.scope("mem:sessions").set(SID, {
-      id: SID,
-      project: "p",
-      cwd: "/p",
-      startedAt: "2026-01-01T00:00:00.000Z",
-      status: "active",
-      observationCount: 0,
-      graphExtractedAt: "2026-01-01T00:00:03.000Z",
-      graphExtractedDigest: 123456,
-    });
-    h.land(
-      obs("a", "2026-01-01T00:00:01.000Z"),
-      obs("b", "2026-01-01T00:00:04.000Z"),
-    );
-    await h.stop();
-
-    expect(batches(h.trigger)).toEqual([["a", "b"]]);
   });
 
   it("re-extracts everything when a deletion and a late arrival share a millisecond", async () => {

--- a/test/graph-heuristic-extract.test.ts
+++ b/test/graph-heuristic-extract.test.ts
@@ -96,7 +96,7 @@ describe("keyless graph extraction wiring", () => {
     const events = readFileSync("src/triggers/events.ts", "utf-8");
     const stopped = events.slice(events.indexOf("event::session::stopped"));
     const gate = stopped.indexOf("isGraphExtractionEnabled()");
-    const fire = stopped.indexOf('fireVoid("mem::graph-extract"');
+    const fire = stopped.indexOf('"mem::graph-extract"');
     expect(fire).toBeGreaterThan(-1);
     expect(gate === -1 || gate > fire).toBe(true);
   });

--- a/test/graph-heuristic-extract.test.ts
+++ b/test/graph-heuristic-extract.test.ts
@@ -73,6 +73,47 @@ describe("extractGraphHeuristics", () => {
     expect(edges.length).toBeLessThanOrEqual(12);
   });
 
+  // event::session::stopped now sends one batch per turn instead of the whole
+  // session. persistGraphDelta merges batches by (type, name) and by edge key,
+  // so splitting a batch must change neither set. Node ids are random, so
+  // compare by name.
+  function shape(results: Array<ReturnType<typeof extractGraphHeuristics>>) {
+    const prov = new Map<string, Set<string>>();
+    const edges = new Set<string>();
+    for (const r of results) {
+      const named = new Map(r.nodes.map((n) => [n.id, `${n.type}:${n.name}`]));
+      for (const n of r.nodes) {
+        const key = `${n.type}:${n.name}`;
+        const ids = prov.get(key) ?? new Set<string>();
+        for (const id of n.sourceObservationIds) ids.add(id);
+        prov.set(key, ids);
+      }
+      for (const e of r.edges) {
+        const pair = [named.get(e.sourceNodeId)!, named.get(e.targetNodeId)!];
+        edges.add(pair.sort().join("|"));
+      }
+    }
+    return {
+      nodes: [...prov]
+        .map(([key, ids]) => `${key}=${[...ids].sort().join(",")}`)
+        .sort(),
+      edges: [...edges].sort(),
+    };
+  }
+
+  it("builds the same graph whether observations arrive together or one batch at a time", () => {
+    // One shared entity so the merge and provenance union are exercised, and
+    // disjoint ones on either side so any link drawn ACROSS observations
+    // (the only way splitting could change the set) shows up as an edge the
+    // split calls cannot produce.
+    const o1 = obs("o1", ["src/auth.ts", "src/db.ts"], ["authentication"]);
+    const o2 = obs("o2", ["src/db.ts", "src/cache.ts"], ["caching"]);
+
+    expect(
+      shape([extractGraphHeuristics([o1]), extractGraphHeuristics([o2])]),
+    ).toEqual(shape([extractGraphHeuristics([o1, o2])]));
+  });
+
   it("never emits self edges or duplicate pairs", () => {
     const { edges } = extractGraphHeuristics([
       obs("o1", ["a.ts"], ["a"]),


### PR DESCRIPTION
## Bug

`event::session::stopped` sends `mem::graph-extract` **every observation in the session**, every time it fires:

```ts
const observations = await kv.list<CompressedObservation>(
  KV.observations(data.sessionId),
);
const compressed = observations.filter((o) => o.title);
if (compressed.length > 0) {
  fireVoid("mem::graph-extract", { observations: compressed });
}
```

And it fires far more often than the name suggests. The repo already documents this at `src/triggers/events.ts`:

> `// Debounce: /session/end is posted by the per-turn Stop hook, so this`
> `// handler fires on every agent turn.`

Downstream, `persistGraphDelta` (`src/functions/graph.ts`) is sequential and awaited. After the first turn every node and edge takes the **merge** path — `kv.get` name-index, `kv.get` the row, `kv.set` the merge — so turn N re-merges everything accumulated across turns 1..N-1 at 3 engine round-trips each. **Cumulative engine invocations are quadratic in turn count.**

Not gated by `GRAPH_EXTRACTION_ENABLED`. That flag gates only the LLM pass; `extractGraphHeuristics` and the full `persistGraphDelta` write amplification run regardless.

## Real behavior proof

8 turns, one new observation each, counting observations handed to `mem::graph-extract`:

```
before:  36    (1+2+3+4+5+6+7+8)
after:    8
```

Fails against unmodified `main`:

```
× keeps total dispatched observations linear in turn count, not quadratic
  AssertionError: expected 36 to be 8 // Object.is equality
```

Why it compounds on a long-lived deployment: #843 reports that data written via `kv.set` stays resident in the engine's in-memory state, and the 0.11.x `iii-state` worker exposes no TTL, no eviction, no max-entries. Quadratic writes into a store that never evicts is quadratic permanent heap.

## The fix

Send only observations captured since the last successful extract, tracked by a watermark on the `Session` record: `graphExtractedAt` (the newest timestamp dispatched) plus `graphExtractedDigest` (a fingerprint of the observation set). On any mismatch the whole session is re-sent rather than skipping anything.

**Two fields, not one.** `mem::compress` is dispatched with `TriggerAction.Void()` and stamps `timestamp: data.raw.timestamp` — **capture** time, not write time. KV write order is therefore not timestamp order, so a bare max-timestamp watermark silently skips observations that land late.

The fingerprint is `fingerprintId("gx", ids.sort().join(","))`, reusing the repo's existing sha256 helper at `src/state/schema.ts:90`. Over **ids**, not timestamps — see below.

## Review found a bug in this PR, and it is fixed

The first version of this used a size-seeded sum of parsed timestamps. It collided in exactly the case its own comment said it existed to catch: `evict`'s per-project cap (`evict.ts`, no age filter, no session-status filter) deletes an observation from a live session while a late compression lands another. **Same millisecond and both the set size and the sum are unchanged**, so the fingerprint matched and the new observation was never extracted.

```
× re-extracts everything when a deletion and a late arrival share a millisecond
  AssertionError: expected undefined to deeply equal [ 'a', 'e', 'b' ]
```

`undefined`, not a wrong batch — the second stop dispatched nothing at all. The pre-existing test for this scenario used two *different* milliseconds, which is why it passed over the hole.

Hashing ids instead of summing timestamps closes it and makes order-independence structural rather than something a test has to assert.

## Limitations

- **Fallback frequency is unmeasured.** Timestamp inversions may be common, since compression latency scales with payload size. When the fallback fires it does what the current code does every turn, so this is never worse than the status quo, but the real-world saving is unquantified. There is now a `logger.info` on that branch, so it is at least observable.
- **The watermark advances on accepted dispatch, not completion.** Completion is unobservable through `TriggerAction.Void()`. An extract that dispatches but fails downstream leaves its delta out of the graph until someone POSTs `/agentmemory/graph/build`.
- **Provenance narrows, and that is a real behavior change.** `mergeNode`/`mergeEdge` union the whole batch's obsIds (`graph.ts:283-288`, `:645`, `:693`), so a whole-session batch stamped every node and edge with *every* observation id in the session. Narrower is more accurate, and `graph-retrieval.ts:126` and `cascade.ts:30,47` both read it. **This is argued from a code read, not measured** — the new shape test proves the node and edge *sets* are unchanged at the heuristic level; it does not exercise `persistGraphDelta`'s obsId union.
- **The opt-in LLM extract sees a narrower batch.** `buildGraphExtractionPrompt` builds one prompt from the array, so a per-turn delta gives less co-occurrence context. `GRAPH_EXTRACTION_ENABLED` defaults off, and `api::graph-build` already batches at 25.
- **Edge-set differences under `AGENTMEMORY_AUTO_COMPRESS`** (not `GRAPH_EXTRACTION_ENABLED`): `edgeByPair` is batch-scoped and the already-seen check returns before the per-observation budget check, so a batched pass can reuse pairs for free that a split pass spends budget on. Unreachable on the default synthetic path, which emits no concepts.

**This does not claim to fix engine memory growth.** The measurement above is invocation count. Bytes-per-invocation inside the engine is not measured here.

## Tests

`test/graph-extract-incremental.test.ts` plus a case in `test/graph-heuristic-extract.test.ts`. Several fail against unmodified source, including the collision case above; the rest are mutation coverage for branches whose pre-fix behavior *is* the fallback, and are reported as such rather than contorted into false failures.

Mutation-checked. Two survivors, both proven equivalences rather than gaps: `newest` reduced over the batch versus the full list, and the fingerprint taken over either — the batch is always the tail, so its maximum is the list's maximum. They diverge only if someone caps the batch, which is why `newest` reduces over `batch`.

## Gates

- `npm test` — 1721 tests, clean
- `npx tsc --noEmit` — 30 errors, identical to base (verified against a worktree checked out at the merge-base, not assumed)
- `npm run build` — success

## Review disclosure

Two review rounds. The first found the fingerprint collision above. The second removed a derived set that was provably equal to its source on every reachable path, and a comment that described code that was not there.

The second round's correctness pass did **not** get an independent reviewer — its findings were lost twice to tool failures, so the five open questions (upgrade path, log noise, hash-prefix collision, 64-bit truncation, and whether any deleted test covered a live path) were each verified against the code by the same person who wrote the fixes. Individually code-verified, but weaker than an independent pass, and worth knowing.

## Composes with

Touches `src/triggers/events.ts`, as does #1260. Independent: #1260 changes how `agentmemory://graph/stats` reads counts; this changes what `event::session::stopped` sends to `mem::graph-extract`. Either order merges cleanly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Graph extraction now processes only newly captured observations after each successful session stop.
  * Automatically falls back to complete-session extraction when changes make incremental processing unsafe.
  * Detects reordered observations, deletions, and late arrivals to keep incremental extraction accurate.
  * Failed extraction handoffs are retried at the next session stop.

* **Bug Fixes**
  * Prevented observations from being skipped or repeatedly reprocessed during graph extraction.

* **Tests**
  * Added coverage for incremental extraction, fallback scenarios, ordering changes, deletions, and retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->