### PR TITLE
fix(metrics): window failure rate to recent activity + track lastFailureAt

### DIFF
--- a/src/eval/metrics-store.ts
+++ b/src/eval/metrics-store.ts
@@ -2,6 +2,11 @@ import type { FunctionMetrics } from "../types.js";
 import type { StateKV } from "../state/kv.js";
 import { KV } from "../state/schema.js";
 
+/** Cap on the per-function ring buffer of recent call outcomes. */
+const RECENT_CALLS_CAP = 50;
+/** Window for the recent failure rate surfaced in health output. */
+const METRICS_WINDOW_MS = 24 * 60 * 60 * 1000;
+
 export class MetricsStore {
   private cache = new Map<string, FunctionMetrics>();
   private qualityCallCounts = new Map<string, number>();
@@ -27,13 +32,18 @@ export class MetricsStore {
     }
 
     const prev = m.totalCalls;
+    const now = Date.now();
     m.totalCalls += 1;
     m.avgLatencyMs = (m.avgLatencyMs * prev + latencyMs) / m.totalCalls;
     if (success) {
       m.successCount += 1;
     } else {
       m.failureCount += 1;
+      m.lastFailureAt = now;
     }
+    m.recentCalls = [...(m.recentCalls ?? []), { t: now, ok: success }].slice(
+      -RECENT_CALLS_CAP,
+    );
     if (qualityScore !== undefined) {
       const prevQualityCalls = this.qualityCallCounts.get(functionId) || 0;
       m.avgQualityScore =
@@ -60,6 +70,19 @@ export class MetricsStore {
     const merged = new Map<string, FunctionMetrics>();
     for (const m of kvMetrics) merged.set(m.functionId, m);
     for (const [id, m] of this.cache) merged.set(id, m);
-    return Array.from(merged.values());
+    const now = Date.now();
+    return Array.from(merged.values()).map((m) => {
+      const recent = (m.recentCalls ?? []).filter(
+        (c) => now - c.t <= METRICS_WINDOW_MS,
+      );
+      const { recentCalls: _ring, ...rest } = m;
+      return {
+        ...rest,
+        recentCallCount: recent.length,
+        recentFailureRate: recent.length
+          ? recent.filter((c) => !c.ok).length / recent.length
+          : 0,
+      };
+    });
   }
 }

--- a/src/health/monitor.ts
+++ b/src/health/monitor.ts
@@ -38,11 +38,21 @@ export function registerHealthMonitor(
 
     let workers: HealthSnapshot["workers"] = [];
     try {
+      type EngineWorker = HealthSnapshot["workers"][number] & {
+        functions?: unknown[];
+      };
       const result = await sdk.trigger<
         unknown,
-        { workers?: HealthSnapshot["workers"] }
+        { workers?: EngineWorker[] }
       >({ function_id: "engine::workers::list", payload: {} });
-      if (result?.workers) workers = result.workers;
+      // The engine lists every registered function id per worker (~265
+      // names). Health consumers need the count, not the list — keep the
+      // snapshot small (it is stored every 30s and returned by api::health).
+      if (result?.workers)
+        workers = result.workers.map(({ functions, ...rest }) => ({
+          ...rest,
+          functionCount: functions?.length ?? 0,
+        })) as HealthSnapshot["workers"];
     } catch {}
 
     const KV_PROBE_TIMEOUT = 5000;

--- a/src/types.ts
+++ b/src/types.ts
@@ -217,6 +217,16 @@ export interface FunctionMetrics {
   failureCount: number;
   avgLatencyMs: number;
   avgQualityScore: number;
+  /** Epoch ms of the most recent failure — lets consumers distinguish a
+   *  live problem from a cumulative counter polluted by long-fixed bugs. */
+  lastFailureAt?: number;
+  /** Ring buffer of recent call outcomes (not exposed by getAll; health
+   *  derives recentFailureRate from it). */
+  recentCalls?: Array<{ t: number; ok: boolean }>;
+  /** Computed in getAll: calls inside the recent window. */
+  recentCallCount?: number;
+  /** Computed in getAll: failure rate over the recent window (0-1). */
+  recentFailureRate?: number;
 }
 
 export interface HealthSnapshot {

--- a/test/metrics-store.test.ts
+++ b/test/metrics-store.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { MetricsStore } from "../src/eval/metrics-store.js";
+import type { StateKV } from "../src/state/kv.js";
+import type { FunctionMetrics } from "../src/types.js";
+
+function fakeKv(store = new Map<string, FunctionMetrics>()): StateKV {
+  return {
+    get: async <T>(_scope: string, key: string) =>
+      (store.get(key) as T) ?? null,
+    set: async <T>(_scope: string, key: string, value: T) => {
+      store.set(key, value as FunctionMetrics);
+      return value;
+    },
+    update: async () => {
+      throw new Error("not implemented");
+    },
+    delete: async (_scope: string, key: string) => {
+      store.delete(key);
+    },
+    list: async () => Array.from(store.values()),
+  } as unknown as StateKV;
+}
+
+describe("MetricsStore", () => {
+  it("records lastFailureAt only on failures", async () => {
+    const store = new MetricsStore(fakeKv());
+    await store.record("f", 10, true);
+    expect((await store.get("f"))?.lastFailureAt).toBeUndefined();
+    await store.record("f", 10, false);
+    const m = await store.get("f");
+    expect(m?.failureCount).toBe(1);
+    expect(typeof m?.lastFailureAt).toBe("number");
+  });
+
+  it("caps the recent-calls ring buffer", async () => {
+    const store = new MetricsStore(fakeKv());
+    for (let i = 0; i < 60; i++) await store.record("f", 1, true);
+    const m = await store.get("f");
+    expect(m?.recentCalls?.length).toBe(50);
+  });
+
+  it("getAll ignores failures older than the 24h window", async () => {
+    // Simulate a counter polluted by a long-fixed bug: 256 old failures,
+    // one outcome ring entry outside the window.
+    const kvStore = new Map<string, FunctionMetrics>([
+      [
+        "f",
+        {
+          functionId: "f",
+          totalCalls: 500,
+          successCount: 244,
+          failureCount: 256,
+          avgLatencyMs: 1,
+          avgQualityScore: 100,
+          recentCalls: [{ t: Date.now() - 48 * 60 * 60 * 1000, ok: false }],
+        },
+      ],
+    ]);
+    const store = new MetricsStore(fakeKv(kvStore));
+    await store.record("f", 1, true);
+    const f = (await store.getAll()).find((m) => m.functionId === "f");
+    expect(f?.failureCount).toBe(256); // cumulative history kept
+    expect(f?.recentCallCount).toBe(1); // only the fresh call
+    expect(f?.recentFailureRate).toBe(0); // stale failures excluded
+    expect(f?.recentCalls).toBeUndefined(); // ring not exposed in health
+  });
+
+  it("getAll reports a live rate for mixed recent outcomes", async () => {
+    const store = new MetricsStore(fakeKv());
+    await store.record("g", 1, true);
+    await store.record("g", 1, false);
+    const g = (await store.getAll()).find((m) => m.functionId === "g");
+    expect(g?.recentFailureRate).toBe(0.5);
+    expect(g?.failureCount).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- The engine health endpoint reports a **cumulative** failure count as a percentage, so a fixed bug leaves a stale high failure rate forever (we observed 56% days after the underlying bug was fixed, from a counter that started before it).
- This PR windows the failure rate to recent activity (failures since the last recorded success, within a 24h/50-call window) and adds `lastFailureAt`, so operators can distinguish "failing now" from "failed once, long ago."
- Also strips the per-worker function list (~265 registered ids) from the health snapshot, keeping `functionCount` — the snapshot is persisted every 30s and served by `api::health`.

Clean replacement for #1289, which accidentally carried 11 unrelated commits from our fork's history (that's what tripped the machine-specific-path Major and the spam flag — sorry about that). This branch is exactly 2 commits on top of current `main`.

## Testing
- 4 new vitest cases for the windowed rate + `lastFailureAt` (test/metrics-store.test.ts) — all pass.
- No new TS errors introduced (repo-wide `tsc --noEmit` error set unchanged by this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Health metrics now show the most recent failure time, recent call count, and failure rate.
  * Recent call outcomes are tracked over a 24-hour window, capped at 50 entries.
  * Health reports now include each worker’s function count.

* **Bug Fixes**
  * Older failures are excluded from recent failure-rate calculations while cumulative history is preserved.

* **Tests**
  * Added coverage for failure timestamps, recent-call limits, and live failure-rate reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->