### PR TITLE
fix(health): measure heap against heap_size_limit, not heapTotal

### DIFF
--- a/src/health/monitor.ts
+++ b/src/health/monitor.ts
@@ -1,4 +1,5 @@
 import type { ISdk } from "iii-sdk";
+import { getHeapStatistics } from "node:v8";
 import type { HealthSnapshot } from "../types.js";
 import type { StateKV } from "../state/kv.js";
 import { KV } from "../state/schema.js";
@@ -69,6 +70,8 @@ export function registerHealthMonitor(
       memory: {
         heapUsed: mem.heapUsed,
         heapTotal: mem.heapTotal,
+        // #1223: hard ceiling, see thresholds.ts for why this beats heapTotal.
+        heapLimit: getHeapStatistics().heap_size_limit,
         rss: mem.rss,
         external: mem.external,
       },

--- a/src/health/monitor.ts
+++ b/src/health/monitor.ts
@@ -70,7 +70,6 @@ export function registerHealthMonitor(
       memory: {
         heapUsed: mem.heapUsed,
         heapTotal: mem.heapTotal,
-        // #1223: hard ceiling, see thresholds.ts for why this beats heapTotal.
         heapLimit: getHeapStatistics().heap_size_limit,
         rss: mem.rss,
         external: mem.external,

--- a/src/health/thresholds.ts
+++ b/src/health/thresholds.ts
@@ -59,9 +59,15 @@ export function evaluateHealth(
     degraded = true;
   }
 
+  // #1223: prefer the V8 hard ceiling. heapTotal is demand-sized, so the
+  // old ratio reported 'critical' on a process at 10% of its real limit.
+  const heapDenominator =
+    snapshot.memory.heapLimit && snapshot.memory.heapLimit > 0
+      ? snapshot.memory.heapLimit
+      : snapshot.memory.heapTotal;
   const memPercent =
-    snapshot.memory.heapTotal > 0
-      ? (snapshot.memory.heapUsed / snapshot.memory.heapTotal) * 100
+    heapDenominator > 0
+      ? (snapshot.memory.heapUsed / heapDenominator) * 100
       : 0;
   const rss = snapshot.memory.rss ?? 0;
   const rssAboveFloor = rss >= cfg.memoryRssFloorBytes;

--- a/src/health/thresholds.ts
+++ b/src/health/thresholds.ts
@@ -59,8 +59,8 @@ export function evaluateHealth(
     degraded = true;
   }
 
-  // #1223: prefer the V8 hard ceiling. heapTotal is demand-sized, so the
-  // old ratio reported 'critical' on a process at 10% of its real limit.
+  // heapTotal is demand-sized, so measuring against it reported critical
+  // on a process at 10% of its real ceiling.
   const heapDenominator =
     snapshot.memory.heapLimit && snapshot.memory.heapLimit > 0
       ? snapshot.memory.heapLimit

--- a/src/types.ts
+++ b/src/types.ts
@@ -225,6 +225,11 @@ export interface HealthSnapshot {
   memory: {
     heapUsed: number;
     heapTotal: number;
+    // #1223: V8's hard ceiling (heap_size_limit). heapTotal is only what
+    // V8 has committed so far and grows to meet demand, so heapUsed over
+    // heapTotal can only ever over-report pressure. Optional so snapshots
+    // persisted before this field keep deserializing.
+    heapLimit?: number;
     rss: number;
     external: number;
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -225,10 +225,8 @@ export interface HealthSnapshot {
   memory: {
     heapUsed: number;
     heapTotal: number;
-    // #1223: V8's hard ceiling (heap_size_limit). heapTotal is only what
-    // V8 has committed so far and grows to meet demand, so heapUsed over
-    // heapTotal can only ever over-report pressure. Optional so snapshots
-    // persisted before this field keep deserializing.
+    // V8's heap_size_limit. Optional so snapshots persisted before this
+    // field keep deserializing.
     heapLimit?: number;
     rss: number;
     external: number;

--- a/test/health-monitor-heap.test.ts
+++ b/test/health-monitor-heap.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { getHeapStatistics } from "node:v8";
+import { registerHealthMonitor } from "../src/health/monitor.js";
+import { KV } from "../src/state/schema.js";
+import type { HealthSnapshot } from "../src/types.js";
+
+// Map-backed mock KV mirrors test/index-persistence.test.ts's, enough
+// surface for StateKV's get/set, cast past the class's private field with
+// `as never` the same way that file does.
+function mockKV() {
+  const store = new Map<string, Map<string, unknown>>();
+  return {
+    get: async <T>(scope: string, key: string): Promise<T | null> => {
+      return (store.get(scope)?.get(key) as T) ?? null;
+    },
+    set: async <T>(scope: string, key: string, data: T): Promise<T> => {
+      if (!store.has(scope)) store.set(scope, new Map());
+      store.get(scope)!.set(key, data);
+      return data;
+    },
+  };
+}
+
+function mockSdk() {
+  return {
+    trigger: async () => ({ workers: [] }),
+  };
+}
+
+async function waitForSnapshot(
+  kv: ReturnType<typeof mockKV>,
+): Promise<HealthSnapshot> {
+  for (let i = 0; i < 50; i++) {
+    const snapshot = await kv.get<HealthSnapshot>(KV.health, "latest");
+    if (snapshot) return snapshot;
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  throw new Error("collectHealth did not persist a snapshot in time");
+}
+
+describe("registerHealthMonitor producer wiring (#1223)", () => {
+  it("persists memory.heapLimit from getHeapStatistics().heap_size_limit", async () => {
+    const kv = mockKV();
+    const { stop } = registerHealthMonitor(mockSdk() as never, kv as never);
+
+    try {
+      const snapshot = await waitForSnapshot(kv);
+
+      // The one assertion pinning collectHealth's producer wiring for
+      // heapLimit - the hard ceiling thresholds.ts measures the memory
+      // ratio against instead of heapTotal (V8's current allocation, not
+      // its cap). Deleting `heapLimit: getHeapStatistics().heap_size_limit`
+      // from src/health/monitor.ts leaves this undefined with an otherwise
+      // green suite.
+      expect(snapshot.memory.heapLimit).toBe(
+        getHeapStatistics().heap_size_limit,
+      );
+    } finally {
+      stop();
+    }
+  });
+});

--- a/test/health-thresholds.test.ts
+++ b/test/health-thresholds.test.ts
@@ -95,3 +95,33 @@ describe("evaluateHealth memory severity", () => {
     expect(strict.status).toBe("healthy");
   });
 });
+
+describe("evaluateHealth heap denominator", () => {
+  it("stays healthy at 10% of the heap limit even when heapTotal is nearly full (#1223)", () => {
+    const s = snap({
+      memory: {
+        heapUsed: 849 * 1024 * 1024,
+        heapTotal: 860 * 1024 * 1024,
+        heapLimit: 8192 * 1024 * 1024,
+        rss: 1200 * 1024 * 1024,
+        external: 0,
+      },
+    });
+    const { status, alerts, notes } = evaluateHealth(s);
+    expect(status).toBe("healthy");
+    expect(alerts).toEqual([]);
+    expect(notes.find((n) => n.startsWith("memory_heap_tight_"))).toBeUndefined();
+  });
+
+  it("falls back to heapTotal when heapLimit is absent (pre-#1223 snapshots)", () => {
+    const s = snap({
+      memory: {
+        heapUsed: 970 * 1024 * 1024,
+        heapTotal: 1000 * 1024 * 1024,
+        rss: 1100 * 1024 * 1024,
+        external: 0,
+      },
+    });
+    expect(evaluateHealth(s).status).toBe("critical");
+  });
+});


### PR DESCRIPTION
## Problem

The health monitor's memory status measures `heapUsed / heapTotal` (#1223). `heapTotal` is V8's *current allocation*, which V8 grows on demand — a healthy process routinely runs at 85–95% of `heapTotal` while sitting far below the actual ceiling. The ratio therefore reports "degraded"/"critical" on processes that are nowhere near out of memory, and it can never distinguish "V8 hasn't grown the heap yet" from "we're about to OOM".

## Fix

Measure against `getHeapStatistics().heap_size_limit` — the hard ceiling V8 will actually enforce — captured into the snapshot as `memory.heapLimit` (optional field on `HealthSnapshot`, so existing persisted snapshots stay valid; the thresholds fall back to the old ratio when it's absent).

## Tests

Threshold-side tests for the new ratio (including the fallback when `heapLimit` is absent), plus a producer-wiring test comparing the persisted snapshot's `memory.heapLimit` against the real unmocked `getHeapStatistics().heap_size_limit` — verified to fail (`undefined` vs. the real value) when the wiring line in `monitor.ts` is deleted, since nothing else pins it.

Full suite: 1714 passed / 1 skipped. `tsc --noEmit` unchanged at the 30 pre-existing errors (none in touched files).

**Known limitation, deliberately out of scope:** `heap_size_limit` excludes native allocations (buffers, stacks, code memory), so a process under *native*-memory pressure can show a healthy heap ratio. Watching for that properly means comparing RSS against the effective process/container memory budget, and the codebase has no budget source (cgroup awareness) today — the existing `memoryRssFloorBytes` config only gates alerts from below. Worth its own issue; this PR stays scoped to removing the false-positive ratio, which made /health return 503 on healthy processes. Note the old ratio did not cover native pressure either — its numerator was heap-only too.

One operational caveat documented in the commit rather than code: in a container, V8 sizes `heap_size_limit` from host memory, not the cgroup limit — `--max-old-space-size` should be set to the container's budget for the ratio to reflect a ceiling V8 will respect. (An `.env.example` note about this rides with the upcoming configurable-thresholds PR, which owns that doc section.)

Closes #1223.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Health monitoring now measures memory usage against the runtime’s maximum heap limit when available.
  * Snapshots without valid heap-limit data continue using total heap size.
  * Health statuses and alerts now more accurately reflect memory pressure.

* **Tests**
  * Added coverage confirming heap-limit data is captured in health snapshots.
  * Added threshold tests for both heap-limit calculations and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->