### PR TITLE
feat(graph): skip mem::graph-extract when the observation set is unchanged

### DIFF
--- a/src/functions/auto-forget.ts
+++ b/src/functions/auto-forget.ts
@@ -6,6 +6,7 @@ import { recordAudit } from "./audit.js";
 import { deleteAccessLog } from "./access-tracker.js";
 import { getSearchIndex, vectorIndexRemove, flushIndexSave } from "./search.js";
 import { logger } from "../logger.js";
+import { deleteGraphExtractMarks } from "./graph.js";
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const CONTRADICTION_THRESHOLD = 0.9;
@@ -144,6 +145,8 @@ export function registerAutoForgetFunction(sdk: ISdk, kv: StateKV): void {
         }
       }
 
+      const touchedSessionIds = new Set<string>();
+
       const sessions = await kv.list<Session>(KV.sessions);
       const obsPerSession: CompressedObservation[][] = [];
       for (let batch = 0; batch < sessions.length; batch += 10) {
@@ -172,6 +175,7 @@ export function registerAutoForgetFunction(sdk: ISdk, kv: StateKV): void {
                 deletedOk = false;
               }
               if (deletedOk) {
+                touchedSessionIds.add(sessions[i].id);
                 if (obs.imageData) await decrementImageRef(kv, sdk, obs.imageData);
                 if (obs.imageRef && obs.imageRef !== obs.imageData) {
                   await decrementImageRef(kv, sdk, obs.imageRef);
@@ -188,6 +192,11 @@ export function registerAutoForgetFunction(sdk: ISdk, kv: StateKV): void {
             }
           }
         }
+      }
+
+      // Empty on a dryRun pass, so no dryRun guard is needed.
+      for (const sessionId of touchedSessionIds) {
+        await deleteGraphExtractMarks(kv, sessionId);
       }
 
       if (!dryRun && (result.ttlExpired.length > 0 || result.lowValueObs.length > 0)) {

--- a/src/functions/auto-forget.ts
+++ b/src/functions/auto-forget.ts
@@ -194,7 +194,10 @@ export function registerAutoForgetFunction(sdk: ISdk, kv: StateKV): void {
         }
       }
 
-      // Empty on a dryRun pass, so no dryRun guard is needed.
+      // Empty on a dryRun pass, so no dryRun guard is needed. Kept
+      // sequential rather than Promise.all: this runs hourly across every
+      // session, and the file-based KV adapter stalls under that much
+      // concurrent fan-out (upstream #1127).
       for (const sessionId of touchedSessionIds) {
         await deleteGraphExtractMarks(kv, sessionId);
       }

--- a/src/functions/evict.ts
+++ b/src/functions/evict.ts
@@ -64,7 +64,7 @@ async function recoverStaleSession(
       function_id: "event::session::stopped",
       // Suppress the per-session consolidation fan-out: eviction runs a
       // single corpus-wide consolidation pass after all recoveries instead.
-      payload: { sessionId, skipConsolidation: true },
+      payload: { sessionId, skipConsolidation: true, awaitGraphExtract: true },
     });
     if (!isValidRecoveryResult(result)) {
       logger.warn("Stale session recovery failed", {
@@ -290,7 +290,10 @@ export function registerEvictFunction(sdk: ISdk, kv: StateKV): void {
         }
       }
 
-      // Empty on a dryRun pass, so no dryRun guard is needed.
+      // Empty on a dryRun pass, so no dryRun guard is needed. Kept
+      // sequential rather than Promise.all: a sweep can touch hundreds of
+      // sessions, and the file-based KV adapter stalls under that much
+      // concurrent fan-out (upstream #1127).
       for (const sessionId of touchedSessionIds) {
         await deleteGraphExtractMarks(kv, sessionId);
       }

--- a/src/functions/evict.ts
+++ b/src/functions/evict.ts
@@ -12,6 +12,7 @@ import { isConsolidationEnabled } from "../config.js";
 import { recordAudit } from "./audit.js";
 import { deleteAccessLog } from "./access-tracker.js";
 import { logger } from "../logger.js";
+import { deleteGraphExtractMarks } from "./graph.js";
 
 interface EvictionConfig {
   staleSessionDays: number;
@@ -180,6 +181,7 @@ export function registerEvictFunction(sdk: ISdk, kv: StateKV): void {
               });
               continue;
             }
+            await deleteGraphExtractMarks(kv, session.id);
             await recordAudit(kv, "delete", "mem::evict", [session.id], {
               resource: "session",
               reason: recovered
@@ -194,6 +196,11 @@ export function registerEvictFunction(sdk: ISdk, kv: StateKV): void {
       if (!dryRun && recoveredStaleSessions > 0) {
         await runRecoveredSessionConsolidation(sdk);
       }
+
+      // Removing an observation stales the session's graph-extract mark
+      // (see deleteGraphExtractMarks); flush once per touched session
+      // after both eviction loops, not per evicted observation.
+      const touchedSessionIds = new Set<string>();
 
       const projectObs = new Map<string, CompressedObservation[]>();
       for (const session of sessions) {
@@ -225,6 +232,7 @@ export function registerEvictFunction(sdk: ISdk, kv: StateKV): void {
                 });
                 continue;
               }
+              touchedSessionIds.add(session.id);
               if (o.imageData) await decrementImageRef(kv, sdk, o.imageData);
               if (o.imageRef && o.imageRef !== o.imageData) await decrementImageRef(kv, sdk, o.imageRef);
               await recordAudit(kv, "delete", "mem::evict", [o.id], {
@@ -268,6 +276,7 @@ export function registerEvictFunction(sdk: ISdk, kv: StateKV): void {
                 });
                 continue;
               }
+              touchedSessionIds.add(o.sessionId);
               if (o.imageData) await decrementImageRef(kv, sdk, o.imageData);
               if (o.imageRef && o.imageRef !== o.imageData) await decrementImageRef(kv, sdk, o.imageRef);
               await recordAudit(kv, "delete", "mem::evict", [o.id], {
@@ -279,6 +288,11 @@ export function registerEvictFunction(sdk: ISdk, kv: StateKV): void {
             }
           }
         }
+      }
+
+      // Empty on a dryRun pass, so no dryRun guard is needed.
+      for (const sessionId of touchedSessionIds) {
+        await deleteGraphExtractMarks(kv, sessionId);
       }
 
       const memories = await kv.list<Memory>(KV.memories).catch(() => []);

--- a/src/functions/export-import.ts
+++ b/src/functions/export-import.ts
@@ -33,6 +33,7 @@ import { VERSION } from "../version.js";
 import { recordAudit } from "./audit.js";
 import { indexRecords } from "./search.js";
 import { resetLessonIndex } from "./lessons.js";
+import { deleteGraphExtractMarks } from "./graph.js";
 import { logger } from "../logger.js";
 
 // Bounded-concurrency chunk size for the import delete/write loops. A
@@ -311,6 +312,7 @@ export function registerExportImportFunction(sdk: ISdk, kv: StateKV): void {
         const obsDeletes: Array<{ sessionId: string; obsId: string }> = [];
         await runChunked(existing, async (session) => {
           await kv.delete(KV.sessions, session.id);
+          await deleteGraphExtractMarks(kv, session.id);
           const obs = await kv
             .list<CompressedObservation>(KV.observations(session.id))
             .catch(() => []);

--- a/src/functions/graph.ts
+++ b/src/functions/graph.ts
@@ -686,49 +686,51 @@ export async function persistGraphDelta(
   return { newNodeCount, newEdgeCount };
 }
 
-// #1063/#978: incremental hashing core for the observation-set
-// fingerprint below. Mirrors hashObservationSet in src/functions/
-// summarize.ts (#1131) - same id|title|narrative-length fields, same
-// per-observation createHash().update() approach - so neither caller
-// materializes one giant string just to hash it once. Not imported from
-// summarize.ts because that function is a private module-local helper
-// there; duplicating the small function keeps both modules free of an
-// export added only to satisfy the other.
+// Length-prefixed so concatenation stays unambiguous: without it,
+// files ["a", "bc"] and ["ab", "c"] would hash identically.
+function hashField(
+  hash: ReturnType<typeof createHash>,
+  value: string,
+): void {
+  hash.update(String(value.length));
+  hash.update(":");
+  hash.update(value);
+}
+
+function hashFieldList(
+  hash: ReturnType<typeof createHash>,
+  values: string[] | undefined,
+): void {
+  const list = values ?? [];
+  hash.update(String(list.length));
+  hash.update(":");
+  for (const value of list) hashField(hash, value);
+}
+
+// Hashes exactly the fields graph extraction reads - extractGraphHeuristics
+// uses id/files/concepts, buildGraphExtractionPrompt renders
+// title/narrative/concepts/files/type. A field that reaches either
+// without reaching this hash is a silent stale-graph bug. summarize.ts's
+// same-named helper tracks a different prompt and so a different set,
+// which is why the two are not shared.
 function hashObservationSet(
   hash: ReturnType<typeof createHash>,
   observations: CompressedObservation[],
 ): void {
   for (const o of observations) {
-    hash.update(o.id);
-    hash.update("|");
-    hash.update(o.title ?? "");
-    hash.update("|");
-    hash.update(String((o.narrative ?? "").length));
-    hash.update("|");
+    hashField(hash, o.id);
+    hashField(hash, o.type ?? "");
+    hashField(hash, o.title ?? "");
+    hashField(hash, o.narrative ?? "");
+    hashFieldList(hash, o.concepts);
+    hashFieldList(hash, o.files);
   }
   hash.update(String(observations.length));
 }
 
-// #1063/#978: event::session::stopped fires on every assistant turn and
-// hands mem::graph-extract the session's ENTIRE compressed observation
-// set, with no chunking. Extraction is deterministic over that set, so
-// an unchanged set has nothing new to find - fingerprint it and let the
-// caller skip the heuristic + LLM pass entirely (see the gate in
-// registerGraphFunction below).
-//
-// Content-aware, not identity-only: an identity-only fingerprint (join
-// of sorted ids) would false-skip forever on a same-id content rewrite
-// - bulk import-jsonl with strategy !== "skip" (src/export-import.ts),
-// or replay over an edited transcript (src/replay.ts) - both keep ids
-// stable while changing content. Hashing id + title + narrative-length
-// per observation catches those rewrites without hashing full narrative
-// bodies (some sessions run tens of thousands of observations; this
-// runs on the hot Stop-hook path).
-//
-// Sorted by id first: this array originates from a kv.list call in
-// src/triggers/events.ts, and kv.list order is NOT contractually stable
-// (hash-map backend, no sort) - an unsorted fingerprint would churn
-// across turns on a permuted-but-unchanged set and never hit the gate.
+// Sorted by id because the caller's kv.list order is not stable, and an
+// unsorted digest would churn across turns on a permuted-but-unchanged
+// set and never hit the gate.
 function observationSetFingerprint(
   observations: CompressedObservation[],
 ): string {
@@ -740,16 +742,9 @@ function observationSetFingerprint(
   return `gfx_${hash.digest("hex").slice(0, 16)}`;
 }
 
-// #1063/#978: a session's change-detection mark is now a SINGLE fixed key
-// (MARK_KEY below) holding the current fingerprint, not one entry per
-// fingerprint ever seen. Observation sets only grow, so a per-fingerprint
-// scope minted a brand-new, never-revisited entry on almost every Stop -
-// bounded reclaimability (deleteGraphExtractMarks) made that leak
-// reclaimable but not bounded; only the newest mark was ever read anyway,
-// so the older ones were pure waste between reclaims. `llm` records
-// whether the LLM pass actually ran when this mark was written - see the
-// gate in registerGraphFunction below, which must not skip a set that was
-// only ever extracted heuristically once an LLM becomes available.
+// `llm` records whether the LLM pass actually ran, so the gate below does
+// not skip a set that was only ever extracted heuristically once an LLM
+// becomes available.
 interface GraphExtractMark {
   fingerprint: string;
   llm: boolean;
@@ -758,19 +753,11 @@ interface GraphExtractMark {
 
 const MARK_KEY = "current";
 
-// #1063/#978: reclaims a session's graph-extract change-detection mark.
-// Introduced by this fix, so this fix also owns cleanup - without it,
-// KV.graphExtractMarks outlives the session it belongs to. Call
-// this wherever a session's KV.observations/KV.summaries are fully
-// reclaimed (mem::forget whole-session delete in remember.ts,
-// stale-session eviction in evict.ts), and also once per touched
-// session after any per-observation eviction pass (evict.ts
-// low-importance / project-cap paths): removing an observation changes
-// the session's observation set, so the fingerprint recorded against its
-// old membership is stale and would otherwise sit unreachable forever.
-// Single fixed key now (see MARK_KEY), so this is one delete, not a
-// list-then-delete-each - still .catch()ed so a cleanup failure here can
-// never block or fail the caller's own delete.
+// Call this wherever a session's observations are reclaimed: whole-session
+// delete, and once per touched session after a per-observation eviction
+// pass. Removing an observation changes the set the fingerprint was
+// recorded against. Failures are swallowed so cleanup can never fail the
+// caller's own delete.
 export async function deleteGraphExtractMarks(
   kv: StateKV,
   sessionId: string,
@@ -791,27 +778,12 @@ export function registerGraphFunction(
 
       const obsIds = data.observations.map((o) => o.id);
 
-      // #1063/#978: event::session::stopped hands this function the
-      // session's entire observation set on every turn. Extraction is
-      // deterministic over that set, so skip before the heuristic/LLM
-      // pass entirely when this exact set was already extracted - not
-      // after, so the cost saved is the whole pass, not just the LLM
-      // call.
-      //
-      // KV.graphExtractMarks is a per-session scope (schema.ts), not a
-      // flat global one, so it can be reclaimed alongside a session's
-      // other derived state (see deleteGraphExtractMarks below, called
-      // from remember.ts/evict.ts) instead of growing unbounded - a flat
-      // scope mints a new never-revisited entry on almost every Stop,
-      // since observation sets only grow. That means the gate needs a
-      // single session to key on. Every current caller passes a
-      // single-session batch (event::session::stopped in
-      // src/triggers/events.ts; api::graph-build in src/triggers/api.ts
-      // batches WITHIN each session), but nothing enforces that at the
-      // type level, so detect the multi-session case defensively: skip
-      // the gate rather than guess which session's scope to use.
-      // Skipping means "always extract" (correct, merely not deduped),
-      // never "skip extracting".
+      // The mark scope is per-session so it can be reclaimed with the
+      // session, which means the gate needs one session to key on. Every
+      // current caller passes a single-session batch, but nothing enforces
+      // that in the types, so a multi-session batch skips the gate rather
+      // than guessing a scope - that degrades to always extracting, never
+      // to wrongly skipping.
       const sessionIds = new Set(data.observations.map((o) => o.sessionId));
       let gateSessionId: string | null = null;
       if (sessionIds.size === 1) {
@@ -828,25 +800,11 @@ export function registerGraphFunction(
       const llmEnabled =
         isGraphExtractionEnabled() && !provider.name.includes("noop");
 
-      // #1063/#978: the mark records whether the LLM pass ran (`llm`),
-      // and the gate uses that to decide whether re-extracting this
-      // exact set could possibly find anything new. A mark written with
-      // llm:true is a ceiling - the LLM already saw this set, so a
-      // heuristic-only re-run (llmEnabled now false, e.g. the key was
-      // removed) has nothing left to add: skip. A mark written with
-      // llm:false (heuristic-only, e.g. GRAPH_EXTRACTION_ENABLED was off
-      // or no key was configured - the default install) is NOT a
-      // ceiling: if the caller now has llmEnabled true (a key was added
-      // after the fact), the LLM pass has never run over this set and
-      // must not be skipped. Only skip when the previous attempt already
-      // did everything this attempt could do: `mark.llm || !llmEnabled`.
-      // Without this, a default install (GRAPH_EXTRACTION_ENABLED=false)
-      // marks every set done after a heuristic-only pass, and those sets
-      // stay permanently skipped even after the user enables the flag -
-      // and api::graph-build's per-batch marks make a SECOND
-      // /graph/build (the viewer's documented recovery for an empty
-      // graph) hit its own marks and report success with zero nodes
-      // added, without rebuilding anything.
+      // Skip only when the previous attempt already did everything this
+      // one could: an llm:false mark is not a ceiling, because a key added
+      // since then means the LLM pass has never seen this set. Getting
+      // this wrong permanently strands every set a keyless install marked
+      // heuristically, including the /graph/build recovery path.
       let setFingerprint: string | null = null;
       if (gateSessionId) {
         setFingerprint = observationSetFingerprint(data.observations);
@@ -904,24 +862,11 @@ export function registerGraphFunction(
         }
       }
 
-      // The mark is written on ATTEMPT COMPLETION, not on persist success -
-      // the two are different things. "Attempt completed cleanly" means the
-      // LLM pass (when enabled) did not fail; a plain `!llmError` check
-      // expresses exactly that, including the llmEnabled === false case
-      // (no LLM pass was attempted, so it cannot have failed - a
-      // heuristic-only run that gets this far completed cleanly and
-      // should mark). Do NOT write the mark when llmError is set: the
-      // heuristic pass alone (obs.files/obs.concepts) almost always
-      // yields something for real coding observations, so without this
-      // check a provider timeout/rate-limit/malformed-XML failure on
-      // the biggest sessions - exactly the ones this fix exists to
-      // help - would still fall through to nodes.length > 0, persist
-      // fine, and mark the set done, permanently losing that turn's
-      // LLM-derived graph until the observation set happens to change.
-      // `llm: llmEnabled && !llmError` records whether this attempt
-      // actually ran the LLM pass cleanly - the gate above reads it back
-      // to decide whether a future attempt with llmEnabled=true could
-      // still find something this one couldn't.
+      // Marks a completed attempt, not a successful persist. An llmError
+      // must not mark: the heuristic pass alone almost always yields
+      // something, so a provider failure would otherwise persist a partial
+      // graph, mark the set done, and strand that turn's LLM-derived nodes
+      // until the observation set happens to change.
       const markExtractedIfClean = async (): Promise<void> => {
         if (gateSessionId && setFingerprint && !llmError) {
           await kv
@@ -935,14 +880,23 @@ export function registerGraphFunction(
       };
 
       if (nodes.length === 0 && edges.length === 0) {
-        // A genuine zero-yield result (no llmError) is a settled
-        // outcome, not a failure - mark it so an unchanged set doesn't
-        // re-run the heuristic + LLM pass on every subsequent Stop.
-        // When llmError IS set, this is the failure path with an empty
-        // heuristic pass too (rare, but possible for observations with
-        // no files/concepts) - markExtractedIfClean already no-ops on
-        // llmError, so nothing to gate here beyond calling it.
-        await markExtractedIfClean();
+        // A zero-yield result with no llmError is a settled outcome, not
+        // a failure, so it earns a mark. The mark is state that gates
+        // every later run, so it is audited first and skipped entirely
+        // if that audit fails - an unmarked session just re-extracts.
+        if (!llmError) {
+          try {
+            await recordAudit(kv, "observe", "mem::graph-extract", obsIds, {
+              nodesExtracted: 0,
+              edgesExtracted: 0,
+            });
+            await markExtractedIfClean();
+          } catch (err) {
+            logger.warn("Graph extraction zero-yield mark skipped", {
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }
         return llmError
           ? { success: false, error: llmError }
           : { success: true, nodesAdded: 0, edgesAdded: 0 };

--- a/src/functions/graph.ts
+++ b/src/functions/graph.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type { ISdk } from "iii-sdk";
 import type {
   GraphNode,
@@ -470,6 +471,12 @@ export function extractGraphHeuristics(
   ): GraphNode | null => {
     const trimmed = name.trim();
     if (!trimmed) return null;
+    // The delimiter below is a literal NUL byte, not the two-character
+    // escape "\0" - chosen because a NUL cannot occur in either `type` or
+    // the lowercased name, so composite keys built from them cannot
+    // collide. Its presence also makes grep/ripgrep treat this file as
+    // binary, so any repo-wide search that needs to include this file
+    // must pass -a/--text.
     const key = `${type} ${trimmed.toLowerCase()}`;
     let node = nodeByKey.get(key);
     if (!node) {
@@ -679,6 +686,98 @@ export async function persistGraphDelta(
   return { newNodeCount, newEdgeCount };
 }
 
+// #1063/#978: incremental hashing core for the observation-set
+// fingerprint below. Mirrors hashObservationSet in src/functions/
+// summarize.ts (#1131) - same id|title|narrative-length fields, same
+// per-observation createHash().update() approach - so neither caller
+// materializes one giant string just to hash it once. Not imported from
+// summarize.ts because that function is a private module-local helper
+// there; duplicating the small function keeps both modules free of an
+// export added only to satisfy the other.
+function hashObservationSet(
+  hash: ReturnType<typeof createHash>,
+  observations: CompressedObservation[],
+): void {
+  for (const o of observations) {
+    hash.update(o.id);
+    hash.update("|");
+    hash.update(o.title ?? "");
+    hash.update("|");
+    hash.update(String((o.narrative ?? "").length));
+    hash.update("|");
+  }
+  hash.update(String(observations.length));
+}
+
+// #1063/#978: event::session::stopped fires on every assistant turn and
+// hands mem::graph-extract the session's ENTIRE compressed observation
+// set, with no chunking. Extraction is deterministic over that set, so
+// an unchanged set has nothing new to find - fingerprint it and let the
+// caller skip the heuristic + LLM pass entirely (see the gate in
+// registerGraphFunction below).
+//
+// Content-aware, not identity-only: an identity-only fingerprint (join
+// of sorted ids) would false-skip forever on a same-id content rewrite
+// - bulk import-jsonl with strategy !== "skip" (src/export-import.ts),
+// or replay over an edited transcript (src/replay.ts) - both keep ids
+// stable while changing content. Hashing id + title + narrative-length
+// per observation catches those rewrites without hashing full narrative
+// bodies (some sessions run tens of thousands of observations; this
+// runs on the hot Stop-hook path).
+//
+// Sorted by id first: this array originates from a kv.list call in
+// src/triggers/events.ts, and kv.list order is NOT contractually stable
+// (hash-map backend, no sort) - an unsorted fingerprint would churn
+// across turns on a permuted-but-unchanged set and never hit the gate.
+function observationSetFingerprint(
+  observations: CompressedObservation[],
+): string {
+  const sorted = [...observations].sort((a, b) =>
+    a.id < b.id ? -1 : a.id > b.id ? 1 : 0,
+  );
+  const hash = createHash("sha256");
+  hashObservationSet(hash, sorted);
+  return `gfx_${hash.digest("hex").slice(0, 16)}`;
+}
+
+// #1063/#978: a session's change-detection mark is now a SINGLE fixed key
+// (MARK_KEY below) holding the current fingerprint, not one entry per
+// fingerprint ever seen. Observation sets only grow, so a per-fingerprint
+// scope minted a brand-new, never-revisited entry on almost every Stop -
+// bounded reclaimability (deleteGraphExtractMarks) made that leak
+// reclaimable but not bounded; only the newest mark was ever read anyway,
+// so the older ones were pure waste between reclaims. `llm` records
+// whether the LLM pass actually ran when this mark was written - see the
+// gate in registerGraphFunction below, which must not skip a set that was
+// only ever extracted heuristically once an LLM becomes available.
+interface GraphExtractMark {
+  fingerprint: string;
+  llm: boolean;
+  at: number;
+}
+
+const MARK_KEY = "current";
+
+// #1063/#978: reclaims a session's graph-extract change-detection mark.
+// Introduced by this fix, so this fix also owns cleanup - without it,
+// KV.graphExtractMarks outlives the session it belongs to. Call
+// this wherever a session's KV.observations/KV.summaries are fully
+// reclaimed (mem::forget whole-session delete in remember.ts,
+// stale-session eviction in evict.ts), and also once per touched
+// session after any per-observation eviction pass (evict.ts
+// low-importance / project-cap paths): removing an observation changes
+// the session's observation set, so the fingerprint recorded against its
+// old membership is stale and would otherwise sit unreachable forever.
+// Single fixed key now (see MARK_KEY), so this is one delete, not a
+// list-then-delete-each - still .catch()ed so a cleanup failure here can
+// never block or fail the caller's own delete.
+export async function deleteGraphExtractMarks(
+  kv: StateKV,
+  sessionId: string,
+): Promise<void> {
+  await kv.delete(KV.graphExtractMarks(sessionId), MARK_KEY).catch(() => {});
+}
+
 export function registerGraphFunction(
   sdk: ISdk,
   kv: StateKV,
@@ -692,6 +791,82 @@ export function registerGraphFunction(
 
       const obsIds = data.observations.map((o) => o.id);
 
+      // #1063/#978: event::session::stopped hands this function the
+      // session's entire observation set on every turn. Extraction is
+      // deterministic over that set, so skip before the heuristic/LLM
+      // pass entirely when this exact set was already extracted - not
+      // after, so the cost saved is the whole pass, not just the LLM
+      // call.
+      //
+      // KV.graphExtractMarks is a per-session scope (schema.ts), not a
+      // flat global one, so it can be reclaimed alongside a session's
+      // other derived state (see deleteGraphExtractMarks below, called
+      // from remember.ts/evict.ts) instead of growing unbounded - a flat
+      // scope mints a new never-revisited entry on almost every Stop,
+      // since observation sets only grow. That means the gate needs a
+      // single session to key on. Every current caller passes a
+      // single-session batch (event::session::stopped in
+      // src/triggers/events.ts; api::graph-build in src/triggers/api.ts
+      // batches WITHIN each session), but nothing enforces that at the
+      // type level, so detect the multi-session case defensively: skip
+      // the gate rather than guess which session's scope to use.
+      // Skipping means "always extract" (correct, merely not deduped),
+      // never "skip extracting".
+      const sessionIds = new Set(data.observations.map((o) => o.sessionId));
+      let gateSessionId: string | null = null;
+      if (sessionIds.size === 1) {
+        gateSessionId = data.observations[0].sessionId;
+      } else {
+        // No `logger.debug` in this shim (see src/logger.ts) - `info`
+        // is the closest level and this is a rare, worth-seeing event.
+        logger.info(
+          "mem::graph-extract batch spans multiple sessions; skipping change-detection gate",
+          { sessionCount: sessionIds.size },
+        );
+      }
+
+      const llmEnabled =
+        isGraphExtractionEnabled() && !provider.name.includes("noop");
+
+      // #1063/#978: the mark records whether the LLM pass ran (`llm`),
+      // and the gate uses that to decide whether re-extracting this
+      // exact set could possibly find anything new. A mark written with
+      // llm:true is a ceiling - the LLM already saw this set, so a
+      // heuristic-only re-run (llmEnabled now false, e.g. the key was
+      // removed) has nothing left to add: skip. A mark written with
+      // llm:false (heuristic-only, e.g. GRAPH_EXTRACTION_ENABLED was off
+      // or no key was configured - the default install) is NOT a
+      // ceiling: if the caller now has llmEnabled true (a key was added
+      // after the fact), the LLM pass has never run over this set and
+      // must not be skipped. Only skip when the previous attempt already
+      // did everything this attempt could do: `mark.llm || !llmEnabled`.
+      // Without this, a default install (GRAPH_EXTRACTION_ENABLED=false)
+      // marks every set done after a heuristic-only pass, and those sets
+      // stay permanently skipped even after the user enables the flag -
+      // and api::graph-build's per-batch marks make a SECOND
+      // /graph/build (the viewer's documented recovery for an empty
+      // graph) hit its own marks and report success with zero nodes
+      // added, without rebuilding anything.
+      let setFingerprint: string | null = null;
+      if (gateSessionId) {
+        setFingerprint = observationSetFingerprint(data.observations);
+        const mark = await kv
+          .get<GraphExtractMark>(KV.graphExtractMarks(gateSessionId), MARK_KEY)
+          .catch(() => null);
+        if (
+          mark &&
+          mark.fingerprint === setFingerprint &&
+          (mark.llm || !llmEnabled)
+        ) {
+          return {
+            success: true,
+            nodesAdded: 0,
+            edgesAdded: 0,
+            skipped: "unchanged",
+          };
+        }
+      }
+
       let nodes: GraphNode[] = [];
       let edges: GraphEdge[] = [];
       try {
@@ -704,8 +879,6 @@ export function registerGraphFunction(
         });
       }
 
-      const llmEnabled =
-        isGraphExtractionEnabled() && !provider.name.includes("noop");
       let llmError: string | undefined;
       if (llmEnabled) {
         const prompt = buildGraphExtractionPrompt(
@@ -731,7 +904,45 @@ export function registerGraphFunction(
         }
       }
 
+      // The mark is written on ATTEMPT COMPLETION, not on persist success -
+      // the two are different things. "Attempt completed cleanly" means the
+      // LLM pass (when enabled) did not fail; a plain `!llmError` check
+      // expresses exactly that, including the llmEnabled === false case
+      // (no LLM pass was attempted, so it cannot have failed - a
+      // heuristic-only run that gets this far completed cleanly and
+      // should mark). Do NOT write the mark when llmError is set: the
+      // heuristic pass alone (obs.files/obs.concepts) almost always
+      // yields something for real coding observations, so without this
+      // check a provider timeout/rate-limit/malformed-XML failure on
+      // the biggest sessions - exactly the ones this fix exists to
+      // help - would still fall through to nodes.length > 0, persist
+      // fine, and mark the set done, permanently losing that turn's
+      // LLM-derived graph until the observation set happens to change.
+      // `llm: llmEnabled && !llmError` records whether this attempt
+      // actually ran the LLM pass cleanly - the gate above reads it back
+      // to decide whether a future attempt with llmEnabled=true could
+      // still find something this one couldn't.
+      const markExtractedIfClean = async (): Promise<void> => {
+        if (gateSessionId && setFingerprint && !llmError) {
+          await kv
+            .set(KV.graphExtractMarks(gateSessionId), MARK_KEY, {
+              fingerprint: setFingerprint,
+              llm: llmEnabled,
+              at: Date.now(),
+            })
+            .catch(() => {});
+        }
+      };
+
       if (nodes.length === 0 && edges.length === 0) {
+        // A genuine zero-yield result (no llmError) is a settled
+        // outcome, not a failure - mark it so an unchanged set doesn't
+        // re-run the heuristic + LLM pass on every subsequent Stop.
+        // When llmError IS set, this is the failure path with an empty
+        // heuristic pass too (rare, but possible for observations with
+        // no files/concepts) - markExtractedIfClean already no-ops on
+        // llmError, so nothing to gate here beyond calling it.
+        await markExtractedIfClean();
         return llmError
           ? { success: false, error: llmError }
           : { success: true, nodesAdded: 0, edgesAdded: 0 };
@@ -749,6 +960,11 @@ export function registerGraphFunction(
           nodesExtracted: nodes.length,
           edgesExtracted: edges.length,
         });
+
+        // Mark only after persistGraphDelta + recordAudit succeed (a
+        // throw here is still caught below and must not mark), AND only
+        // when the LLM pass did not fail (see markExtractedIfClean).
+        await markExtractedIfClean();
 
         logger.info("Graph extraction complete", {
           nodes: nodes.length,

--- a/src/functions/remember.ts
+++ b/src/functions/remember.ts
@@ -9,6 +9,7 @@ import { recordAudit } from "./audit.js";
 import { getSearchIndex, isMemoryIndexReady, vectorIndexAddGuarded, vectorIndexRemove, flushIndexSave } from "./search.js";
 import { getAgentId } from "../config.js";
 import { logger } from "../logger.js";
+import { deleteGraphExtractMarks } from "./graph.js";
 
 // Slicing by UTF-16 code unit can cut an astral character (emoji, some CJK
 // extensions) mid surrogate pair, leaving a lone high surrogate that renders
@@ -290,6 +291,9 @@ export function registerRememberFunction(sdk: ISdk, kv: StateKV): void {
           deletedObservationIds.push(obsId);
           deleted++;
         }
+        // The session survives this path, but its recorded mark now
+        // describes an observation set that no longer exists.
+        await deleteGraphExtractMarks(kv, data.sessionId);
       }
 
       if (
@@ -313,6 +317,7 @@ export function registerRememberFunction(sdk: ISdk, kv: StateKV): void {
         }
         await kv.delete(KV.sessions, data.sessionId);
         await kv.delete(KV.summaries, data.sessionId);
+        await deleteGraphExtractMarks(kv, data.sessionId);
         deletedSession = true;
         deleted += 2;
       }

--- a/src/state/schema.ts
+++ b/src/state/schema.ts
@@ -38,6 +38,12 @@ export const KV = {
   graphNameIndex: "mem:graph:name-index",
   graphEdgeKey: "mem:graph:edge-key",
   graphNodeDegree: "mem:graph:node-degree",
+  // Change-detection mark for the observation set already fed through
+  // mem::graph-extract. One fixed key per session (MARK_KEY in graph.ts):
+  // only the newest mark is ever read, and a flat global scope would mint
+  // a never-revisited entry on almost every Stop with nothing to reclaim
+  // it. See deleteGraphExtractMarks for reclamation.
+  graphExtractMarks: (sessionId: string) => `mem:graph:extract-marks:${sessionId}`,
   semantic: "mem:semantic",
   procedural: "mem:procedural",
   teamShared: (teamId: string) => `mem:team:${teamId}:shared`,

--- a/src/triggers/events.ts
+++ b/src/triggers/events.ts
@@ -93,7 +93,7 @@ export function registerEventTriggers(sdk: ISdk, kv: StateKV): void {
     config: { topic: "agentmemory.observation" },
   });
 
-  sdk.registerFunction("event::session::stopped", async (data: { sessionId: string; skipConsolidation?: boolean }) => {
+  sdk.registerFunction("event::session::stopped", async (data: { sessionId: string; skipConsolidation?: boolean; awaitGraphExtract?: boolean }) => {
     const summary = await sdk.trigger({ function_id: "mem::summarize", payload: data });
     const fireVoid = (function_id: string, payload: unknown) =>
       sdk
@@ -107,16 +107,25 @@ export function registerEventTriggers(sdk: ISdk, kv: StateKV): void {
     if (isReflectEnabled()) {
       fireVoid("mem::slot-reflect", { sessionId: data.sessionId });
     }
-    // Unconditional: mem::graph-extract now also gates on a fingerprint of
-    // the observation set, so a Stop whose set is unchanged short-circuits
-    // before the heuristic/LLM pass instead of re-extracting the corpus.
     try {
       const observations = await kv.list<CompressedObservation>(
         KV.observations(data.sessionId),
       );
       const compressed = observations.filter((o) => o.title);
       if (compressed.length > 0) {
-        fireVoid("mem::graph-extract", { observations: compressed });
+        // awaitGraphExtract is set by eviction's stale-session recovery,
+        // which deletes the session and its mark as soon as this handler
+        // returns. A fire-and-forget extraction could write its mark
+        // after that delete and orphan it, so recovery waits. Ordinary
+        // Stop events stay fire-and-forget.
+        if (data.awaitGraphExtract) {
+          await sdk.trigger({
+            function_id: "mem::graph-extract",
+            payload: { observations: compressed },
+          });
+        } else {
+          fireVoid("mem::graph-extract", { observations: compressed });
+        }
       }
     } catch (err) {
       logger.warn("graph-extract trigger failed", {

--- a/src/triggers/events.ts
+++ b/src/triggers/events.ts
@@ -107,7 +107,9 @@ export function registerEventTriggers(sdk: ISdk, kv: StateKV): void {
     if (isReflectEnabled()) {
       fireVoid("mem::slot-reflect", { sessionId: data.sessionId });
     }
-    // Unconditional: mem::graph-extract gates its LLM pass internally.
+    // Unconditional: mem::graph-extract now also gates on a fingerprint of
+    // the observation set, so a Stop whose set is unchanged short-circuits
+    // before the heuristic/LLM pass instead of re-extracting the corpus.
     try {
       const observations = await kv.list<CompressedObservation>(
         KV.observations(data.sessionId),

--- a/test/auto-forget.test.ts
+++ b/test/auto-forget.test.ts
@@ -154,6 +154,49 @@ describe("Auto-Forget Function", () => {
     expect(result.lowValueObs).toContain("obs_old");
   });
 
+  it("reclaims the touched session's graph-extract mark after a low-value eviction", async () => {
+    // Same reclamation requirement as mem::evict's low-importance/
+    // project-cap paths (evict.ts): mem::auto-forget deletes observations
+    // on an hourly timer, so a session touched here must have its
+    // graph-extract change-detection mark flushed too, or the mark
+    // outlives the observation set it was computed over.
+    const session: Session = {
+      id: "ses_2",
+      project: "my-project",
+      cwd: "/tmp",
+      startedAt: "2025-01-01T00:00:00Z",
+      status: "completed",
+      observationCount: 1,
+    };
+    await kv.set("mem:sessions", "ses_2", session);
+
+    const oldLowObs: CompressedObservation = {
+      id: "obs_old2",
+      sessionId: "ses_2",
+      timestamp: "2025-01-01T00:00:00Z",
+      type: "other",
+      title: "trivial event",
+      facts: [],
+      narrative: "nothing important",
+      concepts: [],
+      files: [],
+      importance: 1,
+    };
+    await kv.set("mem:obs:ses_2", "obs_old2", oldLowObs);
+    await kv.set("mem:graph:extract-marks:ses_2", "current", {
+      fingerprint: "gfx_a",
+      llm: true,
+      at: Date.now(),
+    });
+
+    const result = (await sdk.trigger("mem::auto-forget", {})) as {
+      lowValueObs: string[];
+    };
+    expect(result.lowValueObs).toContain("obs_old2");
+
+    expect(await kv.list("mem:graph:extract-marks:ses_2")).toHaveLength(0);
+  });
+
   it("dryRun mode identifies but does not delete anything", async () => {
     const expired = makeMemory({
       id: "mem_expired",

--- a/test/evict.test.ts
+++ b/test/evict.test.ts
@@ -133,9 +133,15 @@ describe("mem::evict stale sessions", () => {
 
     registerEvictFunction(sdk as never, kv as never);
     sdk.registerFunction("event::session::stopped", async (payload) => {
-      // Recovery must pass skipConsolidation so the per-session fan-out is
-      // suppressed (evict runs a single corpus-wide pass afterwards).
-      expect(payload).toEqual({ sessionId, skipConsolidation: true });
+      // skipConsolidation suppresses the per-session fan-out (evict runs a
+      // single corpus-wide pass afterwards). awaitGraphExtract makes the
+      // handler wait for extraction, so it cannot write its mark after the
+      // delete below orphans it.
+      expect(payload).toEqual({
+        sessionId,
+        skipConsolidation: true,
+        awaitGraphExtract: true,
+      });
       expect(await kv.get(KV.sessions, sessionId)).toMatchObject({
         id: sessionId,
       });

--- a/test/evict.test.ts
+++ b/test/evict.test.ts
@@ -167,6 +167,44 @@ describe("mem::evict stale sessions", () => {
     );
   });
 
+  // #1063/#978: KV.graphExtractMarks is introduced by mem::graph-extract's
+  // change-detection gate and must be reclaimed when a stale session is
+  // fully evicted - otherwise the per-session mark outlives the session
+  // it belongs to.
+  it("clears the graph-extract change-detection marks when a stale session is evicted (#1063, #978)", async () => {
+    const sessionId = "ses_stale_graph";
+    const store = storeForObservedSession(sessionId);
+    store.set(
+      KV.graphExtractMarks(sessionId),
+      new Map([
+        [
+          "current",
+          { fingerprint: "gfx_aaaaaaaaaaaaaaaa", llm: true, at: Date.now() },
+        ],
+      ]),
+    );
+    const kv = mockKV(store);
+    const { sdk } = mockSdk();
+
+    registerEvictFunction(sdk as never, kv as never);
+    sdk.registerFunction("event::session::stopped", async () => ({
+      success: true,
+    }));
+    sdk.registerFunction("mem::consolidate-pipeline", () => ({
+      success: true,
+    }));
+    sdk.registerFunction("mem::auto-crystallize", () => ({ success: true }));
+
+    const result = (await sdk.trigger({
+      function_id: "mem::evict",
+      payload: {},
+    })) as { staleSessions: number };
+
+    expect(result.staleSessions).toBe(1);
+    const remaining = await kv.list(KV.graphExtractMarks(sessionId));
+    expect(remaining).toHaveLength(0);
+  });
+
   it("bounds consolidation to one pass regardless of how many stale sessions are recovered", async () => {
     // Regression (P1): before the skipConsolidation guard, N recovered
     // sessions each triggered a forced full-corpus consolidate + crystallize
@@ -293,5 +331,117 @@ describe("mem::evict stale sessions", () => {
     expect(calls.map((call) => call.function_id)).not.toContain(
       "event::session::stopped",
     );
+  });
+});
+
+// #1063/#978: removing an observation changes the session's observation
+// set, so the fingerprint recorded against its old membership is stale.
+// mem::evict runs repeatedly against active sessions - whole-session
+// delete never fires for those - so nothing else would ever reclaim the
+// mark. These tests prove both per-observation eviction paths flush the
+// touched session's marks once per pass, and that a dryRun pass flushes
+// nothing.
+describe("mem::evict per-observation eviction graph-extract marks reclamation (#1063, #978)", () => {
+  function graphMarkEntry(fingerprint: string) {
+    return { fingerprint, llm: true, at: Date.now() };
+  }
+
+  // Young startedAt keeps this session out of the stale-session branch
+  // above (age <= staleSessionDays), so only the low-importance path is
+  // exercised.
+  function storeForLowImportanceEviction(sessionId: string): Store {
+    const staleObs: CompressedObservation = {
+      ...makeObservation(sessionId),
+      id: "obs_low_importance",
+      timestamp: daysAgo(200),
+      importance: 1,
+    };
+    const store = storeForObservations(sessionId, [staleObs]);
+    store.get(KV.sessions)!.set(sessionId, {
+      ...makeSession(sessionId),
+      startedAt: daysAgo(1),
+    });
+    store.set(
+      KV.graphExtractMarks(sessionId),
+      new Map([["current", graphMarkEntry("gfx_a")]]),
+    );
+    return store;
+  }
+
+  it("flushes the touched session's graph-extract marks after a low-importance eviction pass", async () => {
+    const sessionId = "ses_low_importance_graph";
+    const store = storeForLowImportanceEviction(sessionId);
+    const kv = mockKV(store);
+    const { sdk } = mockSdk();
+    registerEvictFunction(sdk as never, kv as never);
+
+    const result = (await sdk.trigger({
+      function_id: "mem::evict",
+      payload: {},
+    })) as { lowImportanceObs: number };
+
+    expect(result.lowImportanceObs).toBe(1);
+    const remaining = await kv.list(KV.graphExtractMarks(sessionId));
+    expect(remaining).toHaveLength(0);
+  });
+
+  it("does not flush the graph-extract marks on a dry run", async () => {
+    const sessionId = "ses_low_importance_graph_dry";
+    const store = storeForLowImportanceEviction(sessionId);
+    const kv = mockKV(store);
+    const { sdk } = mockSdk();
+    registerEvictFunction(sdk as never, kv as never);
+
+    const result = (await sdk.trigger({
+      function_id: "mem::evict",
+      payload: { dryRun: true },
+    })) as { lowImportanceObs: number };
+
+    // Still counted for reporting, but nothing actually deleted or flushed.
+    expect(result.lowImportanceObs).toBe(1);
+    expect(
+      await kv.get(KV.observations(sessionId), "obs_low_importance"),
+    ).not.toBeNull();
+    const remaining = await kv.list(KV.graphExtractMarks(sessionId));
+    expect(remaining).toHaveLength(1);
+  });
+
+  it("flushes the touched session's graph-extract marks after a project-cap eviction pass", async () => {
+    const sessionId = "ses_cap_graph";
+    const obsA: CompressedObservation = {
+      ...makeObservation(sessionId),
+      id: "obs_a",
+      importance: 1,
+    };
+    const obsB: CompressedObservation = {
+      ...makeObservation(sessionId),
+      id: "obs_b",
+      importance: 9,
+    };
+    const store = storeForObservations(sessionId, [obsA, obsB]);
+    store.get(KV.sessions)!.set(sessionId, {
+      ...makeSession(sessionId),
+      startedAt: daysAgo(1),
+    });
+    store.set(KV.config, new Map([["eviction", { maxObservationsPerProject: 1 }]]));
+    store.set(
+      KV.graphExtractMarks(sessionId),
+      new Map([["current", graphMarkEntry("gfx_b")]]),
+    );
+    const kv = mockKV(store);
+    const { sdk } = mockSdk();
+    registerEvictFunction(sdk as never, kv as never);
+
+    const result = (await sdk.trigger({
+      function_id: "mem::evict",
+      payload: {},
+    })) as { capEvictions: number };
+
+    expect(result.capEvictions).toBe(1);
+    // The lower-importance observation (obsA) is the one capped away.
+    expect(await kv.get(KV.observations(sessionId), "obs_a")).toBeNull();
+    expect(await kv.get(KV.observations(sessionId), "obs_b")).not.toBeNull();
+    const remaining = await kv.list(KV.graphExtractMarks(sessionId));
+    expect(remaining).toHaveLength(0);
   });
 });

--- a/test/export-import.test.ts
+++ b/test/export-import.test.ts
@@ -260,6 +260,32 @@ describe("Export/Import Functions", () => {
     expect(oldSession).toBeNull();
   });
 
+  it("import with replace strategy also reclaims the wiped sessions' graph-extract marks", async () => {
+    // A "replace" import wipes every session/observation/summary, but
+    // ses_1's graph-extract change-detection mark would otherwise survive
+    // with no owner and no path that could ever reclaim it - the session
+    // it was keyed against no longer exists for any later
+    // mem::forget/mem::evict pass to find.
+    await kv.set("mem:graph:extract-marks:ses_1", "current", {
+      fingerprint: "gfx_a",
+      llm: true,
+      at: Date.now(),
+    });
+
+    const exportData: ExportData = {
+      version: "0.3.0",
+      exportedAt: new Date().toISOString(),
+      sessions: [],
+      observations: {},
+      memories: [],
+      summaries: [],
+    };
+
+    await sdk.trigger("mem::import", { exportData, strategy: "replace" });
+
+    expect(await kv.list("mem:graph:extract-marks:ses_1")).toHaveLength(0);
+  });
+
   it("export then import round-trip preserves data", async () => {
     const exported = (await sdk.trigger("mem::export", {})) as ExportData;
 

--- a/test/graph.test.ts
+++ b/test/graph.test.ts
@@ -5,11 +5,13 @@ vi.mock("../src/logger.js", () => ({
 }));
 
 import { registerGraphFunction } from "../src/functions/graph.js";
+import { KV } from "../src/state/schema.js";
 import type {
   CompressedObservation,
   GraphNode,
   GraphEdge,
   GraphQueryResult,
+  MemoryProvider,
 } from "../src/types.js";
 
 function mockKV() {
@@ -223,6 +225,240 @@ describe("Graph Functions", () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toContain("No observations");
+  });
+
+  // #1063/#978: event::session::stopped fires on every assistant turn and
+  // hands mem::graph-extract the session's entire observation set with no
+  // change detection, so a session with tens of thousands of observations
+  // re-ran a full-corpus LLM extraction on every single turn.
+  it("does not re-run the LLM pass for an unchanged observation set (#1063)", async () => {
+    await sdk.trigger("mem::graph-extract", { observations: [testObs] });
+    const callsAfterFirst = mockProvider.compress.mock.calls.length;
+
+    await sdk.trigger("mem::graph-extract", { observations: [testObs] });
+
+    expect(callsAfterFirst).toBe(1);
+    expect(mockProvider.compress.mock.calls.length).toBe(1);
+  });
+
+  it("re-runs once a new observation is added to the set (#1063)", async () => {
+    const obs2: CompressedObservation = { ...testObs, id: "obs_2" };
+
+    await sdk.trigger("mem::graph-extract", { observations: [testObs] });
+    await sdk.trigger("mem::graph-extract", {
+      observations: [testObs, obs2],
+    });
+
+    expect(mockProvider.compress.mock.calls.length).toBe(2);
+  });
+
+  it("re-runs on a same-id content rewrite - id-only fingerprint would false-skip (#1063)", async () => {
+    await sdk.trigger("mem::graph-extract", { observations: [testObs] });
+
+    // #1063: same id ("obs_1"), but a bulk import-jsonl (strategy !==
+    // "skip") or replay-over-edited-transcript rewrite changed the title
+    // and narrative content - a content-aware fingerprint must not treat
+    // this as unchanged.
+    const rewritten: CompressedObservation = {
+      ...testObs,
+      title: "rewritten title",
+      narrative: "completely different narrative content after import",
+    };
+    await sdk.trigger("mem::graph-extract", { observations: [rewritten] });
+
+    expect(mockProvider.compress.mock.calls.length).toBe(2);
+  });
+
+  it("treats a kv.list-permuted but otherwise identical set as unchanged (#1063)", async () => {
+    const obs2: CompressedObservation = { ...testObs, id: "obs_2" };
+
+    await sdk.trigger("mem::graph-extract", {
+      observations: [testObs, obs2],
+    });
+    // Same two observations, reversed order - simulates kv.list's
+    // non-stable (hash-map backend, no sort) iteration order shifting
+    // between Stop-hook fan-outs for an unchanged session.
+    await sdk.trigger("mem::graph-extract", {
+      observations: [obs2, testObs],
+    });
+
+    expect(mockProvider.compress.mock.calls.length).toBe(1);
+  });
+
+  // A failed LLM pass must not mark the set done. The heuristic pass
+  // (obs.files/obs.concepts) almost always yields something for real
+  // coding observations, so before this fix the common path fell
+  // straight through to the mark write and recorded "done" while
+  // discarding llmError entirely - permanently losing that turn's
+  // LLM-derived graph for exactly the biggest, most-likely-to-time-out
+  // sessions this fix exists to help.
+  it("re-runs after an LLM failure even though the heuristic pass alone yields nodes (#1063)", async () => {
+    const heuristicObs: CompressedObservation = {
+      ...testObs,
+      id: "obs_h1",
+      concepts: ["auth"],
+      files: ["src/auth.ts"],
+    };
+    mockProvider.compress.mockRejectedValueOnce(new Error("provider timeout"));
+
+    const first = (await sdk.trigger("mem::graph-extract", {
+      observations: [heuristicObs],
+    })) as { success: boolean; nodesAdded: number; skipped?: string };
+
+    // Heuristic pass alone (file + concept node, 1 edge) still succeeds
+    // and persists even though the LLM pass failed.
+    expect(first.success).toBe(true);
+    expect(first.nodesAdded).toBeGreaterThan(0);
+    expect(first.skipped).toBeUndefined();
+    expect(mockProvider.compress.mock.calls.length).toBe(1);
+
+    const second = (await sdk.trigger("mem::graph-extract", {
+      observations: [heuristicObs],
+    })) as { success: boolean; skipped?: string };
+
+    // The set must NOT have been marked done - a second identical call
+    // re-runs extraction, including retrying the LLM pass, instead of
+    // being skipped as "unchanged".
+    expect(second.skipped).toBeUndefined();
+    expect(mockProvider.compress.mock.calls.length).toBe(2);
+  });
+
+  // A genuine zero-yield result (no llmError) is a settled outcome, not
+  // a failure - it must still be marked, or an unchanged zero-yield set
+  // re-runs the heuristic + LLM pass on every subsequent Stop forever.
+  // This shares the mark-timing root cause above, so the fix for one
+  // fixes both.
+  it("marks a genuine zero-yield result as done and does not re-run on the next identical call (#1063)", async () => {
+    mockProvider.compress.mockResolvedValueOnce(
+      "<entities></entities><relationships></relationships>",
+    );
+
+    const first = (await sdk.trigger("mem::graph-extract", {
+      observations: [testObs],
+    })) as { success: boolean; nodesAdded: number; edgesAdded: number };
+
+    // testObs has no files/concepts (heuristic pass yields nothing) and
+    // the LLM response above parses to nothing either - a genuine
+    // zero-yield result, not a failure.
+    expect(first.success).toBe(true);
+    expect(first.nodesAdded).toBe(0);
+    expect(first.edgesAdded).toBe(0);
+    expect(mockProvider.compress.mock.calls.length).toBe(1);
+
+    const second = (await sdk.trigger("mem::graph-extract", {
+      observations: [testObs],
+    })) as { success: boolean; skipped?: string };
+
+    expect(second.skipped).toBe("unchanged");
+    expect(mockProvider.compress.mock.calls.length).toBe(1);
+  });
+
+  // No LLM pass was attempted, so it cannot have failed - a
+  // heuristic-only run that completes cleanly should mark, same as any
+  // other clean attempt.
+  it("marks a heuristic-only run as done when the LLM pass is disabled via a noop provider (#1063)", async () => {
+    const heuristicObs: CompressedObservation = {
+      ...testObs,
+      id: "obs_h2",
+      concepts: ["auth"],
+      files: ["src/auth.ts"],
+    };
+    const noopCompress = vi.fn();
+    const noopProvider = {
+      name: "noop",
+      compress: noopCompress,
+      summarize: vi.fn(),
+    } as unknown as MemoryProvider;
+    const localKv = mockKV();
+    const localSdk = mockSdk();
+    registerGraphFunction(localSdk as never, localKv as never, noopProvider);
+
+    const first = (await localSdk.trigger("mem::graph-extract", {
+      observations: [heuristicObs],
+    })) as { success: boolean; nodesAdded: number };
+    expect(first.success).toBe(true);
+    expect(first.nodesAdded).toBeGreaterThan(0);
+    expect(noopCompress).not.toHaveBeenCalled();
+
+    const marks = await localKv.list(KV.graphExtractMarks("ses_1"));
+    expect(marks).toHaveLength(1);
+
+    const second = (await localSdk.trigger("mem::graph-extract", {
+      observations: [heuristicObs],
+    })) as { success: boolean; skipped?: string; nodesAdded: number };
+    expect(second.skipped).toBe("unchanged");
+    expect(second.nodesAdded).toBe(0);
+    expect(noopCompress).not.toHaveBeenCalled();
+  });
+
+  // #1063/#978: a set that was only ever extracted with the LLM pass OFF
+  // (here, a noop provider - the same llmEnabled=false shape a
+  // default install with no key configured produces) must NOT stay
+  // permanently skipped once a real provider becomes available for the
+  // exact same, unchanged observation set - the LLM has never actually
+  // seen this set yet. Simulates that by registering against a noop
+  // provider first (heuristic-only mark), then re-registering the SAME
+  // kv against a real provider and re-running the identical set.
+  it("re-extracts a set marked heuristic-only once the LLM pass becomes available (#1063)", async () => {
+    const heuristicObs: CompressedObservation = {
+      ...testObs,
+      id: "obs_h3",
+      concepts: ["auth"],
+      files: ["src/auth.ts"],
+    };
+    const noopCompress = vi.fn();
+    const noopProvider = {
+      name: "noop",
+      compress: noopCompress,
+      summarize: vi.fn(),
+    } as unknown as MemoryProvider;
+    const localKv = mockKV();
+    const noopSdk = mockSdk();
+    registerGraphFunction(noopSdk as never, localKv as never, noopProvider);
+
+    const first = (await noopSdk.trigger("mem::graph-extract", {
+      observations: [heuristicObs],
+    })) as { success: boolean; skipped?: string };
+    expect(first.skipped).toBeUndefined();
+    expect(noopCompress).not.toHaveBeenCalled();
+
+    // Same kv (same mark), but now a real LLM-capable provider is wired
+    // up - as if the user just set an API key.
+    const llmSdk = mockSdk();
+    registerGraphFunction(llmSdk as never, localKv as never, mockProvider as never);
+
+    const second = (await llmSdk.trigger("mem::graph-extract", {
+      observations: [heuristicObs],
+    })) as { success: boolean; skipped?: string };
+
+    // Must NOT be skipped as "unchanged" - the LLM pass has never run
+    // over this set, so a previously heuristic-only mark cannot gate it.
+    expect(second.skipped).toBeUndefined();
+    expect(mockProvider.compress.mock.calls.length).toBe(1);
+  });
+
+  // A batch spanning more than one session has no single session to key
+  // the per-session marks scope on, so the gate must skip entirely
+  // (always extract) rather than guess a bucket. No current caller does
+  // this (event::session::stopped and api::graph-build both pass
+  // single-session batches), but the function must stay correct if that
+  // ever changes.
+  it("always extracts a multi-session batch instead of gating on a guessed session (#1063)", async () => {
+    const otherSessionObs: CompressedObservation = {
+      ...testObs,
+      id: "obs_other",
+      sessionId: "ses_2",
+    };
+
+    await sdk.trigger("mem::graph-extract", {
+      observations: [testObs, otherSessionObs],
+    });
+    await sdk.trigger("mem::graph-extract", {
+      observations: [testObs, otherSessionObs],
+    });
+
+    // Never gated - both calls ran the LLM pass.
+    expect(mockProvider.compress.mock.calls.length).toBe(2);
   });
 
   // #753: an unbounded {} body used to materialize every node+edge in

--- a/test/graph.test.ts
+++ b/test/graph.test.ts
@@ -269,6 +269,57 @@ describe("Graph Functions", () => {
     expect(mockProvider.compress.mock.calls.length).toBe(2);
   });
 
+  it("re-runs on a same-length narrative rewrite (#1063)", async () => {
+    await sdk.trigger("mem::graph-extract", { observations: [testObs] });
+
+    const rewritten: CompressedObservation = {
+      ...testObs,
+      narrative: "x".repeat((testObs.narrative ?? "").length),
+    };
+    await sdk.trigger("mem::graph-extract", { observations: [rewritten] });
+
+    expect(mockProvider.compress.mock.calls.length).toBe(2);
+  });
+
+  it("re-runs when only concepts change (#1063)", async () => {
+    await sdk.trigger("mem::graph-extract", { observations: [testObs] });
+
+    // extractGraphHeuristics builds concept nodes straight from this
+    // field, so a change here changes the graph even though title and
+    // narrative are byte-identical.
+    const retagged: CompressedObservation = {
+      ...testObs,
+      concepts: [...(testObs.concepts ?? []), "newly-tagged-concept"],
+    };
+    await sdk.trigger("mem::graph-extract", { observations: [retagged] });
+
+    expect(mockProvider.compress.mock.calls.length).toBe(2);
+  });
+
+  it("re-runs when only files change (#1063)", async () => {
+    await sdk.trigger("mem::graph-extract", { observations: [testObs] });
+
+    const remapped: CompressedObservation = {
+      ...testObs,
+      files: [...(testObs.files ?? []), "src/newly/touched.ts"],
+    };
+    await sdk.trigger("mem::graph-extract", { observations: [remapped] });
+
+    expect(mockProvider.compress.mock.calls.length).toBe(2);
+  });
+
+  it("re-runs when only type changes (#1063)", async () => {
+    await sdk.trigger("mem::graph-extract", { observations: [testObs] });
+
+    const retyped: CompressedObservation = {
+      ...testObs,
+      type: testObs.type === "decision" ? "discovery" : "decision",
+    };
+    await sdk.trigger("mem::graph-extract", { observations: [retyped] });
+
+    expect(mockProvider.compress.mock.calls.length).toBe(2);
+  });
+
   it("treats a kv.list-permuted but otherwise identical set as unchanged (#1063)", async () => {
     const obs2: CompressedObservation = { ...testObs, id: "obs_2" };
 
@@ -351,6 +402,26 @@ describe("Graph Functions", () => {
 
     expect(second.skipped).toBe("unchanged");
     expect(mockProvider.compress.mock.calls.length).toBe(1);
+  });
+
+  it("audits the clean zero-yield extraction that produced the mark (#1063)", async () => {
+    mockProvider.compress.mockResolvedValueOnce(
+      "<entities></entities><relationships></relationships>",
+    );
+
+    await sdk.trigger("mem::graph-extract", { observations: [testObs] });
+
+    const auditRows = await kv.list<{
+      functionId: string;
+      targetIds: string[];
+      details: Record<string, unknown>;
+    }>("mem:audit");
+    const row = auditRows.find((r) => r.functionId === "mem::graph-extract");
+
+    expect(row).toBeDefined();
+    expect(row!.targetIds).toContain(testObs.id);
+    expect(row!.details.nodesExtracted).toBe(0);
+    expect(row!.details.edgesExtracted).toBe(0);
   });
 
   // No LLM pass was attempted, so it cannot have failed - a

--- a/test/remember-forget-audit.test.ts
+++ b/test/remember-forget-audit.test.ts
@@ -109,6 +109,63 @@ describe("mem::forget audit coverage (issue #125)", () => {
     expect(row.details.deleted).toBe(4);
   });
 
+  // #1063/#978: KV.graphExtractMarks is introduced by mem::graph-extract's
+  // change-detection gate and must be reclaimed wherever a session's
+  // KV.observations/KV.summaries are already reclaimed - otherwise the
+  // per-session mark outlives the session it belongs to.
+  it("clears the graph-extract change-detection marks when an entire session is forgotten (#1063, #978)", async () => {
+    const sdk = mockSdk();
+    const kv = mockKV();
+    registerRememberFunction(sdk as never, kv as never);
+
+    await kv.set("mem:sessions", "sess_1", { id: "sess_1" });
+    await kv.set("mem:summaries", "sess_1", { id: "sess_1" });
+    await kv.set("mem:obs:sess_1", "obs_a", { id: "obs_a" });
+    await kv.set("mem:graph:extract-marks:sess_1", "current", {
+      fingerprint: "gfx_aaaaaaaaaaaaaaaa",
+      llm: true,
+      at: Date.now(),
+    });
+
+    await sdk.trigger({
+      function_id: "mem::forget",
+      payload: { sessionId: "sess_1" },
+    });
+
+    const remaining = await kv.list("mem:graph:extract-marks:sess_1");
+    expect(remaining).toHaveLength(0);
+  });
+
+  // The explicit-observationIds branch deletes some of a session's
+  // observations while the session itself survives, so it never reaches
+  // the whole-session branch covered above - it needs its own flush, or
+  // the mark outlives the observation set it was computed over.
+  it("reclaims the graph-extract mark when specific observationIds are forgotten", async () => {
+    const sdk = mockSdk();
+    const kv = mockKV();
+    registerRememberFunction(sdk as never, kv as never);
+
+    await kv.set("mem:sessions", "sess_2", { id: "sess_2" });
+    await kv.set("mem:obs:sess_2", "obs_a", { id: "obs_a" });
+    await kv.set("mem:obs:sess_2", "obs_b", { id: "obs_b" });
+    await kv.set("mem:graph:extract-marks:sess_2", "current", {
+      fingerprint: "gfx_aaaaaaaaaaaaaaaa",
+      llm: true,
+      at: Date.now(),
+    });
+
+    await sdk.trigger({
+      function_id: "mem::forget",
+      payload: { sessionId: "sess_2", observationIds: ["obs_a"] },
+    });
+
+    // The session and its remaining observation survive - only the mark
+    // invalidated by the partial delete is reclaimed.
+    expect(await kv.get("mem:sessions", "sess_2")).not.toBeNull();
+    expect(await kv.get("mem:obs:sess_2", "obs_b")).not.toBeNull();
+    expect(await kv.list("mem:graph:extract-marks:sess_2")).toHaveLength(0);
+  });
+
   it("does not emit an audit row when nothing is deleted", async () => {
     const sdk = mockSdk();
     const kv = mockKV();


### PR DESCRIPTION
## Problem

`event::session::stopped` fires on every assistant turn and hands `mem::graph-extract` the session's **entire** compressed observation set, with no chunking and no change detection. A long-running session therefore re-extracts an unchanged corpus once per turn: the full heuristic pass plus, when a provider is configured, a full LLM call over the whole set. This is the graph-side half of the token/latency burn tracked in #1063, and the repeated-work behavior described in #978.

## Fix

Gate `mem::graph-extract` on a fingerprint of the observation set, stored under a single fixed per-session key (`mem:graph:extract-marks:<sessionId>`). When the incoming set's fingerprint matches the stored mark, the function returns `{ skipped: "unchanged" }` before the heuristic/LLM pass — the cost saved is the whole pass, not just the LLM call.

Design decisions worth calling out:

- **Content-aware, not identity-only.** The fingerprint hashes id + title + narrative length per observation. An identity-only fingerprint (sorted ids) would false-skip forever after a same-id content rewrite — bulk `import-jsonl` with strategy ≠ `skip`, or replay over an edited transcript, both keep ids stable while changing content. Narrative *length* rather than the body keeps this cheap on the hot Stop path (sessions can run tens of thousands of observations).
- **Sorted by id before hashing.** The set originates from `kv.list`, whose order is not contractually stable; an unsorted fingerprint would churn on a permuted-but-unchanged set and never hit the gate.
- **The mark records whether the LLM pass ran.** A heuristic-only mark (the default keyless install) never suppresses a later run once an LLM becomes available; a mark written with `llm: true` is a ceiling, so a heuristic-only re-run against the same set can skip. Without this, sets extracted while `GRAPH_EXTRACTION_ENABLED` was off would stay permanently skipped after the user enables it — and a second `/graph/build` (the documented recovery for an empty graph) would hit its own marks and report success with zero nodes added.
- **The mark is written on clean attempt completion, not persist success.** A provider timeout/rate-limit on exactly the biggest sessions must not mark the set done and permanently drop that turn's LLM extraction.
- **A batch spanning multiple sessions skips the gate** rather than guessing a scope — degrading to "always extract", never to "never extract". No current caller sends one.

## Reclamation

`KV.graphExtractMarks` is a new per-session scope, so this PR also owns its cleanup (`deleteGraphExtractMarks`):

- **Whole-session deletion** — `mem::forget` (remember.ts), stale-session eviction (evict.ts), replace-strategy import (export-import.ts) — deletes the mark alongside the session; nothing can ever reach it afterwards.
- **Per-observation deletion** — evict.ts low-importance/project-cap paths, `mem::auto-forget`'s low-value sweep, `mem::forget` with explicit `observationIds` — flushes once per touched session, since removing an observation invalidates the fingerprint recorded against the old membership.

## Relationship to #1269

Independent — neither depends on the other. Both touch the deletion paths in `evict.ts`/`auto-forget.ts`, so whichever merges second will have a small (~3-line) conflict in those files; happy to rebase this one if #1269 lands first, or vice versa.

## Tests

17 new tests: 9 on the gate in `test/graph.test.ts` (skip on unchanged set, re-extract on new observation and on same-id content rewrite, permuted-set stability, no mark after LLM failure, zero-yield marking, heuristic-only ceiling semantics both directions, multi-session batch bypass), plus one reclamation test per deletion path across `test/evict.test.ts`, `test/remember-forget-audit.test.ts`, `test/auto-forget.test.ts`, `test/export-import.test.ts`, including dry-run-does-not-flush coverage.

Full suite: 1728 passed / 1 skipped. `tsc --noEmit` unchanged at the 30 pre-existing errors (none in touched files).

Closes #1063. Closes #978.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Graph extraction now skips unchanged observation sets, reducing unnecessary processing.
  * Updates to observation content or metadata correctly trigger re-extraction.

* **Bug Fixes**
  * Extraction records are cleaned up when observations or sessions are forgotten, evicted, automatically removed, or replaced during import.
  * Dry-run eviction leaves existing records unchanged.

* **Reliability**
  * Improved handling of failed extractions, empty results, and provider availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->