### PR TITLE
fix(embedding): boot-time provider visibility and empty-narrative indexing

### DIFF
--- a/src/functions/search.ts
+++ b/src/functions/search.ts
@@ -294,12 +294,17 @@ export async function indexRecords(
     count++
   }
   for (const obs of observations) {
-    if (!obs.title || !obs.narrative) continue
+    // #931: a synthetic compression legitimately has an empty narrative
+    // when the hook carried no prompt, input, or output
+    // (compress-synthetic.ts). Requiring one here dropped those
+    // observations from BOTH the BM25 and vector indexes, while the live
+    // observe.ts path indexed them fine using title + narrative.
+    if (!obs.title) continue
     idx.add(obs)
     await enqueue({
       id: obs.id,
       sessionId: obs.sessionId,
-      text: obs.title + ' ' + obs.narrative,
+      text: obs.narrative ? obs.title + ' ' + obs.narrative : obs.title,
       context: { kind: "observation", logId: obs.id },
     })
     count++

--- a/src/index.ts
+++ b/src/index.ts
@@ -551,35 +551,15 @@ async function main() {
     config.restPort,
   );
 
-  // #931: a broken or absent embedding runtime previously surfaced only as
-  // a per-observation logger.warn inside vectorIndexAddGuarded, so a corpus
-  // could reach six figures at ~1% vector coverage with no visible signal.
-  // Resolve and warm the provider once at boot and say what happened.
-  //
-  // Fire-and-forget: process.on("SIGINT"/"SIGTERM", shutdown) is not
-  // registered until further down this function; awaiting the probe here
-  // would delay that registration by however long the first embed call
-  // takes. A cold local-model load can mean downloading tens of MB, so on
-  // a slow or rate-limited link that could be a long wait - if a rolling
-  // deploy's SIGTERM lands in that window, there is no shutdown handler
-  // installed yet and the process dies without healthMonitor.stop()/
-  // indexPersistence.save()/sdk.shutdown() running, losing the persisted
-  // search index. Detaching this also means there is no reason to bound it
-  // with a timeout: a slow cold load simply reports later instead of being
-  // killed off and logged as a spurious failure for a provider that would
-  // otherwise have worked.
+  // Deliberately not awaited: the SIGINT/SIGTERM handlers are registered
+  // further down this function, and a cold local-model load can take long
+  // enough to download tens of MB. A deploy signal arriving in that window
+  // would kill the process with no shutdown handler installed, losing the
+  // persisted search index.
   if (!embeddingProvider) {
-    // createEmbeddingProvider() returns null in two cases:
-    // EMBEDDING_PROVIDER=none (a deliberate opt-out) and an unrecognized
-    // value (a typo - createEmbeddingProvider's switch falls to
-    // `default: return null` for anything that isn't a known provider
-    // name). Printing a hardcoded "EMBEDDING_PROVIDER=none" here would
-    // blame the opt-out even when the user never set it, so print the
-    // value actually resolved instead.
-    //
-    // logger.info alongside bootLog: this is a deliberate opt-out (or a
-    // typo), not a failure, so info is the right level - but it still
-    // needs to reach the daemon log, which bootLog alone does not.
+    // Reports the resolved value rather than a hardcoded "none", because
+    // createEmbeddingProvider also returns null for an unrecognized
+    // provider name - blaming the opt-out would misdirect a typo.
     logger.info("Embeddings disabled", {
       provider: embeddingConfig.provider ?? "none",
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import {
   createFallbackProvider,
   createEmbeddingProvider,
   createImageEmbeddingProvider,
+  reportEmbeddingProbeResult,
 } from "./providers/index.js";
 import { StateKV } from "./state/kv.js";
 import { KV } from "./state/schema.js";
@@ -101,7 +102,7 @@ import { DedupMap } from "./functions/dedup.js";
 import { registerHealthMonitor } from "./health/monitor.js";
 import { initMetrics, OTEL_CONFIG } from "./telemetry/setup.js";
 import { VERSION } from "./version.js";
-import { bootLog } from "./logger.js";
+import { bootLog, logger } from "./logger.js";
 import { runtimeMetadataPath } from "./runtime-paths.js";
 import { mkdirSync, writeFileSync, unlinkSync } from "node:fs";
 import { dirname } from "node:path";
@@ -549,6 +550,45 @@ async function main() {
     secret,
     config.restPort,
   );
+
+  // #931: a broken or absent embedding runtime previously surfaced only as
+  // a per-observation logger.warn inside vectorIndexAddGuarded, so a corpus
+  // could reach six figures at ~1% vector coverage with no visible signal.
+  // Resolve and warm the provider once at boot and say what happened.
+  //
+  // Fire-and-forget: process.on("SIGINT"/"SIGTERM", shutdown) is not
+  // registered until further down this function; awaiting the probe here
+  // would delay that registration by however long the first embed call
+  // takes. A cold local-model load can mean downloading tens of MB, so on
+  // a slow or rate-limited link that could be a long wait - if a rolling
+  // deploy's SIGTERM lands in that window, there is no shutdown handler
+  // installed yet and the process dies without healthMonitor.stop()/
+  // indexPersistence.save()/sdk.shutdown() running, losing the persisted
+  // search index. Detaching this also means there is no reason to bound it
+  // with a timeout: a slow cold load simply reports later instead of being
+  // killed off and logged as a spurious failure for a provider that would
+  // otherwise have worked.
+  if (!embeddingProvider) {
+    // createEmbeddingProvider() returns null in two cases:
+    // EMBEDDING_PROVIDER=none (a deliberate opt-out) and an unrecognized
+    // value (a typo - createEmbeddingProvider's switch falls to
+    // `default: return null` for anything that isn't a known provider
+    // name). Printing a hardcoded "EMBEDDING_PROVIDER=none" here would
+    // blame the opt-out even when the user never set it, so print the
+    // value actually resolved instead.
+    //
+    // logger.info alongside bootLog: this is a deliberate opt-out (or a
+    // typo), not a failure, so info is the right level - but it still
+    // needs to reach the daemon log, which bootLog alone does not.
+    logger.info("Embeddings disabled", {
+      provider: embeddingConfig.provider ?? "none",
+    });
+    bootLog(
+      `Embeddings: disabled (EMBEDDING_PROVIDER=${embeddingConfig.provider ?? "none"})`,
+    );
+  } else {
+    void reportEmbeddingProbeResult(embeddingProvider);
+  }
 
   const autoForgetIntervalMs = parseInt(process.env.AUTO_FORGET_INTERVAL_MS || "3600000", 10);
   const consolidationIntervalMs = parseInt(process.env.CONSOLIDATION_INTERVAL_MS || "7200000", 10);

--- a/src/providers/embedding/index.ts
+++ b/src/providers/embedding/index.ts
@@ -50,31 +50,18 @@ export function createEmbeddingProvider(): EmbeddingProvider | null {
   }
 }
 
-// #931-class fix: the worker's boot-time embedding probe (src/index.ts)
-// used to report its result only through `bootLog`, which reaches
-// stderr solely under --verbose (see the comment above `bootLog` in
-// src/logger.ts). A daemon (launchd/systemd) start never sets that, so
-// on a live deployment a broken embedding runtime never printed a
-// single line - the corpus reached 201,102 observations at 1.1% vector
-// coverage before anyone noticed. `logger.info`/`logger.warn` reach the
-// daemon log unconditionally, so this reports through `logger` first,
-// with `bootLog` kept alongside so --verbose still shows it in the
-// compact boot summary the CLI builds from the buffer.
-//
-// Exported (rather than left as an inline .then()/.catch() at the call
-// site in src/index.ts) so tests can call and await it directly - the
-// caller dispatches this fire-and-forget, so there is no other way to
-// observe its settlement from outside.
+// Reports through `logger` rather than `bootLog` alone: bootLog only
+// reaches stderr under --verbose, which a daemon start never sets, so a
+// broken embedding runtime used to print nothing at all. Exported so
+// tests can await it - the caller dispatches it fire-and-forget.
 export async function reportEmbeddingProbeResult(
   embeddingProvider: EmbeddingProvider,
 ): Promise<void> {
   try {
-    // Probe embedBatch, not embed: the indexing path
-    // (vectorIndexAddBatchGuarded in search.ts) calls embedBatch, and a
-    // provider can implement the two differently. Verify the shape too -
-    // the guard drops any vector whose length differs from `dimensions`,
-    // so a wrong-shape provider would pass a bare probe call yet index
-    // nothing.
+    // embedBatch, not embed: that is what the indexing path calls, and a
+    // provider can implement the two differently. The shape check matters
+    // because the guard silently drops wrong-length vectors, so a bad
+    // provider would pass a bare probe yet index nothing.
     const vectors = await embeddingProvider.embedBatch([
       "agentmemory boot probe",
     ]);

--- a/src/providers/embedding/index.ts
+++ b/src/providers/embedding/index.ts
@@ -1,5 +1,6 @@
 import type { EmbeddingProvider } from "../../types.js";
 import { detectEmbeddingProvider, getEnvVar } from "../../config.js";
+import { bootLog, logger } from "../../logger.js";
 import { GeminiEmbeddingProvider } from "./gemini.js";
 import { OpenAIEmbeddingProvider } from "./openai.js";
 import { VoyageEmbeddingProvider } from "./voyage.js";
@@ -46,6 +47,63 @@ export function createEmbeddingProvider(): EmbeddingProvider | null {
       return withDimensionGuard(new LocalEmbeddingProvider());
     default:
       return null;
+  }
+}
+
+// #931-class fix: the worker's boot-time embedding probe (src/index.ts)
+// used to report its result only through `bootLog`, which reaches
+// stderr solely under --verbose (see the comment above `bootLog` in
+// src/logger.ts). A daemon (launchd/systemd) start never sets that, so
+// on a live deployment a broken embedding runtime never printed a
+// single line - the corpus reached 201,102 observations at 1.1% vector
+// coverage before anyone noticed. `logger.info`/`logger.warn` reach the
+// daemon log unconditionally, so this reports through `logger` first,
+// with `bootLog` kept alongside so --verbose still shows it in the
+// compact boot summary the CLI builds from the buffer.
+//
+// Exported (rather than left as an inline .then()/.catch() at the call
+// site in src/index.ts) so tests can call and await it directly - the
+// caller dispatches this fire-and-forget, so there is no other way to
+// observe its settlement from outside.
+export async function reportEmbeddingProbeResult(
+  embeddingProvider: EmbeddingProvider,
+): Promise<void> {
+  try {
+    // Probe embedBatch, not embed: the indexing path
+    // (vectorIndexAddBatchGuarded in search.ts) calls embedBatch, and a
+    // provider can implement the two differently. Verify the shape too -
+    // the guard drops any vector whose length differs from `dimensions`,
+    // so a wrong-shape provider would pass a bare probe call yet index
+    // nothing.
+    const vectors = await embeddingProvider.embedBatch([
+      "agentmemory boot probe",
+    ]);
+    if (
+      vectors.length !== 1 ||
+      vectors[0].length !== embeddingProvider.dimensions
+    ) {
+      throw new Error(
+        `embedBatch returned ${vectors.length} vector(s) of length ` +
+          `${vectors[0]?.length ?? 0}, expected 1 of length ${embeddingProvider.dimensions}`,
+      );
+    }
+    logger.info("Embedding provider verified", {
+      provider: embeddingProvider.name,
+      dimensions: embeddingProvider.dimensions,
+    });
+    bootLog(`Embeddings: ${embeddingProvider.name} (${embeddingProvider.dimensions}d)`);
+  } catch (err) {
+    logger.warn(
+      "Embedding provider failed boot probe - semantic search degrades to BM25-only",
+      {
+        provider: embeddingProvider.name,
+        error: err instanceof Error ? err.message : String(err),
+      },
+    );
+    bootLog(
+      `Embeddings: ${embeddingProvider.name} FAILED - semantic search will be BM25-only. ` +
+        (err instanceof Error ? err.message : String(err)),
+    );
   }
 }
 

--- a/src/providers/embedding/local.ts
+++ b/src/providers/embedding/local.ts
@@ -8,7 +8,7 @@ type FeatureExtractor = (
 export class LocalEmbeddingProvider implements EmbeddingProvider {
   readonly name = "local";
   readonly dimensions = 384;
-  private extractor: FeatureExtractor | null = null;
+  private extractorPromise: Promise<FeatureExtractor> | null = null;
 
   async embed(text: string): Promise<Float32Array> {
     const [result] = await this.embedBatch([text]);
@@ -24,24 +24,47 @@ export class LocalEmbeddingProvider implements EmbeddingProvider {
     return output.tolist().map((v) => new Float32Array(v));
   }
 
-  private async getExtractor() {
-    if (this.extractor) return this.extractor;
+  // Caches the in-flight load, not just the loaded extractor: the boot
+  // probe (reportEmbeddingProbeResult) and a BM25 rebuild's embedding
+  // queue can both hit a cold provider at once, and with only a
+  // post-await cache each concurrent caller kicks off its own
+  // pipeline() initialization - duplicate model download, memory, and
+  // startup CPU. The promise is evicted on rejection so a transient
+  // failure (an interrupted model download) is retried on the next
+  // call instead of being cached until restart.
+  private getExtractor(): Promise<FeatureExtractor> {
+    if (!this.extractorPromise) {
+      const loading = this.loadExtractor();
+      this.extractorPromise = loading;
+      loading.catch(() => {
+        if (this.extractorPromise === loading) this.extractorPromise = null;
+      });
+    }
+    return this.extractorPromise;
+  }
+
+  private async loadExtractor(): Promise<FeatureExtractor> {
     let transformers: typeof import("@huggingface/transformers");
     try {
       transformers = await import("@huggingface/transformers");
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === "ERR_MODULE_NOT_FOUND") {
+        // #395: installs predating the package rename carry
+        // @xenova/transformers 2.x, whose pipeline options differ. Say so
+        // explicitly - the symptom is otherwise a silent 0% embed rate.
         throw new Error(
-          "Install @huggingface/transformers for local embeddings: npm install @huggingface/transformers",
+          "Local embeddings need @huggingface/transformers (>=4). " +
+            "Install it with: npm install @huggingface/transformers. " +
+            "The legacy @xenova/transformers 2.x package is NOT compatible " +
+            "with this provider and will not be used even if present.",
         );
       }
       throw err;
     }
-    this.extractor = (await transformers.pipeline(
+    return (await transformers.pipeline(
       "feature-extraction",
       "Xenova/all-MiniLM-L6-v2",
       { dtype: "q8" },
     )) as FeatureExtractor;
-    return this.extractor;
   }
 }

--- a/src/providers/embedding/local.ts
+++ b/src/providers/embedding/local.ts
@@ -24,14 +24,10 @@ export class LocalEmbeddingProvider implements EmbeddingProvider {
     return output.tolist().map((v) => new Float32Array(v));
   }
 
-  // Caches the in-flight load, not just the loaded extractor: the boot
-  // probe (reportEmbeddingProbeResult) and a BM25 rebuild's embedding
-  // queue can both hit a cold provider at once, and with only a
-  // post-await cache each concurrent caller kicks off its own
-  // pipeline() initialization - duplicate model download, memory, and
-  // startup CPU. The promise is evicted on rejection so a transient
-  // failure (an interrupted model download) is retried on the next
-  // call instead of being cached until restart.
+  // Caches the in-flight promise, not just the resolved extractor:
+  // concurrent cold callers would otherwise each start their own model
+  // download. Evicted on rejection so an interrupted download is retried
+  // rather than cached until restart.
   private getExtractor(): Promise<FeatureExtractor> {
     if (!this.extractorPromise) {
       const loading = this.loadExtractor();

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -13,7 +13,11 @@ import { ResilientProvider } from "./resilient.js";
 import { FallbackChainProvider } from "./fallback-chain.js";
 import { getEnvVar } from "../config.js";
 
-export { createEmbeddingProvider, createImageEmbeddingProvider } from "./embedding/index.js";
+export {
+  createEmbeddingProvider,
+  createImageEmbeddingProvider,
+  reportEmbeddingProbeResult,
+} from "./embedding/index.js";
 
 function requireEnvVar(key: string): string {
   const value = getEnvVar(key);

--- a/test/boot-diagnostics-logger.test.ts
+++ b/test/boot-diagnostics-logger.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { readFileSync } from "node:fs";
+import type { EmbeddingProvider } from "../src/types.js";
+
+// #931-class fix: `bootLog` (src/logger.ts) only reaches stderr when
+// --verbose / AGENTMEMORY_VERBOSE is set (setBootVerbose is called from
+// exactly one place, src/cli.ts, driven by a CLI flag a daemon start
+// never passes). Otherwise the line is pushed into an in-memory buffer
+// that nothing ever reads (getBootBuffer has exactly one occurrence in
+// the repo: its own definition). So on a live daemon deploy, every
+// bootLog-only line was silently discarded. This suite proves the
+// embedding boot probe also reaches `logger`, which does land in the
+// daemon's stderr log.
+vi.mock("../src/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  bootLog: vi.fn(),
+}));
+
+import { logger, bootLog } from "../src/logger.js";
+import { reportEmbeddingProbeResult } from "../src/providers/embedding/index.js";
+
+function fakeProvider(
+  overrides: Partial<EmbeddingProvider> & Pick<EmbeddingProvider, "embedBatch">,
+): EmbeddingProvider {
+  return {
+    name: "test-provider",
+    dimensions: 768,
+    embed: async () => new Float32Array(768),
+    ...overrides,
+  };
+}
+
+describe("boot diagnostics reach the daemon log via logger, not just bootLog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("reportEmbeddingProbeResult (the embedding boot probe from src/index.ts)", () => {
+    it("success: logs via logger.info with the provider name and dimensions as structured fields", async () => {
+      const provider = fakeProvider({
+        name: "gemini",
+        dimensions: 768,
+        embedBatch: async (texts) => texts.map(() => new Float32Array(768)),
+      });
+
+      await reportEmbeddingProbeResult(provider);
+
+      expect(logger.info).toHaveBeenCalledWith("Embedding provider verified", {
+        provider: "gemini",
+        dimensions: 768,
+      });
+      expect(logger.warn).not.toHaveBeenCalled();
+      // bootLog is kept alongside for --verbose parity.
+      expect(bootLog).toHaveBeenCalledWith("Embeddings: gemini (768d)");
+    });
+
+    it("failure: logs via logger.warn, including the underlying error and the BM25-only degradation", async () => {
+      const boom = new Error("ECONNREFUSED");
+      const provider = fakeProvider({
+        name: "local",
+        dimensions: 384,
+        embedBatch: async () => {
+          throw boom;
+        },
+      });
+
+      // The call site in src/index.ts dispatches this fire-and-forget
+      // (`void reportEmbeddingProbeResult(embeddingProvider)`), so
+      // main() itself never awaits the failure branch settling. Calling
+      // the exported function directly and awaiting it here is the only
+      // way to observe that branch run to completion.
+      await reportEmbeddingProbeResult(provider);
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        "Embedding provider failed boot probe - semantic search degrades to BM25-only",
+        { provider: "local", error: "ECONNREFUSED" },
+      );
+      expect(logger.info).not.toHaveBeenCalled();
+      expect(bootLog).toHaveBeenCalledWith(
+        "Embeddings: local FAILED - semantic search will be BM25-only. ECONNREFUSED",
+      );
+    });
+
+    it("fails the probe when embedBatch returns a wrong-dimension vector, since the index guard would drop every batch", async () => {
+      const provider = fakeProvider({
+        name: "test-provider",
+        dimensions: 768,
+        embedBatch: async (texts) => texts.map(() => new Float32Array(10)),
+      });
+
+      await reportEmbeddingProbeResult(provider);
+
+      expect(logger.info).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        "Embedding provider failed boot probe - semantic search degrades to BM25-only",
+        {
+          provider: "test-provider",
+          error:
+            "embedBatch returned 1 vector(s) of length 10, expected 1 of length 768",
+        },
+      );
+    });
+
+    it("never rejects even when embedBatch() throws, so the fire-and-forget dispatch cannot surface an unhandled rejection", async () => {
+      const provider = fakeProvider({
+        embedBatch: async () => {
+          throw new Error("boom");
+        },
+      });
+
+      await expect(reportEmbeddingProbeResult(provider)).resolves.toBeUndefined();
+    });
+  });
+});
+
+// The EMBEDDING_PROVIDER=none / disabled branch is left inline in
+// main() (src/index.ts) rather than extracted, since extracting it
+// would have required renaming the `embeddingConfig.provider`
+// expression that test/embedding-boot-log.test.ts already asserts on
+// verbatim. main() itself cannot be invoked from a unit test at all:
+// importing src/index.ts runs `main().catch(...)` as a module-level
+// side effect, which registers a real iii-sdk worker and opens real
+// HTTP listeners - reaching this branch behaviorally would mean
+// standing up the whole daemon, which is disproportionate for one log
+// line. So this is a structural check instead, matching the idiom
+// test/stop-worker-pidfile.test.ts and test/embedding-boot-log.test.ts
+// already use for boot-time wiring in src/index.ts.
+describe("embedding-disabled boot line also reaches logger.info (structural)", () => {
+  it("logs the disabled/opt-out case via logger.info immediately before the existing bootLog line", () => {
+    const source = readFileSync("src/index.ts", "utf-8");
+    expect(source).toMatch(
+      /logger\.info\(\s*"Embeddings disabled",\s*\{\s*provider:\s*embeddingConfig\.provider\s*\?\?\s*"none",\s*\}\s*\);\s*bootLog\(\s*`Embeddings: disabled/,
+    );
+  });
+});

--- a/test/embedding-boot-log.test.ts
+++ b/test/embedding-boot-log.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+
+// createEmbeddingProvider() (src/providers/embedding/index.ts) returns null
+// for TWO different reasons: EMBEDDING_PROVIDER=none (a deliberate
+// opt-out) and an unrecognized value (a typo - the switch's
+// `default: return null`). The boot log used to hardcode
+// "EMBEDDING_PROVIDER=none" in both cases, blaming the opt-out even when
+// the user never set it - in the feature meant to make embedding
+// misconfiguration loud, the loud line misattributed the cause. This is
+// a structural (source-regex) check, matching the idiom
+// test/stop-worker-pidfile.test.ts and test/evict.test.ts's "eviction
+// scheduling" block already use for boot-time wiring in src/index.ts.
+describe("embedding boot log reports the resolved value, not a hardcoded cause", () => {
+  it("interpolates embeddingConfig.provider instead of a literal 'none'", () => {
+    const source = readFileSync("src/index.ts", "utf-8");
+    expect(source).not.toMatch(
+      /bootLog\(\s*"Embeddings: disabled \(EMBEDDING_PROVIDER=none\)"\s*\)/,
+    );
+    expect(source).toMatch(
+      /bootLog\(\s*`Embeddings: disabled \(EMBEDDING_PROVIDER=\$\{embeddingConfig\.provider[^}]*\}\)`,?\s*\);/,
+    );
+  });
+});

--- a/test/local-embedding-provider.test.ts
+++ b/test/local-embedding-provider.test.ts
@@ -5,6 +5,14 @@ afterEach(() => {
   vi.resetModules();
 });
 
+// The factory-less doMock is deliberate: the optional runtime is not in
+// this repo's devDependencies, so vitest's mocker fails to resolve the
+// module and the import rejects with ERR_MODULE_NOT_FOUND - the exact
+// path under test. It cannot be simulated more explicitly: a factory
+// that throws (or rejects with) a coded error gets wrapped in vitest's
+// own "error when mocking a module" error, losing the `code` the
+// provider's mapping keys on. If @huggingface/transformers is ever added
+// to devDependencies, these two tests will need a different seam.
 describe("LocalEmbeddingProvider (package unavailable)", () => {
   it("throws clean install hint when @huggingface/transformers is missing", async () => {
     vi.doMock("@huggingface/transformers");
@@ -12,9 +20,62 @@ describe("LocalEmbeddingProvider (package unavailable)", () => {
     const { LocalEmbeddingProvider: Fresh } = await import(
       "../src/providers/embedding/local.js"
     );
+    // #931: message rewritten to also name the legacy @xenova/transformers
+    // 2.x package as incompatible, since that is exactly what silently sat
+    // installed on the live box while the code imported the renamed
+    // successor - see the "legacy package" test below.
     await expect(new Fresh().embed("hello")).rejects.toThrow(
-      "Install @huggingface/transformers for local embeddings",
+      "Local embeddings need @huggingface/transformers (>=4)",
     );
+  });
+
+  it("names both the current and legacy package when the runtime is missing", async () => {
+    vi.doMock("@huggingface/transformers");
+    vi.resetModules();
+    const { LocalEmbeddingProvider: Fresh } = await import(
+      "../src/providers/embedding/local.js"
+    );
+    const provider = new Fresh();
+    await expect(provider.embed("hello")).rejects.toThrow(
+      /@huggingface\/transformers/,
+    );
+    await expect(provider.embed("hello")).rejects.toThrow(
+      /@xenova\/transformers/,
+    );
+  });
+});
+
+describe("LocalEmbeddingProvider extractor initialization", () => {
+  function mockTransformers(pipeline: unknown) {
+    vi.doMock("@huggingface/transformers", () => ({ pipeline }));
+    vi.resetModules();
+  }
+
+  // Also guards the wrong shape of the concurrency fix in getExtractor:
+  // a bare `??=` of the load promise would cache a rejection forever,
+  // turning one interrupted model download into a dead provider until
+  // restart. (The concurrency dedup itself is not black-box testable
+  // here: vitest's module runner serializes mocked dynamic imports, so
+  // even the pre-fix code shows a single pipeline() call under
+  // Promise.all - verified against plain Node semantics instead.)
+  it("retries after a failed initialization instead of caching the rejection", async () => {
+    const pipeline = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("download interrupted"))
+      .mockImplementation(
+        async () => async (texts: string[]) => ({
+          tolist: () => texts.map(() => [0.1]),
+        }),
+      );
+    mockTransformers(pipeline);
+    const { LocalEmbeddingProvider: Fresh } = await import(
+      "../src/providers/embedding/local.js"
+    );
+    const provider = new Fresh();
+
+    await expect(provider.embed("a")).rejects.toThrow("download interrupted");
+    await expect(provider.embed("a")).resolves.toBeInstanceOf(Float32Array);
+    expect(pipeline).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/test/search-index.test.ts
+++ b/test/search-index.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { SearchIndex } from "../src/state/search-index.js";
 import { segmentCjk } from "../src/state/cjk-segmenter.js";
+import { indexRecords } from "../src/functions/search.js";
 import type { CompressedObservation } from "../src/types.js";
 
 function makeObs(
@@ -289,5 +290,33 @@ describe("SearchIndex", () => {
     ]);
     expect(segmentCjk("leading 项目")).toEqual(["leading", "项目"]);
     expect(segmentCjk("项目 trailing")).toEqual(["项目", "trailing"]);
+  });
+});
+
+describe("indexRecords", () => {
+  // #931: synthetic compressions can have an empty narrative when the hook
+  // carried no prompt, input, or output (compress-synthetic.ts). The gate
+  // used to require both title and narrative, dropping these observations
+  // from the index entirely.
+  it("indexes an observation with an empty narrative (title still carries signal)", async () => {
+    const indexed = await indexRecords(
+      [
+        {
+          id: "o1",
+          sessionId: "s1",
+          timestamp: "2026-08-21T00:00:00.000Z",
+          type: "other",
+          title: "Bash",
+          facts: [],
+          narrative: "",
+          concepts: [],
+          files: [],
+          importance: 5,
+          confidence: 0.3,
+        },
+      ],
+      [],
+    );
+    expect(indexed).toBe(1);
   });
 });

--- a/test/search-index.test.ts
+++ b/test/search-index.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { SearchIndex } from "../src/state/search-index.js";
 import { segmentCjk } from "../src/state/cjk-segmenter.js";
-import { indexRecords } from "../src/functions/search.js";
+import { indexRecords, getSearchIndex } from "../src/functions/search.js";
 import type { CompressedObservation } from "../src/types.js";
 
 function makeObs(
@@ -318,5 +318,11 @@ describe("indexRecords", () => {
       [],
     );
     expect(indexed).toBe(1);
+    // The count alone passes even if o1 never reached the index, which is
+    // the regression this test exists to catch.
+    expect(getSearchIndex().has("o1")).toBe(true);
+    expect(getSearchIndex().search("Bash").map((r) => r.obsId)).toContain(
+      "o1",
+    );
   });
 });


### PR DESCRIPTION
## Problem

#931's underlying complaint is that embedding failures are invisible. Two concrete holes:

1. **A missing or broken embedding runtime surfaced only as a per-write `logger.warn`** inside the vector-index guards. On a live deployment we observed, the corpus reached **201,102 observations at 1.1% vector coverage** before anyone noticed — the installed package was the legacy `@xenova/transformers` 2.x while the code imports the renamed `@huggingface/transformers`, and not one boot line said so.
2. **`indexRecords` silently dropped observations with an empty narrative** from both the BM25 and vector indexes. Synthetic compressions legitimately have an empty narrative when the hook carried no prompt/input/output (`compress-synthetic.ts`), and the live `observe.ts` path indexes those fine — only the rebuild path lost them.

## Fix

**Boot probe (commit 1).** Resolve and warm the embedding provider once at boot with a single `embed()` call, and report the outcome — provider name and dimensions on success, the underlying error plus the BM25-only degradation on failure. Details that matter:

- **Fire-and-forget.** At that point in `main()` the shutdown handlers aren't registered yet, and a cold local-model load can download tens of MB — awaiting the probe would open a window where a rolling deploy's SIGTERM kills the process before `indexPersistence.save()` runs, losing the persisted search index. Detached, a slow cold load simply reports later; no timeout needed.
- **Reported through `logger`, not just `bootLog`.** `bootLog` reaches stderr only under `--verbose`, which a daemon (launchd/systemd) start never passes — its buffer is otherwise never read. That's precisely why hole #1 stayed invisible on the deployment that mattered. `bootLog` is kept alongside for `--verbose` parity.
- **The disabled branch prints the resolved `EMBEDDING_PROVIDER` value** instead of hardcoding `none`, so a typo'd value isn't blamed on the deliberate opt-out.
- **The probe calls `embedBatch`, not `embed`, and verifies the returned shape** (one vector of exactly `dimensions` length) — `embedBatch` is what the indexing path (`vectorIndexAddBatchGuarded`) actually uses, and that guard drops any wrong-length vector, so a wrong-shape provider would pass a bare probe yet index nothing.
- **The local provider's install error now names `@xenova/transformers` 2.x as incompatible** — the exact trap from the observed deployment.
- **`LocalEmbeddingProvider` caches the in-flight extractor load.** The probe and a BM25 rebuild's embedding queue can both hit a cold provider at once; with only a post-`await` cache, each concurrent caller kicks off its own `pipeline()` initialization (duplicate model download/memory — verified against plain Node promise semantics; vitest's module runner serializes mocked dynamic imports, so the concurrency itself isn't black-box testable there). The cached promise is evicted on rejection so a transient download failure retries instead of latching until restart — and that eviction behavior is pinned by a test that fails against the naive `??=` implementation.

**Indexing gate (commit 2).** `indexRecords` now requires only a title, with title-only text for the embedding queue when the narrative is empty — matching what `observe.ts` already does.

## Tests

Probe success/failure/never-rejects via the exported `reportEmbeddingProbeResult` (exported precisely because the call site is fire-and-forget, so awaiting it in a test is the only way to observe settlement); structural checks for the two boot lines in `main()` (which can't be invoked from a unit test — importing `src/index.ts` starts a real worker); the rewritten install error naming both packages; a wrong-shape probe failure; retry-after-failed-init for the extractor cache; and an empty-narrative observation indexing to count 1.

Full suite: 1720 passed / 1 skipped. `tsc --noEmit` unchanged at the 30 pre-existing errors (none in touched files).

One reviewer-style suggestion I investigated and declined: replacing the factory-less `vi.doMock("@huggingface/transformers")` in the package-unavailable tests with a factory that raises `ERR_MODULE_NOT_FOUND`. Vitest wraps any factory throw/rejection in its own "error when mocking a module" error, discarding the `code` the provider's mapping keys on, so the explicit simulation is not expressible; the factory-less form (the repo's existing pattern for these tests) reliably produces the module-not-found path because the optional runtime is not in devDependencies. Documented in a comment at the test site.

Independent of #1283 (local-by-default detection): the probe reports whatever provider resolves under current detection rules, and each PR merges cleanly without the other. Together they close the loop on #931's "embeddings silently absent" story.

Refs #931.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added startup diagnostics for embedding providers, including provider status, successful checks, and configuration details.
  * Embedding failures now clearly fall back to BM25-only search without preventing startup.
* **Bug Fixes**
  * Observations with titles but empty narratives are now searchable.
  * Improved local embedding initialization reliability by preventing duplicate loading and retrying after failures.
  * Updated installation guidance for supported embedding packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->