### PR TITLE
feat(opencode): harden capture plugin with ephemeral transform and prompt cache freezing

### DIFF
--- a/plugin/opencode/agentmemory-capture.ts
+++ b/plugin/opencode/agentmemory-capture.ts
@@ -7,7 +7,7 @@ const API = process.env.AGENTMEMORY_URL || "http://localhost:3111";
 // case-insensitive at the call site so a future casing change cannot silently
 // kill file enrichment again.
 const FILE_TOOLS = new Set(["read", "write", "edit", "glob", "grep"]);
-const FILE_KEYS = ["filePath", "file_path", "path", "file", "pattern"];
+const FILE_KEYS = ["filePath", "file_path", "path", "file"];
 const MAX_STASHED_FILES = 20;
 
 const DEBUG = process.env.OPENCODE_AGENTMEMORY_DEBUG === "1";
@@ -32,13 +32,13 @@ async function post(path: string, body: Record<string, unknown>, timeoutMs = 500
   }
 }
 
-async function postJson(path: string, body: Record<string, unknown>): Promise<unknown | null> {
+async function postJson(path: string, body: Record<string, unknown>, timeoutMs = 5000): Promise<unknown | null> {
   try {
     const res = await fetch(`${API}/agentmemory${path}`, {
       method: "POST",
       headers: authHeaders(),
       body: JSON.stringify(body),
-      signal: AbortSignal.timeout(5000),
+      signal: AbortSignal.timeout(timeoutMs),
     });
     return res.ok ? await res.json() : null;
   } catch (e) {
@@ -75,9 +75,26 @@ let defaultProjectName: string | null = null;
 let defaultProjectCwd: string | null = null;
 const sessionProjects = new Map<string, { name: string; cwd: string }>();
 
-function projectFor(sessionId: string): { name: string | null; cwd: string | null } {
+function projectFor(sessionId: string): { name: string; cwd: string } {
   const p = sessionProjects.get(sessionId);
-  return p ?? { name: defaultProjectName, cwd: defaultProjectCwd };
+  const name = p?.name || defaultProjectName || "default";
+  const cwd = p?.cwd || defaultProjectCwd || process.cwd() || "/";
+  return { name, cwd };
+}
+
+function isAppBundle(dir: string | undefined | null): boolean {
+  if (!dir || typeof dir !== "string") return true;
+  const d = dir.trim();
+  return d.includes(".app/") || d.endsWith(".app");
+}
+
+function resolveCandidateDir(...candidates: (string | undefined | null)[]): string {
+  for (const dir of candidates) {
+    if (dir && typeof dir === "string" && dir.trim().length > 0 && !isAppBundle(dir)) {
+      return dir.trim();
+    }
+  }
+  return process.cwd() || "/";
 }
 
 const projectNameCache = new Map<string, string>();
@@ -92,6 +109,7 @@ function resolveProjectName(dir: string): string {
       cwd: dir,
       stdio: ["ignore", "pipe", "ignore"],
       encoding: "utf8",
+      timeout: 1000,
     }).trim();
     if (top) {
       const name = basename(top);
@@ -101,7 +119,7 @@ function resolveProjectName(dir: string): string {
   } catch {
     // not a git repo, fall through
   }
-  const fallback = basename(dir) || dir;
+  const fallback = basename(dir) || dir || "default";
   projectNameCache.set(dir, fallback);
   return fallback;
 }
@@ -109,6 +127,8 @@ const stashedFiles = new Map<string, Set<string>>();
 const seenSubtaskIds = new Map<string, Set<string>>();
 const seenToolCallIds = new Map<string, Set<string>>();
 const contextInjectedSessions = new Set<string>();
+const pendingSummarizeTimers = new Map<string, ReturnType<typeof setTimeout>>();
+const inFlightSummaries = new Set<string>();
 // cache the context returned by POST /session/start so the chat
 // system-transform hook can inject it without a second /context fetch.
 // Auto-injection now happens at session.created (immediately) AND at
@@ -134,11 +154,48 @@ function toolCallSetFor(sid: string): Set<string> {
   return s;
 }
 
+function cancelPendingSummarize(sid: string): void {
+  const timer = pendingSummarizeTimers.get(sid);
+  if (timer) {
+    clearTimeout(timer);
+    pendingSummarizeTimers.delete(sid);
+  }
+}
+
 function pruneSessionMaps(sid: string): void {
+  cancelPendingSummarize(sid);
+  inFlightSummaries.delete(sid);
   stashedFiles.delete(sid);
   seenSubtaskIds.delete(sid);
   seenToolCallIds.delete(sid);
   sessionProjects.delete(sid);
+}
+
+function scheduleSummarize(sid: string, delayMs = 3000): void {
+  if (!sid || typeof sid !== "string") return;
+  cancelPendingSummarize(sid);
+  if (inFlightSummaries.has(sid)) return;
+
+  const timer = setTimeout(async () => {
+    pendingSummarizeTimers.delete(sid);
+    if (inFlightSummaries.has(sid)) return;
+    inFlightSummaries.add(sid);
+    try {
+      await post("/summarize", { sessionId: sid });
+    } catch (err) {
+      if (DEBUG) {
+        console.error(`[agentmemory] Failed to post /summarize for session ${sid}:`, err);
+      }
+    } finally {
+      inFlightSummaries.delete(sid);
+    }
+  }, delayMs);
+
+  if (typeof (timer as any)?.unref === "function") {
+    (timer as any).unref();
+  }
+
+  pendingSummarizeTimers.set(sid, timer);
 }
 
 function safeSlice(v: unknown, max: number): string {
@@ -192,10 +249,76 @@ function extractFilePaths(args: Record<string, unknown>): string[] {
   for (const key of FILE_KEYS) {
     const val = args[key];
     if (typeof val === "string" && val.length > 0) {
-      files.push(val);
+      // Filter out glob patterns or regexes that aren't literal file paths
+      if (!/[\*\?\{\}\[\]\(\)\|\^\$]/.test(val)) {
+        files.push(val);
+      }
     }
   }
   return files;
+}
+
+async function linkCommitIfApplicable(
+  sid: string,
+  inputArgs: Record<string, unknown> | undefined,
+  outputResult: unknown,
+  cwd?: string,
+): Promise<void> {
+  try {
+    const inputCmd = typeof inputArgs?.command === "string" ? inputArgs.command : "";
+    const outputStr = typeof outputResult === "string" ? outputResult : JSON.stringify(outputResult || "");
+    if (!/\bgit\s+commit\b/.test(inputCmd) && !/\bgit\s+commit\b/.test(outputStr)) return;
+
+    const shaMatch =
+      outputStr.match(/\[[\w./\-]+ ([0-9a-f]{7,40})\]/) ||
+      outputStr.match(/^([0-9a-f]{7,40})\s/m);
+    if (!shaMatch) return;
+    const sha = shaMatch[1];
+    if (!sha) return;
+
+    const effectiveCwd = cwd || projectFor(sid).cwd || process.cwd();
+    const runGit = (args: string[]): string => {
+      return execFileSync("git", args, {
+        cwd: effectiveCwd,
+        stdio: ["ignore", "pipe", "ignore"],
+        encoding: "utf8",
+        timeout: 2000,
+      }).trim();
+    };
+
+    let branch = "";
+    let repo = "";
+    let message = "";
+    let author = "";
+    let files: string[] = [];
+    try {
+      branch = runGit(["rev-parse", "--abbrev-ref", "HEAD"]);
+      const top = runGit(["rev-parse", "--show-toplevel"]);
+      repo = top ? basename(top) : projectFor(sid).name;
+      message = runGit(["log", "-1", "--format=%B", sha]);
+      author = runGit(["log", "-1", "--format=%an", sha]);
+      files = runGit(["diff-tree", "--no-commit-id", "--name-only", "-r", sha]).split("\n").filter(Boolean);
+    } catch {
+      // git lookup fallback
+    }
+
+    await postJson(
+      "/session/commit",
+      {
+        sessionId: sid,
+        sha,
+        branch: branch || "main",
+        repo: repo || projectFor(sid).name,
+        message: message || "git commit",
+        author: author || "unknown",
+        files,
+      },
+      3000,
+    );
+    if (DEBUG) console.error(`[agentmemory] Linked commit ${sha} -> ${sid}`);
+  } catch (e) {
+    if (DEBUG) console.error("[agentmemory] commit link failed:", (e as Error).message);
+  }
 }
 
 function extractErrorMessage(err: unknown): string {
@@ -214,7 +337,13 @@ function extractErrorMessage(err: unknown): string {
 }
 
 export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
-  defaultProjectCwd = ctx.worktree || ctx.project?.id || process.cwd();
+  defaultProjectCwd = resolveCandidateDir(
+    ctx.worktree,
+    (ctx as any)?.project?.directory,
+    (ctx as any)?.directory,
+    ctx.project?.id,
+    process.cwd(),
+  );
   defaultProjectName = resolveProjectName(defaultProjectCwd);
 
   return {
@@ -238,18 +367,18 @@ export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
         // Attribute this session to its own directory when the event
         // carries one; a multi-directory OpenCode process otherwise
         // records every session under whichever repo loaded the plugin.
-        const sessionDir =
-          typeof info?.directory === "string" && info.directory
-            ? info.directory
-            : defaultProjectCwd;
-        let proj: { name: string | null; cwd: string | null };
-        if (sessionDir) {
-          const entry = { cwd: sessionDir, name: resolveProjectName(sessionDir) };
-          sessionProjects.set(sessionId, entry);
-          proj = entry;
-        } else {
-          proj = projectFor(sessionId);
-        }
+        // Skip macOS .app bundles from Desktop mode so we resolve the real project path.
+        const sessionDir = resolveCandidateDir(
+          typeof info?.directory === "string" ? info.directory : undefined,
+          (ctx as any)?.project?.directory,
+          (ctx as any)?.directory,
+          ctx.worktree,
+          ctx.project?.id,
+          defaultProjectCwd,
+          process.cwd(),
+        );
+        const proj = { cwd: sessionDir, name: resolveProjectName(sessionDir) };
+        sessionProjects.set(sessionId, proj);
         const startResult = await postJson("/session/start", {
           sessionId,
           title: info?.title ?? null,
@@ -270,7 +399,13 @@ export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
         }
       }
 
-      // ── session.idle ── (summarize handled in session.status idle branch)
+      // ── session.idle ──
+      if (type === "session.idle") {
+        const sid = props.sessionID || activeSessionId;
+        if (sid) {
+          scheduleSummarize(sid);
+        }
+      }
 
       // ── session.status ──
       if (type === "session.status") {
@@ -278,7 +413,9 @@ export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
         const sid = props.sessionID || activeSessionId;
         if (!sid || !status) return;
         if (status.type === "idle") {
-          await post("/summarize", { sessionId: sid });
+          scheduleSummarize(sid);
+        } else {
+          cancelPendingSummarize(sid);
         }
         await observe(sid, "session_status", {
           status_type: status.type,
@@ -291,7 +428,7 @@ export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
       if (type === "session.compacted") {
         const sid = props.sessionID || activeSessionId;
         if (sid) {
-          await post("/summarize", { sessionId: sid });
+          scheduleSummarize(sid);
           await observe(sid, "session_compacted", {});
         }
       }
@@ -419,7 +556,7 @@ export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
         if (part.type === "tool") {
           const state = part.state as Record<string, unknown> | undefined;
           if (!state) return;
-          const callId = part.callID as string;
+          const callId = (part.callID as string) || (part.id as string);
           if (!callId) return;
           const toolName = part.tool as string;
 
@@ -428,6 +565,9 @@ export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
             if (callSet.has(callId)) return;
             callSet.add(callId);
             const st = state as Record<string, unknown>;
+            if (toolName === "bash" || toolName === "shell") {
+              await linkCommitIfApplicable(sid, st.input as any, st.output, projectFor(sid).cwd);
+            }
             const rawTime = (st.time as any) || {};
             const startTime = typeof rawTime.start === "number" ? rawTime.start : null;
             const endTime = typeof rawTime.end === "number" ? rawTime.end : null;
@@ -593,6 +733,7 @@ export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
     "chat.message": async (input, output) => {
       const sid = input.sessionID || activeSessionId;
       if (!sid) return;
+      cancelPendingSummarize(sid);
       const parts = output.parts || [];
       const files = parts
         .filter((p: any) => p.type === "file")
@@ -662,6 +803,18 @@ export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
       const sid = input.sessionID || activeSessionId;
       if (!sid) return;
 
+      // Skip internal/title-generator LLM requests — OpenCode fires an internal concurrent
+      // title request on turn 1 using the same sessionID. If injected there, the title
+      // generator consumes the one-time injection and the main conversation turn gets nothing! (Issue #1184)
+      if (Array.isArray(output.system)) {
+        const isInternalTitle = output.system.some(
+          (s: string) =>
+            typeof s === "string" &&
+            /title generator|generate a (short|concise|brief) title|title for this conversation|thread title/i.test(s),
+        );
+        if (isInternalTitle) return;
+      }
+
       if (!contextInjectedSessions.has(sid)) {
         if (!Array.isArray(output.system)) return;
         output.system.push(AGENTMEMORY_INSTRUCTIONS);
@@ -684,22 +837,51 @@ export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
         contextInjectedSessions.add(sid);
       }
 
+      // Note: We deliberately do NOT push per-turn dynamic file enrichment into output.system
+      // because mutating the system prompt on subsequent turns invalidates LLM prompt/prefix caching (#720),
+      // creating an unnecessary 12.5x-20x cost multiplier. Instead, volatile file enrichment is attached
+      // in-memory to the tail of user message parts in `experimental.chat.messages.transform`.
+    },
+
+    // ── experimental.chat.messages.transform ──
+    // In-memory message transform hook: attaches volatile file enrichment context to the tail
+    // of the latest user message in-memory without touching SQLite durable events or creating UI clutter.
+    "experimental.chat.messages.transform": async (input, output) => {
+      const msgs = output?.messages;
+      if (!Array.isArray(msgs) || msgs.length === 0) return;
+
+      const lastUserMsg = msgs.filter((m: any) => m.info?.role === "user").pop();
+      if (!lastUserMsg) return;
+      const sid = lastUserMsg.info?.sessionID || activeSessionId;
+      if (!sid) return;
+
       const stash = stashFor(sid);
       if (stash.size === 0) return;
-      const files = [...stash].slice(0, 10);
 
-      const enrichResult = await postJson("/enrich", {
-        sessionId: sid,
-        files,
-        toolName: "enrich_inject",
-      });
+      const stashedFileList = [...stash].slice(0, 10);
+      for (const f of stashedFileList) stash.delete(f);
 
-      const enrichCtx = (enrichResult as any)?.context;
-      if (typeof enrichCtx === "string" && enrichCtx.length > 0) {
-        if (Array.isArray(output.system)) {
-          output.system.push(enrichCtx);
+      const proj = projectFor(sid);
+      try {
+        const enrichResult = await postJson(
+          "/enrich",
+          {
+            sessionId: sid,
+            files: stashedFileList,
+            project: proj.name,
+            toolName: "enrich_inject",
+          },
+          3000,
+        );
+        const enrichCtx = (enrichResult as any)?.context;
+        if (typeof enrichCtx === "string" && enrichCtx.length > 0 && Array.isArray(lastUserMsg.parts)) {
+          const textPart = lastUserMsg.parts.filter((p: any) => p.type === "text").pop() as any;
+          if (textPart) {
+            textPart.text = (textPart.text || "") + `\n\n<agentmemory-file-context>\n${enrichCtx}\n</agentmemory-file-context>`;
+          }
         }
-        for (const f of files) stash.delete(f);
+      } catch (e) {
+        if (DEBUG) console.error("[agentmemory] enrich injection failed:", (e as Error).message);
       }
     },
 

--- a/test/live-verification-5-points.test.ts
+++ b/test/live-verification-5-points.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+describe("Live Verification: 5 Key Fixes for Agentmemory OpenCode Plugin", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let capturedRequests: Array<{ url: string; body: any }>;
+
+  beforeEach(() => {
+    capturedRequests = [];
+    fetchMock = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      const body = init?.body ? JSON.parse(init.body as string) : {};
+      capturedRequests.push({ url, body });
+
+      if (url.includes("/session/start")) {
+        return {
+          ok: true,
+          json: async () => ({ context: "## Injected Start Context" }),
+        };
+      }
+      if (url.includes("/enrich")) {
+        const isProjectA = body.project === "agentmemory";
+        const hasScopedFile = (body.files || []).some((f: string) => f.includes("scoped-file.ts"));
+        const hasAuthFile = (body.files || []).some((f: string) => f.includes("auth.ts"));
+        let context = "";
+        if (hasScopedFile && isProjectA) {
+          context = "PROJECT_A_SECRET: 11111 for scoped-file in project agentmemory";
+        } else if (hasAuthFile) {
+          context = "## Relevant security context for auth.ts";
+        }
+        return {
+          ok: true,
+          json: async () => ({ context }),
+        };
+      }
+      return { ok: true, json: async () => ({ status: "ok" }) };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  // ── FIX 1: Prefix Cache Invariance ──
+  it("Fix 1 (Prefix Cache Invariance): output.system is transformed on Turn 1 and remains 100% frozen/identical across Turns 2, 3, 4, and 5", async () => {
+    const { AgentmemoryCapturePlugin } = await import("../plugin/opencode/agentmemory-capture.ts");
+    const handlers = await (AgentmemoryCapturePlugin as any)({ worktree: "/Volumes/DB/Example Projects/agentmemory" });
+
+    const sessionID = "sess-cache-eval";
+    await handlers.event({
+      event: { type: "session.created", properties: { sessionID } },
+    });
+
+    // Turn 1 System Prompt Transform
+    const turn1Output = { system: ["You are a helpful coding assistant."] };
+    await handlers["experimental.chat.system.transform"]({ sessionID }, turn1Output);
+    expect(turn1Output.system.length).toBeGreaterThanOrEqual(2);
+    const frozenSystemState = [...turn1Output.system];
+
+    // Simulate multiple turns with file reads in between
+    for (let turn = 2; turn <= 5; turn++) {
+      // Simulate file tool execution between turns
+      await handlers["tool.execute.before"](
+        { sessionID, tool: "read" },
+        { args: { filePath: `src/file-${turn}.ts` } },
+      );
+
+      const subsequentTurnOutput = { system: ["You are a helpful coding assistant."] };
+      await handlers["experimental.chat.system.transform"]({ sessionID }, subsequentTurnOutput);
+
+      // Invariant: System prompt on Turn 2+ is NEVER mutated (100% Cache Invariance)
+      expect(subsequentTurnOutput.system).toEqual(["You are a helpful coding assistant."]);
+    }
+  });
+
+  // ── FIX 2: Zero DB Schema Error & Clean UI ──
+  it("Fix 2 (Zero DB Schema Error & Clean UI): chat.message never pushes invalid parts into DB, and context is attached in-memory only", async () => {
+    const { AgentmemoryCapturePlugin } = await import("../plugin/opencode/agentmemory-capture.ts");
+    const handlers = await (AgentmemoryCapturePlugin as any)({ worktree: "/Volumes/DB/Example Projects/agentmemory" });
+
+    const sessionID = "sess-db-clean";
+    await handlers.event({
+      event: { type: "session.created", properties: { sessionID } },
+    });
+
+    // User touches a file
+    await handlers["tool.execute.before"](
+      { sessionID, tool: "read" },
+      { args: { filePath: "src/auth.ts" } },
+    );
+
+    // chat.message is called by OpenCode to persist the user message into SQLite
+    const userMessageData = {
+      parts: [
+        { type: "text", text: "Please refactor auth.ts" },
+      ],
+    };
+    await handlers["chat.message"]({ sessionID, messageID: "msg-001" }, userMessageData);
+
+    // Verification 2A: Persistent DB parts array is completely untouched (0 schema errors, 0 XML tags in DB/UI)
+    expect(userMessageData.parts.length).toBe(1);
+    expect(userMessageData.parts[0].text).toBe("Please refactor auth.ts");
+    expect(userMessageData.parts[0].text).not.toContain("<agentmemory-file-context>");
+
+    // Verification 2B: In-memory transform attaches context immediately before model invocation
+    const inMemoryMsgs = {
+      messages: [
+        {
+          info: { role: "user", sessionID },
+          parts: [{ type: "text", text: "Please refactor auth.ts" }],
+        },
+      ],
+    };
+    await handlers["experimental.chat.messages.transform"]({}, inMemoryMsgs);
+    expect(inMemoryMsgs.messages[0].parts[0].text).toContain("Please refactor auth.ts");
+    expect(inMemoryMsgs.messages[0].parts[0].text).toContain("<agentmemory-file-context>");
+  });
+
+  // ── FIX 3: Stash Loop Fixed (No Infinite API Calls) ──
+  it("Fix 3 (Stash Loop Fixed): opening a fresh file without memory records does NOT cause repetitive /enrich calls on subsequent turns", async () => {
+    const { AgentmemoryCapturePlugin } = await import("../plugin/opencode/agentmemory-capture.ts");
+    const handlers = await (AgentmemoryCapturePlugin as any)({ worktree: "/Volumes/DB/Example Projects/agentmemory" });
+
+    const sessionID = "sess-stash-loop";
+    await handlers.event({
+      event: { type: "session.created", properties: { sessionID } },
+    });
+
+    // Step 1: Tool accesses a fresh file that has no memory
+    await handlers["tool.execute.before"](
+      { sessionID, tool: "read" },
+      { args: { filePath: "test-fixtures/fresh-file.ts" } },
+    );
+
+    // Step 2: Turn 1 triggers /enrich (which returns empty context)
+    const turn1Msgs = {
+      messages: [
+        {
+          info: { role: "user", sessionID },
+          parts: [{ type: "text", text: "Turn 1 question" }],
+        },
+      ],
+    };
+    await handlers["experimental.chat.messages.transform"]({}, turn1Msgs);
+
+    const enrichCallsAfterTurn1 = capturedRequests.filter(r => r.url.includes("/enrich")).length;
+    expect(enrichCallsAfterTurn1).toBe(1);
+
+    // Step 3: Turn 2 user asks another question without touching any new files
+    const turn2Msgs = {
+      messages: [
+        {
+          info: { role: "user", sessionID },
+          parts: [{ type: "text", text: "Turn 2 follow-up question" }],
+        },
+      ],
+    };
+    await handlers["experimental.chat.messages.transform"]({}, turn2Msgs);
+
+    // Verification: Stash was cleared immediately on Turn 1; Turn 2 makes ZERO /enrich calls!
+    const enrichCallsAfterTurn2 = capturedRequests.filter(r => r.url.includes("/enrich")).length;
+    expect(enrichCallsAfterTurn2).toBe(1);
+  });
+
+  // ── FIX 4: Search Pattern & Regex Exclusion ──
+  it("Fix 4 (Search Pattern Exclusion): glob wildcards (**/*.ts) and grep regex patterns are excluded from file stash", async () => {
+    const { AgentmemoryCapturePlugin } = await import("../plugin/opencode/agentmemory-capture.ts");
+    const handlers = await (AgentmemoryCapturePlugin as any)({ worktree: "/Volumes/DB/Example Projects/agentmemory" });
+
+    const sessionID = "sess-pattern-eval";
+    await handlers.event({
+      event: { type: "session.created", properties: { sessionID } },
+    });
+
+    // Simulate glob with wildcard pattern and valid path
+    await handlers["tool.execute.before"](
+      { sessionID, tool: "glob" },
+      { args: { pattern: "**/*.{ts,tsx}", path: "src/components" } },
+    );
+
+    // Simulate grep with regex pattern and valid filePath
+    await handlers["tool.execute.before"](
+      { sessionID, tool: "grep" },
+      { args: { pattern: "export\\s+const\\s+API_URL", filePath: "src/constants.ts" } },
+    );
+
+    // Trigger transform to inspect what gets sent to /enrich
+    const msgs = {
+      messages: [
+        {
+          info: { role: "user", sessionID },
+          parts: [{ type: "text", text: "Find constants" }],
+        },
+      ],
+    };
+    await handlers["experimental.chat.messages.transform"]({}, msgs);
+
+    const enrichCall = capturedRequests.find(r => r.url.includes("/enrich"));
+    expect(enrichCall).toBeDefined();
+    const stashedFiles: string[] = enrichCall?.body.files || [];
+
+    // Verification: Literal file paths ARE included, but regex/glob patterns ARE EXCLUDED
+    expect(stashedFiles).toContain("src/components");
+    expect(stashedFiles).toContain("src/constants.ts");
+    expect(stashedFiles).not.toContain("**/*.{ts,tsx}");
+    expect(stashedFiles).not.toContain("export\\s+const\\s+API_URL");
+  });
+
+  // ── FIX 5: Project Scoping Isolation ──
+  it("Fix 5 (Project Scoping Isolation): /enrich passes project scope, ensuring memory isolation between repositories", async () => {
+    const { AgentmemoryCapturePlugin } = await import("../plugin/opencode/agentmemory-capture.ts");
+    const handlers = await (AgentmemoryCapturePlugin as any)({ worktree: "/Volumes/DB/Example Projects/agentmemory" });
+
+    const sessionID = "sess-project-scope";
+    await handlers.event({
+      event: { type: "session.created", properties: { sessionID, info: { directory: "/Volumes/DB/Example Projects/agentmemory" } } },
+    });
+
+    // Touch scoped file
+    await handlers["tool.execute.before"](
+      { sessionID, tool: "read" },
+      { args: { filePath: "test-fixtures/scoped-file.ts" } },
+    );
+
+    const msgs = {
+      messages: [
+        {
+          info: { role: "user", sessionID },
+          parts: [{ type: "text", text: "Check scoped secret" }],
+        },
+      ],
+    };
+    await handlers["experimental.chat.messages.transform"]({}, msgs);
+
+    const enrichCall = capturedRequests.find(r => r.url.includes("/enrich"));
+    expect(enrichCall).toBeDefined();
+
+    // Verification 5A: Payload explicitly specifies project name
+    expect(enrichCall?.body.project).toBe("agentmemory");
+
+    // Verification 5B: Injected context contains Project A secret and excludes Project B
+    expect(msgs.messages[0].parts[0].text).toContain("PROJECT_A_SECRET: 11111");
+    expect(msgs.messages[0].parts[0].text).not.toContain("PROJECT_B_SECRET: 22222");
+  });
+});

--- a/test/opencode-all-endpoints.test.ts
+++ b/test/opencode-all-endpoints.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+describe("OpenCode plugin complete endpoint & hook matrix test suite", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let capturedRequests: Array<{ url: string; body: any }>;
+
+  beforeEach(() => {
+    capturedRequests = [];
+    fetchMock = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      const body = init?.body ? JSON.parse(init.body as string) : {};
+      capturedRequests.push({ url, body });
+
+      if (url.includes("/session/start")) {
+        return {
+          ok: true,
+          json: async () => ({ context: "## Start Context" }),
+        };
+      }
+      if (url.includes("/context")) {
+        return {
+          ok: true,
+          json: async () => ({ context: "## Fetched Context" }),
+        };
+      }
+      if (url.includes("/enrich")) {
+        return {
+          ok: true,
+          json: async () => ({ context: "## File History for " + (body.files || []).join(", ") }),
+        };
+      }
+      if (url.includes("/session/commit")) {
+        return {
+          ok: true,
+          json: async () => ({ status: "linked", sha: body.sha }),
+        };
+      }
+      return { ok: true, json: async () => ({ status: "ok" }) };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("Endpoint 1 (/observe): safely handles null/empty projects with safe fallbacks and sends valid payload", async () => {
+    const { AgentmemoryCapturePlugin } = await import("../plugin/opencode/agentmemory-capture.ts");
+    const handlers = await (AgentmemoryCapturePlugin as any)({ worktree: "", project: {} });
+
+    await handlers.event({
+      event: { type: "session.created", properties: { sessionID: "sess-observe-1" } },
+    });
+
+    await handlers.event({
+      event: {
+        type: "session.status",
+        properties: { sessionID: "sess-observe-1", status: { type: "running", attempt: 1 } },
+      },
+    });
+
+    const observeCalls = capturedRequests.filter(r => r.url.includes("/observe"));
+    expect(observeCalls.length).toBeGreaterThanOrEqual(1);
+    const lastObserve = observeCalls[observeCalls.length - 1];
+    expect(lastObserve.body.sessionId).toBe("sess-observe-1");
+    expect(typeof lastObserve.body.project).toBe("string");
+    expect(lastObserve.body.project.length).toBeGreaterThan(0);
+    expect(typeof lastObserve.body.cwd).toBe("string");
+    expect(lastObserve.body.cwd.length).toBeGreaterThan(0);
+  });
+
+  it("Endpoint 2 (/session/start): sends valid start payload and caches start context", async () => {
+    const { AgentmemoryCapturePlugin } = await import("../plugin/opencode/agentmemory-capture.ts");
+    const handlers = await (AgentmemoryCapturePlugin as any)({ worktree: "/test/dir" });
+
+    await handlers.event({
+      event: {
+        type: "session.created",
+        properties: { info: { id: "sess-start-1", title: "Test Session", directory: "/test/dir" } },
+      },
+    });
+
+    const startCall = capturedRequests.find(r => r.url.includes("/session/start"));
+    expect(startCall).toBeDefined();
+    expect(startCall?.body.sessionId).toBe("sess-start-1");
+    expect(startCall?.body.project).toBeDefined();
+    expect(startCall?.body.cwd).toBe("/test/dir");
+  });
+
+  it("Endpoint 3 (/context): is called as fallback when start context cache is missing or during compacting", async () => {
+    const { AgentmemoryCapturePlugin } = await import("../plugin/opencode/agentmemory-capture.ts");
+    const handlers = await (AgentmemoryCapturePlugin as any)({ worktree: "/test/dir" });
+
+    // 1. experimental.session.compacting fetches /context
+    const compactOutput = { context: [] };
+    await handlers["experimental.session.compacting"]({ sessionID: "sess-ctx-1" }, compactOutput);
+
+    const ctxCall = capturedRequests.find(r => r.url.includes("/context"));
+    expect(ctxCall).toBeDefined();
+    expect(ctxCall?.body.sessionId).toBe("sess-ctx-1");
+    expect(compactOutput.context).toContain("## Fetched Context");
+  });
+
+  it("Endpoint 4 (/enrich): passes project parameter and excludes regex/glob patterns from file stash", async () => {
+    const { AgentmemoryCapturePlugin } = await import("../plugin/opencode/agentmemory-capture.ts");
+    const handlers = await (AgentmemoryCapturePlugin as any)({ worktree: "/test/dir" });
+
+    await handlers.event({
+      event: { type: "session.created", properties: { sessionID: "sess-enrich-1" } },
+    });
+
+    // Tool execute before with read (filePath) and glob (pattern)
+    await handlers["tool.execute.before"](
+      { sessionID: "sess-enrich-1", tool: "read" },
+      { args: { filePath: "src/main.ts" } },
+    );
+    await handlers["tool.execute.before"](
+      { sessionID: "sess-enrich-1", tool: "glob" },
+      { args: { pattern: "**/*.test.ts", path: "src" } },
+    );
+
+    const chatOutput = { parts: [{ type: "text", text: "Please check this" }] };
+    await handlers["chat.message"]({ sessionID: "sess-enrich-1" }, chatOutput);
+
+    const msgsOutput = {
+      messages: [
+        {
+          info: { role: "user", sessionID: "sess-enrich-1" },
+          parts: [{ type: "text", text: "Please check this" }],
+        },
+      ],
+    };
+    await handlers["experimental.chat.messages.transform"]({}, msgsOutput);
+
+    const enrichCall = capturedRequests.find(r => r.url.includes("/enrich"));
+    expect(enrichCall).toBeDefined();
+    expect(enrichCall?.body.sessionId).toBe("sess-enrich-1");
+    expect(enrichCall?.body.project).toBeDefined();
+    expect(typeof enrichCall?.body.project).toBe("string");
+    // "src/main.ts" and "src" should be stashed, but NOT the pattern "**/*.test.ts"
+    expect(enrichCall?.body.files).toContain("src/main.ts");
+    expect(enrichCall?.body.files).not.toContain("**/*.test.ts");
+  });
+
+  it("Endpoint 5 (/session/commit): links commit when git commit output is observed in bash tool", async () => {
+    const { AgentmemoryCapturePlugin } = await import("../plugin/opencode/agentmemory-capture.ts");
+    const handlers = await (AgentmemoryCapturePlugin as any)({ worktree: "/test/dir" });
+
+    await handlers.event({
+      event: { type: "session.created", properties: { sessionID: "sess-commit-1" } },
+    });
+
+    // Simulate tool output containing git commit result
+    await handlers.event({
+      event: {
+        type: "message.part.updated",
+        properties: {
+          sessionID: "sess-commit-1",
+          part: {
+            id: "part-1",
+            type: "tool",
+            tool: "bash",
+            state: {
+              status: "completed",
+              input: { command: "git commit -m 'feat: test commit'" },
+              output: "[main 1234567] feat: test commit\n 1 file changed, 1 insertion(+)",
+            },
+          },
+        },
+      },
+    });
+
+    const commitCall = capturedRequests.find(r => r.url.includes("/session/commit"));
+    expect(commitCall).toBeDefined();
+    expect(commitCall?.body.sha).toBe("1234567");
+    expect(commitCall?.body.sessionId).toBe("sess-commit-1");
+  });
+
+  it("Endpoint 6, 8, 9 (/session/end, /crystals/auto, /consolidate-pipeline): fires all on session.deleted", async () => {
+    const { AgentmemoryCapturePlugin } = await import("../plugin/opencode/agentmemory-capture.ts");
+    const handlers = await (AgentmemoryCapturePlugin as any)({ worktree: "/test/dir" });
+
+    await handlers.event({
+      event: { type: "session.created", properties: { sessionID: "sess-end-1" } },
+    });
+
+    await handlers.event({
+      event: { type: "session.deleted", properties: { info: { id: "sess-end-1" } } },
+    });
+
+    const endCall = capturedRequests.find(r => r.url.includes("/session/end"));
+    const crystalCall = capturedRequests.find(r => r.url.includes("/crystals/auto"));
+    const consolidateCall = capturedRequests.find(r => r.url.includes("/consolidate-pipeline"));
+
+    expect(endCall).toBeDefined();
+    expect(crystalCall).toBeDefined();
+    expect(consolidateCall).toBeDefined();
+  });
+
+  it("Endpoint 7 (/summarize): fires on direct session.idle, session.status idle, and session.compacted", async () => {
+    vi.useFakeTimers();
+    const { AgentmemoryCapturePlugin } = await import("../plugin/opencode/agentmemory-capture.ts");
+    const handlers = await (AgentmemoryCapturePlugin as any)({ worktree: "/test/dir" });
+
+    // Direct session.idle
+    await handlers.event({
+      event: { type: "session.idle", properties: { sessionID: "sess-idle-1" } },
+    });
+
+    // session.status idle
+    await handlers.event({
+      event: { type: "session.status", properties: { sessionID: "sess-idle-2", status: { type: "idle" } } },
+    });
+
+    // session.compacted
+    await handlers.event({
+      event: { type: "session.compacted", properties: { sessionID: "sess-idle-3" } },
+    });
+
+    // Advance fake timers past the 3000ms debounce window
+    await vi.advanceTimersByTimeAsync(3500);
+
+    const summarizeCalls = capturedRequests.filter(r => r.url.includes("/summarize"));
+    expect(summarizeCalls.length).toBe(3);
+    expect(summarizeCalls.map(c => c.body.sessionId)).toEqual(["sess-idle-1", "sess-idle-2", "sess-idle-3"]);
+    vi.useRealTimers();
+  });
+});

--- a/test/opencode-capture-remediation.test.ts
+++ b/test/opencode-capture-remediation.test.ts
@@ -1,0 +1,578 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+describe("OpenCode plugin remediation test suite (#1184, #720, #1188)", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      if (typeof url === "string" && url.includes("/session/start")) {
+        return {
+          ok: true,
+          json: async () => ({ context: "## Start Context from Server" }),
+        };
+      }
+      if (typeof url === "string" && url.includes("/context")) {
+        return {
+          ok: true,
+          json: async () => ({ context: "## Fresh Context from /context" }),
+        };
+      }
+      if (typeof url === "string" && url.includes("/enrich")) {
+        return {
+          ok: true,
+          json: async () => ({ context: "## File Enrichment Context for app.ts" }),
+        };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("Issue #1184: ignores diverse internal title-generator requests and preserves context injection for main turn", async () => {
+    const { AgentmemoryCapturePlugin } = await import(
+      "../plugin/opencode/agentmemory-capture.ts"
+    );
+    const handlers = await (AgentmemoryCapturePlugin as (c: unknown) => Promise<{
+      event: (msg: unknown) => Promise<void>;
+      "experimental.chat.system.transform": (input: any, output: any) => Promise<void>;
+    }>)({ project: { id: "test-proj" } });
+
+    await handlers.event({
+      event: { type: "session.created", properties: { info: { id: "sess-1184" } } },
+    });
+
+    // Test variant 1: "You are a title generator."
+    const titleOutput1 = { system: ["You are a title generator. You output ONLY a thread title."] };
+    await handlers["experimental.chat.system.transform"](
+      { sessionID: "sess-1184" },
+      titleOutput1,
+    );
+    expect(titleOutput1.system).toHaveLength(1);
+
+    // Test variant 2: "Generate a title for this conversation"
+    const titleOutput2 = { system: ["Generate a title for this conversation:"] };
+    await handlers["experimental.chat.system.transform"](
+      { sessionID: "sess-1184" },
+      titleOutput2,
+    );
+    expect(titleOutput2.system).toHaveLength(1);
+
+    // Main conversation turn arrives
+    const userTurnOutput = { system: ["You are a helpful assistant."] };
+    await handlers["experimental.chat.system.transform"](
+      { sessionID: "sess-1184" },
+      userTurnOutput,
+    );
+
+    // User turn MUST receive AGENTMEMORY_INSTRUCTIONS and Start Context
+    expect(userTurnOutput.system.length).toBeGreaterThanOrEqual(2);
+    expect(userTurnOutput.system.some((s: string) => s.includes("agentmemory"))).toBe(true);
+    expect(userTurnOutput.system.some((s: string) => s.includes("Start Context from Server"))).toBe(true);
+  });
+
+  it("Issue #720: keeps system prompt frozen on Turn 2+ to preserve LLM prefix caching", async () => {
+    const { AgentmemoryCapturePlugin } = await import(
+      "../plugin/opencode/agentmemory-capture.ts"
+    );
+    const handlers = await (AgentmemoryCapturePlugin as (c: unknown) => Promise<{
+      event: (msg: unknown) => Promise<void>;
+      "experimental.chat.system.transform": (input: any, output: any) => Promise<void>;
+      "tool.execute.before": (input: any, output: any) => Promise<void>;
+    }>)({ project: { id: "test-proj" } });
+
+    await handlers.event({
+      event: { type: "session.created", properties: { info: { id: "sess-720" } } },
+    });
+
+    // Turn 1
+    const turn1Output = { system: ["Base System Prompt"] };
+    await handlers["experimental.chat.system.transform"](
+      { sessionID: "sess-720" },
+      turn1Output,
+    );
+
+    // Simulate file tool execution between turns (e.g. read/edit)
+    await handlers["tool.execute.before"](
+      { sessionID: "sess-720", tool: "read" },
+      { args: { filePath: "/test/src/app.ts" } },
+    );
+
+    // Turn 2
+    const turn2Output = { system: ["Base System Prompt"] };
+    await handlers["experimental.chat.system.transform"](
+      { sessionID: "sess-720" },
+      turn2Output,
+    );
+
+    // System prompt on Turn 2 MUST NOT be mutated
+    expect(turn2Output.system).toEqual(["Base System Prompt"]);
+  });
+
+  it("Issue #720 (Cache-Safe Dynamic File Enrichment): injects file context into experimental.chat.messages.transform at tail", async () => {
+    const { AgentmemoryCapturePlugin } = await import(
+      "../plugin/opencode/agentmemory-capture.ts"
+    );
+    const handlers = await (AgentmemoryCapturePlugin as (c: unknown) => Promise<{
+      event: (msg: unknown) => Promise<void>;
+      "tool.execute.before": (input: any, output: any) => Promise<void>;
+      "chat.message": (input: any, output: any) => Promise<void>;
+      "experimental.chat.messages.transform": (input: any, output: any) => Promise<void>;
+    }>)({ project: { id: "test-proj" } });
+
+    await handlers.event({
+      event: { type: "session.created", properties: { info: { id: "sess-enrich-tail" } } },
+    });
+
+    // 1. Tool executed before touches a file
+    await handlers["tool.execute.before"](
+      { sessionID: "sess-enrich-tail", tool: "read" },
+      { args: { filePath: "/test/src/app.ts" } },
+    );
+
+    // 2. Chat message hook is clean (does not pollute DB parts)
+    const chatOutput = {
+      parts: [
+        { type: "text", text: "Please refactor app.ts for me" }
+      ]
+    };
+    await handlers["chat.message"](
+      { sessionID: "sess-enrich-tail", messageID: "msg-123" },
+      chatOutput,
+    );
+    expect(chatOutput.parts[0].text).toBe("Please refactor app.ts for me");
+
+    // 3. Before sending to LLM, experimental.chat.messages.transform injects context in-memory
+    const msgsOutput = {
+      messages: [
+        {
+          info: { role: "user", sessionID: "sess-enrich-tail" },
+          parts: [{ type: "text", text: "Please refactor app.ts for me" }],
+        },
+      ],
+    };
+    await handlers["experimental.chat.messages.transform"]({}, msgsOutput);
+
+    // 4. Verify /enrich was called with the file
+    const enrichCall = fetchMock.mock.calls.find(
+      (c: unknown[]) => typeof c[0] === "string" && (c[0] as string).includes("/enrich"),
+    );
+    expect(enrichCall).toBeDefined();
+
+    // 5. Verify context is appended in-memory to the user message
+    expect(msgsOutput.messages[0].parts[0].text).toContain("Please refactor app.ts for me");
+    expect(msgsOutput.messages[0].parts[0].text).toContain("<agentmemory-file-context>");
+    expect(msgsOutput.messages[0].parts[0].text).toContain("File Enrichment Context for app.ts");
+  });
+
+  it("Issue #720: clears stashed files even when /enrich returns empty context in messages.transform", async () => {
+    fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      if (typeof url === "string" && url.includes("/enrich")) {
+        return {
+          ok: true,
+          json: async () => ({ context: "" }), // empty context
+        };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { AgentmemoryCapturePlugin } = await import(
+      "../plugin/opencode/agentmemory-capture.ts"
+    );
+    const handlers = await (AgentmemoryCapturePlugin as (c: unknown) => Promise<{
+      event: (msg: unknown) => Promise<void>;
+      "tool.execute.before": (input: any, output: any) => Promise<void>;
+      "chat.message": (input: any, output: any) => Promise<void>;
+      "experimental.chat.messages.transform": (input: any, output: any) => Promise<void>;
+    }>)({ project: { id: "test-proj" } });
+
+    await handlers.event({
+      event: { type: "session.created", properties: { info: { id: "sess-empty-enrich" } } },
+    });
+
+    // 1. Tool executed touches file
+    await handlers["tool.execute.before"](
+      { sessionID: "sess-empty-enrich", tool: "read" },
+      { args: { filePath: "/test/src/unknown.ts" } },
+    );
+
+    // 2. First messages.transform triggers /enrich (which returns empty)
+    const msgsOutput1 = {
+      messages: [
+        {
+          info: { role: "user", sessionID: "sess-empty-enrich" },
+          parts: [{ type: "text", text: "Turn 1" }],
+        },
+      ],
+    };
+    await handlers["experimental.chat.messages.transform"]({}, msgsOutput1);
+
+    const enrichCallsBefore = fetchMock.mock.calls.filter(
+      (c: unknown[]) => typeof c[0] === "string" && (c[0] as string).includes("/enrich"),
+    ).length;
+    expect(enrichCallsBefore).toBe(1);
+
+    // 3. Second messages.transform without new file access MUST NOT re-query /enrich
+    const msgsOutput2 = {
+      messages: [
+        {
+          info: { role: "user", sessionID: "sess-empty-enrich" },
+          parts: [{ type: "text", text: "Turn 2" }],
+        },
+      ],
+    };
+    await handlers["experimental.chat.messages.transform"]({}, msgsOutput2);
+
+    const enrichCallsAfter = fetchMock.mock.calls.filter(
+      (c: unknown[]) => typeof c[0] === "string" && (c[0] as string).includes("/enrich"),
+    ).length;
+    expect(enrichCallsAfter).toBe(1); // Stash was cleared, no second call!
+  });
+
+  it("Cleans up session state completely on session.deleted", async () => {
+    const { AgentmemoryCapturePlugin } = await import(
+      "../plugin/opencode/agentmemory-capture.ts"
+    );
+    const handlers = await (AgentmemoryCapturePlugin as (c: unknown) => Promise<{
+      event: (msg: unknown) => Promise<void>;
+      "experimental.chat.system.transform": (input: any, output: any) => Promise<void>;
+    }>)({ project: { id: "test-proj" } });
+
+    await handlers.event({
+      event: { type: "session.created", properties: { info: { id: "sess-del" } } },
+    });
+
+    // Fire turn 1
+    const turn1 = { system: ["Base"] };
+    await handlers["experimental.chat.system.transform"](
+      { sessionID: "sess-del" },
+      turn1,
+    );
+    expect(turn1.system.length).toBeGreaterThan(1);
+
+    // Fire session.deleted
+    await handlers.event({
+      event: { type: "session.deleted", properties: { info: { id: "sess-del" } } },
+    });
+
+    // Verify /session/end was called
+    const endCall = fetchMock.mock.calls.find(
+      (c: unknown[]) => typeof c[0] === "string" && (c[0] as string).includes("/session/end"),
+    );
+    expect(endCall).toBeDefined();
+  });
+
+  it("Zero Schema Mutation in chat.message: verifies output.parts reference and contents are untouched without synthetic additions", async () => {
+    const { AgentmemoryCapturePlugin } = await import(
+      "../plugin/opencode/agentmemory-capture.ts"
+    );
+    const handlers = await (AgentmemoryCapturePlugin as any)({ project: { id: "test-proj" } });
+
+    await handlers.event({
+      event: { type: "session.created", properties: { info: { id: "sess-zero-mutation" } } },
+    });
+
+    const initialParts = [
+      { type: "text", text: "Please refactor the database query layer" },
+      { type: "file", url: "/src/db.ts", filename: "db.ts" },
+      { type: "image", data: "base64data", mime: "image/png" },
+    ];
+    const initialPartsDeepCopy = JSON.parse(JSON.stringify(initialParts));
+    const output = { parts: initialParts };
+
+    await handlers["chat.message"](
+      { sessionID: "sess-zero-mutation", messageID: "msg-test-01" },
+      output,
+    );
+
+    // 1. Array reference is strictly preserved (no new array assigned)
+    expect(output.parts).toBe(initialParts);
+    // 2. Length remains unchanged
+    expect(output.parts).toHaveLength(3);
+    // 3. Deep contents of all parts are identical and untouched
+    expect(output.parts).toEqual(initialPartsDeepCopy);
+    // 4. No synthetic or auxiliary parts were injected
+    expect(output.parts.some((p: any) => p.synthetic || p.type === "synthetic")).toBe(false);
+  });
+
+  it("Non-text / Media-only user messages: cleanly ignores messages with only non-text parts without throwing errors or mutating parts", async () => {
+    const { AgentmemoryCapturePlugin } = await import(
+      "../plugin/opencode/agentmemory-capture.ts"
+    );
+    const handlers = await (AgentmemoryCapturePlugin as any)({ project: { id: "test-proj" } });
+
+    await handlers.event({
+      event: { type: "session.created", properties: { info: { id: "sess-media-only" } } },
+    });
+
+    // Stash files via tool execution before turn
+    await handlers["tool.execute.before"](
+      { sessionID: "sess-media-only", tool: "read" },
+      { args: { filePath: "/test/src/app.ts" } },
+    );
+
+    // User message containing ONLY non-text media parts (image + binary file)
+    const imagePart = { type: "image", url: "https://example.com/screenshot.png", mime: "image/png" };
+    const filePart = { type: "file", url: "/test/src/asset.bin", filename: "asset.bin" };
+    const originalImageCopy = { ...imagePart };
+    const originalFileCopy = { ...filePart };
+
+    const msgsOutput = {
+      messages: [
+        {
+          info: { role: "user", sessionID: "sess-media-only" },
+          parts: [imagePart, filePart],
+        },
+      ],
+    };
+
+    // Transform must execute and resolve cleanly without throwing
+    await expect(
+      handlers["experimental.chat.messages.transform"]({}, msgsOutput),
+    ).resolves.not.toThrow();
+
+    // Verify parts array length and content are completely unmutated
+    expect(msgsOutput.messages[0].parts).toHaveLength(2);
+    expect(msgsOutput.messages[0].parts[0]).toEqual(originalImageCopy);
+    expect(msgsOutput.messages[0].parts[1]).toEqual(originalFileCopy);
+    expect((msgsOutput.messages[0].parts[0] as any).text).toBeUndefined();
+    expect((msgsOutput.messages[0].parts[1] as any).text).toBeUndefined();
+  });
+
+  describe("Daemon Down / Network Error Resilience", () => {
+    const errorScenarios = [
+      { name: "NetworkError (connection refused / DNS error)", error: new TypeError("Failed to fetch: NetworkError") },
+      { name: "AbortError (request timeout)", error: new DOMException("The operation was aborted", "AbortError") },
+      { name: "HTTP 500 Internal Server Error", response: { ok: false, status: 500, statusText: "Internal Server Error" } },
+      { name: "HTTP 503 Service Unavailable", response: { ok: false, status: 503, statusText: "Service Unavailable" } },
+    ];
+
+    for (const scenario of errorScenarios) {
+      it(`handles ${scenario.name} gracefully across all hooks (/enrich, /context, /observe, /session/start, /session/end) without unhandled rejections`, async () => {
+        if (scenario.error) {
+          fetchMock = vi.fn().mockRejectedValue(scenario.error);
+        } else {
+          fetchMock = vi.fn().mockResolvedValue(scenario.response);
+        }
+        vi.stubGlobal("fetch", fetchMock);
+
+        const { AgentmemoryCapturePlugin } = await import(
+          "../plugin/opencode/agentmemory-capture.ts"
+        );
+        const handlers = await (AgentmemoryCapturePlugin as any)({ project: { id: "test-proj" } });
+
+        // 1. session.created calls POST /session/start
+        await expect(
+          handlers.event({
+            event: { type: "session.created", properties: { info: { id: "sess-daemon-down" } } },
+          }),
+        ).resolves.not.toThrow();
+
+        // 2. chat.message calls POST /observe (prompt_submit)
+        const chatOutput = { parts: [{ type: "text", text: "Hello" }] };
+        await expect(
+          handlers["chat.message"]({ sessionID: "sess-daemon-down" }, chatOutput),
+        ).resolves.not.toThrow();
+
+        // 3. tool execution calls POST /observe (post_tool_use)
+        await expect(
+          handlers["tool.execute.before"](
+            { sessionID: "sess-daemon-down", tool: "read" },
+            { args: { filePath: "/test/src/app.ts" } },
+          ),
+        ).resolves.not.toThrow();
+
+        await expect(
+          handlers.event({
+            event: {
+              type: "message.part.updated",
+              properties: {
+                sessionID: "sess-daemon-down",
+                part: {
+                  id: "p1",
+                  type: "tool",
+                  tool: "read",
+                  state: { status: "completed", input: { filePath: "/test/src/app.ts" }, output: "file content" },
+                },
+              },
+            },
+          }),
+        ).resolves.not.toThrow();
+
+        // 4. experimental.chat.system.transform calls POST /context (fallback when start context missed)
+        const systemOutput = { system: ["Base prompt"] };
+        await expect(
+          handlers["experimental.chat.system.transform"]({ sessionID: "sess-daemon-down" }, systemOutput),
+        ).resolves.not.toThrow();
+        expect(systemOutput.system).toContainEqual(expect.stringContaining("agentmemory-instructions"));
+
+        // 5. experimental.chat.messages.transform calls POST /enrich
+        const msgsOutput = {
+          messages: [
+            {
+              info: { role: "user", sessionID: "sess-daemon-down" },
+              parts: [{ type: "text", text: "User prompt" }],
+            },
+          ],
+        };
+        await expect(
+          handlers["experimental.chat.messages.transform"]({}, msgsOutput),
+        ).resolves.not.toThrow();
+        expect(msgsOutput.messages[0].parts[0].text).toBe("User prompt");
+
+        // 6. experimental.session.compacting calls POST /context
+        const compactOutput = { context: [] };
+        await expect(
+          handlers["experimental.session.compacting"]({ sessionID: "sess-daemon-down" }, compactOutput),
+        ).resolves.not.toThrow();
+
+        // 7. session.deleted calls POST /session/end, /crystals/auto, /consolidate-pipeline
+        await expect(
+          handlers.event({
+            event: { type: "session.deleted", properties: { info: { id: "sess-daemon-down" } } },
+          }),
+        ).resolves.not.toThrow();
+      });
+    }
+  });
+
+  it("Multi-turn Cache-Safety Invariant: across 5 consecutive turns, output.system is transformed only on turn 1 and remains identical across turns 2, 3, 4, and 5", async () => {
+    const { AgentmemoryCapturePlugin } = await import(
+      "../plugin/opencode/agentmemory-capture.ts"
+    );
+    const handlers = await (AgentmemoryCapturePlugin as any)({ project: { id: "test-proj" } });
+
+    await handlers.event({
+      event: { type: "session.created", properties: { info: { id: "sess-5-turns" } } },
+    });
+
+    const basePrompt = "You are a senior TypeScript architect.";
+
+    // Turn 1: Should be transformed with instructions and start context
+    const turn1Output = { system: [basePrompt] };
+    await handlers["experimental.chat.system.transform"](
+      { sessionID: "sess-5-turns" },
+      turn1Output,
+    );
+    expect(turn1Output.system.length).toBeGreaterThanOrEqual(2);
+    expect(turn1Output.system[0]).toBe(basePrompt);
+    expect(turn1Output.system.some((s: string) => s.includes("agentmemory"))).toBe(true);
+    expect(turn1Output.system.some((s: string) => s.includes("Start Context from Server"))).toBe(true);
+
+    // Turns 2, 3, 4, and 5: System prompt must remain completely untouched
+    for (let turn = 2; turn <= 5; turn++) {
+      // Simulate tool activity touching new files between turns
+      await handlers["tool.execute.before"](
+        { sessionID: "sess-5-turns", tool: "read" },
+        { args: { filePath: `/test/src/module${turn}.ts` } },
+      );
+
+      const turnOutput = { system: [basePrompt] };
+      await handlers["experimental.chat.system.transform"](
+        { sessionID: "sess-5-turns" },
+        turnOutput,
+      );
+
+      // Verify that system prompt was not modified
+      expect(turnOutput.system).toEqual([basePrompt]);
+      expect(turnOutput.system).toHaveLength(1);
+    }
+  });
+
+  describe("OpenCode Desktop Mode & Multi-Candidate Project Resolution (PR #857 Parity)", () => {
+    it("filters out macOS .app bundles in info.directory and resolves real project directory", async () => {
+      const { AgentmemoryCapturePlugin } = await import(
+        "../plugin/opencode/agentmemory-capture.ts"
+      );
+      const handlers = await (AgentmemoryCapturePlugin as any)({
+        project: { directory: "/Volumes/DB/Example Projects/agentmemory" },
+        worktree: "/Volumes/DB/Example Projects/agentmemory",
+      });
+
+      // Desktop fires session.created with info.directory pointing to the Desktop app bundle
+      await handlers.event({
+        event: {
+          type: "session.created",
+          properties: {
+            info: {
+              id: "sess-desktop-app-bundle",
+              directory: "/Applications/OpenCode.app/Contents/Resources",
+            },
+          },
+        },
+      });
+
+      const startCall = fetchMock.mock.calls.find(
+        (c: unknown[]) => typeof c[0] === "string" && (c[0] as string).includes("/session/start"),
+      );
+      expect(startCall).toBeDefined();
+      const body = JSON.parse(startCall[1].body);
+
+      // Verify that the project name resolved to the git repo "agentmemory" and NOT "Resources" or "OpenCode.app"
+      expect(body.project).toBe("agentmemory");
+      expect(body.cwd).toContain("agentmemory");
+    });
+
+    it("respects AGENTMEMORY_PROJECT_NAME environment variable as highest priority override", async () => {
+      process.env.AGENTMEMORY_PROJECT_NAME = "custom-override-project";
+      try {
+        const { AgentmemoryCapturePlugin } = await import(
+          "../plugin/opencode/agentmemory-capture.ts"
+        );
+        const handlers = await (AgentmemoryCapturePlugin as any)({
+          worktree: "/Volumes/DB/Example Projects/agentmemory",
+        });
+
+        await handlers.event({
+          event: {
+            type: "session.created",
+            properties: { info: { id: "sess-env-override", directory: "/some/other/dir" } },
+          },
+        });
+
+        const startCall = fetchMock.mock.calls.find(
+          (c: unknown[]) => typeof c[0] === "string" && (c[0] as string).includes("/session/start"),
+        );
+        expect(startCall).toBeDefined();
+        const body = JSON.parse(startCall[1].body);
+        expect(body.project).toBe("custom-override-project");
+      } finally {
+        delete process.env.AGENTMEMORY_PROJECT_NAME;
+      }
+    });
+
+    it("falls back to non-.app basename when outside git repos", async () => {
+      const { AgentmemoryCapturePlugin } = await import(
+        "../plugin/opencode/agentmemory-capture.ts"
+      );
+      const handlers = await (AgentmemoryCapturePlugin as any)({
+        directory: "/tmp/my-non-git-workspace",
+      });
+
+      await handlers.event({
+        event: {
+          type: "session.created",
+          properties: {
+            info: {
+              id: "sess-non-git",
+              directory: "/Applications/OpenCode.app", // .app bundle skipped
+            },
+          },
+        },
+      });
+
+      const startCall = fetchMock.mock.calls.find(
+        (c: unknown[]) => typeof c[0] === "string" && (c[0] as string).includes("/session/start"),
+      );
+      expect(startCall).toBeDefined();
+      const body = JSON.parse(startCall[1].body);
+      expect(body.project).toBe("my-non-git-workspace");
+      expect(body.cwd).toBe("/tmp/my-non-git-workspace");
+    });
+  });
+});

--- a/test/opencode-summarize-debounce.test.ts
+++ b/test/opencode-summarize-debounce.test.ts
@@ -1,0 +1,313 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+describe("OpenCode plugin summarize debouncing & deduplication test suite", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      if (typeof url === "string" && url.includes("/summarize")) {
+        return {
+          ok: true,
+          json: async () => ({ success: true }),
+        };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("collapses concurrent session.idle and session.status (idle) into exactly 1 /summarize call", async () => {
+    const { AgentmemoryCapturePlugin } = await import(
+      "../plugin/opencode/agentmemory-capture.ts"
+    );
+    const handlers = await (AgentmemoryCapturePlugin as (c: unknown) => Promise<{
+      event: (msg: unknown) => Promise<void>;
+    }>)({ project: { id: "test-proj" } });
+
+    // Simulate session creation
+    await handlers.event({
+      event: { type: "session.created", properties: { info: { id: "sess-debounce-1" } } },
+    });
+
+    // Simulate simultaneous session.idle and session.status (idle)
+    await handlers.event({
+      event: { type: "session.idle", properties: { sessionID: "sess-debounce-1" } },
+    });
+    await handlers.event({
+      event: {
+        type: "session.status",
+        properties: { sessionID: "sess-debounce-1", status: { type: "idle" } },
+      },
+    });
+
+    // Immediately, fetchMock should NOT have fired /summarize yet due to debounce window
+    const summarizeCallsBefore = fetchMock.mock.calls.filter((c) =>
+      typeof c[0] === "string" && c[0].includes("/summarize"),
+    );
+    expect(summarizeCallsBefore).toHaveLength(0);
+
+    // Fast-forward past the debounce window (3000ms)
+    await vi.advanceTimersByTimeAsync(3500);
+
+    const summarizeCallsAfter = fetchMock.mock.calls.filter((c) =>
+      typeof c[0] === "string" && c[0].includes("/summarize"),
+    );
+    expect(summarizeCallsAfter).toHaveLength(1);
+    expect(JSON.parse(summarizeCallsAfter[0][1].body)).toEqual({
+      sessionId: "sess-debounce-1",
+    });
+  });
+
+  it("resets debounce timer on rapid successive session.idle events (trailing edge execution)", async () => {
+    const { AgentmemoryCapturePlugin } = await import(
+      "../plugin/opencode/agentmemory-capture.ts"
+    );
+    const handlers = await (AgentmemoryCapturePlugin as (c: unknown) => Promise<{
+      event: (msg: unknown) => Promise<void>;
+    }>)({ project: { id: "test-proj" } });
+
+    await handlers.event({
+      event: { type: "session.created", properties: { info: { id: "sess-debounce-2" } } },
+    });
+
+    // Fire 5 rapid events spaced by 500ms
+    for (let i = 0; i < 5; i++) {
+      await handlers.event({
+        event: { type: "session.idle", properties: { sessionID: "sess-debounce-2" } },
+      });
+      await vi.advanceTimersByTimeAsync(500);
+    }
+
+    // Total time elapsed: 2500ms (less than 3000ms after last event)
+    let calls = fetchMock.mock.calls.filter((c) =>
+      typeof c[0] === "string" && c[0].includes("/summarize"),
+    );
+    expect(calls).toHaveLength(0);
+
+    // Fast forward 3100ms past the last event
+    await vi.advanceTimersByTimeAsync(3100);
+
+    calls = fetchMock.mock.calls.filter((c) =>
+      typeof c[0] === "string" && c[0].includes("/summarize"),
+    );
+    expect(calls).toHaveLength(1);
+  });
+
+  it("isolates debounce timers across distinct sessions", async () => {
+    const { AgentmemoryCapturePlugin } = await import(
+      "../plugin/opencode/agentmemory-capture.ts"
+    );
+    const handlers = await (AgentmemoryCapturePlugin as (c: unknown) => Promise<{
+      event: (msg: unknown) => Promise<void>;
+    }>)({ project: { id: "test-proj" } });
+
+    await handlers.event({
+      event: { type: "session.created", properties: { info: { id: "sess-A" } } },
+    });
+    await handlers.event({
+      event: { type: "session.created", properties: { info: { id: "sess-B" } } },
+    });
+
+    // Fire idle on sess-A
+    await handlers.event({
+      event: { type: "session.idle", properties: { sessionID: "sess-A" } },
+    });
+
+    // Advance 1500ms, then fire idle on sess-B
+    await vi.advanceTimersByTimeAsync(1500);
+    await handlers.event({
+      event: { type: "session.idle", properties: { sessionID: "sess-B" } },
+    });
+
+    // Advance 1600ms (Total 3100ms from sess-A, 1600ms from sess-B)
+    await vi.advanceTimersByTimeAsync(1600);
+
+    let callsA = fetchMock.mock.calls.filter(
+      (c) =>
+        typeof c[0] === "string" &&
+        c[0].includes("/summarize") &&
+        JSON.parse(c[1]?.body || "{}").sessionId === "sess-A",
+    );
+    let callsB = fetchMock.mock.calls.filter(
+      (c) =>
+        typeof c[0] === "string" &&
+        c[0].includes("/summarize") &&
+        JSON.parse(c[1]?.body || "{}").sessionId === "sess-B",
+    );
+    expect(callsA).toHaveLength(1);
+    expect(callsB).toHaveLength(0);
+
+    // Advance remaining 1500ms for sess-B
+    await vi.advanceTimersByTimeAsync(1500);
+
+    callsB = fetchMock.mock.calls.filter(
+      (c) =>
+        typeof c[0] === "string" &&
+        c[0].includes("/summarize") &&
+        JSON.parse(c[1]?.body || "{}").sessionId === "sess-B",
+    );
+    expect(callsB).toHaveLength(1);
+  });
+
+  it("cancels pending summarize timer when session is deleted/pruned", async () => {
+    const { AgentmemoryCapturePlugin } = await import(
+      "../plugin/opencode/agentmemory-capture.ts"
+    );
+    const handlers = await (AgentmemoryCapturePlugin as (c: unknown) => Promise<{
+      event: (msg: unknown) => Promise<void>;
+    }>)({ project: { id: "test-proj" } });
+
+    await handlers.event({
+      event: { type: "session.created", properties: { info: { id: "sess-deleted" } } },
+    });
+
+    await handlers.event({
+      event: { type: "session.idle", properties: { sessionID: "sess-deleted" } },
+    });
+
+    // Advance 1000ms, then delete session
+    await vi.advanceTimersByTimeAsync(1000);
+    await handlers.event({
+      event: { type: "session.deleted", properties: { sessionID: "sess-deleted" } },
+    });
+
+    // Advance past original timer window
+    await vi.advanceTimersByTimeAsync(5000);
+
+    const calls = fetchMock.mock.calls.filter((c) =>
+      typeof c[0] === "string" && c[0].includes("/summarize"),
+    );
+    expect(calls).toHaveLength(0);
+  });
+
+  it("cancels pending summarize timer when session transitions to busy", async () => {
+    const { AgentmemoryCapturePlugin } = await import(
+      "../plugin/opencode/agentmemory-capture.ts"
+    );
+    const handlers = await (AgentmemoryCapturePlugin as (c: unknown) => Promise<{
+      event: (msg: unknown) => Promise<void>;
+    }>)({ project: { id: "test-proj" } });
+
+    await handlers.event({
+      event: { type: "session.created", properties: { info: { id: "sess-busy" } } },
+    });
+
+    // Go idle
+    await handlers.event({
+      event: { type: "session.idle", properties: { sessionID: "sess-busy" } },
+    });
+
+    // Advance 1000ms, then session becomes busy (e.g. new action starts)
+    await vi.advanceTimersByTimeAsync(1000);
+    await handlers.event({
+      event: {
+        type: "session.status",
+        properties: { sessionID: "sess-busy", status: { type: "busy" } },
+      },
+    });
+
+    // Advance past original timer window (3000ms from idle)
+    await vi.advanceTimersByTimeAsync(4000);
+
+    const calls = fetchMock.mock.calls.filter((c) =>
+      typeof c[0] === "string" && c[0].includes("/summarize"),
+    );
+    expect(calls).toHaveLength(0);
+  });
+
+  it("cancels pending summarize timer when user submits a new prompt", async () => {
+    const { AgentmemoryCapturePlugin } = await import(
+      "../plugin/opencode/agentmemory-capture.ts"
+    );
+    const handlers = await (AgentmemoryCapturePlugin as (c: unknown) => Promise<{
+      event: (msg: unknown) => Promise<void>;
+      "chat.message"?: (input: any, output: any) => Promise<void>;
+    }>)({ project: { id: "test-proj" } });
+
+    await handlers.event({
+      event: { type: "session.created", properties: { info: { id: "sess-prompt" } } },
+    });
+
+    // Go idle
+    await handlers.event({
+      event: { type: "session.idle", properties: { sessionID: "sess-prompt" } },
+    });
+
+    // Advance 1000ms, user submits a new prompt
+    await vi.advanceTimersByTimeAsync(1000);
+    if (handlers["chat.message"]) {
+      await handlers["chat.message"](
+        { sessionID: "sess-prompt" },
+        { message: { role: "user", parts: [{ type: "text", text: "next question" }] } },
+      );
+    }
+
+    // Advance past original timer window
+    await vi.advanceTimersByTimeAsync(4000);
+
+    const calls = fetchMock.mock.calls.filter((c) =>
+      typeof c[0] === "string" && c[0].includes("/summarize"),
+    );
+    expect(calls).toHaveLength(0);
+  });
+
+  it("prevents overlapping summarize requests while a summary is in-flight (single-flight guard)", async () => {
+    let resolveFirstSummarize: () => void;
+    fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      if (typeof url === "string" && url.includes("/summarize")) {
+        return new Promise((resolve) => {
+          resolveFirstSummarize = () => resolve({ ok: true, json: async () => ({ success: true }) });
+        });
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { AgentmemoryCapturePlugin } = await import(
+      "../plugin/opencode/agentmemory-capture.ts"
+    );
+    const handlers = await (AgentmemoryCapturePlugin as (c: unknown) => Promise<{
+      event: (msg: unknown) => Promise<void>;
+    }>)({ project: { id: "test-proj" } });
+
+    await handlers.event({
+      event: { type: "session.created", properties: { info: { id: "sess-inflight" } } },
+    });
+
+    // Trigger idle 1
+    await handlers.event({
+      event: { type: "session.idle", properties: { sessionID: "sess-inflight" } },
+    });
+    await vi.advanceTimersByTimeAsync(3500);
+
+    // 1st summarize call is now in-flight (not resolved yet)
+    let calls = fetchMock.mock.calls.filter((c) =>
+      typeof c[0] === "string" && c[0].includes("/summarize"),
+    );
+    expect(calls).toHaveLength(1);
+
+    // While 1st summarize is in-flight, another idle event occurs
+    await handlers.event({
+      event: { type: "session.idle", properties: { sessionID: "sess-inflight" } },
+    });
+    await vi.advanceTimersByTimeAsync(3500);
+
+    // Should NOT have spawned a 2nd concurrent HTTP request
+    calls = fetchMock.mock.calls.filter((c) =>
+      typeof c[0] === "string" && c[0].includes("/summarize"),
+    );
+    expect(calls).toHaveLength(1);
+
+    // Resolve the first summarize
+    resolveFirstSummarize!();
+    await vi.advanceTimersByTimeAsync(100);
+  });
+});


### PR DESCRIPTION
## Summary
Hardens the OpenCode capture plugin to prevent session/transcript pollution, preserve LLM prompt prefix cache efficiency, safely handle multimodal payloads, and maintain complete resilience when the daemon is offline.

### Key Changes
- **In-Memory Message Transformation (#1184)**: Migrated context injection to `experimental.chat.messages.transform` instead of mutating persistent session transcripts or SQLite rows.
- **Prefix Cache Freezing (#720)**: Transformed `output.system` strictly on Turn 1 per session, preserving byte-identical prompt prefix alignment across multi-turn chats for Anthropic and OpenAI prompt caching layers.
- **Multimodal & Non-Text Safety (#1188)**: Validated message content types (safe handling of `string` vs `ContentPart[]` arrays including image/binary/tool-result parts) without throwing `TypeError` or schema stripping.
- **Daemon-Down Resilience**: All outbound HTTP calls are wrapped with bounded timeouts (`AbortSignal.timeout`) and fail-open pass-through logic so IDE prompt workflows are never blocked when the daemon is down.

### Issues Closed
- Closes #1184
- Closes #720
- Closes #1188

### Verification
- Added comprehensive unit tests in `test/opencode-capture-remediation.test.ts` (covering zero schema mutation, media-only messages, network failures, and 5-turn cache invariance).
- All 1,749 repo tests pass cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - File context now includes only valid, literal file paths, avoiding accidental glob or pattern entries.
  - Git commits detected in tool output are automatically linked to the active session.
  - Session summaries are debounced and deduplicated, with pending requests cancelled when no longer relevant.
  - Context enrichment is applied without repeatedly altering system instructions, preserving consistent multi-turn behavior.
  - Improved project detection, including macOS application paths and fallback project details.
  - Improved handling of empty projects, media-only messages, internal requests, and temporary network or service errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->