### PR TITLE
perf(summarize): memoize per-chunk partials and skip unchanged sessions

### DIFF
--- a/src/functions/auto-forget.ts
+++ b/src/functions/auto-forget.ts
@@ -5,6 +5,7 @@ import { StateKV } from "../state/kv.js";
 import { recordAudit } from "./audit.js";
 import { deleteAccessLog } from "./access-tracker.js";
 import { getSearchIndex, vectorIndexRemove, flushIndexSave } from "./search.js";
+import { deleteSummaryChunks } from "./summarize.js";
 import { logger } from "../logger.js";
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
@@ -157,6 +158,8 @@ export function registerAutoForgetFunction(sdk: ISdk, kv: StateKV): void {
         );
         obsPerSession.push(...results);
       }
+      const touchedSessionIds = new Set<string>();
+
       for (let i = 0; i < sessions.length; i++) {
         for (const obs of obsPerSession[i]) {
           if (!obs.timestamp) continue;
@@ -172,6 +175,7 @@ export function registerAutoForgetFunction(sdk: ISdk, kv: StateKV): void {
                 deletedOk = false;
               }
               if (deletedOk) {
+                touchedSessionIds.add(sessions[i].id);
                 if (obs.imageData) await decrementImageRef(kv, sdk, obs.imageData);
                 if (obs.imageRef && obs.imageRef !== obs.imageData) {
                   await decrementImageRef(kv, sdk, obs.imageRef);
@@ -188,6 +192,10 @@ export function registerAutoForgetFunction(sdk: ISdk, kv: StateKV): void {
             }
           }
         }
+      }
+
+      for (const sessionId of touchedSessionIds) {
+        await deleteSummaryChunks(kv, sessionId);
       }
 
       if (!dryRun && (result.ttlExpired.length > 0 || result.lowValueObs.length > 0)) {

--- a/src/functions/evict.ts
+++ b/src/functions/evict.ts
@@ -13,6 +13,7 @@ import { recordAudit } from "./audit.js";
 import { deleteAccessLog } from "./access-tracker.js";
 import { logger } from "../logger.js";
 import { deleteSummaryChunks } from "./summarize.js";
+import { withKeyedLock, sessionWriteLockKey } from "../state/keyed-mutex.js";
 
 interface EvictionConfig {
   staleSessionDays: number;
@@ -171,7 +172,19 @@ export function registerEvictFunction(sdk: ISdk, kv: StateKV): void {
             }
 
             try {
-              await kv.delete(KV.sessions, session.id);
+              // Shared with mem::summarize's write step: a run that
+              // already passed its session-exists check would otherwise
+              // write these rows back with nothing left to reclaim them.
+              // The KV.summaries delete covers the ordering where that run
+              // wins the lock — this branch is otherwise reached only for
+              // sessions with no summary, though they can still hold chunk
+              // partials from a run whose final reduce failed after the
+              // per-chunk calls succeeded.
+              await withKeyedLock(sessionWriteLockKey(session.id), async () => {
+                await kv.delete(KV.sessions, session.id);
+                await kv.delete(KV.summaries, session.id);
+                await deleteSummaryChunks(kv, session.id);
+              });
               stats.staleSessions++;
             } catch (err) {
               logger.warn("Eviction delete failed", {
@@ -181,10 +194,6 @@ export function registerEvictFunction(sdk: ISdk, kv: StateKV): void {
               });
               continue;
             }
-            // Reached only for sessions with no KV.summaries entry, which
-            // can still hold chunk partials from a run whose final reduce
-            // failed after the per-chunk calls succeeded.
-            await deleteSummaryChunks(kv, session.id);
             await recordAudit(kv, "delete", "mem::evict", [session.id], {
               resource: "session",
               reason: recovered

--- a/src/functions/evict.ts
+++ b/src/functions/evict.ts
@@ -172,14 +172,9 @@ export function registerEvictFunction(sdk: ISdk, kv: StateKV): void {
             }
 
             try {
-              // Shared with mem::summarize's write step: a run that
-              // already passed its session-exists check would otherwise
-              // write these rows back with nothing left to reclaim them.
-              // The KV.summaries delete covers the ordering where that run
-              // wins the lock — this branch is otherwise reached only for
-              // sessions with no summary, though they can still hold chunk
-              // partials from a run whose final reduce failed after the
-              // per-chunk calls succeeded.
+              // The KV.summaries delete is not dead code: this branch is
+              // reached only for sessions with no summary, but a summarize
+              // run that wins the lock leaves one behind.
               await withKeyedLock(sessionWriteLockKey(session.id), async () => {
                 await kv.delete(KV.sessions, session.id);
                 await kv.delete(KV.summaries, session.id);

--- a/src/functions/evict.ts
+++ b/src/functions/evict.ts
@@ -12,6 +12,7 @@ import { isConsolidationEnabled } from "../config.js";
 import { recordAudit } from "./audit.js";
 import { deleteAccessLog } from "./access-tracker.js";
 import { logger } from "../logger.js";
+import { deleteSummaryChunks } from "./summarize.js";
 
 interface EvictionConfig {
   staleSessionDays: number;
@@ -180,6 +181,10 @@ export function registerEvictFunction(sdk: ISdk, kv: StateKV): void {
               });
               continue;
             }
+            // Reached only for sessions with no KV.summaries entry, which
+            // can still hold chunk partials from a run whose final reduce
+            // failed after the per-chunk calls succeeded.
+            await deleteSummaryChunks(kv, session.id);
             await recordAudit(kv, "delete", "mem::evict", [session.id], {
               resource: "session",
               reason: recovered
@@ -194,6 +199,12 @@ export function registerEvictFunction(sdk: ISdk, kv: StateKV): void {
       if (!dryRun && recoveredStaleSessions > 0) {
         await runRecoveredSessionConsolidation(sdk);
       }
+
+      // Evicting one observation shifts every downstream chunk boundary,
+      // orphaning the session's whole chunk cache. Collect sessions here
+      // and flush each once after both loops, rather than per evicted
+      // observation.
+      const touchedSessionIds = new Set<string>();
 
       const projectObs = new Map<string, CompressedObservation[]>();
       for (const session of sessions) {
@@ -225,6 +236,7 @@ export function registerEvictFunction(sdk: ISdk, kv: StateKV): void {
                 });
                 continue;
               }
+              touchedSessionIds.add(session.id);
               if (o.imageData) await decrementImageRef(kv, sdk, o.imageData);
               if (o.imageRef && o.imageRef !== o.imageData) await decrementImageRef(kv, sdk, o.imageRef);
               await recordAudit(kv, "delete", "mem::evict", [o.id], {
@@ -268,6 +280,7 @@ export function registerEvictFunction(sdk: ISdk, kv: StateKV): void {
                 });
                 continue;
               }
+              touchedSessionIds.add(o.sessionId);
               if (o.imageData) await decrementImageRef(kv, sdk, o.imageData);
               if (o.imageRef && o.imageRef !== o.imageData) await decrementImageRef(kv, sdk, o.imageRef);
               await recordAudit(kv, "delete", "mem::evict", [o.id], {
@@ -279,6 +292,14 @@ export function registerEvictFunction(sdk: ISdk, kv: StateKV): void {
             }
           }
         }
+      }
+
+      // Empty on a dryRun pass, so this needs no separate dryRun guard.
+      // Kept sequential rather than Promise.all: a sweep can touch
+      // hundreds of sessions, and the file-based KV adapter stalls under
+      // that much concurrent fan-out (upstream #1127).
+      for (const sessionId of touchedSessionIds) {
+        await deleteSummaryChunks(kv, sessionId);
       }
 
       const memories = await kv.list<Memory>(KV.memories).catch(() => []);

--- a/src/functions/export-import.ts
+++ b/src/functions/export-import.ts
@@ -33,6 +33,7 @@ import { VERSION } from "../version.js";
 import { recordAudit } from "./audit.js";
 import { indexRecords } from "./search.js";
 import { deleteSummaryChunks } from "./summarize.js";
+import { withKeyedLock, sessionWriteLockKey } from "../state/keyed-mutex.js";
 import { resetLessonIndex } from "./lessons.js";
 import { logger } from "../logger.js";
 
@@ -311,15 +312,21 @@ export function registerExportImportFunction(sdk: ISdk, kv: StateKV): void {
         // multiplies in-flight deletes to chunk-size squared.
         const obsDeletes: Array<{ sessionId: string; obsId: string }> = [];
         await runChunked(existing, async (session) => {
-          await kv.delete(KV.sessions, session.id);
+          // Shared with mem::summarize's write step: a run that already
+          // passed its session-exists check would otherwise write the
+          // session's rows back behind this wipe. The KV.summaries sweep
+          // below lists after this pass, so it still catches a summary
+          // written by a run that won the lock.
+          await withKeyedLock(sessionWriteLockKey(session.id), async () => {
+            await kv.delete(KV.sessions, session.id);
+            await deleteSummaryChunks(kv, session.id);
+          });
           const obs = await kv
             .list<CompressedObservation>(KV.observations(session.id))
             .catch(() => []);
           for (const o of obs) {
             obsDeletes.push({ sessionId: session.id, obsId: o.id });
           }
-          // The session row is gone, so no later pass can find this cache.
-          await deleteSummaryChunks(kv, session.id);
         });
         await runChunked(obsDeletes, (d) =>
           kv.delete(KV.observations(d.sessionId), d.obsId),

--- a/src/functions/export-import.ts
+++ b/src/functions/export-import.ts
@@ -32,6 +32,7 @@ import { StateKV } from "../state/kv.js";
 import { VERSION } from "../version.js";
 import { recordAudit } from "./audit.js";
 import { indexRecords } from "./search.js";
+import { deleteSummaryChunks } from "./summarize.js";
 import { resetLessonIndex } from "./lessons.js";
 import { logger } from "../logger.js";
 
@@ -317,6 +318,8 @@ export function registerExportImportFunction(sdk: ISdk, kv: StateKV): void {
           for (const o of obs) {
             obsDeletes.push({ sessionId: session.id, obsId: o.id });
           }
+          // The session row is gone, so no later pass can find this cache.
+          await deleteSummaryChunks(kv, session.id);
         });
         await runChunked(obsDeletes, (d) =>
           kv.delete(KV.observations(d.sessionId), d.obsId),

--- a/src/functions/export-import.ts
+++ b/src/functions/export-import.ts
@@ -312,11 +312,9 @@ export function registerExportImportFunction(sdk: ISdk, kv: StateKV): void {
         // multiplies in-flight deletes to chunk-size squared.
         const obsDeletes: Array<{ sessionId: string; obsId: string }> = [];
         await runChunked(existing, async (session) => {
-          // Shared with mem::summarize's write step: a run that already
-          // passed its session-exists check would otherwise write the
-          // session's rows back behind this wipe. The KV.summaries sweep
-          // below lists after this pass, so it still catches a summary
-          // written by a run that won the lock.
+          // No KV.summaries delete here: the sweep below lists after this
+          // pass, so it catches a summary written by a run that won the
+          // lock.
           await withKeyedLock(sessionWriteLockKey(session.id), async () => {
             await kv.delete(KV.sessions, session.id);
             await deleteSummaryChunks(kv, session.id);

--- a/src/functions/remember.ts
+++ b/src/functions/remember.ts
@@ -9,6 +9,7 @@ import { recordAudit } from "./audit.js";
 import { getSearchIndex, isMemoryIndexReady, vectorIndexAddGuarded, vectorIndexRemove, flushIndexSave } from "./search.js";
 import { getAgentId } from "../config.js";
 import { logger } from "../logger.js";
+import { deleteSummaryChunks } from "./summarize.js";
 
 // Slicing by UTF-16 code unit can cut an astral character (emoji, some CJK
 // extensions) mid surrogate pair, leaving a lone high surrogate that renders
@@ -313,6 +314,7 @@ export function registerRememberFunction(sdk: ISdk, kv: StateKV): void {
         }
         await kv.delete(KV.sessions, data.sessionId);
         await kv.delete(KV.summaries, data.sessionId);
+        await deleteSummaryChunks(kv, data.sessionId);
         deletedSession = true;
         deleted += 2;
       }

--- a/src/functions/remember.ts
+++ b/src/functions/remember.ts
@@ -2,7 +2,7 @@ import { TriggerAction, type ISdk } from "iii-sdk";
 import type { Memory } from "../types.js";
 import { KV, generateId, jaccardSimilarity } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
-import { withKeyedLock } from "../state/keyed-mutex.js";
+import { withKeyedLock, sessionWriteLockKey } from "../state/keyed-mutex.js";
 import { memoryToObservation } from "../state/memory-utils.js";
 import { deleteAccessLog } from "./access-tracker.js";
 import { recordAudit } from "./audit.js";
@@ -315,9 +315,16 @@ export function registerRememberFunction(sdk: ISdk, kv: StateKV): void {
           deletedObservationIds.push(obs.id);
           deleted++;
         }
-        await kv.delete(KV.sessions, data.sessionId);
-        await kv.delete(KV.summaries, data.sessionId);
-        await deleteSummaryChunks(kv, data.sessionId);
+        // Taken against an in-flight mem::summarize, which re-checks the
+        // session before writing: without the shared key a run that passed
+        // that check writes its rows back after this deletes them, and no
+        // later run reclaims them.
+        const sessionId = data.sessionId;
+        await withKeyedLock(sessionWriteLockKey(sessionId), async () => {
+          await kv.delete(KV.sessions, sessionId);
+          await kv.delete(KV.summaries, sessionId);
+          await deleteSummaryChunks(kv, sessionId);
+        });
         deletedSession = true;
         deleted += 2;
       }

--- a/src/functions/remember.ts
+++ b/src/functions/remember.ts
@@ -291,6 +291,9 @@ export function registerRememberFunction(sdk: ISdk, kv: StateKV): void {
           deletedObservationIds.push(obsId);
           deleted++;
         }
+        // The session survives, so the whole-session branch below never
+        // runs for this path.
+        await deleteSummaryChunks(kv, data.sessionId);
       }
 
       if (

--- a/src/functions/remember.ts
+++ b/src/functions/remember.ts
@@ -315,10 +315,6 @@ export function registerRememberFunction(sdk: ISdk, kv: StateKV): void {
           deletedObservationIds.push(obs.id);
           deleted++;
         }
-        // Taken against an in-flight mem::summarize, which re-checks the
-        // session before writing: without the shared key a run that passed
-        // that check writes its rows back after this deletes them, and no
-        // later run reclaims them.
         const sessionId = data.sessionId;
         await withKeyedLock(sessionWriteLockKey(sessionId), async () => {
           await kv.delete(KV.sessions, sessionId);

--- a/src/functions/summarize.ts
+++ b/src/functions/summarize.ts
@@ -7,6 +7,7 @@ import type {
 } from "../types.js";
 import { KV } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
+import { withKeyedLock } from "../state/keyed-mutex.js";
 import {
   SUMMARY_SYSTEM,
   buildSummaryPrompt,
@@ -240,6 +241,10 @@ export function registerSummarizeFunction(
       }
       const sessionId = data.sessionId.trim();
 
+      // #1203: api::summarize stays publicly reachable, so dropping the
+      // hook's duplicate POST does not by itself prevent two concurrent
+      // full-history passes over identical input. Serialize per session.
+      return withKeyedLock(`mem:summarize:${sessionId}`, async () => {
       const session = await kv.get<Session>(KV.sessions, sessionId);
       if (!session) {
         logger.warn("Session not found for summarize", {
@@ -393,6 +398,7 @@ export function registerSummarizeFunction(
         });
         return { success: false, error: msg };
       }
+      });
     },
   );
 }

--- a/src/functions/summarize.ts
+++ b/src/functions/summarize.ts
@@ -8,7 +8,7 @@ import type {
 } from "../types.js";
 import { KV } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
-import { withKeyedLock } from "../state/keyed-mutex.js";
+import { withKeyedLock, sessionWriteLockKey } from "../state/keyed-mutex.js";
 import {
   SUMMARY_SYSTEM,
   buildSummaryPrompt,
@@ -510,7 +510,32 @@ export function registerSummarizeFunction(
         const qualityScore = scoreSummary(summaryForValidation);
 
         summary.sourceFingerprint = fingerprint;
-        await kv.set(KV.summaries, sessionId, summary);
+        const wrote = await withKeyedLock(
+          sessionWriteLockKey(sessionId),
+          async () => {
+            // The provider call above runs for seconds while holding only
+            // the summarize lock, which deletion paths do not take. A
+            // whole-session delete landing in that window would otherwise
+            // be undone here, and nothing reclaims the result: every later
+            // run bails at session_not_found before reaching any cleanup.
+            if (!(await kv.get<Session>(KV.sessions, sessionId))) {
+              await deleteSummaryChunks(kv, sessionId);
+              return false;
+            }
+            await kv.set(KV.summaries, sessionId, summary);
+            return true;
+          },
+        );
+        if (!wrote) {
+          const latencyMs = Date.now() - startMs;
+          if (metricsStore) {
+            await metricsStore.record("mem::summarize", latencyMs, false);
+          }
+          logger.info("Summarize discarded — session deleted mid-run", {
+            sessionId,
+          });
+          return { success: false, error: "session_deleted" };
+        }
         await safeAudit(kv, "compress", "mem::summarize", [sessionId], {
           title: summary.title,
           observationCount: compressed.length,

--- a/src/functions/summarize.ts
+++ b/src/functions/summarize.ts
@@ -513,11 +513,8 @@ export function registerSummarizeFunction(
         const wrote = await withKeyedLock(
           sessionWriteLockKey(sessionId),
           async () => {
-            // The provider call above runs for seconds while holding only
-            // the summarize lock, which deletion paths do not take. A
-            // whole-session delete landing in that window would otherwise
-            // be undone here, and nothing reclaims the result: every later
-            // run bails at session_not_found before reaching any cleanup.
+            // Not redundant with the check on entry: the provider call
+            // between them runs for seconds, and a delete can land there.
             if (!(await kv.get<Session>(KV.sessions, sessionId))) {
               await deleteSummaryChunks(kv, sessionId);
               return false;

--- a/src/functions/summarize.ts
+++ b/src/functions/summarize.ts
@@ -1,4 +1,5 @@
 import type { ISdk } from "iii-sdk";
+import { createHash } from "node:crypto";
 import type {
   CompressedObservation,
   SessionSummary,
@@ -98,6 +99,7 @@ async function summarizeChunkWithRetry(
 // partials merged via a reduce call.
 async function produceSummaryXml(
   provider: MemoryProvider,
+  kv: StateKV,
   compressed: CompressedObservation[],
   sessionId: string,
   project: string,
@@ -138,7 +140,17 @@ async function produceSummaryXml(
     await Promise.all(
       batch.map(async (chunk, j) => {
         const idx = batchStart + j;
-        partialByIdx[idx] = await summarizeChunkWithRetry(
+        // A full chunk is immutable once the session grows past it, so
+        // only the trailing chunk misses.
+        const chunkKey = chunkFingerprint(chunk);
+        const cached = await kv
+          .get<CachedChunkSummary>(KV.summaryChunks(sessionId), chunkKey)
+          .catch(() => null);
+        if (cached) {
+          partialByIdx[idx] = cached.partial;
+          return;
+        }
+        const partial = await summarizeChunkWithRetry(
           provider,
           chunk,
           sessionId,
@@ -146,9 +158,34 @@ async function produceSummaryXml(
           idx,
           chunks.length,
         );
+        partialByIdx[idx] = partial;
+        if (partial) {
+          const entry: CachedChunkSummary = { chunkKey, partial };
+          await kv
+            .set(KV.summaryChunks(sessionId), chunkKey, entry)
+            .catch(() => {});
+        }
       }),
     );
   }
+
+  // On a live session only the trailing chunk's membership changes turn
+  // to turn, so each turn mints a new content-keyed entry and orphans the
+  // previous turn's. Nothing else reclaims those - deleteSummaryChunks
+  // fires only on a whole-session reclaim or an eviction touch, neither of
+  // which happens for an active session - so without this the cache grows
+  // by one dead entry per turn forever.
+  const liveChunkKeys = new Set(chunks.map((chunk) => chunkFingerprint(chunk)));
+  const cachedEntries = await kv
+    .list<CachedChunkSummary>(KV.summaryChunks(sessionId))
+    .catch(() => []);
+  await Promise.all(
+    cachedEntries
+      .filter((entry) => !liveChunkKeys.has(entry.chunkKey))
+      .map((entry) =>
+        kv.delete(KV.summaryChunks(sessionId), entry.chunkKey).catch(() => {}),
+      ),
+  );
 
   const skipped = partialByIdx.filter((p) => p === null).length;
   const partials = partialByIdx.filter((p): p is SessionSummary => p !== null);
@@ -227,14 +264,104 @@ function parseSummaryXml(
   };
 }
 
+// Length-prefixed so concatenation stays unambiguous: without it,
+// facts ["a", "bc"] and ["ab", "c"] would hash identically.
+function hashField(
+  hash: ReturnType<typeof createHash>,
+  value: string,
+): void {
+  hash.update(String(value.length));
+  hash.update(":");
+  hash.update(value);
+}
+
+function hashFieldList(
+  hash: ReturnType<typeof createHash>,
+  values: string[] | undefined,
+): void {
+  const list = values ?? [];
+  hash.update(String(list.length));
+  hash.update(":");
+  for (const value of list) hashField(hash, value);
+}
+
+// Hashes exactly the fields buildSummaryPrompt renders, so a digest match
+// means the LLM would receive a byte-identical prompt. Keep this in sync
+// with src/prompts/summary.ts: a field that reaches the prompt without
+// reaching this hash is a silent stale-summary bug. `concepts` is
+// deliberately absent - buildSummaryPrompt declares it but its template
+// never renders it, so hashing it would force re-summarization that
+// cannot change the output.
+function hashObservationSet(
+  hash: ReturnType<typeof createHash>,
+  observations: CompressedObservation[],
+): void {
+  for (const o of observations) {
+    hashField(hash, o.id);
+    hashField(hash, o.type ?? "");
+    hashField(hash, o.title ?? "");
+    hashField(hash, o.narrative ?? "");
+    hashFieldList(hash, o.facts);
+    hashFieldList(hash, o.files);
+  }
+  hash.update(String(observations.length));
+}
+
+// Sorted by id so the digest survives KV list-order churn. The handler
+// already sorts before calling this; the sort is repeated here so
+// correctness does not depend on caller discipline.
+function sourceFingerprint(compressed: CompressedObservation[]): string {
+  const sorted = [...compressed].sort((a, b) =>
+    a.id < b.id ? -1 : a.id > b.id ? 1 : 0,
+  );
+  const hash = createHash("sha256");
+  hashObservationSet(hash, sorted);
+  return `sfp_${hash.digest("hex").slice(0, 16)}`;
+}
+
+// Not sorted, unlike sourceFingerprint: chunk order is positional and
+// drives obsRangeStart/obsRangeEnd in the reduce step, so it is part of
+// what the key identifies rather than list-order noise to normalize away.
+function chunkFingerprint(chunk: CompressedObservation[]): string {
+  const hash = createHash("sha256");
+  hashObservationSet(hash, chunk);
+  return `chk_${hash.digest("hex").slice(0, 16)}`;
+}
+
+// The key is stored alongside the value because iii-sdk's IState.list()
+// returns values only, leaving deleteSummaryChunks nothing to delete by.
+interface CachedChunkSummary {
+  chunkKey: string;
+  partial: SessionSummary;
+}
+
+// Call this wherever a session's observations are reclaimed: whole-session
+// delete (mem::forget, stale-session eviction) and once per touched session
+// after a per-observation eviction pass. Removing even one observation
+// shifts every downstream chunk's membership, so it orphans the session's
+// entire chunk cache, not just the entry covering that observation.
+export async function deleteSummaryChunks(
+  kv: StateKV,
+  sessionId: string,
+): Promise<void> {
+  const entries = await kv
+    .list<CachedChunkSummary>(KV.summaryChunks(sessionId))
+    .catch(() => []);
+  await Promise.all(
+    entries.map((entry) =>
+      kv.delete(KV.summaryChunks(sessionId), entry.chunkKey).catch(() => {}),
+    ),
+  );
+}
+
 export function registerSummarizeFunction(
   sdk: ISdk,
   kv: StateKV,
   provider: MemoryProvider,
   metricsStore?: MetricsStore,
 ): void {
-  sdk.registerFunction("mem::summarize", 
-    async (data: { sessionId: string } | undefined) => {
+  sdk.registerFunction("mem::summarize",
+    async (data: { sessionId: string; force?: boolean } | undefined) => {
       const startMs = Date.now();
       if (!data || typeof data.sessionId !== "string" || !data.sessionId.trim()) {
         return { success: false, error: "sessionId is required" };
@@ -256,13 +383,33 @@ export function registerSummarizeFunction(
       const observations = await kv.list<CompressedObservation>(
         KV.observations(sessionId),
       );
-      const compressed = observations.filter((o) => o.title);
+      // kv.list order is not stable (the file_based store is a hash map),
+      // and chunk boundaries must be positionally stable across turns or
+      // every chunk key changes when the order shifts. generateId's base36
+      // timestamp prefix is a fixed 8 chars until 2059, so sorting by id
+      // is also sorting chronologically - which is the order the LLM and
+      // the reduce step's obsRange labels should see anyway.
+      const compressed = observations
+        .filter((o) => o.title)
+        .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
 
       if (compressed.length === 0) {
         logger.info("No observations to summarize", {
           sessionId,
         });
         return { success: false, error: "no_observations" };
+      }
+
+      // The Stop hook fires every assistant turn, so without this every
+      // turn re-sends the whole session: quadratic in turn count.
+      const fingerprint = sourceFingerprint(compressed);
+      const existing = await kv.get<SessionSummary>(KV.summaries, sessionId);
+      if (!data.force && existing?.sourceFingerprint === fingerprint) {
+        logger.info("Summarize skipped — observations unchanged", {
+          sessionId,
+          observationCount: compressed.length,
+        });
+        return { success: true, summary: existing, skipped: "unchanged" };
       }
 
       if (provider.name === "noop") {
@@ -290,6 +437,7 @@ export function registerSummarizeFunction(
         for (let attempt = 1; attempt <= 2; attempt++) {
           const produced = await produceSummaryXml(
             provider,
+            kv,
             compressed,
             sessionId,
             session.project,
@@ -361,6 +509,7 @@ export function registerSummarizeFunction(
 
         const qualityScore = scoreSummary(summaryForValidation);
 
+        summary.sourceFingerprint = fingerprint;
         await kv.set(KV.summaries, sessionId, summary);
         await safeAudit(kv, "compress", "mem::summarize", [sessionId], {
           title: summary.title,

--- a/src/state/keyed-mutex.ts
+++ b/src/state/keyed-mutex.ts
@@ -17,10 +17,12 @@ export function withKeyedLock<T>(
   return next;
 }
 
-// mem::summarize holds its own per-session lock across the provider call,
-// which is far too coarse for a deletion to wait on. This narrower key
-// covers only the summary-row write, so deletion paths serialize against
-// that write without blocking behind an LLM round trip.
+// Held by mem::summarize over its summary-row write and by every path
+// that deletes a whole session: unshared, a run that already passed its
+// session-exists check writes the rows back after a delete, and every
+// later run bails at session_not_found before reaching any cleanup.
+// Separate from mem::summarize's own lock, which spans the provider call
+// and would park a user-initiated mem::forget behind an LLM round trip.
 export function sessionWriteLockKey(sessionId: string): string {
   return `mem:session-write:${sessionId}`;
 }

--- a/src/state/keyed-mutex.ts
+++ b/src/state/keyed-mutex.ts
@@ -16,3 +16,11 @@ export function withKeyedLock<T>(
   });
   return next;
 }
+
+// mem::summarize holds its own per-session lock across the provider call,
+// which is far too coarse for a deletion to wait on. This narrower key
+// covers only the summary-row write, so deletion paths serialize against
+// that write without blocking behind an LLM round trip.
+export function sessionWriteLockKey(sessionId: string): string {
+  return `mem:session-write:${sessionId}`;
+}

--- a/src/state/schema.ts
+++ b/src/state/schema.ts
@@ -4,6 +4,7 @@ import { hasCjk, segmentCjk } from "./cjk-segmenter.js";
 export const KV = {
   sessions: "mem:sessions",
   observations: (sessionId: string) => `mem:obs:${sessionId}`,
+  summaryChunks: (sessionId: string) => `mem:summary-chunks:${sessionId}`,
   memories: "mem:memories",
   summaries: "mem:summaries",
   config: "mem:config",

--- a/src/types.ts
+++ b/src/types.ts
@@ -134,6 +134,9 @@ export interface SessionSummary {
   filesModified: string[];
   concepts: string[];
   observationCount: number;
+  // Fingerprint of the observation set this summary was produced from;
+  // mem::summarize short-circuits while it still matches.
+  sourceFingerprint?: string;
 }
 
 export type HookType =

--- a/test/agent-isolation-search.test.ts
+++ b/test/agent-isolation-search.test.ts
@@ -4,7 +4,10 @@ vi.mock("../src/logger.js", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
-vi.mock("../src/state/keyed-mutex.js", () => ({
+// Spread the real module so exports beyond withKeyedLock (sessionWriteLockKey)
+// keep their implementations instead of silently becoming undefined.
+vi.mock("../src/state/keyed-mutex.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/state/keyed-mutex.js")>()),
   withKeyedLock: <T>(_key: string, fn: () => Promise<T>) => fn(),
 }));
 

--- a/test/auto-forget.test.ts
+++ b/test/auto-forget.test.ts
@@ -270,4 +270,41 @@ describe("Auto-Forget Function", () => {
 
     expect(result.contradictions.length).toBe(0);
   });
+
+  it("reclaims the touched session's chunk cache after a low-value eviction", async () => {
+    const session: Session = {
+      id: "ses_2",
+      project: "my-project",
+      cwd: "/tmp",
+      startedAt: "2025-01-01T00:00:00Z",
+      status: "completed",
+      observationCount: 1,
+    };
+    await kv.set("mem:sessions", "ses_2", session);
+
+    const oldLowObs: CompressedObservation = {
+      id: "obs_old2",
+      sessionId: "ses_2",
+      timestamp: "2025-01-01T00:00:00Z",
+      type: "other",
+      title: "trivial event",
+      facts: [],
+      narrative: "nothing important",
+      concepts: [],
+      files: [],
+      importance: 1,
+    };
+    await kv.set("mem:obs:ses_2", "obs_old2", oldLowObs);
+    await kv.set("mem:summary-chunks:ses_2", "chk_a", {
+      chunkKey: "chk_a",
+      partial: { title: "cached partial" },
+    });
+
+    const result = (await sdk.trigger("mem::auto-forget", {})) as {
+      lowValueObs: string[];
+    };
+    expect(result.lowValueObs).toContain("obs_old2");
+
+    expect(await kv.list("mem:summary-chunks:ses_2")).toHaveLength(0);
+  });
 });

--- a/test/cross-project-isolation.test.ts
+++ b/test/cross-project-isolation.test.ts
@@ -4,7 +4,10 @@ vi.mock("../src/logger.js", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
-vi.mock("../src/state/keyed-mutex.js", () => ({
+// Spread the real module so exports beyond withKeyedLock (sessionWriteLockKey)
+// keep their implementations instead of silently becoming undefined.
+vi.mock("../src/state/keyed-mutex.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/state/keyed-mutex.js")>()),
   withKeyedLock: <T>(_key: string, fn: () => Promise<T>) => fn(),
 }));
 

--- a/test/evict.test.ts
+++ b/test/evict.test.ts
@@ -167,6 +167,47 @@ describe("mem::evict stale sessions", () => {
     );
   });
 
+  // #1131 review finding 2: KV.summaryChunks is introduced by
+  // mem::summarize and must be reclaimed wherever a stale session is
+  // fully evicted, or the per-chunk cache scope outlives the session it
+  // belongs to (this eviction path only runs for sessions with no
+  // KV.summaries entry, but a chunked summarize can still leave chunk
+  // partials cached if the final reduce/validation step failed after
+  // successful per-chunk calls).
+  it("clears the per-chunk summary cache when a stale session is evicted (#1131)", async () => {
+    const sessionId = "ses_stale";
+    const store = storeForObservedSession(sessionId);
+    store.set(
+      KV.summaryChunks(sessionId),
+      new Map([
+        [
+          "chk_aaaaaaaaaaaaaaaa",
+          { chunkKey: "chk_aaaaaaaaaaaaaaaa", partial: { title: "t" } },
+        ],
+      ]),
+    );
+    const kv = mockKV(store);
+    const { sdk } = mockSdk();
+
+    registerEvictFunction(sdk as never, kv as never);
+    sdk.registerFunction("event::session::stopped", async () => ({
+      success: true,
+    }));
+    sdk.registerFunction("mem::consolidate-pipeline", () => ({
+      success: true,
+    }));
+    sdk.registerFunction("mem::auto-crystallize", () => ({ success: true }));
+
+    const result = (await sdk.trigger({
+      function_id: "mem::evict",
+      payload: {},
+    })) as { staleSessions: number };
+
+    expect(result.staleSessions).toBe(1);
+    const remaining = await kv.list(KV.summaryChunks(sessionId));
+    expect(remaining).toHaveLength(0);
+  });
+
   it("bounds consolidation to one pass regardless of how many stale sessions are recovered", async () => {
     // Regression (P1): before the skipConsolidation guard, N recovered
     // sessions each triggered a forced full-corpus consolidate + crystallize
@@ -293,5 +334,118 @@ describe("mem::evict stale sessions", () => {
     expect(calls.map((call) => call.function_id)).not.toContain(
       "event::session::stopped",
     );
+  });
+});
+
+// #1131 review round 2: evicting even one observation shifts every
+// downstream chunk boundary for that session, orphaning its entire
+// per-chunk summary cache at once - not just the one entry touching the
+// evicted observation. mem::evict runs repeatedly against active
+// sessions (whole-session delete never fires for those), so leaving
+// orphaned generations in place is a recurring, unbounded leak. These
+// tests prove the low-importance eviction path flushes the touched
+// session's cache once per pass, and that a dryRun pass flushes nothing.
+describe("mem::evict per-observation eviction chunk cache reclamation (#1131)", () => {
+  function chunkCacheEntry(chunkKey: string) {
+    return { chunkKey, partial: { title: "cached partial" } };
+  }
+
+  // Young startedAt keeps this session out of the stale-session branch
+  // above (age <= staleSessionDays), so only the low-importance path is
+  // exercised.
+  function storeForLowImportanceEviction(sessionId: string): Store {
+    const staleObs: CompressedObservation = {
+      ...makeObservation(sessionId),
+      id: "obs_low_importance",
+      timestamp: daysAgo(200),
+      importance: 1,
+    };
+    const store = storeForObservations(sessionId, [staleObs]);
+    store.get(KV.sessions)!.set(sessionId, {
+      ...makeSession(sessionId),
+      startedAt: daysAgo(1),
+    });
+    store.set(
+      KV.summaryChunks(sessionId),
+      new Map([["chk_a", chunkCacheEntry("chk_a")]]),
+    );
+    return store;
+  }
+
+  it("flushes the touched session's chunk cache after a low-importance eviction pass", async () => {
+    const sessionId = "ses_low_importance";
+    const store = storeForLowImportanceEviction(sessionId);
+    const kv = mockKV(store);
+    const { sdk } = mockSdk();
+    registerEvictFunction(sdk as never, kv as never);
+
+    const result = (await sdk.trigger({
+      function_id: "mem::evict",
+      payload: {},
+    })) as { lowImportanceObs: number };
+
+    expect(result.lowImportanceObs).toBe(1);
+    const remaining = await kv.list(KV.summaryChunks(sessionId));
+    expect(remaining).toHaveLength(0);
+  });
+
+  it("does not flush the chunk cache on a dry run", async () => {
+    const sessionId = "ses_low_importance_dry";
+    const store = storeForLowImportanceEviction(sessionId);
+    const kv = mockKV(store);
+    const { sdk } = mockSdk();
+    registerEvictFunction(sdk as never, kv as never);
+
+    const result = (await sdk.trigger({
+      function_id: "mem::evict",
+      payload: { dryRun: true },
+    })) as { lowImportanceObs: number };
+
+    // Still counted for reporting, but nothing actually deleted or flushed.
+    expect(result.lowImportanceObs).toBe(1);
+    expect(
+      await kv.get(KV.observations(sessionId), "obs_low_importance"),
+    ).not.toBeNull();
+    const remaining = await kv.list(KV.summaryChunks(sessionId));
+    expect(remaining).toHaveLength(1);
+  });
+
+  it("flushes the touched session's chunk cache after a project-cap eviction pass", async () => {
+    const sessionId = "ses_cap";
+    const obsA: CompressedObservation = {
+      ...makeObservation(sessionId),
+      id: "obs_a",
+      importance: 1,
+    };
+    const obsB: CompressedObservation = {
+      ...makeObservation(sessionId),
+      id: "obs_b",
+      importance: 9,
+    };
+    const store = storeForObservations(sessionId, [obsA, obsB]);
+    store.get(KV.sessions)!.set(sessionId, {
+      ...makeSession(sessionId),
+      startedAt: daysAgo(1),
+    });
+    store.set(KV.config, new Map([["eviction", { maxObservationsPerProject: 1 }]]));
+    store.set(
+      KV.summaryChunks(sessionId),
+      new Map([["chk_b", chunkCacheEntry("chk_b")]]),
+    );
+    const kv = mockKV(store);
+    const { sdk } = mockSdk();
+    registerEvictFunction(sdk as never, kv as never);
+
+    const result = (await sdk.trigger({
+      function_id: "mem::evict",
+      payload: {},
+    })) as { capEvictions: number };
+
+    expect(result.capEvictions).toBe(1);
+    // The lower-importance observation (obsA) is the one capped away.
+    expect(await kv.get(KV.observations(sessionId), "obs_a")).toBeNull();
+    expect(await kv.get(KV.observations(sessionId), "obs_b")).not.toBeNull();
+    const remaining = await kv.list(KV.summaryChunks(sessionId));
+    expect(remaining).toHaveLength(0);
   });
 });

--- a/test/export-import.test.ts
+++ b/test/export-import.test.ts
@@ -260,6 +260,26 @@ describe("Export/Import Functions", () => {
     expect(oldSession).toBeNull();
   });
 
+  it("import with replace strategy also reclaims the wiped sessions' chunk cache", async () => {
+    await kv.set("mem:summary-chunks:ses_1", "chk_a", {
+      chunkKey: "chk_a",
+      partial: { title: "cached partial" },
+    });
+
+    const exportData: ExportData = {
+      version: "0.3.0",
+      exportedAt: new Date().toISOString(),
+      sessions: [],
+      observations: {},
+      memories: [],
+      summaries: [],
+    };
+
+    await sdk.trigger("mem::import", { exportData, strategy: "replace" });
+
+    expect(await kv.list("mem:summary-chunks:ses_1")).toHaveLength(0);
+  });
+
   it("export then import round-trip preserves data", async () => {
     const exported = (await sdk.trigger("mem::export", {})) as ExportData;
 

--- a/test/remember-forget-audit.test.ts
+++ b/test/remember-forget-audit.test.ts
@@ -272,4 +272,29 @@ describe("mem::forget search-index cleanup", () => {
 
     expect(persistence.save).toHaveBeenCalled();
   });
+
+  it("reclaims the chunk cache when specific observationIds are forgotten", async () => {
+    const sdk = mockSdk();
+    const kv = mockKV();
+    registerRememberFunction(sdk as never, kv as never);
+
+    await kv.set("mem:sessions", "sess_2", { id: "sess_2" });
+    await kv.set("mem:obs:sess_2", "obs_a", { id: "obs_a" });
+    await kv.set("mem:obs:sess_2", "obs_b", { id: "obs_b" });
+    await kv.set("mem:summary-chunks:sess_2", "chk_a", {
+      chunkKey: "chk_a",
+      partial: { title: "cached partial" },
+    });
+
+    await sdk.trigger({
+      function_id: "mem::forget",
+      payload: { sessionId: "sess_2", observationIds: ["obs_a"] },
+    });
+
+    // The session and its remaining observation survive; only the cache
+    // invalidated by the partial delete is reclaimed.
+    expect(await kv.get("mem:sessions", "sess_2")).not.toBeNull();
+    expect(await kv.get("mem:obs:sess_2", "obs_b")).not.toBeNull();
+    expect(await kv.list("mem:summary-chunks:sess_2")).toHaveLength(0);
+  });
 });

--- a/test/remember-forget-audit.test.ts
+++ b/test/remember-forget-audit.test.ts
@@ -109,6 +109,36 @@ describe("mem::forget audit coverage (issue #125)", () => {
     expect(row.details.deleted).toBe(4);
   });
 
+  // #1131 review finding 2: KV.summaryChunks is introduced by
+  // mem::summarize and must be reclaimed wherever a session's
+  // KV.observations/KV.summaries are already reclaimed, or the per-chunk
+  // cache scope outlives the session it belongs to.
+  it("clears the per-chunk summary cache when an entire session is forgotten (#1131)", async () => {
+    const sdk = mockSdk();
+    const kv = mockKV();
+    registerRememberFunction(sdk as never, kv as never);
+
+    await kv.set("mem:sessions", "sess_1", { id: "sess_1" });
+    await kv.set("mem:summaries", "sess_1", { id: "sess_1" });
+    await kv.set("mem:obs:sess_1", "obs_a", { id: "obs_a" });
+    await kv.set("mem:summary-chunks:sess_1", "chk_aaaaaaaaaaaaaaaa", {
+      chunkKey: "chk_aaaaaaaaaaaaaaaa",
+      partial: { title: "t" },
+    });
+    await kv.set("mem:summary-chunks:sess_1", "chk_bbbbbbbbbbbbbbbb", {
+      chunkKey: "chk_bbbbbbbbbbbbbbbb",
+      partial: { title: "t2" },
+    });
+
+    await sdk.trigger({
+      function_id: "mem::forget",
+      payload: { sessionId: "sess_1" },
+    });
+
+    const remaining = await kv.list("mem:summary-chunks:sess_1");
+    expect(remaining).toHaveLength(0);
+  });
+
   it("does not emit an audit row when nothing is deleted", async () => {
     const sdk = mockSdk();
     const kv = mockKV();

--- a/test/remember-forget-audit.test.ts
+++ b/test/remember-forget-audit.test.ts
@@ -4,7 +4,10 @@ vi.mock("../src/logger.js", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
-vi.mock("../src/state/keyed-mutex.js", () => ({
+// Spread the real module so exports beyond withKeyedLock (sessionWriteLockKey)
+// keep their implementations instead of silently becoming undefined.
+vi.mock("../src/state/keyed-mutex.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/state/keyed-mutex.js")>()),
   withKeyedLock: <T>(_key: string, fn: () => Promise<T>) => fn(),
 }));
 

--- a/test/remember-project-scope.test.ts
+++ b/test/remember-project-scope.test.ts
@@ -4,7 +4,10 @@ vi.mock("../src/logger.js", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
-vi.mock("../src/state/keyed-mutex.js", () => ({
+// Spread the real module so exports beyond withKeyedLock (sessionWriteLockKey)
+// keep their implementations instead of silently becoming undefined.
+vi.mock("../src/state/keyed-mutex.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/state/keyed-mutex.js")>()),
   withKeyedLock: <T>(_key: string, fn: () => Promise<T>) => fn(),
 }));
 

--- a/test/summarize-delete-race.test.ts
+++ b/test/summarize-delete-race.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../src/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("../src/eval/schemas.js", () => ({ SummaryOutputSchema: {} }));
+vi.mock("../src/eval/validator.js", () => ({
+  validateOutput: () => ({ valid: true, result: { errors: [] } }),
+}));
+vi.mock("../src/eval/quality.js", () => ({ scoreSummary: () => 100 }));
+vi.mock("../src/functions/audit.js", () => ({
+  safeAudit: vi.fn(),
+  recordAudit: vi.fn(),
+}));
+
+vi.mock("../src/config.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/config.js")>()),
+  isConsolidationEnabled: () => false,
+}));
+
+import { registerSummarizeFunction } from "../src/functions/summarize.js";
+import { registerRememberFunction } from "../src/functions/remember.js";
+import { registerEvictFunction } from "../src/functions/evict.js";
+import { registerExportImportFunction } from "../src/functions/export-import.js";
+import type {
+  CompressedObservation,
+  MemoryProvider,
+  Session,
+} from "../src/types.js";
+
+function mockKV() {
+  const store = new Map<string, Map<string, unknown>>();
+  return {
+    store,
+    get: async <T>(scope: string, key: string): Promise<T | null> =>
+      (store.get(scope)?.get(key) as T) ?? null,
+    set: async <T>(scope: string, key: string, data: T): Promise<T> => {
+      if (!store.has(scope)) store.set(scope, new Map());
+      store.get(scope)!.set(key, data);
+      return data;
+    },
+    delete: async (scope: string, key: string): Promise<void> => {
+      store.get(scope)?.delete(key);
+    },
+    list: async <T>(scope: string): Promise<T[]> => {
+      const entries = store.get(scope);
+      return entries ? (Array.from(entries.values()) as T[]) : [];
+    },
+  };
+}
+
+function mockSdk() {
+  const functions = new Map<string, Function>();
+  return {
+    functions,
+    registerFunction: (id: string, handler: Function) => {
+      functions.set(id, handler);
+    },
+    registerTrigger: () => {},
+    trigger: async (input: { function_id: string; payload: unknown }) => {
+      const fn = functions.get(input.function_id);
+      if (!fn) throw new Error(`unknown fn ${input.function_id}`);
+      return fn(input.payload);
+    },
+  };
+}
+
+function makeObs(i: number, sessionId: string): CompressedObservation {
+  return {
+    id: `obs_${i}`,
+    sessionId,
+    timestamp: new Date().toISOString(),
+    type: "conversation",
+    title: `obs ${i}`,
+    facts: [`fact ${i}`],
+    narrative: `narrative for obs ${i}`,
+    concepts: [],
+    files: [`src/file_${i}.ts`],
+    importance: 5,
+  };
+}
+
+async function tick(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function deferred(): { promise: Promise<void>; release: () => void } {
+  let release!: () => void;
+  const promise = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return { promise, release };
+}
+
+const SUMMARY_XML =
+  "<summary><title>orphan</title><narrative>n</narrative>" +
+  "<decisions></decisions><files></files><concepts></concepts></summary>";
+
+interface Race {
+  summarizing: Promise<unknown>;
+  pastRecheck: Promise<void>;
+  releaseWrite: () => void;
+}
+
+// Parks an in-flight mem::summarize at the point where it has already
+// confirmed the session exists but has not yet written the summary row.
+// That window is the only interleaving the existence re-check cannot
+// close on its own, so every deletion path has to serialize against it.
+async function startGatedSummarize(
+  sdk: ReturnType<typeof mockSdk>,
+  kv: ReturnType<typeof mockKV>,
+  sessionId: string,
+  startedAt: string,
+): Promise<Race> {
+  const session: Session = {
+    id: sessionId,
+    project: "test-project",
+    cwd: "/tmp",
+    startedAt,
+    status: "completed",
+    observationCount: 2,
+  };
+  await kv.set("mem:sessions", sessionId, session);
+  for (let i = 0; i < 2; i++) {
+    const o = makeObs(i, sessionId);
+    await kv.set(`mem:obs:${sessionId}`, o.id, o);
+  }
+
+  const providerGate = deferred();
+  const provider = {
+    name: "test",
+    compress: async () => "",
+    summarize: async () => {
+      await providerGate.promise;
+      return SUMMARY_XML;
+    },
+  } as unknown as MemoryProvider;
+
+  // The handler reads mem:sessions twice: once on entry, once as the
+  // existence re-check just before writing.
+  const pastRecheck = deferred();
+  let sessionReads = 0;
+  const rawGet = kv.get;
+  kv.get = async <T>(scope: string, key: string): Promise<T | null> => {
+    const value = await rawGet<T>(scope, key);
+    if (scope === "mem:sessions") {
+      sessionReads += 1;
+      if (sessionReads === 2) pastRecheck.release();
+    }
+    return value;
+  };
+
+  const writeGate = deferred();
+  const rawSet = kv.set;
+  kv.set = async <T>(scope: string, key: string, data: T): Promise<T> => {
+    if (scope === "mem:summaries") await writeGate.promise;
+    return rawSet(scope, key, data);
+  };
+
+  registerSummarizeFunction(sdk as never, kv as never, provider);
+  const summarizing = sdk.trigger({
+    function_id: "mem::summarize",
+    payload: { sessionId },
+  });
+  await tick();
+  providerGate.release();
+
+  return {
+    summarizing,
+    pastRecheck: pastRecheck.promise,
+    releaseWrite: writeGate.release,
+  };
+}
+
+async function expectNoOrphan(
+  kv: ReturnType<typeof mockKV>,
+  sessionId: string,
+): Promise<void> {
+  expect(await kv.get("mem:sessions", sessionId)).toBeNull();
+  expect(await kv.get("mem:summaries", sessionId)).toBeNull();
+  expect(await kv.list(`mem:summary-chunks:${sessionId}`)).toEqual([]);
+}
+
+describe("whole-session deletion racing an in-flight mem::summarize", () => {
+  it("mem::forget leaves no summary behind when it lands inside the write window", async () => {
+    const sdk = mockSdk();
+    const kv = mockKV();
+    const sessionId = "sess_forget";
+    const race = await startGatedSummarize(
+      sdk,
+      kv,
+      sessionId,
+      new Date().toISOString(),
+    );
+
+    registerRememberFunction(sdk as never, kv as never);
+    await race.pastRecheck;
+    const forgetting = sdk.trigger({
+      function_id: "mem::forget",
+      payload: { sessionId },
+    });
+    for (let i = 0; i < 10; i++) await tick();
+
+    race.releaseWrite();
+    await Promise.all([race.summarizing, forgetting]);
+
+    await expectNoOrphan(kv, sessionId);
+  });
+
+  it("stale-session eviction leaves no summary behind when it lands inside the write window", async () => {
+    const sdk = mockSdk();
+    const kv = mockKV();
+    const sessionId = "sess_evict";
+    const staleStart = new Date(
+      Date.now() - 31 * 24 * 60 * 60 * 1000,
+    ).toISOString();
+    const race = await startGatedSummarize(sdk, kv, sessionId, staleStart);
+
+    sdk.registerFunction("event::session::stopped", async () => ({
+      success: true,
+    }));
+    registerEvictFunction(sdk as never, kv as never);
+    await race.pastRecheck;
+    const evicting = sdk.trigger({
+      function_id: "mem::evict",
+      payload: {},
+    });
+    for (let i = 0; i < 10; i++) await tick();
+
+    race.releaseWrite();
+    await Promise.all([race.summarizing, evicting]);
+
+    await expectNoOrphan(kv, sessionId);
+  });
+
+  it("replace-strategy import leaves no summary behind when it lands inside the write window", async () => {
+    const sdk = mockSdk();
+    const kv = mockKV();
+    const sessionId = "sess_import";
+    const race = await startGatedSummarize(
+      sdk,
+      kv,
+      sessionId,
+      new Date().toISOString(),
+    );
+
+    registerExportImportFunction(sdk as never, kv as never);
+    await race.pastRecheck;
+    const importing = sdk.trigger({
+      function_id: "mem::import",
+      payload: {
+        strategy: "replace",
+        exportData: {
+          version: "0.9.29",
+          sessions: [],
+          observations: {},
+          memories: [],
+          summaries: [],
+        },
+      },
+    });
+    for (let i = 0; i < 10; i++) await tick();
+
+    race.releaseWrite();
+    await Promise.all([race.summarizing, importing]);
+
+    await expectNoOrphan(kv, sessionId);
+  });
+});

--- a/test/summarize.test.ts
+++ b/test/summarize.test.ts
@@ -480,3 +480,52 @@ describe("mem::summarize chunking", () => {
     expect(result.error).toBe("parse_failed");
   });
 });
+
+describe("mem::summarize concurrency", () => {
+  it("serializes concurrent runs for the same session (#1203)", async () => {
+    const kv = mockKV();
+    await kv.set("sessions", "s1", {
+      id: "s1",
+      project: "p",
+      cwd: "/tmp",
+      startedAt: new Date().toISOString(),
+      status: "active",
+      observationCount: 1,
+    } as Session);
+    await kv.set("obs:s1", "o1", {
+      id: "o1",
+      sessionId: "s1",
+      timestamp: new Date().toISOString(),
+      type: "other",
+      title: "t",
+      facts: [],
+      narrative: "n",
+      concepts: [],
+      files: [],
+      importance: 5,
+      confidence: 0.3,
+    } as CompressedObservation);
+
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const provider: MemoryProvider = {
+      name: "test",
+      compress: async () => "",
+      summarize: async () => {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await new Promise((r) => setTimeout(r, 20));
+        inFlight--;
+        return "<summary><title>T</title><narrative>N</narrative></summary>";
+      },
+    } as unknown as MemoryProvider;
+
+    const sdk = mockSdk();
+    registerSummarizeFunction(sdk as never, kv as never, provider);
+    const fn = sdk.functions.get("mem::summarize")!;
+
+    await Promise.all([fn({ sessionId: "s1" }), fn({ sessionId: "s1" })]);
+
+    expect(maxInFlight).toBe(1);
+  });
+});

--- a/test/summarize.test.ts
+++ b/test/summarize.test.ts
@@ -4,14 +4,24 @@ vi.mock("../src/logger.js", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
-vi.mock("../src/state/schema.js", () => ({
-  KV: {
-    sessions: "sessions",
-    summaries: "summaries",
-    observations: (sessionId: string) => `obs:${sessionId}`,
-    audit: "audit",
-  },
-}));
+// #1131: spread the real module so anything summarize.ts imports from
+// schema.js beyond KV (e.g. fingerprintId) keeps its real implementation
+// instead of silently becoming undefined — only KV needs a test double.
+vi.mock("../src/state/schema.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/state/schema.js")>();
+  return {
+    ...actual,
+    KV: {
+      sessions: "sessions",
+      summaries: "summaries",
+      observations: (sessionId: string) => `obs:${sessionId}`,
+      // #1131: per-chunk summary partial cache; must be present or the
+      // chunk-memoization path sees an undefined scope key.
+      summaryChunks: (sessionId: string) => `summary-chunks:${sessionId}`,
+      audit: "audit",
+    },
+  };
+});
 
 vi.mock("../src/eval/schemas.js", () => ({
   SummaryOutputSchema: {},
@@ -527,5 +537,475 @@ describe("mem::summarize concurrency", () => {
     await Promise.all([fn({ sessionId: "s1" }), fn({ sessionId: "s1" })]);
 
     expect(maxInFlight).toBe(1);
+  });
+});
+
+describe("mem::summarize change detection", () => {
+  it("does not call the provider twice for an unchanged session (#1131)", async () => {
+    const kv = mockKV();
+    await kv.set("sessions", "s2", {
+      id: "s2",
+      project: "p",
+      cwd: "/tmp",
+      startedAt: new Date().toISOString(),
+      status: "active",
+      observationCount: 1,
+    } as Session);
+    await kv.set("obs:s2", "o1", {
+      id: "o1",
+      sessionId: "s2",
+      timestamp: "2026-08-21T00:00:00.000Z",
+      type: "other",
+      title: "t",
+      facts: [],
+      narrative: "n",
+      concepts: [],
+      files: [],
+      importance: 5,
+      confidence: 0.3,
+    } as CompressedObservation);
+
+    let calls = 0;
+    const provider: MemoryProvider = {
+      name: "test",
+      compress: async () => "",
+      summarize: async () => {
+        calls++;
+        return "<summary><title>T</title><narrative>N</narrative></summary>";
+      },
+    } as unknown as MemoryProvider;
+
+    const sdk = mockSdk();
+    registerSummarizeFunction(sdk as never, kv as never, provider);
+    const fn = sdk.functions.get("mem::summarize")!;
+
+    const first = await fn({ sessionId: "s2" });
+    const second = await fn({ sessionId: "s2" });
+
+    expect(calls).toBe(1);
+    expect(second.success).toBe(true);
+    expect(second.skipped).toBe("unchanged");
+    expect(second.summary.title).toBe(first.summary.title);
+  });
+
+  it("re-summarizes once a new observation lands (#1131)", async () => {
+    const kv = mockKV();
+    await kv.set("sessions", "s3", {
+      id: "s3",
+      project: "p",
+      cwd: "/tmp",
+      startedAt: new Date().toISOString(),
+      status: "active",
+      observationCount: 1,
+    } as Session);
+    const obs = (id: string): CompressedObservation => ({
+      id,
+      sessionId: "s3",
+      timestamp: "2026-08-21T00:00:00.000Z",
+      type: "other",
+      title: "t",
+      facts: [],
+      narrative: "n",
+      concepts: [],
+      files: [],
+      importance: 5,
+      confidence: 0.3,
+    });
+    await kv.set("obs:s3", "o1", obs("o1"));
+
+    let calls = 0;
+    const provider: MemoryProvider = {
+      name: "test",
+      compress: async () => "",
+      summarize: async () => {
+        calls++;
+        return "<summary><title>T</title><narrative>N</narrative></summary>";
+      },
+    } as unknown as MemoryProvider;
+
+    const sdk = mockSdk();
+    registerSummarizeFunction(sdk as never, kv as never, provider);
+    const fn = sdk.functions.get("mem::summarize")!;
+
+    await fn({ sessionId: "s3" });
+    await kv.set("obs:s3", "o2", obs("o2"));
+    await fn({ sessionId: "s3" });
+
+    expect(calls).toBe(2);
+  });
+
+  it("re-summarizes on a same-id content rewrite — id-only fingerprint would false-skip (#1131)", async () => {
+    const kv = mockKV();
+    await kv.set("sessions", "s4", {
+      id: "s4",
+      project: "p",
+      cwd: "/tmp",
+      startedAt: new Date().toISOString(),
+      status: "active",
+      observationCount: 1,
+    } as Session);
+    await kv.set("obs:s4", "o1", {
+      id: "o1",
+      sessionId: "s4",
+      timestamp: "2026-08-21T00:00:00.000Z",
+      type: "other",
+      title: "original title",
+      facts: [],
+      narrative: "original narrative",
+      concepts: [],
+      files: [],
+      importance: 5,
+      confidence: 0.3,
+    } as CompressedObservation);
+
+    let calls = 0;
+    const provider: MemoryProvider = {
+      name: "test",
+      compress: async () => "",
+      summarize: async () => {
+        calls++;
+        return "<summary><title>T</title><narrative>N</narrative></summary>";
+      },
+    } as unknown as MemoryProvider;
+
+    const sdk = mockSdk();
+    registerSummarizeFunction(sdk as never, kv as never, provider);
+    const fn = sdk.functions.get("mem::summarize")!;
+
+    await fn({ sessionId: "s4" });
+
+    // #1131: same id ("o1"), but a bulk import-jsonl or replay rewrite
+    // changed the title and narrative content — content-aware fingerprint
+    // must not treat this as unchanged.
+    await kv.set("obs:s4", "o1", {
+      id: "o1",
+      sessionId: "s4",
+      timestamp: "2026-08-21T00:00:00.000Z",
+      type: "other",
+      title: "rewritten title",
+      facts: [],
+      narrative: "completely different narrative content after import",
+      concepts: [],
+      files: [],
+      importance: 5,
+      confidence: 0.3,
+    } as CompressedObservation);
+
+    const second = await fn({ sessionId: "s4" });
+
+    expect(calls).toBe(2);
+    expect(second.success).toBe(true);
+    expect(second.skipped).toBeUndefined();
+  });
+
+  it("re-summarizes when only facts change — title and narrative length are unchanged (#1131)", async () => {
+    const kv = mockKV();
+    await kv.set("sessions", "s5", {
+      id: "s5",
+      project: "p",
+      cwd: "/tmp",
+      startedAt: new Date().toISOString(),
+      status: "active",
+      observationCount: 1,
+    } as Session);
+    const base = {
+      id: "o1",
+      sessionId: "s5",
+      timestamp: "2026-08-21T00:00:00.000Z",
+      type: "other" as const,
+      title: "stable title",
+      narrative: "stable narrative",
+      concepts: [],
+      files: [],
+      importance: 5,
+      confidence: 0.3,
+    };
+    await kv.set("obs:s5", "o1", {
+      ...base,
+      facts: ["first fact"],
+    } as CompressedObservation);
+
+    let calls = 0;
+    const provider: MemoryProvider = {
+      name: "test",
+      compress: async () => "",
+      summarize: async () => {
+        calls++;
+        return "<summary><title>T</title><narrative>N</narrative></summary>";
+      },
+    } as unknown as MemoryProvider;
+
+    const sdk = mockSdk();
+    registerSummarizeFunction(sdk as never, kv as never, provider);
+    const fn = sdk.functions.get("mem::summarize")!;
+
+    await fn({ sessionId: "s5" });
+
+    // buildSummaryPrompt renders facts, so this changes the LLM input even
+    // though id, title and narrative are byte-identical. Hashing only
+    // id/title/narrative-length would false-skip here.
+    await kv.set("obs:s5", "o1", {
+      ...base,
+      facts: ["a completely different fact"],
+    } as CompressedObservation);
+
+    const second = await fn({ sessionId: "s5" });
+
+    expect(calls).toBe(2);
+    expect(second.success).toBe(true);
+    expect(second.skipped).toBeUndefined();
+  });
+
+  it("re-summarizes when only files change (#1131)", async () => {
+    const kv = mockKV();
+    await kv.set("sessions", "s6", {
+      id: "s6",
+      project: "p",
+      cwd: "/tmp",
+      startedAt: new Date().toISOString(),
+      status: "active",
+      observationCount: 1,
+    } as Session);
+    const base = {
+      id: "o1",
+      sessionId: "s6",
+      timestamp: "2026-08-21T00:00:00.000Z",
+      type: "other" as const,
+      title: "stable title",
+      narrative: "stable narrative",
+      facts: [],
+      concepts: [],
+      importance: 5,
+      confidence: 0.3,
+    };
+    await kv.set("obs:s6", "o1", {
+      ...base,
+      files: ["src/a.ts"],
+    } as CompressedObservation);
+
+    let calls = 0;
+    const provider: MemoryProvider = {
+      name: "test",
+      compress: async () => "",
+      summarize: async () => {
+        calls++;
+        return "<summary><title>T</title><narrative>N</narrative></summary>";
+      },
+    } as unknown as MemoryProvider;
+
+    const sdk = mockSdk();
+    registerSummarizeFunction(sdk as never, kv as never, provider);
+    const fn = sdk.functions.get("mem::summarize")!;
+
+    await fn({ sessionId: "s6" });
+
+    await kv.set("obs:s6", "o1", {
+      ...base,
+      files: ["src/b.ts"],
+    } as CompressedObservation);
+
+    const second = await fn({ sessionId: "s6" });
+
+    expect(calls).toBe(2);
+    expect(second.success).toBe(true);
+    expect(second.skipped).toBeUndefined();
+  });
+});
+
+describe("mem::summarize chunk memoization", () => {
+  const OLD = process.env.SUMMARIZE_CHUNK_SIZE;
+  beforeEach(() => { process.env.SUMMARIZE_CHUNK_SIZE = "2"; });
+  afterEach(() => {
+    if (OLD === undefined) delete process.env.SUMMARIZE_CHUNK_SIZE;
+    else process.env.SUMMARIZE_CHUNK_SIZE = OLD;
+  });
+
+  it("reuses full chunks when one observation is appended (#1131)", async () => {
+    const kv = mockKV();
+    await kv.set("sessions", "s4", {
+      id: "s4",
+      project: "p",
+      cwd: "/tmp",
+      startedAt: new Date().toISOString(),
+      status: "active",
+      observationCount: 0,
+    } as Session);
+    const obs = (id: string): CompressedObservation => ({
+      id,
+      sessionId: "s4",
+      timestamp: "2026-08-21T00:00:00.000Z",
+      type: "other",
+      title: `t-${id}`,
+      facts: [],
+      narrative: "n",
+      concepts: [],
+      files: [],
+      importance: 5,
+      confidence: 0.3,
+    });
+    for (const id of ["o1", "o2", "o3", "o4"]) {
+      await kv.set("obs:s4", id, obs(id));
+    }
+
+    let calls = 0;
+    const provider: MemoryProvider = {
+      name: "test",
+      compress: async () => "",
+      summarize: async () => {
+        calls++;
+        return "<summary><title>T</title><narrative>N</narrative></summary>";
+      },
+    } as unknown as MemoryProvider;
+
+    const sdk = mockSdk();
+    registerSummarizeFunction(sdk as never, kv as never, provider);
+    const fn = sdk.functions.get("mem::summarize")!;
+
+    // 4 obs / chunk size 2 = 2 chunks + 1 reduce = 3 calls.
+    await fn({ sessionId: "s4" });
+    expect(calls).toBe(3);
+
+    // Append a 5th: chunks 1 and 2 are unchanged and must be reused.
+    // Only the new partial chunk + the reduce should hit the provider.
+    calls = 0;
+    await kv.set("obs:s4", "o5", obs("o5"));
+    await fn({ sessionId: "s4" });
+    expect(calls).toBe(2);
+  });
+
+  // Chunks are contiguous slices from index 0, so on a live session only
+  // the trailing chunk's fingerprint changes turn to turn - each turn's
+  // trailing-chunk write used to mint a brand-new content-keyed entry
+  // while the previous turn's trailing entry became permanently
+  // unreachable dead weight (nothing else prunes it for an active
+  // session). Verified empirically before the fix: chunk size 2 with one
+  // observation appended per turn left 11 stored entries behind 6 live
+  // chunks at turn 12. This drives the same session through 11 turns
+  // (one appended observation each) and asserts the stored cache never
+  // holds more than the session's current live chunk count.
+  it("prunes dead chunk-cache entries so stored entries equal live chunks after several turns", async () => {
+    const kv = mockKV();
+    await kv.set("sessions", "s5", {
+      id: "s5",
+      project: "p",
+      cwd: "/tmp",
+      startedAt: new Date().toISOString(),
+      status: "active",
+      observationCount: 0,
+    } as Session);
+    const obs = (id: string): CompressedObservation => ({
+      id,
+      sessionId: "s5",
+      timestamp: "2026-08-21T00:00:00.000Z",
+      type: "other",
+      title: `t-${id}`,
+      facts: [],
+      narrative: "n",
+      concepts: [],
+      files: [],
+      importance: 5,
+      confidence: 0.3,
+    });
+
+    const provider: MemoryProvider = {
+      name: "test",
+      compress: async () => "",
+      summarize: async () =>
+        "<summary><title>T</title><narrative>N</narrative></summary>",
+    } as unknown as MemoryProvider;
+
+    const sdk = mockSdk();
+    registerSummarizeFunction(sdk as never, kv as never, provider);
+    const fn = sdk.functions.get("mem::summarize")!;
+
+    await kv.set("obs:s5", "o1", obs("o1"));
+    await kv.set("obs:s5", "o2", obs("o2"));
+
+    for (let n = 3; n <= 12; n++) {
+      await kv.set("obs:s5", `o${n}`, obs(`o${n}`));
+      await fn({ sessionId: "s5" });
+
+      const liveChunks = Math.ceil(n / 2); // SUMMARIZE_CHUNK_SIZE=2 (beforeEach)
+      const stored = await kv.list("summary-chunks:s5");
+      expect(stored).toHaveLength(liveChunks);
+    }
+  });
+
+  // #1131: kv.list order is not contractually stable
+  // (file_based backend is a hash map; sourceFingerprint already defends
+  // against this for the same reason). Without sorting `compressed` by id
+  // before chunking, a list-order permutation between turns reshuffles
+  // which observations land in which positional chunk, so every chunk key
+  // changes and every chunk misses - the memoization above would degrade
+  // to a no-op on a real store. This test wraps mockKV().list to return a
+  // reversed copy of the observations scope on the second call (turn N+1)
+  // and asserts the cache still hits, proving chunking is keyed off a
+  // stable (id-sorted) ordering rather than raw kv.list order.
+  it("reuses full chunks even when kv.list returns a permuted order between turns (#1131)", async () => {
+    const base = mockKV();
+    let obsListCalls = 0;
+    const kv = {
+      ...base,
+      list: async <T>(scope: string): Promise<T[]> => {
+        const values = await base.list<T>(scope);
+        if (scope !== "obs:s6") return values;
+        obsListCalls++;
+        // First call (turn N): natural insertion order. Every call after
+        // (turn N+1 onward): reversed - simulates a hash-map-backed
+        // store whose iteration order shifts across writes.
+        return obsListCalls === 1 ? values : [...values].reverse();
+      },
+    };
+    await kv.set("sessions", "s6", {
+      id: "s6",
+      project: "p",
+      cwd: "/tmp",
+      startedAt: new Date().toISOString(),
+      status: "active",
+      observationCount: 0,
+    } as Session);
+    const obs = (id: string): CompressedObservation => ({
+      id,
+      sessionId: "s6",
+      timestamp: "2026-08-21T00:00:00.000Z",
+      type: "other",
+      title: `t-${id}`,
+      facts: [],
+      narrative: "n",
+      concepts: [],
+      files: [],
+      importance: 5,
+      confidence: 0.3,
+    });
+    for (const id of ["o1", "o2", "o3", "o4"]) {
+      await kv.set("obs:s6", id, obs(id));
+    }
+
+    let calls = 0;
+    const provider: MemoryProvider = {
+      name: "test",
+      compress: async () => "",
+      summarize: async () => {
+        calls++;
+        return "<summary><title>T</title><narrative>N</narrative></summary>";
+      },
+    } as unknown as MemoryProvider;
+
+    const sdk = mockSdk();
+    registerSummarizeFunction(sdk as never, kv as never, provider);
+    const fn = sdk.functions.get("mem::summarize")!;
+
+    // 4 obs / chunk size 2 = 2 chunks + 1 reduce = 3 calls.
+    await fn({ sessionId: "s6" });
+    expect(calls).toBe(3);
+
+    // Append a 5th observation. kv.list now returns the whole set in
+    // reversed order (obsListCalls === 2), but chunk boundaries must
+    // still be computed from an id-sorted copy, so chunks 1 and 2 are
+    // still recognized as unchanged and reused.
+    calls = 0;
+    await kv.set("obs:s6", "o5", obs("o5"));
+    await fn({ sessionId: "s6" });
+    expect(calls).toBe(2);
   });
 });

--- a/test/summarize.test.ts
+++ b/test/summarize.test.ts
@@ -1009,3 +1009,44 @@ describe("mem::summarize chunk memoization", () => {
     expect(calls).toBe(2);
   });
 });
+
+describe("mem::summarize session deleted mid-run", () => {
+  async function tick(): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+
+  it("writes no summary when the session is deleted during the provider call", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let entered = 0;
+    const provider = {
+      name: "test",
+      compress: async () => "",
+      summarize: async () => {
+        entered += 1;
+        await gate;
+        return summaryXml({ title: "orphan" });
+      },
+    } as unknown as MemoryProvider;
+
+    const { handler, kv } = await setupHandler({
+      sessionId: "s_del",
+      obsCount: 3,
+      provider,
+    });
+
+    const run = handler({ sessionId: "s_del" });
+    while (entered === 0) await tick();
+
+    await kv.delete("sessions", "s_del");
+    await kv.delete("summaries", "s_del");
+
+    release();
+    const result = await run;
+
+    expect(kv.store.get("summaries")?.get("s_del")).toBeUndefined();
+    expect(result.success).toBe(false);
+  });
+});

--- a/test/vector-index-populate.test.ts
+++ b/test/vector-index-populate.test.ts
@@ -4,7 +4,10 @@ vi.mock("../src/logger.js", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
-vi.mock("../src/state/keyed-mutex.js", () => ({
+// Spread the real module so exports beyond withKeyedLock (sessionWriteLockKey)
+// keep their implementations instead of silently becoming undefined.
+vi.mock("../src/state/keyed-mutex.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/state/keyed-mutex.js")>()),
   withKeyedLock: <T>(_key: string, fn: () => Promise<T>) => fn(),
 }));
 


### PR DESCRIPTION
## What

`mem::summarize` re-summarizes a session from scratch on every run. The Claude Code Stop hook fires on **every assistant turn**, not at session end, so a session that reaches N observations does O(N²) summarization work over its lifetime — and for sessions past the chunking threshold, every turn re-runs *every* chunk's LLM call, not just the part that changed.

This adds two layers of change detection:

1. **Session-level skip** — hash the compressed observation set (`sourceFingerprint`) and return the stored summary unchanged when the input is byte-identical to what produced it.
2. **Chunk-level memoization** — cache each chunk's summary partial under a content-addressed key (`chunkFingerprint`), so appending one observation to a 400-observation session re-runs one chunk instead of all of them.

Plus the cache-reclamation paths those two require, and a per-session lock so concurrent runs don't both do the full work.

## What the fingerprints hash

Both keys hash exactly the fields `buildSummaryPrompt` renders — `id`, `type`, `title`, `narrative`, `facts`, `files` — so a digest match means the LLM would receive a byte-identical prompt. `src/prompts/summary.ts` is the contract: a field that reaches the prompt without reaching the hash is a silent stale-summary bug, and there is a comment on `hashObservationSet` saying so. `concepts` is deliberately excluded — `buildSummaryPrompt` declares it but its template never renders it, so hashing it would force re-summarization that cannot change the output.

Fields are length-prefixed before hashing, so `facts: ["a", "bc"]` and `["ab", "c"]` do not collide.

An id-only key would be unsound: a same-id rewrite (bulk `import-jsonl` with `strategy !== "skip"`, or `replay` over an edited transcript) preserves every id while changing the text. Three tests cover the cases a weaker key would miss — a title-and-narrative rewrite, a facts-only change, and a files-only change.

An `observationCount` comparison is also unsound as a change signal: observations are **not** append-only. Four paths delete from live sessions — `evict.ts` per-observation eviction (age + importance, on a timer), `evict.ts` project-scoped eviction, `mem::forget` with explicit `observationIds`, and `export-import.ts`. A delete plus an equal-size append leaves the count unchanged and the content entirely different.

## Ordering

`kv.list` is not order-stable — the `file_based` store is a hash map. `sourceFingerprint` sorts defensively, but chunk *boundaries* must be positionally stable across turns too, or every chunk key changes when the list order shifts and the cache never hits. The handler therefore sorts by id once before both fingerprinting and chunk slicing.

That sort doubles as a correctness fix: `generateId`'s base36 timestamp prefix is a fixed 8 chars until 2059, so id order is chronological order. Observations now reach the LLM — and the reduce step's `obsRangeStart`/`obsRangeEnd` labels — in chronological order instead of arbitrary hash order. `test/summarize.test.ts` covers a permuted `kv.list` between turns.

## Cache reclamation

`KV.summaryChunks` is introduced here, so this change owns its cleanup. Entries are reclaimed on:

- whole-session delete (`mem::forget`, `remember.ts`)
- stale-session and per-observation eviction (`evict.ts`) — per-observation eviction shifts every downstream chunk boundary, and whole-session delete never fires for a live session, so nothing else would reclaim these
- explicit-ids `mem::forget`, same reason
- every summarize run, which prunes entries whose keys are no longer live chunks

Without the last one the trailing chunk's key changes on each append and the cache grows unbounded.

## On #1203

The per-session `withKeyedLock` here does not remove the duplicate dispatch — `api::summarize` stays publicly reachable, so two concurrent full-history passes over identical input are still possible. It serializes them, so the second one reaches the fingerprint skip instead of repeating the LLM work. Removing the duplicate trigger itself is a separate change.

## How to verify

```bash
npx vitest run test/summarize.test.ts test/evict.test.ts test/remember-forget-audit.test.ts
npm test        # full suite: 159 files, 1725 pass, 1 skip
npx tsc --noEmit
```

`tsc` reports 30 pre-existing errors on `main` and the same 30 here — none in any file this branch touches.

New coverage: concurrent-run serialization; unchanged-session skip; re-summarize on append; re-summarize on a same-id rewrite, on a facts-only change, and on a files-only change; chunk reuse on append; chunk reuse under permuted `kv.list`; dead-entry pruning; and cache reclamation from each eviction and forget path.

Fixes #1131.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved summary generation with per-chunk caching and change detection.
  * Added support for forcing summary regeneration.
  * Summaries now process observations chronologically for more consistent results.

* **Bug Fixes**
  * Prevented duplicate summary work during concurrent session processing.
  * Prevented deleted sessions from receiving orphaned summaries.
  * Summary caches are cleared when sessions or observations are removed, including imports and automatic cleanup.
  * Unchanged summaries are preserved while outdated cached chunks are cleaned up.
  * Dry-run evictions no longer modify summary caches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->