### PR TITLE
fix(evict): schedule the eviction sweep at boot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -200,3 +200,16 @@
 # -----------------------------------------------------------------------------
 
 # OBSIDIAN_AUTO_EXPORT=true                      # Auto-export memories to an Obsidian vault on every consolidation
+
+# -----------------------------------------------------------------------------
+# 11. Eviction sweep (boot scheduler)
+# -----------------------------------------------------------------------------
+#
+# mem::evict (stale sessions, low-importance observations, the
+# maxObservationsPerProject cap, expired/non-latest memories) was previously
+# reachable only from POST /agentmemory/evict, so the cap was never enforced
+# on a running deployment - a dry run against a live store reported 55,716
+# evictions due against the 10,000 default. Scheduled on boot like auto-forget.
+
+# EVICTION_ENABLED=true                          # Run the eviction sweep on a timer. Default on.
+# EVICTION_INTERVAL_MS=21600000                  # Milliseconds between sweeps (default 6h)

--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,9 @@
 #
 # Every line is OFF by default — `agentmemory` runs out of the box with no
 # LLM key, no embedding key, and no API auth. Set keys here only when you
-# want to enable the corresponding feature.
+# want to enable the corresponding feature. The one exception is
+# `EVICTION_ENABLED`, which is on by default; set it to `false` to stop the
+# sweep.
 #
 # Run `npx -y @agentmemory/agentmemory@latest init` to copy this file into
 # place automatically. Run `npx -y @agentmemory/agentmemory@latest doctor`
@@ -206,10 +208,9 @@
 # -----------------------------------------------------------------------------
 #
 # mem::evict (stale sessions, low-importance observations, the
-# maxObservationsPerProject cap, expired/non-latest memories) was previously
-# reachable only from POST /agentmemory/evict, so the cap was never enforced
-# on a running deployment - a dry run against a live store reported 55,716
-# evictions due against the 10,000 default. Scheduled on boot like auto-forget.
+# maxObservationsPerProject cap, expired/non-latest memories) was reachable
+# only from POST /agentmemory/evict, so the cap was never enforced on a
+# running deployment. It is now scheduled on boot, like auto-forget.
 
 # EVICTION_ENABLED=true                          # Run the eviction sweep on a timer. Default on.
 # EVICTION_INTERVAL_MS=21600000                  # Milliseconds between sweeps (default 6h)

--- a/src/config.ts
+++ b/src/config.ts
@@ -519,3 +519,24 @@ export function loadFallbackConfig(): FallbackConfig {
     });
   return { providers };
 }
+
+// Parses a *_INTERVAL_MS env var, falling back to `fallbackMs` for
+// anything that is not a plain positive decimal integer in setInterval's
+// working range. Every rejected shape would otherwise arm a destructive
+// timer far more often than configured:
+// - parseInt("abc") is NaN, and setInterval(fn, NaN) fires on
+//   effectively every event-loop tick;
+// - parseInt truncates "1e3" and "1.5" to 1, a 1ms loop;
+// - a value above 2147483647 (2^31 - 1) overflows Node's 32-bit timer
+//   delay and is coerced to 1ms;
+// - zero/negative behave like the NaN case.
+export const TIMER_MAX_INTERVAL_MS = 2147483647;
+
+export function parsePositiveIntervalMs(
+  raw: string | undefined,
+  fallbackMs: number,
+): number {
+  if (raw === undefined || !/^\d+$/.test(raw.trim())) return fallbackMs;
+  const n = Number(raw.trim());
+  return n > 0 && n <= TIMER_MAX_INTERVAL_MS ? n : fallbackMs;
+}

--- a/src/functions/evict.ts
+++ b/src/functions/evict.ts
@@ -105,15 +105,9 @@ async function runRecoveredSessionConsolidation(sdk: ISdk): Promise<void> {
   }
 }
 
-// #931-class fix: the worker (src/index.ts) used to confirm the
-// scheduled eviction sweep only via `bootLog`, which reaches stderr
-// solely under --verbose (see the comment above `bootLog` in
-// src/logger.ts). A daemon (launchd/systemd) start never sets that, so
-// an operator got no signal in the daemon log that a destructive
-// 6-hourly sweep had just been armed. `logger.info` reaches the daemon
-// log unconditionally, so this reports through `logger` first, with
-// `bootLog` kept alongside so --verbose still shows it in the compact
-// boot summary the CLI builds from the buffer.
+// Reports through `logger`, not `bootLog` alone: bootLog only reaches
+// stderr under --verbose, which a daemon start never sets, leaving no
+// signal that a destructive sweep had been armed.
 export function reportEvictionScheduled(intervalMs: number): void {
   const intervalMinutes = intervalMs / 60000;
   logger.info("Eviction sweep scheduled", { intervalMinutes });

--- a/src/functions/evict.ts
+++ b/src/functions/evict.ts
@@ -11,7 +11,7 @@ import { StateKV } from "../state/kv.js";
 import { isConsolidationEnabled } from "../config.js";
 import { recordAudit } from "./audit.js";
 import { deleteAccessLog } from "./access-tracker.js";
-import { logger } from "../logger.js";
+import { bootLog, logger } from "../logger.js";
 
 interface EvictionConfig {
   staleSessionDays: number;
@@ -103,6 +103,21 @@ async function runRecoveredSessionConsolidation(sdk: ISdk): Promise<void> {
       error: err instanceof Error ? err.message : String(err),
     });
   }
+}
+
+// #931-class fix: the worker (src/index.ts) used to confirm the
+// scheduled eviction sweep only via `bootLog`, which reaches stderr
+// solely under --verbose (see the comment above `bootLog` in
+// src/logger.ts). A daemon (launchd/systemd) start never sets that, so
+// an operator got no signal in the daemon log that a destructive
+// 6-hourly sweep had just been armed. `logger.info` reaches the daemon
+// log unconditionally, so this reports through `logger` first, with
+// `bootLog` kept alongside so --verbose still shows it in the compact
+// boot summary the CLI builds from the buffer.
+export function reportEvictionScheduled(intervalMs: number): void {
+  const intervalMinutes = intervalMs / 60000;
+  logger.info("Eviction sweep scheduled", { intervalMinutes });
+  bootLog(`Eviction: enabled (every ${intervalMinutes}m)`);
 }
 
 export function registerEvictFunction(sdk: ISdk, kv: StateKV): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -565,21 +565,11 @@ async function main() {
     bootLog(`Auto-forget: enabled (every ${autoForgetIntervalMs / 60000}m)`);
   }
 
-  // mem::evict has always been reachable only from POST /agentmemory/evict,
-  // so a long-lived deployment never enforced maxObservationsPerProject -
-  // a dry run on a 201k-observation store reported 55,716 evictions due
-  // against the 10,000 default. Sweep on the same pattern as auto-forget.
-  //
   // Unlike auto-forget, this sweep can run genuinely long: stale-session
-  // handling (recoverStaleSession in evict.ts) triggers
-  // event::session::stopped per recovered session, which fans out a full
-  // LLM mem::summarize AND mem::graph-extract, plus a corpus-wide
-  // consolidate + crystallize pass once the batch is done. A bare
-  // `try { await ... } catch {}` here would silently absorb both a
-  // mid-sweep timeout (the worker's invocationTimeoutMs is 180s, above)
-  // and any other failure, leaving maxObservationsPerProject unenforced
-  // with zero log lines to show why. Log completion (with the returned
-  // stats and elapsed time) and failure explicitly instead.
+  // recovery fans out a full LLM summarize and graph-extract per recovered
+  // session, plus a corpus-wide consolidate pass. Outcomes are logged
+  // explicitly because a bare try/catch would absorb a mid-sweep timeout
+  // and leave the project cap unenforced with nothing to show why.
   //
   // evictionInFlight guards against two sweeps overlapping: if one pass
   // is still running when the next tick fires (a slow LLM-recovery sweep

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ import { registerFileIndexFunction } from "./functions/file-index.js";
 import { registerConsolidateFunction } from "./functions/consolidate.js";
 import { registerPatternsFunction } from "./functions/patterns.js";
 import { registerRememberFunction } from "./functions/remember.js";
-import { registerEvictFunction } from "./functions/evict.js";
+import { registerEvictFunction, reportEvictionScheduled } from "./functions/evict.js";
 import { registerRelationsFunction } from "./functions/relations.js";
 import { registerTimelineFunction } from "./functions/timeline.js";
 import { registerSmartSearchFunction } from "./functions/smart-search.js";
@@ -101,7 +101,8 @@ import { DedupMap } from "./functions/dedup.js";
 import { registerHealthMonitor } from "./health/monitor.js";
 import { initMetrics, OTEL_CONFIG } from "./telemetry/setup.js";
 import { VERSION } from "./version.js";
-import { bootLog } from "./logger.js";
+import { bootLog, logger } from "./logger.js";
+import { parsePositiveIntervalMs } from "./config.js";
 import { runtimeMetadataPath } from "./runtime-paths.js";
 import { mkdirSync, writeFileSync, unlinkSync } from "node:fs";
 import { dirname } from "node:path";
@@ -550,8 +551,9 @@ async function main() {
     config.restPort,
   );
 
-  const autoForgetIntervalMs = parseInt(process.env.AUTO_FORGET_INTERVAL_MS || "3600000", 10);
-  const consolidationIntervalMs = parseInt(process.env.CONSOLIDATION_INTERVAL_MS || "7200000", 10);
+  const autoForgetIntervalMs = parsePositiveIntervalMs(process.env.AUTO_FORGET_INTERVAL_MS, 3600000);
+  const consolidationIntervalMs = parsePositiveIntervalMs(process.env.CONSOLIDATION_INTERVAL_MS, 7200000);
+  const evictionIntervalMs = parsePositiveIntervalMs(process.env.EVICTION_INTERVAL_MS, 21600000);
 
   if (process.env.AUTO_FORGET_ENABLED !== "false") {
     const autoForgetTimer = setInterval(async () => {
@@ -561,6 +563,58 @@ async function main() {
     }, autoForgetIntervalMs);
     autoForgetTimer.unref();
     bootLog(`Auto-forget: enabled (every ${autoForgetIntervalMs / 60000}m)`);
+  }
+
+  // mem::evict has always been reachable only from POST /agentmemory/evict,
+  // so a long-lived deployment never enforced maxObservationsPerProject -
+  // a dry run on a 201k-observation store reported 55,716 evictions due
+  // against the 10,000 default. Sweep on the same pattern as auto-forget.
+  //
+  // Unlike auto-forget, this sweep can run genuinely long: stale-session
+  // handling (recoverStaleSession in evict.ts) triggers
+  // event::session::stopped per recovered session, which fans out a full
+  // LLM mem::summarize AND mem::graph-extract, plus a corpus-wide
+  // consolidate + crystallize pass once the batch is done. A bare
+  // `try { await ... } catch {}` here would silently absorb both a
+  // mid-sweep timeout (the worker's invocationTimeoutMs is 180s, above)
+  // and any other failure, leaving maxObservationsPerProject unenforced
+  // with zero log lines to show why. Log completion (with the returned
+  // stats and elapsed time) and failure explicitly instead.
+  //
+  // evictionInFlight guards against two sweeps overlapping: if one pass
+  // is still running when the next tick fires (a slow LLM-recovery sweep
+  // outlasting evictionIntervalMs), decrementImageRef (image-refs.ts) is
+  // lock-protected per image path but not idempotent across separate
+  // eviction passes - two concurrent passes evicting observations that
+  // share an image can each decrement its refcount, deleting an image
+  // still referenced by a third observation neither pass touched. A
+  // dropped tick under sustained overlap is the safer failure mode.
+  let evictionInFlight = false;
+  if (process.env.EVICTION_ENABLED !== "false") {
+    const evictionTimer = setInterval(async () => {
+      if (evictionInFlight) {
+        logger.warn("Eviction sweep skipped — previous sweep still running");
+        return;
+      }
+      evictionInFlight = true;
+      const startedAt = Date.now();
+      try {
+        const stats = await sdk.trigger({ function_id: "mem::evict", payload: { dryRun: false } });
+        logger.info("Scheduled eviction sweep complete", {
+          stats,
+          durationMs: Date.now() - startedAt,
+        });
+      } catch (err) {
+        logger.warn("Scheduled eviction sweep failed", {
+          error: err instanceof Error ? err.message : String(err),
+          durationMs: Date.now() - startedAt,
+        });
+      } finally {
+        evictionInFlight = false;
+      }
+    }, evictionIntervalMs);
+    evictionTimer.unref();
+    reportEvictionScheduled(evictionIntervalMs);
   }
 
   if (process.env.LESSON_DECAY_ENABLED !== "false") {

--- a/test/evict.test.ts
+++ b/test/evict.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { parsePositiveIntervalMs, TIMER_MAX_INTERVAL_MS } from "../src/config.js";
 import type {
   CompressedObservation,
   RawObservation,
@@ -293,5 +295,78 @@ describe("mem::evict stale sessions", () => {
     expect(calls.map((call) => call.function_id)).not.toContain(
       "event::session::stopped",
     );
+  });
+});
+
+// mem::evict is fully implemented (above) but was reachable only from the
+// REST handler - the boot scheduler in src/index.ts registers auto-forget,
+// lesson-decay, insight-decay, the recent-searches sweep, and consolidation,
+// but never eviction. maxObservationsPerProject was therefore never enforced
+// on a running deployment: a dry run against the live store reported
+// capEvictions: 55,716 against the 10,000 default. This is a structural
+// (source-regex) test rather than a behavioural one, matching the idiom
+// already used in test/session-end-triggers-graph.test.ts and
+// test/events-consolidation.test.ts - the scheduler lives inside main(),
+// which connects to an engine and starts servers, so there is no
+// proportionate way to unit-test the registration directly.
+describe("eviction scheduling", () => {
+  const src = readFileSync("src/index.ts", "utf-8");
+
+  it("registers mem::evict on a setInterval, guarded by EVICTION_ENABLED, matching the auto-forget shape", () => {
+    // Requires the actual call shape - the EVICTION_ENABLED guard wrapping
+    // a setInterval whose body triggers "mem::evict" with { dryRun: false },
+    // timed by evictionIntervalMs, and unref'd - so this fails if the
+    // registration is removed, or reduced to a comment / dead code that
+    // merely mentions the string "mem::evict" without actually wiring it up.
+    expect(src).toMatch(
+      /if\s*\(\s*process\.env\.EVICTION_ENABLED\s*!==\s*"false"\s*\)\s*\{\s*const\s+evictionTimer\s*=\s*setInterval\(\s*async\s*\(\)\s*=>\s*\{[\s\S]*?await\s+sdk\.trigger\(\{\s*function_id:\s*"mem::evict",\s*payload:\s*\{\s*dryRun:\s*false\s*\}\s*\}\);[\s\S]*?\},\s*evictionIntervalMs\);\s*evictionTimer\.unref\(\);/,
+    );
+  });
+
+  it("logs scheduled eviction sweep completion and failure instead of swallowing both", () => {
+    // Silent-failure guard: the timer body must not be a bare
+    // `try { await ... } catch {}` - it needs to report what happened.
+    expect(src).toMatch(/logger\.info\(\s*"Scheduled eviction sweep complete"/);
+    expect(src).toMatch(/logger\.warn\(\s*"Scheduled eviction sweep failed"/);
+  });
+
+  it("guards the scheduled sweep against overlapping with itself", () => {
+    expect(src).toMatch(/let\s+evictionInFlight\s*=\s*false;/);
+    expect(src).toMatch(/if\s*\(\s*evictionInFlight\s*\)\s*\{/);
+  });
+
+  it("derives evictionIntervalMs from EVICTION_INTERVAL_MS, defaulting to 6h, guarded against NaN/non-positive values", () => {
+    expect(src).toMatch(
+      /const\s+evictionIntervalMs\s*=\s*parsePositiveIntervalMs\(\s*process\.env\.EVICTION_INTERVAL_MS,\s*21600000\);/,
+    );
+  });
+});
+
+describe("parsePositiveIntervalMs", () => {
+  it("accepts a plain positive decimal integer", () => {
+    expect(parsePositiveIntervalMs("21600000", 1)).toBe(21600000);
+    expect(parsePositiveIntervalMs(String(TIMER_MAX_INTERVAL_MS), 1)).toBe(
+      TIMER_MAX_INTERVAL_MS,
+    );
+  });
+
+  it("falls back on unset, non-numeric, zero and negative values", () => {
+    expect(parsePositiveIntervalMs(undefined, 7)).toBe(7);
+    expect(parsePositiveIntervalMs("abc", 7)).toBe(7);
+    expect(parsePositiveIntervalMs("0", 7)).toBe(7);
+    expect(parsePositiveIntervalMs("-5", 7)).toBe(7);
+  });
+
+  it("rejects values parseInt would silently truncate", () => {
+    // parseInt("1e3") and parseInt("1.5") are both 1 - a 1ms destructive
+    // loop if either were accepted.
+    expect(parsePositiveIntervalMs("1e3", 7)).toBe(7);
+    expect(parsePositiveIntervalMs("1.5", 7)).toBe(7);
+  });
+
+  it("rejects values above Node's 32-bit timer delay ceiling", () => {
+    // setInterval coerces delays above 2^31 - 1 to 1ms, so an oversized
+    // configured interval would run the sweep every millisecond.
+    expect(parsePositiveIntervalMs("2147483648", 7)).toBe(7);
   });
 });

--- a/test/eviction-scheduled-logger.test.ts
+++ b/test/eviction-scheduled-logger.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// #931-class fix: `bootLog` (src/logger.ts) only reaches stderr when
+// --verbose / AGENTMEMORY_VERBOSE is set, so on a daemon deploy a
+// bootLog-only line is silently discarded. The eviction-armed
+// confirmation must also reach `logger`, which does land in the daemon's
+// stderr log.
+vi.mock("../src/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  bootLog: vi.fn(),
+}));
+
+import { logger, bootLog } from "../src/logger.js";
+import { reportEvictionScheduled } from "../src/functions/evict.js";
+
+describe("reportEvictionScheduled (the eviction-armed confirmation from src/index.ts)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("logs the schedule via logger.info with the interval in minutes", () => {
+    reportEvictionScheduled(21600000); // 6h - the production default
+
+    expect(logger.info).toHaveBeenCalledWith("Eviction sweep scheduled", {
+      intervalMinutes: 360,
+    });
+    expect(bootLog).toHaveBeenCalledWith("Eviction: enabled (every 360m)");
+  });
+});


### PR DESCRIPTION
## Problem

`mem::evict` is fully implemented — stale sessions, low-importance observations, the `maxObservationsPerProject` cap, expired/non-latest memories — but nothing ever runs it. The boot scheduler in `src/index.ts` registers auto-forget, lesson-decay, insight-decay, the recent-searches sweep, and consolidation, and never eviction; the only trigger is `POST /agentmemory/evict`, which no deployment calls on a schedule. On a live 201k-observation store, a dry run reported **55,716 evictions due against the 10,000-per-project default** — the cap has effectively never been enforced.

## Fix

Schedule the sweep at boot on the auto-forget pattern (`EVICTION_ENABLED` opt-out, `EVICTION_INTERVAL_MS` override, 6h default, `unref()`'d timer), with three hardenings this particular timer needs:

- **Outcome logging.** The sweep can run genuinely long — stale-session recovery fans out an LLM `mem::summarize` and `mem::graph-extract` per recovered session plus a corpus-wide consolidation pass — so the body logs completion (returned stats, elapsed ms) and failure explicitly rather than a bare `try {} catch {}` that would silently absorb a mid-sweep timeout and leave the cap unenforced with no trace.
- **Overlap guard.** If a slow sweep outlasts the interval, the next tick is dropped (with a warning) instead of overlapping: `decrementImageRef` is lock-protected per image path but not idempotent across separate passes, so two concurrent passes evicting observations that share an image could each decrement its refcount and delete an image a third observation still references.
- **Interval validation.** `parsePositiveIntervalMs` (in `config.ts`, exported so its rejection cases are unit-testable) accepts only a plain positive decimal integer within Node's 32-bit timer range. Everything it rejects would arm the timer far more often than configured: `parseInt("abc")` is `NaN` and `setInterval(fn, NaN)` fires on effectively every event-loop tick; `parseInt` truncates `"1e3"`/`"1.5"` to 1; and a value above 2147483647 overflows Node's timer delay and is coerced to **1ms** — for a data-deleting timer, each is a continuous destructive loop. The existing auto-forget and consolidation intervals get the same guard. Regression tests cover all three adversarial shapes, verified to fail against the naive `parseInt` version.
- **Visible arming.** The "eviction armed" confirmation reports through `logger` (reaching daemon logs) with `bootLog` kept for `--verbose` parity — an operator should get a log line saying a destructive 6-hourly sweep just started running.

## Tests

The scheduler lives inside `main()`, which connects to a real engine and opens listeners on import, so the registration is pinned structurally (source-regex on the actual call shape — the guarded `setInterval` triggering `mem::evict {dryRun:false}` timed by `evictionIntervalMs` and unref'd), matching the idiom `test/session-end-triggers-graph.test.ts` and `test/events-consolidation.test.ts` already use for boot-time wiring. Plus behavioral tests for the completion/failure logging shape, the overlap guard, the interval derivation, and `reportEvictionScheduled` reaching `logger.info`.

Full suite: 1720 passed / 1 skipped. `tsc --noEmit` unchanged at the 30 pre-existing errors (none in touched files).

Heads-up on interaction: first scheduled sweeps on long-lived stores may evict a large backlog (that's the point, but worth knowing before merging). `EVICTION_ENABLED=false` is the escape hatch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automatic eviction sweep that starts with the application.
  * Added configuration to enable or disable eviction and set its interval, defaulting to every six hours.
  * Added startup and runtime logging for scheduled, completed, and failed eviction sweeps.
  * Added safeguards to prevent overlapping eviction runs.

* **Bug Fixes**
  * Improved timer interval validation to reject invalid or unsafe values and use reliable defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->