### PR TITLE
fix(resilient): content filter rejections must not open the circuit breaker

### DIFF
--- a/src/providers/resilient.ts
+++ b/src/providers/resilient.ts
@@ -1,24 +1,9 @@
 import type { MemoryProvider, CircuitBreakerState } from "../types.js";
 import { CircuitBreaker } from "./circuit-breaker.js";
 
-/**
- * A rejection that means "this particular payload is not acceptable" rather
- * than "the provider is unhealthy".
- *
- * Azure OpenAI content filters are the motivating case. Prompt Shields flags
- * tool output that merely *looks* like a jailbreak — a README describing
- * prompt injection, a security test fixture, an error log quoting user input:
- *
- *   400 {"error":{"code":"content_filter", ...
- *        "innererror":{"code":"ResponsibleAIPolicyViolation",
- *        "content_filter_result":{"jailbreak":{"detected":true,"filtered":true}}}}}
- *
- * Counting those as provider failures means three filtered observations inside
- * the failure window trip the breaker, and every *other* compression then
- * fails with `circuit_breaker_open` for the recovery timeout. One awkward file
- * costs a batch of unrelated observations. The provider is answering fine, so
- * leave the breaker closed and let just that one call fail.
- */
+// Azure Prompt Shields rejects ordinary material — a SECURITY.md describing
+// prompt injection is enough — so these arrive often enough to trip the
+// breaker and take unrelated compressions down with them. See #1276.
 export function isPayloadRejection(err: unknown): boolean {
   const message = err instanceof Error ? err.message : String(err);
   return /content_filter|ResponsibleAIPolicyViolation/.test(message);

--- a/src/providers/resilient.ts
+++ b/src/providers/resilient.ts
@@ -4,9 +4,14 @@ import { CircuitBreaker } from "./circuit-breaker.js";
 // Azure Prompt Shields rejects ordinary material — a SECURITY.md describing
 // prompt injection is enough — so these arrive often enough to trip the
 // breaker and take unrelated compressions down with them. See #1276.
+const FILTER_CODE = /content_filter|ResponsibleAIPolicyViolation/;
+// The status the provider itself recorded, before any echoed upstream body:
+// a gateway that quotes a filter rejection is still a gateway failure.
+const REJECTED_STATUS = /^[^{]*\(400\)/;
+
 export function isPayloadRejection(err: unknown): boolean {
   const message = err instanceof Error ? err.message : String(err);
-  return /content_filter|ResponsibleAIPolicyViolation/.test(message);
+  return REJECTED_STATUS.test(message) && FILTER_CODE.test(message);
 }
 
 export class ResilientProvider implements MemoryProvider {

--- a/src/providers/resilient.ts
+++ b/src/providers/resilient.ts
@@ -1,6 +1,29 @@
 import type { MemoryProvider, CircuitBreakerState } from "../types.js";
 import { CircuitBreaker } from "./circuit-breaker.js";
 
+/**
+ * A rejection that means "this particular payload is not acceptable" rather
+ * than "the provider is unhealthy".
+ *
+ * Azure OpenAI content filters are the motivating case. Prompt Shields flags
+ * tool output that merely *looks* like a jailbreak — a README describing
+ * prompt injection, a security test fixture, an error log quoting user input:
+ *
+ *   400 {"error":{"code":"content_filter", ...
+ *        "innererror":{"code":"ResponsibleAIPolicyViolation",
+ *        "content_filter_result":{"jailbreak":{"detected":true,"filtered":true}}}}}
+ *
+ * Counting those as provider failures means three filtered observations inside
+ * the failure window trip the breaker, and every *other* compression then
+ * fails with `circuit_breaker_open` for the recovery timeout. One awkward file
+ * costs a batch of unrelated observations. The provider is answering fine, so
+ * leave the breaker closed and let just that one call fail.
+ */
+export function isPayloadRejection(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return /content_filter|ResponsibleAIPolicyViolation/.test(message);
+}
+
 export class ResilientProvider implements MemoryProvider {
   private breaker = new CircuitBreaker();
   name: string;
@@ -18,7 +41,9 @@ export class ResilientProvider implements MemoryProvider {
       this.breaker.recordSuccess();
       return result;
     } catch (err) {
-      this.breaker.recordFailure();
+      if (!isPayloadRejection(err)) {
+        this.breaker.recordFailure();
+      }
       throw err;
     }
   }

--- a/test/resilient-content-filter.test.ts
+++ b/test/resilient-content-filter.test.ts
@@ -16,6 +16,12 @@ const CONTENT_FILTER_ERROR = new Error(
     '"content_filter_result":{"jailbreak":{"detected":true,"filtered":true}}}}}',
 );
 
+const GATEWAY_ECHO_ERROR = new Error(
+  'OpenAI API error (502): {"error":{"message":"upstream returned an error: ' +
+    '{\\"code\\":\\"content_filter\\",\\"innererror\\":' +
+    '{\\"code\\":\\"ResponsibleAIPolicyViolation\\"}}","code":"bad_gateway"}}',
+);
+
 function providerThatFails(err: Error, okAfter = Infinity): MemoryProvider {
   let calls = 0;
   return {
@@ -34,13 +40,28 @@ function providerThatFails(err: Error, okAfter = Infinity): MemoryProvider {
 describe("isPayloadRejection", () => {
   it("recognises Azure content filter rejections", () => {
     expect(isPayloadRejection(CONTENT_FILTER_ERROR)).toBe(true);
-    expect(isPayloadRejection(new Error("ResponsibleAIPolicyViolation"))).toBe(true);
+    expect(
+      isPayloadRejection(
+        new Error('OpenAI API error (400): {"error":{"code":"ResponsibleAIPolicyViolation"}}'),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not treat the filter code alone as a rejection", () => {
+    // No status means no evidence that the provider rejected this payload.
+    expect(isPayloadRejection(new Error("ResponsibleAIPolicyViolation"))).toBe(false);
   });
 
   it("treats genuine provider trouble as a failure", () => {
     expect(isPayloadRejection(new Error("OpenAI API error (503): upstream down"))).toBe(false);
     expect(isPayloadRejection(new Error("request timed out after 60000ms"))).toBe(false);
     expect(isPayloadRejection("socket hang up")).toBe(false);
+  });
+
+  it("does not excuse a gateway failure that merely quotes the filter body", () => {
+    // A 502 from an Azure gateway that echoes the upstream body. The tokens are
+    // present, the status is not 400: the provider is genuinely unhealthy.
+    expect(isPayloadRejection(GATEWAY_ECHO_ERROR)).toBe(false);
   });
 });
 
@@ -65,6 +86,16 @@ describe("ResilientProvider — content filter vs circuit breaker", () => {
 
     // Before this change the fourth call threw circuit_breaker_open instead.
     await expect(provider.compress("sys", "harmless")).resolves.toBe("<observation/>");
+  });
+
+  it("opens the breaker when a gateway failure quotes the filter body", async () => {
+    const provider = new ResilientProvider(providerThatFails(GATEWAY_ECHO_ERROR));
+
+    for (let i = 0; i < 3; i++) {
+      await expect(provider.compress("sys", "x")).rejects.toThrow(/502/);
+    }
+
+    expect(provider.circuitState.state).toBe("open");
   });
 
   it("still opens the breaker for real provider failures", async () => {

--- a/test/resilient-content-filter.test.ts
+++ b/test/resilient-content-filter.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+import { ResilientProvider, isPayloadRejection } from "../src/providers/resilient.js";
+import type { MemoryProvider } from "../src/types.js";
+
+/**
+ * Azure Prompt Shields rejects tool output that looks like a jailbreak — which
+ * includes benign material such as a SECURITY.md explaining prompt injection.
+ * Those rejections must not open the circuit breaker, or one awkward file
+ * takes every unrelated compression down with it for the recovery timeout.
+ */
+
+const CONTENT_FILTER_ERROR = new Error(
+  'OpenAI API error (400): {"error":{"message":"The response was filtered due to ' +
+    'the prompt triggering Azure OpenAI\'s content management policy.",' +
+    '"code":"content_filter","status":400,"innererror":{"code":"ResponsibleAIPolicyViolation",' +
+    '"content_filter_result":{"jailbreak":{"detected":true,"filtered":true}}}}}',
+);
+
+function providerThatFails(err: Error, okAfter = Infinity): MemoryProvider {
+  let calls = 0;
+  return {
+    name: "stub",
+    async compress() {
+      calls += 1;
+      if (calls > okAfter) return "<observation/>";
+      throw err;
+    },
+    async summarize() {
+      return "<summary/>";
+    },
+  } as MemoryProvider;
+}
+
+describe("isPayloadRejection", () => {
+  it("recognises Azure content filter rejections", () => {
+    expect(isPayloadRejection(CONTENT_FILTER_ERROR)).toBe(true);
+    expect(isPayloadRejection(new Error("ResponsibleAIPolicyViolation"))).toBe(true);
+  });
+
+  it("treats genuine provider trouble as a failure", () => {
+    expect(isPayloadRejection(new Error("OpenAI API error (503): upstream down"))).toBe(false);
+    expect(isPayloadRejection(new Error("request timed out after 60000ms"))).toBe(false);
+    expect(isPayloadRejection("socket hang up")).toBe(false);
+  });
+});
+
+describe("ResilientProvider — content filter vs circuit breaker", () => {
+  it("keeps the breaker closed across repeated filter rejections", async () => {
+    const provider = new ResilientProvider(providerThatFails(CONTENT_FILTER_ERROR));
+
+    for (let i = 0; i < 5; i++) {
+      await expect(provider.compress("sys", "bad")).rejects.toThrow(/content_filter/);
+    }
+
+    expect(provider.circuitState.state).toBe("closed");
+  });
+
+  it("lets an unrelated call through after filtered ones", async () => {
+    // fails with content_filter three times, succeeds from the fourth call on
+    const provider = new ResilientProvider(providerThatFails(CONTENT_FILTER_ERROR, 3));
+
+    for (let i = 0; i < 3; i++) {
+      await expect(provider.compress("sys", "bad")).rejects.toThrow(/content_filter/);
+    }
+
+    // Before this change the fourth call threw circuit_breaker_open instead.
+    await expect(provider.compress("sys", "harmless")).resolves.toBe("<observation/>");
+  });
+
+  it("still opens the breaker for real provider failures", async () => {
+    const provider = new ResilientProvider(
+      providerThatFails(new Error("OpenAI API error (503): upstream down")),
+    );
+
+    for (let i = 0; i < 3; i++) {
+      await expect(provider.compress("sys", "x")).rejects.toThrow(/503/);
+    }
+
+    expect(provider.circuitState.state).toBe("open");
+    await expect(provider.compress("sys", "x")).rejects.toThrow("circuit_breaker_open");
+  });
+});


### PR DESCRIPTION
Fixes #1276.

## What

`ResilientProvider.call()` calls `recordFailure()` on every throw. Azure content filter rejections are throws, so three of them inside the failure window open the breaker and the next 30s of compressions fail with `circuit_breaker_open` — including observations that have nothing wrong with them.

A content filter rejection is a property of one payload, not a health signal about the provider. This skips `recordFailure()` for it. The call still fails; only the blast radius changes.

## Why this fires often in practice

Azure's Prompt Shields flags input that looks like a jailbreak attempt, and a memory system compresses arbitrary tool output. Measured against a `gpt-5.4-mini` deployment with the default filter, in the prompt shape `buildCompressionPrompt()` actually produces: source code, error logs and credentials all pass, but injection-style text is rejected — and so is a `SECURITY.md` that merely *describes* prompt injection. Ordinary documentation is enough to trigger it. Details and the full `content_filter_result` are in #1276.

## How to verify

`test/resilient-content-filter.test.ts`:

- `isPayloadRejection()` recognises `content_filter` / `ResponsibleAIPolicyViolation` and does not misclassify 503s, timeouts or socket errors
- five consecutive filter rejections leave the breaker `closed`
- an unrelated call after three filtered ones succeeds — this is the regression; it previously threw `circuit_breaker_open`
- three genuine provider failures still open the breaker, and the next call is short-circuited

Confirmed end to end as well: five filtered observations followed by a harmless one now yield five `content_filter` failures and one successful compression, with no `circuit_breaker_open` in between. Before the change the harmless one failed too.

```
npm test          # 1716 passing (1711 before, +5 here)
npm run build     # clean
```

## Scope

Deliberately narrow. There is a reasonable argument that no 4xx should count toward the breaker, since none of them indicate the provider is unhealthy — but that is a larger behavioural change, and the filter case is the one I have evidence for. `isPayloadRejection()` is exported so that rule has somewhere to grow if you want it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Azure OpenAI content-filter rejections are now correctly distinguished from provider failures.
  * Repeated content-filter rejections no longer trigger the resilience circuit breaker.
  * Genuine provider failures, including timeouts, outages, and gateway errors, continue to activate failure protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->