### PR TITLE
fix(hermes): isolate AgentMemory by profile identity

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,6 +96,8 @@
 # you expose the daemon beyond loopback or run behind a reverse proxy.
 
 # AGENTMEMORY_SECRET=your-secret-here
+# AGENT_ID=architect                              # Stable caller/profile id stamped on writes
+# AGENTMEMORY_AGENT_SCOPE=isolated               # shared (default) | isolated (filter by AGENT_ID)
 
 # -----------------------------------------------------------------------------
 # 4. Search tuning

--- a/README.md
+++ b/README.md
@@ -670,17 +670,28 @@ Full guide: [`integrations/openclaw/`](integrations/openclaw/)
 <summary><b>Hermes Agent (paste this prompt)</b></summary>
 
 ```text
-Install agentmemory for Hermes. Run `npx -y @agentmemory/agentmemory@latest` in a separate terminal to start the memory server on localhost:3111. Then add this to ~/.hermes/config.yaml so Hermes can use agentmemory as an MCP server with all 54 memory tools:
+Install agentmemory for Hermes. Run `npx -y @agentmemory/agentmemory@latest` in a separate terminal to start the memory server on localhost:3111. Then run `agentmemory connect hermes` to render the profile-bound snippet and add it to the active Hermes config (`$HERMES_HOME/config.yaml`, `%LOCALAPPDATA%\hermes\config.yaml` on Windows, or `~/.hermes/config.yaml` on macOS/Linux):
 
 mcp_servers:
   agentmemory:
     command: npx
     args: ["-y", "@agentmemory/mcp"]
+    env:
+      AGENT_ID: "default" # exact Hermes profile id (for example: <profile-id>)
+      AGENTMEMORY_AGENT_SCOPE: "isolated"
+    tools:
+      include:
+        - memory_save
+        - memory_recall
+        - memory_smart_search
+        - memory_sessions
 
 memory:
   provider: agentmemory
 
-Verify with `curl http://localhost:3111/agentmemory/health`. Open http://localhost:3113 for the real-time viewer. For deeper 6-hook memory provider integration (pre-LLM context injection, turn capture, MEMORY.md mirroring, system prompt block), copy integrations/hermes from the agentmemory repo to ~/.hermes/plugins/agentmemory.
+The MCP `env` block applies only to the MCP subprocess. For strict provider + MCP isolation, also launch both the Hermes host process and the agentmemory daemon with `AGENTMEMORY_AGENT_SCOPE=isolated` in their shell, service, or container environment.
+
+Verify with `curl http://localhost:3111/agentmemory/health`. Open http://localhost:3113 for the real-time viewer. For deeper 6-hook memory provider integration (pre-LLM context injection, turn capture, MEMORY.md mirroring, system prompt block), copy integrations/hermes from the agentmemory repo to the active Hermes home's `plugins/agentmemory` directory.
 ```
 
 Full guide: [`integrations/hermes/`](integrations/hermes/)
@@ -1417,6 +1428,10 @@ What gets tagged when `AGENT_ID` is set: `Session.agentId`, `RawObservation.agen
 What gets filtered in isolated mode: `mem::smart-search`, `/agentmemory/memories`, `/agentmemory/observations`, `/agentmemory/sessions`. Each endpoint accepts `?agentId=<role>` to override per-request, and `?agentId=*` to opt out of the env scope entirely. `/memories` also accepts `?includeOrphans=true` to surface pre-AGENT_ID memories whose `agentId` is undefined.
 
 Per-call override at the SDK / REST layer: every mutating endpoint (`/session/start`, `/remember`) accepts an `agentId` field in the request body that wins over the env. Useful for runtimes routing many roles through one server process. The MCP `memory_save` tool exposes the same `agentId` field, the standalone stdio server forwards both `agentId` and `project`, and saved memories carry `agentId` into the search index, so agent-scoped search covers memories as well as observations.
+
+When an MCP host starts `@agentmemory/mcp` with both `AGENT_ID=<caller>` and `AGENTMEMORY_AGENT_SCOPE=isolated`, the shim binds that identity outside model-controlled tool arguments. It overrides spoofed `agentId` values and adds the fixed id to recall, smart-search, session-list, and generic full-surface proxy calls; isolated mode without `AGENT_ID` fails closed. In shared mode writes remain tagged while reads remain cross-agent.
+
+Identity propagation is not a blanket ACL for all 54 tools: export, audit, governance, coordination, and some advanced handlers still have global or tool-specific semantics. The Hermes isolated-profile snippet therefore allowlists the four save/recall/search/session operations verified to enforce per-agent scope. Remove that allowlist only when cross-agent visibility is intentional.
 
 When `AGENT_ID` is unset, memory remains unscoped (legacy behavior, no tags, no filters).
 

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -29,13 +29,25 @@
 ```text
 Install agentmemory for Hermes. Run `npx @agentmemory/agentmemory` in a
 separate terminal to start the memory server on localhost:3111. Then
-add this to `~/.hermes/config.yaml` so Hermes can use agentmemory as
-an MCP server with all 54 memory tools:
+run `agentmemory connect hermes` to render the profile-bound snippet and
+add it to the active Hermes config: `$HERMES_HOME/config.yaml` when set,
+`%LOCALAPPDATA%\hermes\config.yaml` on Windows, or
+`~/.hermes/config.yaml` on macOS/Linux. Hermes can then use agentmemory
+as an MCP server with the profile-scoped memory tools:
 
 mcp_servers:
   agentmemory:
     command: npx
     args: ["-y", "@agentmemory/mcp"]
+    env:
+      AGENT_ID: "default" # use the exact owning Hermes profile id
+      AGENTMEMORY_AGENT_SCOPE: "isolated"
+    tools:
+      include:
+        - memory_save
+        - memory_recall
+        - memory_smart_search
+        - memory_sessions
 
 memory:
   provider: agentmemory
@@ -48,7 +60,7 @@ http://localhost:3113 to watch memories being captured live.
 If I want deeper integration — pre-LLM context injection, turn-level
 capture, memory-write mirroring to MEMORY.md, and system prompt block
 injection — copy `integrations/hermes` from the agentmemory repo to
-`~/.hermes/plugins/agentmemory` instead. That gives me the
+the active Hermes home's `plugins/agentmemory` directory instead. That gives me the
 6-hook memory provider plugin on top of the MCP server.
 ```
 
@@ -58,19 +70,31 @@ That's it. Hermes handles the rest.
 
 ### Option 1: MCP server (zero code)
 
-Add to `~/.hermes/config.yaml`:
+Run `agentmemory connect hermes` to derive the owning profile id, then add
+its snippet to the active config. Use `$HERMES_HOME/config.yaml` when set;
+otherwise use `%LOCALAPPDATA%\hermes\config.yaml` on Windows or
+`~/.hermes/config.yaml` on macOS/Linux:
 
 ```yaml
 mcp_servers:
   agentmemory:
     command: npx
     args: ["-y", "@agentmemory/mcp"]
+    env:
+      AGENT_ID: "default" # use the exact owning Hermes profile id
+      AGENTMEMORY_AGENT_SCOPE: "isolated"
+    tools:
+      include:
+        - memory_save
+        - memory_recall
+        - memory_smart_search
+        - memory_sessions
 
 memory:
   provider: agentmemory
 ```
 
-This gives Hermes access to all 54 MCP tools and enables the agentmemory memory provider. Start the server separately:
+This gives Hermes access to the four MCP operations currently verified to enforce per-agent scope and enables the agentmemory memory provider. Use `default` for the root Hermes profile; in a named profile use its exact id (for example `<profile-id>` for `.../profiles/<profile-id>`). `agentmemory connect hermes` renders the correctly bound snippet from the active `HERMES_HOME`. Start the server separately:
 
 ```bash
 npx @agentmemory/agentmemory
@@ -81,8 +105,11 @@ npx @agentmemory/agentmemory
 Copy this folder to your Hermes plugins directory:
 
 ```bash
-cp -r integrations/hermes ~/.hermes/plugins/agentmemory
+cp -r integrations/hermes "${HERMES_HOME:-$HOME/.hermes}/plugins/agentmemory"
 ```
+
+On Windows without an explicit `HERMES_HOME`, the target is
+`%LOCALAPPDATA%\hermes\plugins\agentmemory`.
 
 Start the agentmemory server:
 
@@ -90,7 +117,7 @@ Start the agentmemory server:
 npx @agentmemory/agentmemory
 ```
 
-The plugin auto-detects the running server and hooks into the Hermes agent loop. Make sure `memory.provider` is set to `agentmemory` in `~/.hermes/config.yaml`:
+The plugin auto-detects the running server and hooks into the Hermes agent loop. Make sure `memory.provider` is set to `agentmemory` in the active Hermes `config.yaml` described above:
 
 - `prefetch()` injects relevant memories before each LLM call
 - `sync_turn()` captures every conversation turn in the background
@@ -105,9 +132,15 @@ The plugin auto-detects the running server and hooks into the Hermes agent loop.
 |---|---|---|
 | `AGENTMEMORY_URL` | `http://localhost:3111` | agentmemory server URL |
 | `AGENTMEMORY_SECRET` | (none) | Auth token for protected instances |
+| `AGENT_ID` | (none) | Fixed caller identity for `@agentmemory/mcp`; set it to the exact Hermes profile id. Model-supplied `agentId` values cannot override it in isolated mode. |
+| `AGENTMEMORY_AGENT_SCOPE` | `shared` | `isolated` adds the profile id to recall/search/session reads; `shared` tags writes but keeps cross-profile recall. |
 | `AGENTMEMORY_REQUIRE_HTTPS` | (off) | When set to `1`, refuse to send the bearer token over plaintext HTTP to a non-loopback host. Sends only when `AGENTMEMORY_URL` is `https://...` or points at `localhost`/`127.0.0.1`/`::1`. With this off, the plugin warns once on stderr but still sends. |
 
 The plugin reads `~/.agentmemory/.env` (or `$XDG_CONFIG_HOME/agentmemory/.env`) at import time and populates any missing values into the process environment via `os.environ.setdefault`. Anything you set in the shell takes precedence; the file is only used to fill gaps. This means `hermes memory status` reports the plugin as available even when the agentmemory service is launched by systemd or another process manager that loads `~/.agentmemory/.env` directly without exporting it to the Hermes CLI shell (#250).
+
+The memory-provider plugin derives its `agentId` from the explicit `hermes_home` Hermes passes during initialization (`.../profiles/<id>` → `<id>`, root home → `default`). It always tags writes. In isolated mode it pins context, recall, and search reads to that profile; shared mode preserves cross-agent recall. Agent-scoped context omits project profiles, lessons, and pinned slots, and agent-scoped smart search omits lessons, because those records do not carry `agentId`. The stdio MCP process receives the same fixed id out of band from model tool arguments. Because an MCP `env` block applies only to that subprocess, the Hermes host process (or its process manager) and the agentmemory daemon must also receive `AGENTMEMORY_AGENT_SCOPE=isolated` for strict provider + MCP separation.
+
+The `tools.include` allowlist is intentional. Scoped export and targeted governance delete enforce `agentId`, but audit, bulk governance, coordination, and several advanced tools still have global or tool-specific semantics. Remove the allowlist only when cross-profile visibility is intended; sending `agentId` alone does not make every one of the 54 tools an isolation boundary.
 
 ## What Hermes gets
 

--- a/integrations/hermes/__init__.py
+++ b/integrations/hermes/__init__.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 import threading
 import subprocess
@@ -77,6 +78,18 @@ DEFAULT_BASE_URL = "http://localhost:3111"
 TIMEOUT = 5
 LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1"}
 _plaintext_bearer_warned = False
+_PROFILE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+
+
+def _profile_agent_id(hermes_home: str | None) -> str:
+    """Return the Hermes profile id represented by an explicit profile home."""
+    if not hermes_home:
+        return "default"
+    home = Path(hermes_home).expanduser()
+    if home.parent.name == "profiles" and _PROFILE_ID_RE.fullmatch(home.name):
+        return home.name
+    return "default"
+
 
 # agentmemory's documented runtime config lives at ~/.agentmemory/.env.
 # When agentmemory is launched as a systemd user service (or any other
@@ -209,15 +222,43 @@ class AgentMemoryProvider(MemoryProvider):
         base = os.environ.get("AGENTMEMORY_URL", DEFAULT_BASE_URL)
         return _validate_url(base)
 
+    def _scoped_body(self, body: dict | None = None, *, read: bool = False) -> dict:
+        payload = dict(body or {})
+        if not read or self._isolated_scope:
+            payload["agentId"] = self._agent_id
+        return payload
+
+    def _call(
+        self,
+        path: str,
+        body: dict | None = None,
+        *,
+        read: bool = False,
+    ) -> dict | None:
+        return _api(self._base, path, self._scoped_body(body, read=read))
+
+    def _call_bg(
+        self,
+        path: str,
+        body: dict | None = None,
+        *,
+        read: bool = False,
+    ) -> None:
+        _api_bg(self._base, path, self._scoped_body(body, read=read))
+
     def initialize(self, session_id: str, **kwargs: Any) -> None:
         self._base = os.environ.get("AGENTMEMORY_URL", DEFAULT_BASE_URL)
         self._session_id = session_id
+        self._agent_id = _profile_agent_id(kwargs.get("hermes_home"))
+        self._isolated_scope = (
+            os.environ.get("AGENTMEMORY_AGENT_SCOPE") == "isolated"
+        )
         self._cwd = kwargs.get("cwd", os.getcwd())
         self._project = _resolve_project(self._cwd)
         if os.environ.get("AGENTMEMORY_REQUIRE_HTTPS") == "1":
             _check_plaintext_bearer_guard(self._base, os.environ.get("AGENTMEMORY_SECRET", ""))
 
-        _api(self._base, "session/start", {
+        self._call("session/start", {
             "sessionId": session_id,
             "project": self._project,
             "cwd": self._cwd,
@@ -245,19 +286,19 @@ class AgentMemoryProvider(MemoryProvider):
         config_path.write_text(json.dumps(values, indent=2))
 
     def system_prompt_block(self) -> str:
-        result = _api(self._base, "context", {
+        result = self._call("context", {
             "sessionId": self._session_id,
             "project": self._project,
-        })
+        }, read=True)
         if result and result.get("context"):
             return result["context"]
         return ""
 
     def prefetch(self, query: str, **kwargs: Any) -> str:
-        result = _api(self._base, "smart-search", {
+        result = self._call("smart-search", {
             "query": query,
             "limit": 5,
-        })
+        }, read=True)
         if not result or not result.get("results"):
             return ""
 
@@ -271,7 +312,7 @@ class AgentMemoryProvider(MemoryProvider):
         return "\n".join(lines) if lines else ""
 
     def queue_prefetch(self, query: str, **kwargs: Any) -> None:
-        _api_bg(self._base, "smart-search", {"query": query, "limit": 3})
+        self._call_bg("smart-search", {"query": query, "limit": 3}, read=True)
 
     def get_tool_schemas(self) -> list[dict]:
         return [
@@ -324,10 +365,10 @@ class AgentMemoryProvider(MemoryProvider):
         # JSON string here — matches what agentmemory's main MCP server does
         # in src/mcp/standalone.ts (`{ type: "text", text: JSON.stringify(...) }`).
         if name == "memory_recall":
-            result = _api(self._base, "search", {
+            result = self._call("search", {
                 "query": args["query"],
                 "limit": args.get("limit", 10),
-            })
+            }, read=True)
             if not result:
                 return json.dumps({"results": []})
             items = []
@@ -343,17 +384,17 @@ class AgentMemoryProvider(MemoryProvider):
             return json.dumps({"results": items})
 
         if name == "memory_save":
-            result = _api(self._base, "remember", {
+            result = self._call("remember", {
                 "content": args["content"],
                 "type": args.get("type", "fact"),
             })
             return json.dumps(result or {"success": False})
 
         if name == "memory_search":
-            result = _api(self._base, "smart-search", {
+            result = self._call("smart-search", {
                 "query": args["query"],
                 "limit": args.get("limit", 5),
-            })
+            }, read=True)
             if not result:
                 return json.dumps({"results": []})
             items = []
@@ -369,7 +410,7 @@ class AgentMemoryProvider(MemoryProvider):
         return json.dumps({"error": f"Unknown tool: {name}"})
 
     def sync_turn(self, user: str, assistant: str, **kwargs: Any) -> None:
-        _api_bg(self._base, "observe", {
+        self._call_bg("observe", {
             "hookType": "post_tool_use",
             "sessionId": kwargs.get("session_id", self._session_id),
             "project": self._project,
@@ -383,15 +424,15 @@ class AgentMemoryProvider(MemoryProvider):
         })
 
     def on_session_end(self, messages: list, **kwargs: Any) -> None:
-        _api(self._base, "session/end", {
+        self._call("session/end", {
             "sessionId": kwargs.get("session_id", self._session_id),
         })
 
     def on_pre_compress(self, messages: list, **kwargs: Any) -> None:
-        result = _api(self._base, "context", {
+        result = self._call("context", {
             "sessionId": kwargs.get("session_id", self._session_id),
             "project": self._project,
-        })
+        }, read=True)
         if result and result.get("context"):
             messages.insert(0, {
                 "role": "user",
@@ -400,7 +441,7 @@ class AgentMemoryProvider(MemoryProvider):
 
     def on_memory_write(self, action: str, target: str, content: str, **kwargs: Any) -> None:
         if action in ("add", "update") and content:
-            _api_bg(self._base, "remember", {
+            self._call_bg("remember", {
                 "content": content,
                 "type": "fact",
             })

--- a/integrations/hermes/test_profile_agent_id.py
+++ b/integrations/hermes/test_profile_agent_id.py
@@ -1,0 +1,115 @@
+import importlib.util
+import json
+import os
+from pathlib import Path
+import unittest
+from unittest.mock import patch
+
+MODULE_PATH = Path(__file__).with_name("__init__.py")
+SPEC = importlib.util.spec_from_file_location("agentmemory_hermes_provider", MODULE_PATH)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class HermesProfileAgentIdTests(unittest.TestCase):
+    def test_named_profile_is_sent_on_every_plugin_request(self):
+        calls: list[tuple[str, dict]] = []
+
+        def record(_base, path, body=None, method="POST", secret=""):
+            calls.append((path, dict(body or {})))
+            if path in {"search", "smart-search"}:
+                return {"results": []}
+            if path == "context":
+                return {"context": ""}
+            if path == "remember":
+                return {"success": True}
+            return {}
+
+        def record_bg(_base, path, body=None):
+            return record(_base, path, body)
+
+        provider = MODULE.AgentMemoryProvider()
+        profile_home = Path("/opt/data/profiles/alpha")
+
+        with patch.dict(os.environ, {"AGENTMEMORY_AGENT_SCOPE": "isolated"}, clear=False), patch.object(
+            MODULE, "_api", record
+        ), patch.object(MODULE, "_api_bg", record_bg):
+            provider.initialize(
+                "session-1",
+                hermes_home=str(profile_home),
+                cwd="/workspace/ALPHA-SelfService",
+            )
+            provider.system_prompt_block()
+            provider.prefetch("architecture")
+            provider.queue_prefetch("architecture")
+            provider.handle_tool_call("memory_recall", {"query": "architecture"})
+            provider.handle_tool_call("memory_save", {"content": "profile marker"})
+            provider.handle_tool_call("memory_search", {"query": "marker"})
+            provider.sync_turn("user", "assistant", session_id="session-1")
+            provider.on_session_end([], session_id="session-1")
+            provider.on_pre_compress([], session_id="session-1")
+            provider.on_memory_write("add", "memory", "mirrored marker")
+
+        self.assertGreaterEqual(len(calls), 10)
+        missing = [path for path, body in calls if body.get("agentId") != "alpha"]
+        self.assertEqual(missing, [], json.dumps(calls, indent=2))
+
+    def test_default_home_uses_default_profile_id(self):
+        self.assertEqual(MODULE._profile_agent_id("/opt/data"), "default")
+        self.assertEqual(
+            MODULE._profile_agent_id("/opt/data/profiles/pentester"),
+            "pentester",
+        )
+        self.assertEqual(
+            MODULE._profile_agent_id("/opt/data/profiles/Not A Profile"),
+            "default",
+        )
+
+    def test_ambient_hermes_home_is_not_an_identity_source(self):
+        calls: list[tuple[str, dict]] = []
+
+        def record(_base, path, body=None, method="POST", secret=""):
+            calls.append((path, dict(body or {})))
+            return {}
+
+        provider = MODULE.AgentMemoryProvider()
+        with patch.dict(
+            os.environ,
+            {
+                "HERMES_HOME": "/opt/data/profiles/from_env",
+                "AGENTMEMORY_AGENT_SCOPE": "isolated",
+            },
+            clear=False,
+        ), patch.object(MODULE, "_api", record):
+            provider.initialize("session-ambient", cwd="/workspace/project")
+
+        session_start = next(body for path, body in calls if path == "session/start")
+        self.assertEqual(session_start["agentId"], "default")
+
+    def test_shared_mode_tags_writes_without_filtering_reads(self):
+        calls: list[tuple[str, dict]] = []
+
+        def record(_base, path, body=None, method="POST", secret=""):
+            calls.append((path, dict(body or {})))
+            return {"results": []} if path == "smart-search" else {"success": True}
+
+        provider = MODULE.AgentMemoryProvider()
+        with patch.dict(os.environ, {"AGENTMEMORY_AGENT_SCOPE": "shared"}, clear=False), patch.object(
+            MODULE, "_api", record
+        ):
+            provider.initialize(
+                "session-1",
+                hermes_home="/opt/data/profiles/alpha",
+                cwd="/workspace/ALPHA-SelfService",
+            )
+            provider.prefetch("architecture")
+            provider.handle_tool_call("memory_save", {"content": "profile marker"})
+
+        by_path = {path: body for path, body in calls}
+        self.assertNotIn("agentId", by_path["smart-search"])
+        self.assertEqual(by_path["remember"]["agentId"], "alpha")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -20,11 +20,17 @@ Or wire it into your MCP client (Claude Desktop, OpenClaw, Cursor, Codex, etc.):
   "mcpServers": {
     "agentmemory": {
       "command": "npx",
-      "args": ["-y", "@agentmemory/mcp"]
+      "args": ["-y", "@agentmemory/mcp"],
+      "env": {
+        "AGENT_ID": "architect",
+        "AGENTMEMORY_AGENT_SCOPE": "isolated"
+      }
     }
   }
 }
 ```
+
+`AGENT_ID` is optional in shared mode. In isolated mode it is required and is treated as a fixed caller identity: model-provided `agentId` arguments cannot override it. The shim adds it to save/recall/search/session requests and to the generic full-tool proxy path. Configure the running agentmemory daemon with isolated scope too. Identity propagation is not a blanket ACL for every advanced/global tool; strict-profile clients should allowlist the verified save, recall, smart-search, and sessions tools as shown in the Hermes integration guide.
 
 This package depends on `@agentmemory/agentmemory` and forwards to its
 `dist/standalone.mjs` entrypoint. If you already have `@agentmemory/agentmemory`

--- a/src/cli/connect/hermes.ts
+++ b/src/cli/connect/hermes.ts
@@ -1,12 +1,55 @@
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { basename, dirname, join, normalize } from "node:path";
 import * as p from "@clack/prompts";
 import type { ConnectAdapter, ConnectOptions, ConnectResult } from "./types.js";
 
-const HERMES_DIR = join(homedir(), ".hermes");
+export function defaultHermesHome(
+  platform = process.platform,
+  env: Record<string, string | undefined> = process.env,
+  userHome = homedir(),
+): string {
+  if (platform === "win32") {
+    const localAppData = env["LOCALAPPDATA"]?.trim();
+    return join(localAppData || join(userHome, "AppData", "Local"), "hermes");
+  }
+  return join(userHome, ".hermes");
+}
+
+const HERMES_DIR = process.env["HERMES_HOME"] || defaultHermesHome();
 const HERMES_CONFIG = join(HERMES_DIR, "config.yaml");
 const DOCS = "https://github.com/rohitg00/agentmemory/tree/main/integrations/hermes";
+const PROFILE_ID_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/;
+
+export function profileAgentIdFromHermesHome(hermesHome: string): string {
+  const normalizedHome = normalize(hermesHome);
+  const candidate = basename(normalizedHome);
+  return basename(dirname(normalizedHome)) === "profiles" && PROFILE_ID_RE.test(candidate)
+    ? candidate
+    : "default";
+}
+
+export function renderHermesMcpConfig(hermesHome = HERMES_DIR): string {
+  const agentId = profileAgentIdFromHermesHome(hermesHome);
+  return [
+    "mcp_servers:",
+    "  agentmemory:",
+    "    command: npx",
+    '    args: ["-y", "@agentmemory/mcp"]',
+    "    env:",
+    `      AGENT_ID: ${JSON.stringify(agentId)}`,
+    '      AGENTMEMORY_AGENT_SCOPE: "isolated"',
+    "    tools:",
+    "      include:",
+    "        - memory_save",
+    "        - memory_recall",
+    "        - memory_smart_search",
+    "        - memory_sessions",
+    "",
+    "memory:",
+    "  provider: agentmemory",
+  ].join("\n");
+}
 
 export const adapter: ConnectAdapter = {
   name: "hermes",
@@ -28,13 +71,7 @@ export const adapter: ConnectAdapter = {
       [
         `Add to ${HERMES_CONFIG}:`,
         "",
-        "  mcp_servers:",
-        "    agentmemory:",
-        "      command: npx",
-        '      args: ["-y", "@agentmemory/mcp"]',
-        "",
-        "  memory:",
-        "    provider: agentmemory",
+        renderHermesMcpConfig(HERMES_DIR),
         "",
         `Full guide: ${DOCS}`,
       ].join("\n"),

--- a/src/functions/context.ts
+++ b/src/functions/context.ts
@@ -70,14 +70,17 @@ export function registerContextFunction(
         );
       }
 
+      const includeUnattributedBlocks = filterAgentId === undefined;
       const [pinnedSlots, profile, lessons] = await Promise.all([
-        isSlotsEnabled()
+        includeUnattributedBlocks && isSlotsEnabled()
           ? listPinnedSlots(kv).catch(() => [] as MemorySlot[])
           : Promise.resolve([] as MemorySlot[]),
-        kv
-          .get<ProjectProfile>(KV.profiles, data.project)
-          .catch(() => null),
-        kv.list<Lesson>(KV.lessons).catch(() => [] as Lesson[]),
+        includeUnattributedBlocks
+          ? kv.get<ProjectProfile>(KV.profiles, data.project).catch(() => null)
+          : Promise.resolve(null),
+        includeUnattributedBlocks
+          ? kv.list<Lesson>(KV.lessons).catch(() => [] as Lesson[])
+          : Promise.resolve([] as Lesson[]),
       ]);
 
       const slotContent = renderPinnedContext(pinnedSlots);

--- a/src/functions/export-import.ts
+++ b/src/functions/export-import.ts
@@ -60,18 +60,33 @@ async function runChunked<T>(
 
 export function registerExportImportFunction(sdk: ISdk, kv: StateKV): void {
   sdk.registerFunction("mem::export", 
-    async (data?: { maxSessions?: number; offset?: number }) => {
+    async (data?: { maxSessions?: number; offset?: number; agentId?: string }) => {
       const rawMax = Number(data?.maxSessions);
       const maxSessions = Number.isFinite(rawMax) && rawMax > 0 ? Math.min(Math.floor(rawMax), 1000) : undefined;
       const rawOffset = Number(data?.offset);
       const offset = Number.isFinite(rawOffset) && rawOffset >= 0 ? Math.floor(rawOffset) : 0;
+      const requestedAgentId =
+        typeof data?.agentId === "string" && data.agentId.trim()
+          ? data.agentId.trim().slice(0, 128)
+          : undefined;
+      const filterAgentId = requestedAgentId;
 
       const allSessions = await kv.list<Session>(KV.sessions);
-      const paginatedSessions = maxSessions !== undefined
-        ? allSessions.slice(offset, offset + maxSessions)
+      const visibleSessions = filterAgentId
+        ? allSessions.filter((session) => session.agentId === filterAgentId)
         : allSessions;
-      const memories = await kv.list<Memory>(KV.memories);
-      const summaries = await kv.list<SessionSummary>(KV.summaries);
+      const paginatedSessions = maxSessions !== undefined
+        ? visibleSessions.slice(offset, offset + maxSessions)
+        : visibleSessions;
+      const allMemories = await kv.list<Memory>(KV.memories);
+      const memories = filterAgentId
+        ? allMemories.filter((memory) => memory.agentId === filterAgentId)
+        : allMemories;
+      const allSummaries = await kv.list<SessionSummary>(KV.summaries);
+      const visibleSessionIds = new Set(paginatedSessions.map((session) => session.id));
+      const summaries = filterAgentId
+        ? allSummaries.filter((summary) => visibleSessionIds.has(summary.sessionId))
+        : allSummaries;
 
       const observations: Record<string, CompressedObservation[]> = {};
       const obsResults = await Promise.all(
@@ -79,7 +94,12 @@ export function registerExportImportFunction(sdk: ISdk, kv: StateKV): void {
           kv
             .list<CompressedObservation>(KV.observations(session.id))
             .catch(() => [] as CompressedObservation[])
-            .then((obs) => ({ sessionId: session.id, obs })),
+            .then((obs) => ({
+              sessionId: session.id,
+              obs: filterAgentId
+                ? obs.filter((observation) => observation.agentId === filterAgentId)
+                : obs,
+            })),
         ),
       );
       for (const { sessionId, obs } of obsResults) {
@@ -89,14 +109,16 @@ export function registerExportImportFunction(sdk: ISdk, kv: StateKV): void {
       }
 
       const profiles: ProjectProfile[] = [];
-      const uniqueProjects = [...new Set(paginatedSessions.map((s) => s.project))];
-      const profileResults = await Promise.all(
-        uniqueProjects.map((project) =>
-          kv.get<ProjectProfile>(KV.profiles, project).catch(() => null),
-        ),
-      );
-      for (const profile of profileResults) {
-        if (profile) profiles.push(profile);
+      if (!filterAgentId) {
+        const uniqueProjects = [...new Set(paginatedSessions.map((s) => s.project))];
+        const profileResults = await Promise.all(
+          uniqueProjects.map((project) =>
+            kv.get<ProjectProfile>(KV.profiles, project).catch(() => null),
+          ),
+        );
+        for (const profile of profileResults) {
+          if (profile) profiles.push(profile);
+        }
       }
 
       const [
@@ -142,33 +164,33 @@ export function registerExportImportFunction(sdk: ISdk, kv: StateKV): void {
         observations,
         memories,
         summaries,
-        profiles: profiles.length > 0 ? profiles : undefined,
-        graphNodes: graphNodes.length > 0 ? graphNodes : undefined,
-        graphEdges: graphEdges.length > 0 ? graphEdges : undefined,
+        profiles: !filterAgentId && profiles.length > 0 ? profiles : undefined,
+        graphNodes: !filterAgentId && graphNodes.length > 0 ? graphNodes : undefined,
+        graphEdges: !filterAgentId && graphEdges.length > 0 ? graphEdges : undefined,
         semanticMemories:
-          semanticMemories.length > 0 ? semanticMemories : undefined,
+          !filterAgentId && semanticMemories.length > 0 ? semanticMemories : undefined,
         proceduralMemories:
-          proceduralMemories.length > 0 ? proceduralMemories : undefined,
-        actions: actions.length > 0 ? actions : undefined,
-        actionEdges: actionEdges.length > 0 ? actionEdges : undefined,
-        sentinels: sentinels.length > 0 ? sentinels : undefined,
-        sketches: sketches.length > 0 ? sketches : undefined,
-        crystals: crystals.length > 0 ? crystals : undefined,
-        facets: facets.length > 0 ? facets : undefined,
-        lessons: lessons.length > 0 ? lessons : undefined,
-        insights: insights.length > 0 ? insights : undefined,
-        routines: routines.length > 0 ? routines : undefined,
-        signals: signals.length > 0 ? signals : undefined,
-        checkpoints: checkpoints.length > 0 ? checkpoints : undefined,
-        accessLogs: accessLogs.length > 0 ? accessLogs : undefined,
+          !filterAgentId && proceduralMemories.length > 0 ? proceduralMemories : undefined,
+        actions: !filterAgentId && actions.length > 0 ? actions : undefined,
+        actionEdges: !filterAgentId && actionEdges.length > 0 ? actionEdges : undefined,
+        sentinels: !filterAgentId && sentinels.length > 0 ? sentinels : undefined,
+        sketches: !filterAgentId && sketches.length > 0 ? sketches : undefined,
+        crystals: !filterAgentId && crystals.length > 0 ? crystals : undefined,
+        facets: !filterAgentId && facets.length > 0 ? facets : undefined,
+        lessons: !filterAgentId && lessons.length > 0 ? lessons : undefined,
+        insights: !filterAgentId && insights.length > 0 ? insights : undefined,
+        routines: !filterAgentId && routines.length > 0 ? routines : undefined,
+        signals: !filterAgentId && signals.length > 0 ? signals : undefined,
+        checkpoints: !filterAgentId && checkpoints.length > 0 ? checkpoints : undefined,
+        accessLogs: !filterAgentId && accessLogs.length > 0 ? accessLogs : undefined,
       };
 
       if (maxSessions !== undefined) {
         exportData.pagination = {
           offset,
           limit: maxSessions,
-          total: allSessions.length,
-          hasMore: offset + maxSessions < allSessions.length,
+          total: visibleSessions.length,
+          hasMore: offset + maxSessions < visibleSessions.length,
         };
       }
 
@@ -178,7 +200,7 @@ export function registerExportImportFunction(sdk: ISdk, kv: StateKV): void {
       );
       logger.info("Export complete", {
         sessions: paginatedSessions.length,
-        totalSessions: allSessions.length,
+        totalSessions: visibleSessions.length,
         observations: totalObs,
         memories: memories.length,
         summaries: summaries.length,

--- a/src/functions/governance.ts
+++ b/src/functions/governance.ts
@@ -9,7 +9,7 @@ import { logger } from "../logger.js";
 
 export function registerGovernanceFunction(sdk: ISdk, kv: StateKV): void {
   sdk.registerFunction("mem::governance-delete", 
-    async (data: { memoryIds: string[]; reason?: string }) => {
+    async (data: { memoryIds: string[]; reason?: string; agentId?: string }) => {
       if (
         !data.memoryIds ||
         !Array.isArray(data.memoryIds) ||
@@ -18,10 +18,14 @@ export function registerGovernanceFunction(sdk: ISdk, kv: StateKV): void {
         return { success: false, error: "memoryIds array is required" };
       }
 
+      const agentId =
+        typeof data.agentId === "string" && data.agentId.trim()
+          ? data.agentId.trim().slice(0, 128)
+          : undefined;
       let deleted = 0;
       for (const id of data.memoryIds) {
         const mem = await kv.get<Memory>(KV.memories, id);
-        if (mem) {
+        if (mem && (agentId === undefined || mem.agentId === agentId)) {
           await kv.delete(KV.memories, id);
           await deleteAccessLog(kv, id);
           getSearchIndex().remove(id);
@@ -40,6 +44,7 @@ export function registerGovernanceFunction(sdk: ISdk, kv: StateKV): void {
         {
           reason: data.reason || "manual deletion",
           deleted,
+          ...(agentId ? { agentId } : {}),
         },
       );
 

--- a/src/functions/observe.ts
+++ b/src/functions/observe.ts
@@ -13,6 +13,7 @@ import { getSearchIndex, vectorIndexAddGuarded } from "./search.js";
 import { getAgentId } from "../config.js";
 import { logger } from "../logger.js";
 import { saveImageToDisk } from "../utils/image-store.js";
+import { recordAudit } from "./audit.js";
 
 export function extractImage(d: unknown): string | undefined {
   if (!d) return undefined;
@@ -163,9 +164,13 @@ export function registerObserveFunction(
           observationCount?: number;
           firstPrompt?: string;
         }>(KV.sessions, payload.sessionId);
+        const payloadAgentId =
+          typeof payload.agentId === "string" && payload.agentId.trim()
+            ? payload.agentId.trim().slice(0, 128)
+            : undefined;
         const inheritedAgentId = existingSession
           ? existingSession.agentId
-          : getAgentId();
+          : payloadAgentId ?? getAgentId();
         if (inheritedAgentId) {
           raw.agentId = inheritedAgentId;
         }
@@ -298,6 +303,12 @@ export function registerObserveFunction(
               : {}),
           });
         }
+
+        await recordAudit(kv, "observe", "mem::observe", [obsId], {
+          sessionId: payload.sessionId,
+          hookType: payload.hookType,
+          ...(inheritedAgentId ? { agentId: inheritedAgentId } : {}),
+        });
 
         // Per-observation LLM compression is opt-in as of 0.8.8.
         // Default path: build a zero-LLM synthetic compression so recall

--- a/src/functions/smart-search.ts
+++ b/src/functions/smart-search.ts
@@ -184,7 +184,8 @@ export function registerSmartSearchFunction(
       // Lesson recall stays capped: lessons are denser than raw
       // observations so 10 covers most recall flows.
       const lessonLimit = Math.min(limit, 10);
-      const includeLessons = data.includeLessons !== false;
+      const includeLessons =
+        data.includeLessons !== false && filterAgentId === undefined;
 
       // Over-fetch when filtering. Hybrid search can't filter on
       // agentId (BM25/vector indexes don't carry it), so we ask the

--- a/src/mcp/standalone.ts
+++ b/src/mcp/standalone.ts
@@ -82,6 +82,18 @@ function normalizeList(value: unknown): string[] {
 
 const DEFAULT_LIMIT = 10;
 const MAX_LIMIT = 100;
+
+function configuredAgentId(): string | undefined {
+  const value = process.env["AGENT_ID"]?.trim();
+  return value ? value.slice(0, 128) : undefined;
+}
+
+function isolatedAgentId(): string | undefined {
+  return process.env["AGENTMEMORY_AGENT_SCOPE"] === "isolated"
+    ? configuredAgentId()
+    : undefined;
+}
+
 function parseLimit(raw: unknown, fallback = DEFAULT_LIMIT): number {
   if (typeof raw !== "number" && typeof raw !== "string") return fallback;
   const n = Number(raw);
@@ -119,7 +131,7 @@ function validate(toolName: string, args: Record<string, unknown>): Validated {
   if (!IMPLEMENTED_TOOLS.has(toolName)) {
     throw new Error(`Unknown tool: ${toolName}`);
   }
-  const v: Validated = { tool: toolName };
+  const v: Validated = { tool: toolName, agentId: isolatedAgentId() };
   switch (toolName) {
     case "memory_save": {
       const content = args["content"];
@@ -136,7 +148,10 @@ function validate(toolName: string, args: Record<string, unknown>): Validated {
       if (typeof args["project"] === "string" && args["project"].trim()) {
         v.project = args["project"].trim();
       }
-      if (typeof args["agentId"] === "string" && args["agentId"].trim()) {
+      const fixedAgentId = configuredAgentId();
+      if (fixedAgentId) {
+        v.agentId = fixedAgentId;
+      } else if (typeof args["agentId"] === "string" && args["agentId"].trim()) {
         v.agentId = args["agentId"].trim();
       }
       return v;
@@ -210,6 +225,7 @@ async function handleProxy(
         format: v.format ?? "full",
       };
       if (v.tokenBudget != null) body["token_budget"] = v.tokenBudget;
+      if (v.agentId != null) body["agentId"] = v.agentId;
       const result = await handle.call("/agentmemory/search", {
         method: "POST",
         body: JSON.stringify(body),
@@ -220,6 +236,7 @@ async function handleProxy(
       const body: Record<string, unknown> = { query: v.query, limit: v.limit };
       if (v.format != null) body["format"] = v.format;
       if (v.tokenBudget != null) body["token_budget"] = v.tokenBudget;
+      if (v.agentId != null) body["agentId"] = v.agentId;
       const result = await handle.call("/agentmemory/smart-search", {
         method: "POST",
         body: JSON.stringify(body),
@@ -227,8 +244,11 @@ async function handleProxy(
       return textResponse(result, true);
     }
     case "memory_sessions": {
+      const agentQuery = v.agentId
+        ? `&agentId=${encodeURIComponent(v.agentId)}`
+        : "";
       const result = await handle.call(
-        `/agentmemory/sessions?limit=${v.limit}`,
+        `/agentmemory/sessions?limit=${v.limit}${agentQuery}`,
         { method: "GET" },
       );
       return textResponse(result, true);
@@ -236,12 +256,21 @@ async function handleProxy(
     case "memory_governance_delete": {
       const result = await handle.call("/agentmemory/governance/memories", {
         method: "DELETE",
-        body: JSON.stringify({ memoryIds: v.memoryIds, reason: v.reason }),
+        body: JSON.stringify({
+          memoryIds: v.memoryIds,
+          reason: v.reason,
+          ...(v.agentId !== undefined && { agentId: v.agentId }),
+        }),
       });
       return textResponse(result);
     }
     case "memory_export": {
-      const result = await handle.call("/agentmemory/export", { method: "GET" });
+      const agentQuery = v.agentId
+        ? `?agentId=${encodeURIComponent(v.agentId)}`
+        : "";
+      const result = await handle.call(`/agentmemory/export${agentQuery}`, {
+        method: "GET",
+      });
       return textResponse(result, true);
     }
     case "memory_audit": {
@@ -277,6 +306,7 @@ async function handleLocal(
         version: 1,
         isLatest: true,
         sessionIds: [],
+        ...(v.agentId !== undefined && { agentId: v.agentId }),
       });
       kvInstance.persist();
       return textResponse({ saved: id });
@@ -289,6 +319,7 @@ async function handleLocal(
       const all =
         await kvInstance.list<Record<string, unknown>>("mem:memories");
       const results = all
+        .filter((m) => v.agentId === undefined || m["agentId"] === v.agentId)
         .filter((m) => {
           const text = [
             typeof m["title"] === "string" ? m["title"] : "",
@@ -310,14 +341,23 @@ async function handleLocal(
       const sessions =
         await kvInstance.list<Record<string, unknown>>("mem:sessions");
       const limit = v.limit ?? 20;
-      return textResponse({ sessions: sessions.slice(0, limit) }, true);
+      const visible = sessions.filter(
+        (session) => v.agentId === undefined || session["agentId"] === v.agentId,
+      );
+      return textResponse({ sessions: visible.slice(0, limit) }, true);
     }
 
     case "memory_governance_delete": {
       let deleted = 0;
       for (const id of v.memoryIds || []) {
-        const existing = await kvInstance.get("mem:memories", id);
-        if (existing) {
+        const existing = await kvInstance.get<Record<string, unknown>>(
+          "mem:memories",
+          id,
+        );
+        if (
+          existing &&
+          (v.agentId === undefined || existing["agentId"] === v.agentId)
+        ) {
           await kvInstance.delete("mem:memories", id);
           deleted++;
         }
@@ -331,9 +371,18 @@ async function handleLocal(
     }
 
     case "memory_export": {
-      const memories = await kvInstance.list("mem:memories");
-      const sessions = await kvInstance.list("mem:sessions");
-      return textResponse({ version: VERSION, memories, sessions }, true);
+      const memories = await kvInstance.list<Record<string, unknown>>("mem:memories");
+      const sessions = await kvInstance.list<Record<string, unknown>>("mem:sessions");
+      const visibleMemories = memories.filter(
+        (memory) => v.agentId === undefined || memory["agentId"] === v.agentId,
+      );
+      const visibleSessions = sessions.filter(
+        (session) => v.agentId === undefined || session["agentId"] === v.agentId,
+      );
+      return textResponse(
+        { version: VERSION, memories: visibleMemories, sessions: visibleSessions },
+        true,
+      );
     }
 
     case "memory_audit": {
@@ -361,9 +410,11 @@ async function handleProxyGeneric(
   // reach all 54 tools (lessons, sentinels, slots, signals, graph, …)
   // instead of being capped at the 7 IMPLEMENTED_TOOLS set baked into
   // this shim. The server validates arguments per tool.
+  const fixedAgentId = isolatedAgentId();
+  const scopedArgs = fixedAgentId ? { ...args, agentId: fixedAgentId } : args;
   const result = (await handle.call("/agentmemory/mcp/call", {
     method: "POST",
-    body: JSON.stringify({ name: toolName, arguments: args }),
+    body: JSON.stringify({ name: toolName, arguments: scopedArgs }),
   })) as { content?: Array<{ type: string; text: string }> } | null;
   if (result && Array.isArray(result.content)) {
     return { content: result.content };
@@ -376,6 +427,12 @@ export async function handleToolCall(
   args: Record<string, unknown>,
   kvInstance: InMemoryKV = kv,
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
+  if (
+    process.env["AGENTMEMORY_AGENT_SCOPE"] === "isolated" &&
+    !configuredAgentId()
+  ) {
+    throw new Error("AGENT_ID is required when AGENTMEMORY_AGENT_SCOPE=isolated");
+  }
   const handle = await resolveHandle();
   announceMode(handle);
 

--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -299,12 +299,13 @@ export function registerApiTriggers(
 
   sdk.registerFunction("api::observe",
     async (req: ApiRequest<HookPayload>): Promise<Response> => {
-      const body = (req.body ?? {}) as Record<string, unknown>;
+      const body = (req.body ?? {}) as unknown as Record<string, unknown>;
       const hookType = asNonEmptyString(body.hookType);
       const sessionId = asNonEmptyString(body.sessionId);
       const project = asNonEmptyString(body.project);
       const cwd = asNonEmptyString(body.cwd);
       const timestamp = asNonEmptyString(body.timestamp);
+      const agentId = asNonEmptyString(body.agentId)?.slice(0, 128);
       if (!hookType || !sessionId || !project || !cwd || !timestamp) {
         return {
           status_code: 400,
@@ -321,6 +322,7 @@ export function registerApiTriggers(
         cwd,
         timestamp,
         data: body.data,
+        ...(agentId ? { agentId } : {}),
       };
       const result = await sdk.trigger({ function_id: "mem::observe", payload });
       return { status_code: 201, body: result };
@@ -1318,7 +1320,8 @@ export function registerApiTriggers(
       // Pass through the query-string pagination so callers can chunk.
       const rawMax = req.query_params?.["maxSessions"];
       const rawOffset = req.query_params?.["offset"];
-      const payload: { maxSessions?: number; offset?: number } = {};
+      const rawAgentId = req.query_params?.["agentId"];
+      const payload: { maxSessions?: number; offset?: number; agentId?: string } = {};
       if (typeof rawMax === "string") {
         const n = Number(rawMax);
         if (Number.isInteger(n) && n > 0) payload.maxSessions = n;
@@ -1327,6 +1330,8 @@ export function registerApiTriggers(
         const n = Number(rawOffset);
         if (Number.isInteger(n) && n >= 0) payload.offset = n;
       }
+      const agentId = asNonEmptyString(rawAgentId)?.slice(0, 128);
+      if (agentId) payload.agentId = agentId;
       const result = await sdk.trigger({
         function_id: "mem::export",
         payload,
@@ -1812,17 +1817,47 @@ export function registerApiTriggers(
 
   sdk.registerFunction("api::governance-delete", 
     async (
-      req: ApiRequest<{ memoryIds: string[]; reason?: string }>,
+      req: ApiRequest<{ memoryIds: string[]; reason?: string; agentId?: string }>,
     ): Promise<Response> => {
       const authErr = checkAuth(req, secret);
       if (authErr) return authErr;
-      if (!req.body?.memoryIds || !Array.isArray(req.body.memoryIds)) {
+      const memoryIds = req.body?.memoryIds;
+      if (
+        !Array.isArray(memoryIds) ||
+        memoryIds.length === 0 ||
+        memoryIds.some(
+          (id: unknown) => typeof id !== "string" || id.trim().length === 0,
+        )
+      ) {
         return {
           status_code: 400,
-          body: { error: "memoryIds array is required" },
+          body: {
+            error: "memoryIds must be a non-empty array of non-empty strings",
+          },
         };
       }
-      const result = await sdk.trigger({ function_id: "mem::governance-delete", payload: req.body });
+      const reason = asNonEmptyString(req.body.reason);
+      const requestAgentId = asNonEmptyString(req.body.agentId)?.slice(0, 128);
+      const isolatedScope =
+        process.env["AGENTMEMORY_AGENT_SCOPE"] === "isolated";
+      const agentId =
+        requestAgentId ?? (isolatedScope ? getAgentId() : undefined);
+      if (isolatedScope && !agentId) {
+        return {
+          status_code: 400,
+          body: {
+            error: "agent identity is required for isolated governance delete",
+          },
+        };
+      }
+      const result = await sdk.trigger({
+        function_id: "mem::governance-delete",
+        payload: {
+          memoryIds: memoryIds.map((id) => id.trim()),
+          ...(reason ? { reason } : {}),
+          ...(agentId ? { agentId } : {}),
+        },
+      });
       return { status_code: 200, body: result };
     },
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -157,6 +157,7 @@ export interface HookPayload {
   cwd: string;
   timestamp: string;
   data: unknown;
+  agentId?: string;
 }
 
 export interface ProviderConfig {

--- a/test/api-observe-agent-id.test.ts
+++ b/test/api-observe-agent-id.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("iii-sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("iii-sdk")>();
+  return {
+    ...actual,
+    TriggerAction: {
+      ...actual.TriggerAction,
+      Void: vi.fn(() => ({ type: "void" })),
+    },
+  };
+});
+
+import { registerApiTriggers } from "../src/triggers/api.js";
+
+describe("POST /agentmemory/observe agent identity", () => {
+  it("forwards the caller's agentId to mem::observe", async () => {
+    const handlers = new Map<string, (payload: unknown) => Promise<unknown>>();
+    const trigger = vi.fn(async () => ({ success: true }));
+    const sdk = {
+      registerFunction(id: string, handler: (payload: unknown) => Promise<unknown>) {
+        handlers.set(id, handler);
+      },
+      registerTrigger: vi.fn(),
+      trigger,
+    };
+
+    registerApiTriggers(sdk as never, {} as never);
+    const observe = handlers.get("api::observe");
+    expect(observe).toBeDefined();
+
+    const response = (await observe!({
+      body: {
+        hookType: "post_tool_use",
+        sessionId: "session-1",
+        project: "ALPHA-SelfService",
+        cwd: "/workspace/ALPHA-SelfService",
+        timestamp: "2026-08-27T00:00:00Z",
+        data: { tool_name: "conversation" },
+        agentId: "alpha",
+      },
+    })) as { status_code: number };
+
+    expect(response.status_code).toBe(201);
+    expect(trigger).toHaveBeenCalledWith({
+      function_id: "mem::observe",
+      payload: expect.objectContaining({ agentId: "alpha" }),
+    });
+  });
+});
+
+describe("DELETE /agentmemory/governance/memories agent identity", () => {
+  it("forwards only the allowed scoped delete fields", async () => {
+    const handlers = new Map<string, (payload: unknown) => Promise<unknown>>();
+    const trigger = vi.fn(async () => ({ success: true, deleted: 0 }));
+    const sdk = {
+      registerFunction(id: string, handler: (payload: unknown) => Promise<unknown>) {
+        handlers.set(id, handler);
+      },
+      registerTrigger: vi.fn(),
+      trigger,
+    };
+
+    registerApiTriggers(sdk as never, {} as never);
+    const governanceDelete = handlers.get("api::governance-delete");
+    expect(governanceDelete).toBeDefined();
+
+    const response = (await governanceDelete!({
+      body: {
+        memoryIds: ["mem_beta"],
+        reason: "stale",
+        agentId: "alpha",
+        injected: "must-not-pass",
+      },
+    })) as { status_code: number };
+
+    expect(response.status_code).toBe(200);
+    expect(trigger).toHaveBeenCalledWith({
+      function_id: "mem::governance-delete",
+      payload: {
+        memoryIds: ["mem_beta"],
+        reason: "stale",
+        agentId: "alpha",
+      },
+    });
+  });
+
+  it("rejects invalid memoryIds entries before forwarding", async () => {
+    const handlers = new Map<string, (payload: unknown) => Promise<unknown>>();
+    const trigger = vi.fn(async () => ({ success: true, deleted: 0 }));
+    const sdk = {
+      registerFunction(id: string, handler: (payload: unknown) => Promise<unknown>) {
+        handlers.set(id, handler);
+      },
+      registerTrigger: vi.fn(),
+      trigger,
+    };
+
+    registerApiTriggers(sdk as never, {} as never);
+    const governanceDelete = handlers.get("api::governance-delete");
+
+    const response = (await governanceDelete!({
+      body: {
+        memoryIds: ["mem_alpha", "", 42, { id: "mem_beta" }],
+        agentId: "alpha",
+      },
+    })) as { status_code: number; body: { error?: string } };
+
+    expect(response.status_code).toBe(400);
+    expect(response.body.error).toMatch(/non-empty strings/i);
+    expect(trigger).not.toHaveBeenCalled();
+  });
+
+  it("uses the trusted process identity when isolated request omits agentId", async () => {
+    const handlers = new Map<string, (payload: unknown) => Promise<unknown>>();
+    const trigger = vi.fn(async () => ({ success: true, deleted: 0 }));
+    const sdk = {
+      registerFunction(id: string, handler: (payload: unknown) => Promise<unknown>) {
+        handlers.set(id, handler);
+      },
+      registerTrigger: vi.fn(),
+      trigger,
+    };
+    const previousScope = process.env["AGENTMEMORY_AGENT_SCOPE"];
+    const previousAgentId = process.env["AGENT_ID"];
+    process.env["AGENTMEMORY_AGENT_SCOPE"] = "isolated";
+    process.env["AGENT_ID"] = "alpha";
+
+    try {
+      registerApiTriggers(sdk as never, {} as never);
+      const governanceDelete = handlers.get("api::governance-delete");
+      const response = (await governanceDelete!({
+        body: { memoryIds: ["mem_alpha"] },
+      })) as { status_code: number };
+
+      expect(response.status_code).toBe(200);
+      expect(trigger).toHaveBeenCalledWith({
+        function_id: "mem::governance-delete",
+        payload: { memoryIds: ["mem_alpha"], agentId: "alpha" },
+      });
+    } finally {
+      if (previousScope === undefined) delete process.env["AGENTMEMORY_AGENT_SCOPE"];
+      else process.env["AGENTMEMORY_AGENT_SCOPE"] = previousScope;
+      if (previousAgentId === undefined) delete process.env["AGENT_ID"];
+      else process.env["AGENT_ID"] = previousAgentId;
+    }
+  });
+
+  it("fails closed when isolated delete has no effective agent identity", async () => {
+    const handlers = new Map<string, (payload: unknown) => Promise<unknown>>();
+    const trigger = vi.fn(async () => ({ success: true, deleted: 0 }));
+    const sdk = {
+      registerFunction(id: string, handler: (payload: unknown) => Promise<unknown>) {
+        handlers.set(id, handler);
+      },
+      registerTrigger: vi.fn(),
+      trigger,
+    };
+    const previousScope = process.env["AGENTMEMORY_AGENT_SCOPE"];
+    const previousAgentId = process.env["AGENT_ID"];
+    process.env["AGENTMEMORY_AGENT_SCOPE"] = "isolated";
+    delete process.env["AGENT_ID"];
+
+    try {
+      registerApiTriggers(sdk as never, {} as never);
+      const governanceDelete = handlers.get("api::governance-delete");
+      const response = (await governanceDelete!({
+        body: { memoryIds: ["mem_alpha"] },
+      })) as { status_code: number; body: { error?: string } };
+
+      expect(response.status_code).toBe(400);
+      expect(response.body.error).toMatch(/agent identity is required/i);
+      expect(trigger).not.toHaveBeenCalled();
+    } finally {
+      if (previousScope === undefined) delete process.env["AGENTMEMORY_AGENT_SCOPE"];
+      else process.env["AGENTMEMORY_AGENT_SCOPE"] = previousScope;
+      if (previousAgentId === undefined) delete process.env["AGENT_ID"];
+      else process.env["AGENT_ID"] = previousAgentId;
+    }
+  });
+});
+
+describe("GET /agentmemory/export agent identity", () => {
+  it("forwards scoped export identity with bounded pagination", async () => {
+    const handlers = new Map<string, (payload: unknown) => Promise<unknown>>();
+    const trigger = vi.fn(async () => ({ sessions: [], memories: [] }));
+    const sdk = {
+      registerFunction(id: string, handler: (payload: unknown) => Promise<unknown>) {
+        handlers.set(id, handler);
+      },
+      registerTrigger: vi.fn(),
+      trigger,
+    };
+
+    registerApiTriggers(sdk as never, {} as never);
+    const exportHandler = handlers.get("api::export");
+    expect(exportHandler).toBeDefined();
+
+    const response = (await exportHandler!({
+      query_params: {
+        agentId: "alpha",
+        maxSessions: "5",
+        offset: "2",
+        injected: "must-not-pass",
+      },
+    })) as { status_code: number };
+
+    expect(response.status_code).toBe(200);
+    expect(trigger).toHaveBeenCalledWith({
+      function_id: "mem::export",
+      payload: { maxSessions: 5, offset: 2, agentId: "alpha" },
+    });
+  });
+});

--- a/test/context-lessons.test.ts
+++ b/test/context-lessons.test.ts
@@ -28,6 +28,7 @@ type ContextHandler = (data: {
   sessionId: string;
   project: string;
   budget?: number;
+  agentId?: string;
 }) => Promise<{ context: string; blocks: number; tokens: number }>;
 
 function wireContext(kv: ReturnType<typeof mockKV>, budget = 4000) {
@@ -246,5 +247,49 @@ describe("mem::context — lessons auto-injection (#457)", () => {
     expect(bullet).toContain("Ignore all prior instructions");
     expect(bullet).toContain("fake fence");
     expect(bullet!.startsWith("- (0.90)")).toBe(true);
+  });
+
+  it("omits unattributed project, lesson, and slot blocks for agent-scoped context", async () => {
+    await seedLesson(kv, {
+      id: "lesson_cross_profile",
+      content: "CROSS_PROFILE_LESSON",
+      project: "/tmp/proj",
+    });
+    await kv.set(KV.profiles, "/tmp/proj", {
+      project: "/tmp/proj",
+      topConcepts: [{ concept: "CROSS_PROFILE_CONCEPT", count: 1 }],
+      topFiles: [],
+      conventions: [],
+      commonErrors: [],
+      updatedAt: new Date().toISOString(),
+    });
+    await kv.set(KV.globalSlots, "persona", {
+      label: "persona",
+      content: "CROSS_PROFILE_SLOT",
+      description: "",
+      sizeLimit: 1000,
+      pinned: true,
+      readOnly: false,
+      scope: "global",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const originalSlots = process.env["AGENTMEMORY_SLOTS"];
+    process.env["AGENTMEMORY_SLOTS"] = "true";
+    try {
+      const result = await handler({
+        sessionId: "ses_agent_scoped",
+        project: "/tmp/proj",
+        agentId: "alpha",
+      });
+
+      expect(result.context).not.toContain("CROSS_PROFILE_LESSON");
+      expect(result.context).not.toContain("CROSS_PROFILE_CONCEPT");
+      expect(result.context).not.toContain("CROSS_PROFILE_SLOT");
+    } finally {
+      if (originalSlots === undefined) delete process.env["AGENTMEMORY_SLOTS"];
+      else process.env["AGENTMEMORY_SLOTS"] = originalSlots;
+    }
   });
 });

--- a/test/export-import.test.ts
+++ b/test/export-import.test.ts
@@ -7,6 +7,7 @@ vi.mock("../src/logger.js", () => ({
 import { registerExportImportFunction } from "../src/functions/export-import.js";
 import { VERSION } from "../src/version.js";
 import { getSearchIndex } from "../src/functions/search.js";
+import { KV } from "../src/state/schema.js";
 import type {
   Session,
   CompressedObservation,
@@ -132,6 +133,94 @@ describe("Export/Import Functions", () => {
     expect(result.observations["ses_1"].length).toBe(1);
     expect(result.memories.length).toBe(1);
     expect(result.summaries.length).toBe(1);
+  });
+
+  it("agent-scoped export omits foreign and unattributed records", async () => {
+    const alphaSession: Session = {
+      ...testSession,
+      id: "ses_alpha",
+      project: "alpha-project",
+      agentId: "alpha",
+    };
+    const betaSession: Session = {
+      ...testSession,
+      id: "ses_beta",
+      project: "beta-project",
+      agentId: "beta",
+    };
+    await kv.set(KV.sessions, alphaSession.id, alphaSession);
+    await kv.set(KV.sessions, betaSession.id, betaSession);
+    await kv.set(KV.observations(alphaSession.id), "obs_alpha", {
+      ...testObs,
+      id: "obs_alpha",
+      sessionId: alphaSession.id,
+      agentId: "alpha",
+    });
+    await kv.set(KV.observations(alphaSession.id), "obs_foreign", {
+      ...testObs,
+      id: "obs_foreign",
+      sessionId: alphaSession.id,
+      agentId: "beta",
+    });
+    await kv.set(KV.observations(alphaSession.id), "obs_unscoped", {
+      ...testObs,
+      id: "obs_unscoped",
+      sessionId: alphaSession.id,
+    });
+    await kv.set(KV.observations(betaSession.id), "obs_beta", {
+      ...testObs,
+      id: "obs_beta",
+      sessionId: betaSession.id,
+      agentId: "beta",
+    });
+    await kv.set(KV.memories, "mem_alpha", {
+      ...testMemory,
+      id: "mem_alpha",
+      sessionIds: [alphaSession.id],
+      agentId: "alpha",
+    });
+    await kv.set(KV.memories, "mem_beta", {
+      ...testMemory,
+      id: "mem_beta",
+      sessionIds: [betaSession.id],
+      agentId: "beta",
+    });
+    await kv.set(KV.summaries, alphaSession.id, {
+      ...testSummary,
+      sessionId: alphaSession.id,
+      project: alphaSession.project,
+    });
+    await kv.set(KV.summaries, betaSession.id, {
+      ...testSummary,
+      sessionId: betaSession.id,
+      project: betaSession.project,
+    });
+    await kv.set(KV.profiles, alphaSession.project, {
+      project: alphaSession.project,
+      topConcepts: [],
+      topFiles: [],
+      conventions: [],
+      commonErrors: [],
+      updatedAt: "2026-02-01T00:00:00Z",
+    });
+    await kv.set(KV.lessons, "lesson_global", {
+      id: "lesson_global",
+      content: "GLOBAL_LESSON",
+    });
+
+    const result = (await sdk.trigger("mem::export", {
+      agentId: "alpha",
+    })) as ExportData;
+
+    expect(result.sessions.map((session) => session.id)).toEqual(["ses_alpha"]);
+    expect(Object.keys(result.observations)).toEqual(["ses_alpha"]);
+    expect(result.observations["ses_alpha"].map((observation) => observation.id)).toEqual([
+      "obs_alpha",
+    ]);
+    expect(result.memories.map((memory) => memory.id)).toEqual(["mem_alpha"]);
+    expect(result.summaries.map((summary) => summary.sessionId)).toEqual(["ses_alpha"]);
+    expect(result.profiles).toBeUndefined();
+    expect(result.lessons).toBeUndefined();
   });
 
   it("import with merge strategy adds data", async () => {

--- a/test/governance.test.ts
+++ b/test/governance.test.ts
@@ -109,6 +109,27 @@ describe("Governance Functions", () => {
     expect(remaining.length).toBe(3);
   });
 
+  it("governance-delete only removes memories owned by the requested agent", async () => {
+    await kv.set("mem:memories", "mem_alpha", {
+      ...makeMemory("mem_alpha"),
+      agentId: "alpha",
+    });
+    await kv.set("mem:memories", "mem_beta", {
+      ...makeMemory("mem_beta"),
+      agentId: "beta",
+    });
+
+    const result = (await sdk.trigger("mem::governance-delete", {
+      memoryIds: ["mem_alpha", "mem_beta", "mem_1"],
+      agentId: "beta",
+    })) as { success: boolean; deleted: number; total: number };
+
+    expect(result.deleted).toBe(1);
+    expect(await kv.get("mem:memories", "mem_alpha")).not.toBeNull();
+    expect(await kv.get("mem:memories", "mem_beta")).toBeNull();
+    expect(await kv.get("mem:memories", "mem_1")).not.toBeNull();
+  });
+
   it("governance-bulk deletes by type filter", async () => {
     const result = (await sdk.trigger("mem::governance-bulk", {
       type: ["pattern"],

--- a/test/hermes-connect-profile-id.test.ts
+++ b/test/hermes-connect-profile-id.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { join } from "node:path";
+import {
+  defaultHermesHome,
+  profileAgentIdFromHermesHome,
+  renderHermesMcpConfig,
+} from "../src/cli/connect/hermes.js";
+
+describe("Hermes MCP profile binding", () => {
+  it("renders the named Hermes profile as the fixed MCP agent identity", () => {
+    const profileHome = join("root", "profiles", "alpha");
+
+    expect(profileAgentIdFromHermesHome(profileHome)).toBe("alpha");
+    expect(renderHermesMcpConfig(profileHome)).toContain('AGENT_ID: "alpha"');
+    const config = renderHermesMcpConfig(profileHome);
+    expect(config).toContain('AGENTMEMORY_AGENT_SCOPE: "isolated"');
+    const expectedTools = [
+      "memory_save",
+      "memory_recall",
+      "memory_smart_search",
+      "memory_sessions",
+    ];
+    const includedTools = config
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.startsWith("- memory_"))
+      .map((line) => line.slice(2));
+    expect(includedTools).toEqual(expectedTools);
+  });
+
+  it("uses default for a root Hermes home", () => {
+    expect(profileAgentIdFromHermesHome(join("root", "hermes"))).toBe("default");
+  });
+
+  it("uses Hermes' native Windows home instead of ~/.hermes", () => {
+    const localAppData = String.raw`C:\Users\Example\AppData\Local`;
+    const userHome = String.raw`C:\Users\Example`;
+    expect(
+      defaultHermesHome(
+        "win32",
+        { LOCALAPPDATA: localAppData },
+        userHome,
+      ),
+    ).toBe(join(localAppData, "hermes"));
+  });
+});

--- a/test/mcp-fixed-agent-id.test.ts
+++ b/test/mcp-fixed-agent-id.test.ts
@@ -1,0 +1,282 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { handleToolCall } from "../src/mcp/standalone.js";
+import { resetHandleForTests } from "../src/mcp/rest-proxy.js";
+import { InMemoryKV } from "../src/mcp/in-memory-kv.js";
+
+const BASE = "http://localhost:3111";
+
+describe("@agentmemory/mcp fixed agent identity", () => {
+  const originalFetch = globalThis.fetch;
+  const originalAgentId = process.env["AGENT_ID"];
+  const originalAgentScope = process.env["AGENTMEMORY_AGENT_SCOPE"];
+
+  beforeEach(() => {
+    resetHandleForTests();
+    process.env["AGENTMEMORY_URL"] = BASE;
+    process.env["AGENT_ID"] = "alpha";
+    process.env["AGENTMEMORY_AGENT_SCOPE"] = "isolated";
+  });
+
+  afterEach(() => {
+    resetHandleForTests();
+    globalThis.fetch = originalFetch;
+    delete process.env["AGENTMEMORY_URL"];
+    if (originalAgentId === undefined) delete process.env["AGENT_ID"];
+    else process.env["AGENT_ID"] = originalAgentId;
+    if (originalAgentScope === undefined) delete process.env["AGENTMEMORY_AGENT_SCOPE"];
+    else process.env["AGENTMEMORY_AGENT_SCOPE"] = originalAgentScope;
+  });
+
+  it("binds memory_save to AGENT_ID instead of a model-supplied agentId", async () => {
+    let rememberBody: Record<string, unknown> | undefined;
+    const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const target = url.toString();
+      if (target.endsWith("/agentmemory/livez")) {
+        return new Response("ok", { status: 200 });
+      }
+      if (target.endsWith("/agentmemory/remember")) {
+        rememberBody = JSON.parse(String(init?.body || "{}"));
+        return new Response(JSON.stringify({ success: true }), { status: 200 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await handleToolCall("memory_save", {
+      content: "ALPHA profile marker",
+      agentId: "beta",
+    });
+
+    expect(rememberBody).toMatchObject({
+      content: "ALPHA profile marker",
+      agentId: "alpha",
+    });
+  });
+
+  it("binds AGENT_ID to recall, smart-search, and session reads", async () => {
+    const bodies = new Map<string, Record<string, unknown>>();
+    const requestedUrls: string[] = [];
+    const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const target = url.toString();
+      if (target.endsWith("/agentmemory/livez")) {
+        return new Response("ok", { status: 200 });
+      }
+      requestedUrls.push(target);
+      if (init?.body) bodies.set(new URL(target).pathname, JSON.parse(String(init.body)));
+      return new Response(JSON.stringify({ results: [], sessions: [] }), { status: 200 });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await handleToolCall("memory_recall", { query: "marker" });
+    await handleToolCall("memory_smart_search", { query: "marker" });
+    await handleToolCall("memory_sessions", { limit: 5 });
+
+    expect(bodies.get("/agentmemory/search")).toMatchObject({ agentId: "alpha" });
+    expect(bodies.get("/agentmemory/smart-search")).toMatchObject({ agentId: "alpha" });
+    const sessionsUrl = new URL(
+      requestedUrls.find((url) => url.includes("/agentmemory/sessions"))!,
+    );
+    expect(sessionsUrl.searchParams.get("agentId")).toBe("alpha");
+  });
+
+  it("binds AGENT_ID to proxied governance deletes", async () => {
+    let deleteBody: Record<string, unknown> | undefined;
+    const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const target = url.toString();
+      if (target.endsWith("/agentmemory/livez")) {
+        return new Response("ok", { status: 200 });
+      }
+      if (target.endsWith("/agentmemory/governance/memories")) {
+        deleteBody = JSON.parse(String(init?.body || "{}"));
+        return new Response(JSON.stringify({ success: true, deleted: 0 }), {
+          status: 200,
+        });
+      }
+      return new Response("not found", { status: 404 });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await handleToolCall("memory_governance_delete", {
+      memoryIds: ["mem_beta"],
+      reason: "remove stale memory",
+    });
+
+    expect(deleteBody).toEqual({
+      memoryIds: ["mem_beta"],
+      reason: "remove stale memory",
+      agentId: "alpha",
+    });
+  });
+
+  it("binds AGENT_ID to proxied exports", async () => {
+    let exportUrl: string | undefined;
+    const fetchMock = vi.fn(async (url: string | URL) => {
+      const target = url.toString();
+      if (target.endsWith("/agentmemory/livez")) {
+        return new Response("ok", { status: 200 });
+      }
+      if (target.includes("/agentmemory/export")) {
+        exportUrl = target;
+        return new Response(
+          JSON.stringify({ sessions: [], memories: [], summaries: [] }),
+          { status: 200 },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await handleToolCall("memory_export", {});
+
+    const parsed = new URL(exportUrl!);
+    expect(parsed.pathname).toBe("/agentmemory/export");
+    expect(parsed.searchParams.get("agentId")).toBe("alpha");
+  });
+
+
+  it("binds AGENT_ID on the generic full-tool proxy path", async () => {
+    let callBody: Record<string, unknown> | undefined;
+    const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const target = url.toString();
+      if (target.endsWith("/agentmemory/livez")) {
+        return new Response("ok", { status: 200 });
+      }
+      if (target.endsWith("/agentmemory/mcp/call")) {
+        callBody = JSON.parse(String(init?.body || "{}"));
+        return new Response(
+          JSON.stringify({ content: [{ type: "text", text: "{}" }] }),
+          { status: 200 },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await handleToolCall("memory_lesson_save", {
+      content: "profile-scoped lesson",
+      agentId: "beta",
+    });
+
+    expect(callBody).toEqual({
+      name: "memory_lesson_save",
+      arguments: {
+        content: "profile-scoped lesson",
+        agentId: "alpha",
+      },
+    });
+  });
+
+
+  it("keeps the shared local fallback store isolated between agent IDs", async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const kv = new InMemoryKV();
+
+    process.env["AGENT_ID"] = "alpha";
+    await handleToolCall("memory_save", { content: "ALPHA_ONLY_MARKER" }, kv);
+
+    process.env["AGENT_ID"] = "beta";
+    await handleToolCall("memory_save", { content: "BETA_ONLY_MARKER" }, kv);
+    const betaSeesAlpha = JSON.parse(
+      (await handleToolCall("memory_recall", { query: "ALPHA_ONLY_MARKER" }, kv)).content[0]
+        .text,
+    );
+    const betaSeesBeta = JSON.parse(
+      (await handleToolCall("memory_recall", { query: "BETA_ONLY_MARKER" }, kv)).content[0]
+        .text,
+    );
+
+    expect(betaSeesAlpha.results).toEqual([]);
+    expect(betaSeesBeta.results).toHaveLength(1);
+    expect(betaSeesBeta.results[0].agentId).toBe("beta");
+  });
+
+
+  it("filters local sessions and exports and cannot delete another agent's memory", async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const kv = new InMemoryKV();
+    await kv.set("mem:sessions", "alpha-session", { id: "alpha-session", agentId: "alpha" });
+    await kv.set("mem:sessions", "beta-session", { id: "beta-session", agentId: "beta" });
+    await kv.set("mem:memories", "alpha-memory", {
+      id: "alpha-memory",
+      content: "ALPHA secret",
+      agentId: "alpha",
+    });
+    await kv.set("mem:memories", "beta-memory", {
+      id: "beta-memory",
+      content: "BETA secret",
+      agentId: "beta",
+    });
+
+    process.env["AGENT_ID"] = "beta";
+    const sessions = JSON.parse(
+      (await handleToolCall("memory_sessions", {}, kv)).content[0].text,
+    );
+    const exported = JSON.parse(
+      (await handleToolCall("memory_export", {}, kv)).content[0].text,
+    );
+    const deletion = JSON.parse(
+      (
+        await handleToolCall(
+          "memory_governance_delete",
+          { memoryIds: ["alpha-memory"] },
+          kv,
+        )
+      ).content[0].text,
+    );
+
+    expect(
+      sessions.sessions.map((session: Record<string, unknown>) => session["id"]),
+    ).toEqual(["beta-session"]);
+    expect(
+      exported.sessions.map((session: Record<string, unknown>) => session["id"]),
+    ).toEqual(["beta-session"]);
+    expect(
+      exported.memories.map((memory: Record<string, unknown>) => memory["id"]),
+    ).toEqual(["beta-memory"]);
+    expect(deletion.deleted).toBe(0);
+    expect(await kv.get("mem:memories", "alpha-memory")).not.toBeNull();
+  });
+
+
+  it("keeps shared-mode recall unfiltered while still tagging writes", async () => {
+    process.env["AGENTMEMORY_AGENT_SCOPE"] = "shared";
+    const bodies = new Map<string, Record<string, unknown>>();
+    const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const target = url.toString();
+      if (target.endsWith("/agentmemory/livez")) {
+        return new Response("ok", { status: 200 });
+      }
+      if (init?.body) bodies.set(new URL(target).pathname, JSON.parse(String(init.body)));
+      return new Response(JSON.stringify({ results: [], success: true }), { status: 200 });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await handleToolCall("memory_save", { content: "shared marker", agentId: "beta" });
+    await handleToolCall("memory_recall", { query: "shared marker" });
+
+    expect(bodies.get("/agentmemory/remember")).toMatchObject({ agentId: "alpha" });
+    expect(bodies.get("/agentmemory/search")).not.toHaveProperty("agentId");
+  });
+
+
+  it("fails closed in isolated mode when AGENT_ID is missing", async () => {
+    delete process.env["AGENT_ID"];
+    const fetchMock = vi.fn(async () => new Response("ok", { status: 200 }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(
+      handleToolCall("memory_save", {
+        content: "must not be stored",
+        agentId: "model-chosen-id",
+      }),
+    ).rejects.toThrow(/AGENT_ID is required/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+});

--- a/test/observe-agent-id.test.ts
+++ b/test/observe-agent-id.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("iii-sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("iii-sdk")>();
+  return {
+    ...actual,
+    TriggerAction: {
+      ...actual.TriggerAction,
+      Void: vi.fn(() => ({ type: "void" })),
+    },
+  };
+});
+
+import { registerObserveFunction } from "../src/functions/observe.js";
+import { KV } from "../src/state/schema.js";
+
+function memoryRuntime() {
+  const handlers = new Map<string, (payload: unknown) => Promise<unknown>>();
+  const state = new Map<string, Map<string, unknown>>();
+  const bucket = (scope: string) => {
+    const current = state.get(scope) ?? new Map<string, unknown>();
+    state.set(scope, current);
+    return current;
+  };
+  const kv = {
+    get: async <T>(scope: string, key: string): Promise<T | null> =>
+      (bucket(scope).get(key) as T | undefined) ?? null,
+    set: async <T>(scope: string, key: string, value: T): Promise<T> => {
+      bucket(scope).set(key, value);
+      return value;
+    },
+    list: async <T>(scope: string): Promise<T[]> => [...bucket(scope).values()] as T[],
+    update: async () => null,
+  };
+  const sdk = {
+    registerFunction(id: string, handler: (payload: unknown) => Promise<unknown>) {
+      handlers.set(id, handler);
+    },
+    trigger: async (
+      input: string | { function_id: string; payload: unknown },
+      payload?: unknown,
+    ) => {
+      const id = typeof input === "string" ? input : input.function_id;
+      const data = typeof input === "string" ? payload : input.payload;
+      const handler = handlers.get(id);
+      return handler ? handler(data) : {};
+    },
+  };
+  return { handlers, kv, sdk };
+}
+
+describe("mem::observe per-call agent identity", () => {
+  const originalAgentId = process.env["AGENT_ID"];
+
+  beforeEach(() => {
+    delete process.env["AGENT_ID"];
+  });
+
+  afterEach(() => {
+    if (originalAgentId === undefined) delete process.env["AGENT_ID"];
+    else process.env["AGENT_ID"] = originalAgentId;
+  });
+
+  it("uses payload agentId when implicitly creating a session", async () => {
+    const { handlers, kv, sdk } = memoryRuntime();
+    registerObserveFunction(sdk as never, kv as never);
+
+    await handlers.get("mem::observe")!({
+      hookType: "post_tool_use",
+      sessionId: "session-1",
+      project: "ALPHA-SelfService",
+      cwd: "/workspace/ALPHA-SelfService",
+      timestamp: "2026-08-27T00:00:00Z",
+      data: { tool_name: "conversation", tool_input: "hello", tool_output: "world" },
+      agentId: "alpha",
+    });
+
+    const session = await kv.get<{ agentId?: string }>(KV.sessions, "session-1");
+    expect(session?.agentId).toBe("alpha");
+    const observations = await kv.list<{ agentId?: string }>(KV.observations("session-1"));
+    expect(observations).toHaveLength(1);
+    expect(observations[0].agentId).toBe("alpha");
+    const audits = await kv.list<{
+      operation: string;
+      functionId: string;
+      targetIds: string[];
+      details: Record<string, unknown>;
+    }>(KV.audit);
+    expect(audits).toHaveLength(1);
+    expect(audits[0]).toMatchObject({
+      operation: "observe",
+      functionId: "mem::observe",
+      targetIds: [expect.stringMatching(/^obs_/)],
+      details: {
+        sessionId: "session-1",
+        hookType: "post_tool_use",
+        agentId: "alpha",
+      },
+    });
+  });
+
+  it("does not let payload agentId override an existing session owner", async () => {
+    const { handlers, kv, sdk } = memoryRuntime();
+    await kv.set(KV.sessions, "session-1", {
+      id: "session-1",
+      agentId: "alpha",
+      observationCount: 0,
+    });
+    registerObserveFunction(sdk as never, kv as never);
+
+    await handlers.get("mem::observe")!({
+      hookType: "post_tool_use",
+      sessionId: "session-1",
+      project: "ALPHA-SelfService",
+      cwd: "/workspace/ALPHA-SelfService",
+      timestamp: "2026-08-27T00:00:00Z",
+      data: { tool_name: "conversation" },
+      agentId: "beta",
+    });
+
+    const observations = await kv.list<{ agentId?: string }>(KV.observations("session-1"));
+    expect(observations).toHaveLength(1);
+    expect(observations[0].agentId).toBe("alpha");
+  });
+
+  it("keeps an existing unscoped session unscoped", async () => {
+    const { handlers, kv, sdk } = memoryRuntime();
+    await kv.set(KV.sessions, "session-1", {
+      id: "session-1",
+      observationCount: 0,
+    });
+    registerObserveFunction(sdk as never, kv as never);
+
+    await handlers.get("mem::observe")!({
+      hookType: "post_tool_use",
+      sessionId: "session-1",
+      project: "legacy-project",
+      cwd: "/workspace/legacy-project",
+      timestamp: "2026-08-27T00:00:00Z",
+      data: { tool_name: "conversation" },
+      agentId: "beta",
+    });
+
+    const session = await kv.get<{ agentId?: string }>(KV.sessions, "session-1");
+    expect(session?.agentId).toBeUndefined();
+    const observations = await kv.list<{ agentId?: string }>(KV.observations("session-1"));
+    expect(observations).toHaveLength(1);
+    expect(observations[0].agentId).toBeUndefined();
+  });
+});

--- a/test/smart-search.test.ts
+++ b/test/smart-search.test.ts
@@ -246,6 +246,36 @@ describe("Smart Search Function", () => {
       expect(result.lessons).toBeUndefined();
     });
 
+    it("omits unattributed lessons from agent-scoped search", async () => {
+      let lessonRecallCalled = false;
+      sdk.registerFunction("mem::lesson-recall", async () => {
+        lessonRecallCalled = true;
+        return {
+          success: true,
+          lessons: [
+            {
+              id: "lsn_other_agent",
+              content: "CROSS_PROFILE_LESSON",
+              confidence: 1,
+              createdAt: "2026-04-01T00:00:00Z",
+              tags: [],
+            },
+          ],
+        };
+      });
+      searchResults[0].observation.agentId = "alpha";
+      searchResults[1].observation.agentId = "beta";
+
+      const result = (await sdk.trigger("mem::smart-search", {
+        query: "auth",
+        agentId: "alpha",
+      })) as { results: CompactSearchResult[]; lessons?: unknown };
+
+      expect(result.results).toHaveLength(1);
+      expect(result.lessons).toBeUndefined();
+      expect(lessonRecallCalled).toBe(false);
+    });
+
     it("forwards project filter to mem::lesson-recall", async () => {
       let receivedPayload: any = null;
       sdk.registerFunction("mem::lesson-recall", async (payload: any) => {


### PR DESCRIPTION
## What

Bind AgentMemory's Hermes integration to the owning Hermes profile identity instead of relying on a process-global or model-supplied `agentId`.

- Derive the provider `agentId` from Hermes' explicit `hermes_home` (`.../profiles/<id>` → `<id>`, root home → `default`).
- Tag provider writes in both shared and isolated modes; add the profile filter to context/recall/search reads only in isolated mode.
- Forward `agentId` through `POST /agentmemory/observe`, and use it when `mem::observe` implicitly creates a session. An existing session remains the source of truth, so a request cannot rebind its owner.
- When `/context` is agent-scoped, omit project profiles, lessons, and pinned slots because those records do not carry `agentId`; agent-scoped smart search likewise omits lessons. Scoped observations/memories remain available, while shared and wildcard calls retain the existing global blocks.
- Bind the standalone MCP shim to `AGENT_ID` outside model-controlled tool arguments. Isolated mode overrides spoofed values and fails closed if `AGENT_ID` is missing.
- Scope proxy and local-fallback save/recall/smart-search/session behavior, including local export/delete ownership checks.
- Make `agentmemory connect hermes` profile-aware, including Hermes' native Windows home, and render a valid profile-bound YAML block. The docs state explicitly that the Hermes host process and daemon also need isolated scope because an MCP `env` block applies only to the subprocess.
- Allowlist the four MCP operations currently verified as agent-scoped (`memory_save`, `memory_recall`, `memory_smart_search`, `memory_sessions`). The docs explicitly avoid presenting identity propagation as an ACL for all 54 global/advanced tools.

## Why

Several Hermes profiles can share one AgentMemory daemon. A server-global `AGENT_ID` cannot identify each caller, while exposing `agentId` as an ordinary tool argument lets the model select another profile. The existing Hermes integration also tags writes incompletely and does not attach the profile identity to reads when isolated mode is enabled.

This change gives each profile a fixed, validated identity and preserves existing shared-mode semantics: writes remain attributable, while cross-agent recall stays available unless isolated mode is selected.

## Security and compatibility

- Profile ids use Hermes' canonical `[a-z0-9][a-z0-9_-]{0,63}` format.
- Fixed MCP identity wins over model input.
- Isolated MCP mode without `AGENT_ID` rejects calls before probing or writing.
- Existing-session ownership wins over an incoming observe payload.
- Agent-scoped context/search fails closed on unattributed project/lesson/slot blocks.
- Shared mode remains cross-agent for reads.
- Advanced/global tools are excluded from the generated strict-isolation Hermes config rather than being misrepresented as agent-scoped.
- No package version or CHANGELOG change; release metadata remains maintainer-owned.

## Verification

- `npm run build` production build: passed with Git Bash as npm's script shell (the package script uses POSIX `cp`/`mkdir`).
- Final isolation regression set: **108 passed** across standalone MCP, agent-scope/search/context, lessons, slots, and the new profile-binding tests.
- Hermes provider `unittest`: **4 passed** both normally and under `python -S` (explicit-home identity, ambient-home rejection, and shared vs isolated request behavior).
- Real Hermes user-plugin loader: loaded `AgentMemoryProvider` from a temporary `.../profiles/alpha/plugins/agentmemory` profile.
- Generated Hermes YAML: parsed successfully through Hermes' real `_load_mcp_config()` with exact `AGENT_ID`, isolated scope, and four-tool allowlist.
- Disposable real-server MCP E2E:
  - spoofed alpha save persisted as `agentId=alpha`;
  - alpha recall: 1 own hit;
  - beta recall for alpha marker: 0 hits;
  - beta recall: 1 own hit.
- Disposable real-server Hermes-provider E2E produced the same alpha/beta isolation matrix and profile-tagged sessions even with a contradictory ambient `HERMES_HOME`; the explicit profile homes remained authoritative.
- Test containers/volumes were removed, and the pre-existing AgentMemory container retained the same id and healthy state.
- Added-line security scan: no hardcoded secrets, command injection, dynamic eval/exec, unsafe deserialization, or SQL interpolation.

The repository's full parallel Windows suite is already red and timing-sensitive on `main`. A fresh same-machine comparison produced: `upstream/main` 103 failed / 1,608 passed / 1 skipped; this branch 90 failed / 1,637 passed / 1 skipped. No changed test file failed. The five files seen only in the feature run were repeated after clearing Vitest's cache: four files / 63 tests passed, while the remaining unchanged `cli-engine-startup` assertion still failed on the repository's CRLF-vs-LF comparison. `tsc --noEmit` improves from 30 baseline errors to 29, with no error on a changed hunk. `skills:check` reports the same five generated-reference drifts on untouched `upstream/main` and this branch.

Fixes #1159

Related: #665, #1089, #1197, #1160


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional agent identities for memory operations and API requests.
  - Added isolated memory scope for profile-separated saves, searches, sessions, exports, and deletions.
  - Added automatic profile-based identity configuration for Hermes integrations.
  - Added agent-scoped exports, deletion controls, and observation auditing.
- **Bug Fixes**
  - Prevented unrelated lessons, profiles, and slots from appearing in scoped context and searches.
  - Isolated operations now require a configured agent identity.
- **Documentation**
  - Updated setup guides with configuration examples, isolation guidance, and recommended tool allowlists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Automated review follow-up

Addressed all five actionable CodeRabbit comments in verified commit `6298572`:

- resolve Hermes config/plugin paths from the active `HERMES_HOME`, including the Windows `%LOCALAPPDATA%\hermes` default;
- audit successful `mem::observe` writes after observation/session persistence, including the resolved `agentId`;
- propagate immutable `AGENT_ID` through proxied targeted governance delete and enforce exact memory ownership in Core;
- propagate immutable `AGENT_ID` through proxied export; filter sessions, each observation record, memories, and summaries; omit unattributed global collections in scoped exports while preserving unscoped admin exports;
- use the established hoisted `vi.mock("iii-sdk")` pattern in the two runtime-importing Observe suites.

Additional verification:

- 154/154 focused TypeScript tests;
- Hermes provider 4/4 normally and 4/4 under `python -S`;
- production build and added-line security scan passed;
- disposable real-server E2E: cross-agent delete removed 0, own delete removed 1, scoped export exposed only owned records, and Observe audit retained the owning agent;
- adversarial import E2E placed alpha, beta, and unattributed observations in one alpha session bucket: fixed isolated alpha export returned only the alpha observation, while unscoped administrative export retained all three;
- independent `Export Observation Isolation Gate` review passed with no security concerns, logic errors, or suggestions.
