### PR TITLE
fix(health): report CPU as machine-relative, not single-core

### DIFF
--- a/src/health/monitor.ts
+++ b/src/health/monitor.ts
@@ -1,8 +1,21 @@
 import type { ISdk } from "iii-sdk";
+import { cpus } from "node:os";
 import type { HealthSnapshot } from "../types.js";
 import type { StateKV } from "../state/kv.js";
 import { KV } from "../state/schema.js";
 import { evaluateHealth } from "./thresholds.js";
+
+// #1235: process.cpuUsage() deltas are single-core time, so a process
+// using 2.44 cores reads as 244%. thresholds.ts treats 90 as "90% of the
+// machine", so every multi-core host tripped cpu_critical and /health
+// returned 503. Normalize at the producer, where the core count is known.
+export function normalizeCpuPercent(
+  singleCorePercent: number,
+  coreCount: number = cpus().length,
+): number {
+  const cores = coreCount > 0 ? coreCount : 1;
+  return singleCorePercent / cores;
+}
 
 export function registerHealthMonitor(
   sdk: ISdk,
@@ -27,8 +40,10 @@ export function registerHealthMonitor(
     const elapsedMs = now - prevCpuTime;
     const userDelta = currentCpu.user - prevCpuUsage.user;
     const systemDelta = currentCpu.system - prevCpuUsage.system;
-    const cpuPercent =
+    const singleCoreCpuPercent =
       elapsedMs > 0 ? ((userDelta + systemDelta) / 1000 / elapsedMs) * 100 : 0;
+    const coreCount = cpus().length;
+    const cpuPercent = normalizeCpuPercent(singleCoreCpuPercent, coreCount);
     prevCpuUsage = currentCpu;
     prevCpuTime = now;
 
@@ -76,6 +91,7 @@ export function registerHealthMonitor(
         userMicros: currentCpu.user,
         systemMicros: currentCpu.system,
         percent: Math.round(cpuPercent * 100) / 100,
+        cores: coreCount,
       },
       eventLoopLagMs,
       uptimeSeconds: uptime,

--- a/src/health/monitor.ts
+++ b/src/health/monitor.ts
@@ -42,7 +42,13 @@ export function registerHealthMonitor(
     const systemDelta = currentCpu.system - prevCpuUsage.system;
     const singleCoreCpuPercent =
       elapsedMs > 0 ? ((userDelta + systemDelta) / 1000 / elapsedMs) * 100 : 0;
-    const coreCount = cpus().length;
+    // #1235: clamp here, not just inside normalizeCpuPercent, so the divisor
+    // we record in the snapshot (cores) is the same number we divided by.
+    // Storing the raw (possibly 0) os.cpus().length would make cpu.cores
+    // lie about the divisor in exactly the empty-array edge case the clamp
+    // exists for.
+    const rawCoreCount = cpus().length;
+    const coreCount = rawCoreCount > 0 ? rawCoreCount : 1;
     const cpuPercent = normalizeCpuPercent(singleCoreCpuPercent, coreCount);
     prevCpuUsage = currentCpu;
     prevCpuTime = now;

--- a/src/types.ts
+++ b/src/types.ts
@@ -228,7 +228,9 @@ export interface HealthSnapshot {
     rss: number;
     external: number;
   };
-  cpu: { userMicros: number; systemMicros: number; percent: number };
+  // #1235: percent is machine-relative (100 = every core saturated).
+  // cores records the divisor so a snapshot stays interpretable.
+  cpu: { userMicros: number; systemMicros: number; percent: number; cores?: number };
   eventLoopLagMs: number;
   uptimeSeconds: number;
   kvConnectivity?: { status: string; latencyMs?: number; error?: string };

--- a/test/health-monitor-cpu.test.ts
+++ b/test/health-monitor-cpu.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { cpus } from "node:os";
+import { normalizeCpuPercent } from "../src/health/monitor.js";
+
+describe("normalizeCpuPercent", () => {
+  it("divides single-core percent by the core count (#1235)", () => {
+    expect(normalizeCpuPercent(244, 16)).toBeCloseTo(15.25, 2);
+  });
+
+  it("clamps a zero or bogus core count to 1 rather than dividing by zero", () => {
+    expect(normalizeCpuPercent(50, 0)).toBe(50);
+  });
+
+  it("uses the real core count by default", () => {
+    expect(normalizeCpuPercent(cpus().length * 100)).toBeCloseTo(100, 2);
+  });
+});

--- a/test/health-monitor-cpu.test.ts
+++ b/test/health-monitor-cpu.test.ts
@@ -1,6 +1,23 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { cpus } from "node:os";
-import { normalizeCpuPercent } from "../src/health/monitor.js";
+import { normalizeCpuPercent, registerHealthMonitor } from "../src/health/monitor.js";
+import { KV } from "../src/state/schema.js";
+import type { HealthSnapshot } from "../src/types.js";
+
+// #1235: fix a deterministic core count for the producer-wiring test below,
+// independent of how many cores the machine running the suite actually has.
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return {
+    ...actual,
+    cpus: () =>
+      Array.from({ length: 8 }, () => ({
+        model: "mock",
+        speed: 0,
+        times: { user: 0, nice: 0, sys: 0, idle: 0, irq: 0 },
+      })),
+  };
+});
 
 describe("normalizeCpuPercent", () => {
   it("divides single-core percent by the core count (#1235)", () => {
@@ -13,5 +30,79 @@ describe("normalizeCpuPercent", () => {
 
   it("uses the real core count by default", () => {
     expect(normalizeCpuPercent(cpus().length * 100)).toBeCloseTo(100, 2);
+  });
+});
+
+// #1235: mock KV mirrors test/index-persistence.test.ts's Map-backed mock,
+// enough surface for StateKV's get/set, cast past the class's private field
+// with `as never` the same way that file does.
+function mockKV() {
+  const store = new Map<string, Map<string, unknown>>();
+  return {
+    get: async <T>(scope: string, key: string): Promise<T | null> => {
+      return (store.get(scope)?.get(key) as T) ?? null;
+    },
+    set: async <T>(scope: string, key: string, data: T): Promise<T> => {
+      if (!store.has(scope)) store.set(scope, new Map());
+      store.get(scope)!.set(key, data);
+      return data;
+    },
+  };
+}
+
+function mockSdk() {
+  return {
+    trigger: async () => ({ workers: [] }),
+  };
+}
+
+async function waitForSnapshot(
+  kv: ReturnType<typeof mockKV>,
+): Promise<HealthSnapshot> {
+  for (let i = 0; i < 50; i++) {
+    const snapshot = await kv.get<HealthSnapshot>(KV.health, "latest");
+    if (snapshot) return snapshot;
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  throw new Error("collectHealth did not persist a snapshot in time");
+}
+
+describe("registerHealthMonitor producer wiring (#1235)", () => {
+  it("persists a machine-relative cpu.percent with the divisor it used", async () => {
+    // Pin process.cpuUsage() and Date.now() so the single-core cpu delta
+    // and elapsed time collectHealth computes are exact, not host-dependent.
+    // Call order inside registerHealthMonitor/collectHealth (verified by
+    // reading src/health/monitor.ts): cpuUsage() for prevCpuUsage, then
+    // Date.now() for prevCpuTime, both synchronously before collectHealth()
+    // is invoked; then collectHealth's own cpuUsage()/Date.now() calls,
+    // still before its first await. So the queued values below land as:
+    // prev = {user:0}, current = {user:5_000_000}, elapsed = 1000ms.
+    const cpuUsageSpy = vi
+      .spyOn(process, "cpuUsage")
+      .mockReturnValueOnce({ user: 0, system: 0 } as NodeJS.CpuUsage)
+      .mockReturnValueOnce({ user: 5_000_000, system: 0 } as NodeJS.CpuUsage);
+    const dateNowSpy = vi
+      .spyOn(Date, "now")
+      .mockReturnValueOnce(1_000_000)
+      .mockReturnValueOnce(1_001_000);
+
+    const kv = mockKV();
+    const sdk = mockSdk();
+    const { stop } = registerHealthMonitor(sdk as never, kv as never);
+
+    try {
+      const snapshot = await waitForSnapshot(kv);
+
+      // 5_000_000us / 1000 / 1000ms * 100 = 500% single-core. If
+      // normalizeCpuPercent were bypassed (cpuPercent = singleCoreCpuPercent
+      // directly), this would read 500, not 62.5 -- this assertion fails
+      // under that regression.
+      expect(snapshot.cpu.cores).toBe(8);
+      expect(snapshot.cpu.percent).toBeCloseTo(62.5, 2);
+    } finally {
+      stop();
+      cpuUsageSpy.mockRestore();
+      dateNowSpy.mockRestore();
+    }
   });
 });

--- a/test/health-thresholds.test.ts
+++ b/test/health-thresholds.test.ts
@@ -95,3 +95,18 @@ describe("evaluateHealth memory severity", () => {
     expect(strict.status).toBe("healthy");
   });
 });
+
+describe("evaluateHealth cpu scale", () => {
+  it("treats cpu.percent as machine-relative (#1235)", () => {
+    // 244% single-core on 16 cores is 15.25% of the machine.
+    const s = snap({ cpu: { userMicros: 0, systemMicros: 0, percent: 15.25, cores: 16 } });
+    expect(evaluateHealth(s).status).toBe("healthy");
+  });
+
+  it("still goes critical on genuine machine-wide saturation", () => {
+    const s = snap({ cpu: { userMicros: 0, systemMicros: 0, percent: 95, cores: 16 } });
+    const { status, alerts } = evaluateHealth(s);
+    expect(status).toBe("critical");
+    expect(alerts.find((a) => a.startsWith("cpu_critical_"))).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Problem

`process.cpuUsage()` deltas measure single-core time, so 2.44 cores' worth of work reads as **244%**, while `thresholds.ts` treats its `cpuCriticalPercent` (90) as a machine-relative percentage. On effectively every multi-core host doing real work, `cpu_critical` trips and `/health` returns 503 for a process using a fraction of the machine (#1235).

## Fix

Normalize at the producer: `collectHealth` divides the single-core percentage by the core count (`normalizeCpuPercent`, exported for direct unit testing), clamping a zero/bogus `os.cpus().length` to 1 rather than dividing by zero. The snapshot records the divisor actually used as `cpu.cores` — the clamped value, not raw `os.cpus().length`, so the stored telemetry and the divisor are provably the same number even in the empty-`cpus()` edge case the clamp exists for.

## Tests

Unit tests on `normalizeCpuPercent` (division, clamp, real-core default), threshold-side tests for machine-relative interpretation (15.25% healthy where the old reading of 244% would have been critical; genuine 95% machine-wide saturation still critical), and a producer-wiring test driving `registerHealthMonitor`/`collectHealth` end to end with mocked `process.cpuUsage()`/`Date.now()`/`os.cpus()`, reading the persisted snapshot from a mock KV — verified to fail (500 vs 62.5) if the `normalizeCpuPercent` call is bypassed.

Full suite: 1717 passed / 1 skipped. `tsc --noEmit` unchanged at the 30 pre-existing errors (none in touched files).

Sibling of #1285 (heap denominator) — the two `/health` 503 false-positive sources; independent, either merges first. A follow-up PR makes the thresholds themselves configurable (#226) and depends on both.

Closes #1235.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected CPU health percentages to account for the number of CPU cores.
  * Health snapshots now include the core count, making CPU metrics easier to interpret.
  * Updated CPU health thresholds and alerts to use machine-relative utilization.

* **Tests**
  * Added coverage for multi-core CPU normalization and edge cases.
  * Added validation for healthy and critical CPU threshold behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->