### PR TITLE
fix(embedding): fall back to the local provider instead of none

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,16 +66,17 @@
 # 2. Embedding provider — auto-detected, override via EMBEDDING_PROVIDER
 # -----------------------------------------------------------------------------
 #
-# Without an embedding provider, vector embeddings are disabled. `mem::search`
-# uses BM25; `mem::smart-search` can also fuse structural graph matches when
-# graph data exists. Remote
-# provider detection order: EMBEDDING_PROVIDER override → GEMINI_API_KEY →
-# OPENAI_API_KEY → VOYAGE_API_KEY → COHERE_API_KEY → OPENROUTER_API_KEY →
-# BM25-only. Local embeddings are an explicit opt-in, not the keyless default.
-# `EMBEDDING_PROVIDER=local` uses Xenova/all-MiniLM-L6-v2 (384-dim) on-device;
-# the first embedding request downloads the model and needs network access.
+# Without an embedding key, agentmemory falls back to the local on-device
+# provider by default instead of running BM25-only. Detection order:
+# EMBEDDING_PROVIDER override → GEMINI_API_KEY → OPENAI_API_KEY →
+# VOYAGE_API_KEY → COHERE_API_KEY → OPENROUTER_API_KEY → local
+# (Xenova/all-MiniLM-L6-v2, 384-dim, on-device; the first embedding
+# request downloads the model and needs network access).
+# EMBEDDING_PROVIDER=none disables embeddings explicitly: `mem::search`
+# uses BM25, and `mem::smart-search` can still fuse structural graph
+# matches when graph data exists.
 
-# EMBEDDING_PROVIDER=local                       # local | openai | voyage | cohere | gemini | openrouter
+# EMBEDDING_PROVIDER=local                       # none | local | openai | voyage | cohere | gemini | openrouter
 
 # VOYAGE_API_KEY=pa-...                          # Optimised for code embeddings
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -271,6 +271,9 @@ export function detectEmbeddingProvider(
 ): string | null {
   const source = env ?? getMergedEnv();
   const forced = source["EMBEDDING_PROVIDER"];
+  // #395: an explicit opt-out has to stay reachable now that local is
+  // the fallback rather than null.
+  if (forced === "none") return null;
   if (forced) return forced;
 
   if (source["GEMINI_API_KEY"]) return "gemini";
@@ -278,7 +281,13 @@ export function detectEmbeddingProvider(
   if (source["VOYAGE_API_KEY"]) return "voyage";
   if (source["COHERE_API_KEY"]) return "cohere";
   if (source["OPENROUTER_API_KEY"]) return "openrouter";
-  return null;
+  // #395/#931: returning null here left currentEmbeddingProvider unset,
+  // so vectorIndexAddGuarded and indexRecords silently no-opped for
+  // every observation and semantic search returned zero hits forever.
+  // The local provider needs no key; its optional @huggingface/transformers
+  // dependency resolves lazily on first use, so a missing package surfaces
+  // as a per-write warning from the vector-index guards, not a boot error.
+  return "local";
 }
 
 export function loadClaudeBridgeConfig(): ClaudeBridgeConfig {

--- a/src/config.ts
+++ b/src/config.ts
@@ -271,8 +271,8 @@ export function detectEmbeddingProvider(
 ): string | null {
   const source = env ?? getMergedEnv();
   const forced = source["EMBEDDING_PROVIDER"];
-  // #395: an explicit opt-out has to stay reachable now that local is
-  // the fallback rather than null.
+  // Keeps an explicit opt-out reachable now that the fallback is a real
+  // provider rather than null.
   if (forced === "none") return null;
   if (forced) return forced;
 
@@ -281,12 +281,10 @@ export function detectEmbeddingProvider(
   if (source["VOYAGE_API_KEY"]) return "voyage";
   if (source["COHERE_API_KEY"]) return "cohere";
   if (source["OPENROUTER_API_KEY"]) return "openrouter";
-  // #395/#931: returning null here left currentEmbeddingProvider unset,
-  // so vectorIndexAddGuarded and indexRecords silently no-opped for
-  // every observation and semantic search returned zero hits forever.
-  // The local provider needs no key; its optional @huggingface/transformers
-  // dependency resolves lazily on first use, so a missing package surfaces
-  // as a per-write warning from the vector-index guards, not a boot error.
+  // Falls back to local rather than null: null left the provider unset, so
+  // indexing silently no-opped and semantic search returned nothing. Local
+  // needs no key, and its optional dependency resolves lazily, so a missing
+  // package surfaces as a per-write warning rather than a boot failure.
   return "local";
 }
 

--- a/test/embedding-provider.test.ts
+++ b/test/embedding-provider.test.ts
@@ -5,6 +5,8 @@ import {
 } from "../src/providers/embedding/index.js";
 import { GeminiEmbeddingProvider } from "../src/providers/embedding/gemini.js";
 import { OpenAIEmbeddingProvider } from "../src/providers/embedding/openai.js";
+import { LocalEmbeddingProvider } from "../src/providers/embedding/local.js";
+import { detectEmbeddingProvider } from "../src/config.js";
 import type { EmbeddingProvider } from "../src/types.js";
 
 describe("createEmbeddingProvider", () => {
@@ -24,7 +26,16 @@ describe("createEmbeddingProvider", () => {
     process.env = originalEnv;
   });
 
-  it("returns null when no API keys are set", () => {
+  // #395/#931: this used to assert the defect - a keyless install left
+  // currentEmbeddingProvider null and every vector write silently
+  // no-opped. Local is now the fallback provider.
+  it("returns LocalEmbeddingProvider when no API keys are set", () => {
+    const provider = createEmbeddingProvider();
+    expect(provider).toBeInstanceOf(LocalEmbeddingProvider);
+  });
+
+  it("returns null when EMBEDDING_PROVIDER=none opts out explicitly", () => {
+    process.env["EMBEDDING_PROVIDER"] = "none";
     const provider = createEmbeddingProvider();
     expect(provider).toBeNull();
   });
@@ -49,6 +60,26 @@ describe("createEmbeddingProvider", () => {
     process.env["EMBEDDING_PROVIDER"] = "openai";
     const provider = createEmbeddingProvider();
     expect(provider).toBeInstanceOf(OpenAIEmbeddingProvider);
+  });
+});
+
+describe("detectEmbeddingProvider local fallback", () => {
+  it("falls back to local when no cloud key is set (#395, #931)", () => {
+    expect(detectEmbeddingProvider({})).toBe("local");
+  });
+
+  it("still prefers an explicitly configured provider", () => {
+    expect(detectEmbeddingProvider({ EMBEDDING_PROVIDER: "openai" })).toBe(
+      "openai",
+    );
+  });
+
+  it("still prefers a cloud key over local", () => {
+    expect(detectEmbeddingProvider({ GEMINI_API_KEY: "k" })).toBe("gemini");
+  });
+
+  it("honours an explicit opt-out", () => {
+    expect(detectEmbeddingProvider({ EMBEDDING_PROVIDER: "none" })).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Problem

On a keyless install, `detectEmbeddingProvider` returns `null` unless `EMBEDDING_PROVIDER` is set explicitly. That leaves `currentEmbeddingProvider` unset, so `vectorIndexAddGuarded` and `indexRecords` silently no-op for **every** observation — semantic search returns zero hits forever, with no error surfaced anywhere. This is the root cause behind the zero-coverage reports in #395 and the missing-embeddings half of #931: the local provider existed but was an explicit opt-in nobody was told about, not the keyless default.

## Fix

- **Fall back to `local`** (Xenova/all-MiniLM-L6-v2, 384-dim, on-device, no key required) when no cloud key is configured, instead of returning `null`. The local provider's optional `@huggingface/transformers` dependency resolves lazily on the first `embed()` call, so a missing package surfaces as a per-write warning from the existing vector-index guards — not a boot failure.
- **`EMBEDDING_PROVIDER=none` becomes the explicit opt-out**, preserving a deliberate BM25-only mode.
- `.env.example` updated: the "without an embedding key, BM25-only" claim is stale under this change, and `none` joins the documented value list.

**Deliberate behavior change worth your sign-off:** a keyless install now downloads the local embedding model on the first embedding request (network access required at that moment) unless a cloud key is configured or `EMBEDDING_PROVIDER=none` opts out. If you'd rather keep opt-in semantics, say so and I'll rework this into a louder warning instead — but as-is, the default install ships with semantic search silently broken.

## Tests

`test/embedding-provider.test.ts` previously asserted the defect directly ("returns null when no API keys are set" for `createEmbeddingProvider()`); that test now expects a `LocalEmbeddingProvider` instance, with companion tests for the `none` opt-out and a new `detectEmbeddingProvider` block covering the fallback, explicit-provider precedence, cloud-key precedence, and opt-out.

Full suite: 1716 passed / 1 skipped. `tsc --noEmit` unchanged at the 30 pre-existing errors (none in touched files).

A follow-up PR adds boot-time provider visibility (probe + health reporting) and fixes the indexing gate for empty-narrative observations — kept separate so this behavior change can be discussed on its own.

Closes #395. Refs #931.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local on-device embeddings are now enabled by default when no cloud provider is configured.
  * Semantic search and vector indexing remain available without external API keys.
  * Added an explicit `none` option to disable embeddings while retaining BM25 and structural graph search.

* **Documentation**
  * Updated environment configuration guidance to reflect provider detection order and available options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->