### PR TITLE
fix(hooks): retry a failed observe POST instead of dropping it

### DIFF
--- a/plugin/scripts/notification.mjs
+++ b/plugin/scripts/notification.mjs
@@ -33,7 +33,7 @@ function hookCwd(data) {
 //#endregion
 //#region src/hooks/_post.ts
 async function postWithRetry(url, headers, body, budgetMs = 1e3) {
-	const retryDelayMs = Math.floor(budgetMs / 8);
+	const retryDelayMs = Math.min(250, Math.floor(budgetMs / 8));
 	const attemptMs = Math.floor((budgetMs - retryDelayMs) / 2);
 	for (let attempt = 0; attempt < 2; attempt++) {
 		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));

--- a/plugin/scripts/notification.mjs
+++ b/plugin/scripts/notification.mjs
@@ -32,11 +32,10 @@ function hookCwd(data) {
 }
 //#endregion
 //#region src/hooks/_post.ts
-async function postWithRetry(url, headers, body, budgetMs = 1e3) {
-	const retryDelayMs = Math.min(250, Math.floor(budgetMs / 8));
-	const attemptMs = Math.floor((budgetMs - retryDelayMs) / 2);
+const RETRY_DELAY_MS = 100;
+async function postWithRetry(url, headers, body, attemptMs = 400) {
 	for (let attempt = 0; attempt < 2; attempt++) {
-		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));
+		if (attempt) await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
 		try {
 			if ((await fetch(url, {
 				method: "POST",

--- a/plugin/scripts/notification.mjs
+++ b/plugin/scripts/notification.mjs
@@ -31,6 +31,23 @@ function hookCwd(data) {
 	if (projectDir && projectDir.trim()) return projectDir;
 }
 //#endregion
+//#region src/hooks/_post.ts
+async function postWithRetry(url, headers, body, opts = {}) {
+	const timeoutMs = opts.timeoutMs ?? 3e3;
+	const retryDelayMs = opts.retryDelayMs ?? 250;
+	for (let attempt = 0; attempt < 2; attempt++) {
+		try {
+			if ((await fetch(url, {
+				method: "POST",
+				headers,
+				body,
+				signal: AbortSignal.timeout(timeoutMs)
+			})).ok) return;
+		} catch {}
+		if (attempt === 0) await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+	}
+}
+//#endregion
 //#region src/hooks/notification.ts
 function isSdkChildContext(payload) {
 	if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -64,24 +81,19 @@ async function main() {
 	].find((v) => typeof v === "string" && v.length > 0);
 	const sessionId = typeof rawSessionId === "string" ? rawSessionId : "unknown";
 	const cwd = hookCwd(data) || process.cwd();
-	fetch(`${REST_URL}/agentmemory/observe`, {
-		method: "POST",
-		headers: authHeaders(),
-		body: JSON.stringify({
-			hookType: "notification",
-			sessionId,
-			project: resolveProject(cwd),
-			cwd,
-			timestamp: (/* @__PURE__ */ new Date()).toISOString(),
-			data: {
-				notification_type: notificationType,
-				title: data.title,
-				message: data.message
-			}
-		}),
-		signal: AbortSignal.timeout(2e3)
-	}).catch(() => {});
-	setTimeout(() => process.exit(0), 500).unref();
+	postWithRetry(`${REST_URL}/agentmemory/observe`, authHeaders(), JSON.stringify({
+		hookType: "notification",
+		sessionId,
+		project: resolveProject(cwd),
+		cwd,
+		timestamp: (/* @__PURE__ */ new Date()).toISOString(),
+		data: {
+			notification_type: notificationType,
+			title: data.title,
+			message: data.message
+		}
+	}), { timeoutMs: 2e3 });
+	setTimeout(() => process.exit(0), 1e3).unref();
 }
 main().catch(() => process.exit(0));
 //#endregion

--- a/plugin/scripts/notification.mjs
+++ b/plugin/scripts/notification.mjs
@@ -33,7 +33,7 @@ function hookCwd(data) {
 //#endregion
 //#region src/hooks/_post.ts
 async function postWithRetry(url, headers, body, budgetMs = 1e3) {
-	const retryDelayMs = Math.min(250, Math.floor(budgetMs / 8));
+	const retryDelayMs = Math.floor(budgetMs / 8);
 	const attemptMs = Math.floor((budgetMs - retryDelayMs) / 2);
 	for (let attempt = 0; attempt < 2; attempt++) {
 		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));

--- a/plugin/scripts/notification.mjs
+++ b/plugin/scripts/notification.mjs
@@ -32,7 +32,9 @@ function hookCwd(data) {
 }
 //#endregion
 //#region src/hooks/_post.ts
-async function postWithRetry(url, headers, body, retryDelayMs = 250) {
+async function postWithRetry(url, headers, body, budgetMs = 1e3) {
+	const retryDelayMs = Math.min(250, Math.floor(budgetMs / 8));
+	const attemptMs = Math.floor((budgetMs - retryDelayMs) / 2);
 	for (let attempt = 0; attempt < 2; attempt++) {
 		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));
 		try {
@@ -40,9 +42,12 @@ async function postWithRetry(url, headers, body, retryDelayMs = 250) {
 				method: "POST",
 				headers,
 				body,
-				signal: AbortSignal.timeout(3e3)
+				signal: AbortSignal.timeout(attemptMs)
 			})).ok) return;
-		} catch {}
+		} catch (err) {
+			const name = err?.name;
+			if (name === "TimeoutError" || name === "AbortError") return;
+		}
 	}
 }
 //#endregion

--- a/plugin/scripts/notification.mjs
+++ b/plugin/scripts/notification.mjs
@@ -30,12 +30,9 @@ function hookCwd(data) {
 	const projectDir = process.env["DEVIN_PROJECT_DIR"] || process.env["CLAUDE_PROJECT_DIR"];
 	if (projectDir && projectDir.trim()) return projectDir;
 }
-//#endregion
-//#region src/hooks/_post.ts
-const RETRY_DELAY_MS = 100;
 async function postWithRetry(url, headers, body, attemptMs = 400) {
 	for (let attempt = 0; attempt < 2; attempt++) {
-		if (attempt) await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
+		if (attempt) await new Promise((r) => setTimeout(r, 100));
 		try {
 			if ((await fetch(url, {
 				method: "POST",

--- a/plugin/scripts/notification.mjs
+++ b/plugin/scripts/notification.mjs
@@ -32,19 +32,17 @@ function hookCwd(data) {
 }
 //#endregion
 //#region src/hooks/_post.ts
-async function postWithRetry(url, headers, body, opts = {}) {
-	const timeoutMs = opts.timeoutMs ?? 3e3;
-	const retryDelayMs = opts.retryDelayMs ?? 250;
+async function postWithRetry(url, headers, body, retryDelayMs = 250) {
 	for (let attempt = 0; attempt < 2; attempt++) {
+		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));
 		try {
 			if ((await fetch(url, {
 				method: "POST",
 				headers,
 				body,
-				signal: AbortSignal.timeout(timeoutMs)
+				signal: AbortSignal.timeout(3e3)
 			})).ok) return;
 		} catch {}
-		if (attempt === 0) await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
 	}
 }
 //#endregion
@@ -92,7 +90,7 @@ async function main() {
 			title: data.title,
 			message: data.message
 		}
-	}), { timeoutMs: 2e3 });
+	}));
 	setTimeout(() => process.exit(0), 1e3).unref();
 }
 main().catch(() => process.exit(0));

--- a/plugin/scripts/post-tool-failure.mjs
+++ b/plugin/scripts/post-tool-failure.mjs
@@ -32,19 +32,17 @@ function hookCwd(data) {
 }
 //#endregion
 //#region src/hooks/_post.ts
-async function postWithRetry(url, headers, body, opts = {}) {
-	const timeoutMs = opts.timeoutMs ?? 3e3;
-	const retryDelayMs = opts.retryDelayMs ?? 250;
+async function postWithRetry(url, headers, body, retryDelayMs = 250) {
 	for (let attempt = 0; attempt < 2; attempt++) {
+		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));
 		try {
 			if ((await fetch(url, {
 				method: "POST",
 				headers,
 				body,
-				signal: AbortSignal.timeout(timeoutMs)
+				signal: AbortSignal.timeout(3e3)
 			})).ok) return;
 		} catch {}
-		if (attempt === 0) await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
 	}
 }
 //#endregion

--- a/plugin/scripts/post-tool-failure.mjs
+++ b/plugin/scripts/post-tool-failure.mjs
@@ -33,7 +33,7 @@ function hookCwd(data) {
 //#endregion
 //#region src/hooks/_post.ts
 async function postWithRetry(url, headers, body, budgetMs = 1e3) {
-	const retryDelayMs = Math.floor(budgetMs / 8);
+	const retryDelayMs = Math.min(250, Math.floor(budgetMs / 8));
 	const attemptMs = Math.floor((budgetMs - retryDelayMs) / 2);
 	for (let attempt = 0; attempt < 2; attempt++) {
 		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));

--- a/plugin/scripts/post-tool-failure.mjs
+++ b/plugin/scripts/post-tool-failure.mjs
@@ -32,11 +32,10 @@ function hookCwd(data) {
 }
 //#endregion
 //#region src/hooks/_post.ts
-async function postWithRetry(url, headers, body, budgetMs = 1e3) {
-	const retryDelayMs = Math.min(250, Math.floor(budgetMs / 8));
-	const attemptMs = Math.floor((budgetMs - retryDelayMs) / 2);
+const RETRY_DELAY_MS = 100;
+async function postWithRetry(url, headers, body, attemptMs = 400) {
 	for (let attempt = 0; attempt < 2; attempt++) {
-		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));
+		if (attempt) await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
 		try {
 			if ((await fetch(url, {
 				method: "POST",

--- a/plugin/scripts/post-tool-failure.mjs
+++ b/plugin/scripts/post-tool-failure.mjs
@@ -33,7 +33,7 @@ function hookCwd(data) {
 //#endregion
 //#region src/hooks/_post.ts
 async function postWithRetry(url, headers, body, budgetMs = 1e3) {
-	const retryDelayMs = Math.min(250, Math.floor(budgetMs / 8));
+	const retryDelayMs = Math.floor(budgetMs / 8);
 	const attemptMs = Math.floor((budgetMs - retryDelayMs) / 2);
 	for (let attempt = 0; attempt < 2; attempt++) {
 		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));

--- a/plugin/scripts/post-tool-failure.mjs
+++ b/plugin/scripts/post-tool-failure.mjs
@@ -32,7 +32,9 @@ function hookCwd(data) {
 }
 //#endregion
 //#region src/hooks/_post.ts
-async function postWithRetry(url, headers, body, retryDelayMs = 250) {
+async function postWithRetry(url, headers, body, budgetMs = 1e3) {
+	const retryDelayMs = Math.min(250, Math.floor(budgetMs / 8));
+	const attemptMs = Math.floor((budgetMs - retryDelayMs) / 2);
 	for (let attempt = 0; attempt < 2; attempt++) {
 		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));
 		try {
@@ -40,9 +42,12 @@ async function postWithRetry(url, headers, body, retryDelayMs = 250) {
 				method: "POST",
 				headers,
 				body,
-				signal: AbortSignal.timeout(3e3)
+				signal: AbortSignal.timeout(attemptMs)
 			})).ok) return;
-		} catch {}
+		} catch (err) {
+			const name = err?.name;
+			if (name === "TimeoutError" || name === "AbortError") return;
+		}
 	}
 }
 //#endregion

--- a/plugin/scripts/post-tool-failure.mjs
+++ b/plugin/scripts/post-tool-failure.mjs
@@ -30,12 +30,9 @@ function hookCwd(data) {
 	const projectDir = process.env["DEVIN_PROJECT_DIR"] || process.env["CLAUDE_PROJECT_DIR"];
 	if (projectDir && projectDir.trim()) return projectDir;
 }
-//#endregion
-//#region src/hooks/_post.ts
-const RETRY_DELAY_MS = 100;
 async function postWithRetry(url, headers, body, attemptMs = 400) {
 	for (let attempt = 0; attempt < 2; attempt++) {
-		if (attempt) await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
+		if (attempt) await new Promise((r) => setTimeout(r, 100));
 		try {
 			if ((await fetch(url, {
 				method: "POST",

--- a/plugin/scripts/post-tool-failure.mjs
+++ b/plugin/scripts/post-tool-failure.mjs
@@ -31,6 +31,23 @@ function hookCwd(data) {
 	if (projectDir && projectDir.trim()) return projectDir;
 }
 //#endregion
+//#region src/hooks/_post.ts
+async function postWithRetry(url, headers, body, opts = {}) {
+	const timeoutMs = opts.timeoutMs ?? 3e3;
+	const retryDelayMs = opts.retryDelayMs ?? 250;
+	for (let attempt = 0; attempt < 2; attempt++) {
+		try {
+			if ((await fetch(url, {
+				method: "POST",
+				headers,
+				body,
+				signal: AbortSignal.timeout(timeoutMs)
+			})).ok) return;
+		} catch {}
+		if (attempt === 0) await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+	}
+}
+//#endregion
 //#region src/hooks/post-tool-failure.ts
 function isSdkChildContext(payload) {
 	if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -61,24 +78,19 @@ async function main() {
 	const toolInput = data.tool_input ?? data.toolArgs;
 	const error = data.error ?? data.errorMessage;
 	const cwd = hookCwd(data) || process.cwd();
-	fetch(`${REST_URL}/agentmemory/observe`, {
-		method: "POST",
-		headers: authHeaders(),
-		body: JSON.stringify({
-			hookType: "post_tool_failure",
-			sessionId,
-			project: resolveProject(cwd),
-			cwd,
-			timestamp: (/* @__PURE__ */ new Date()).toISOString(),
-			data: {
-				tool_name: toolName,
-				tool_input: typeof toolInput === "string" ? toolInput.slice(0, 4e3) : JSON.stringify(toolInput ?? "").slice(0, 4e3),
-				error: typeof error === "string" ? error.slice(0, 4e3) : JSON.stringify(error ?? "").slice(0, 4e3)
-			}
-		}),
-		signal: AbortSignal.timeout(3e3)
-	}).catch(() => {});
-	setTimeout(() => process.exit(0), 500).unref();
+	postWithRetry(`${REST_URL}/agentmemory/observe`, authHeaders(), JSON.stringify({
+		hookType: "post_tool_failure",
+		sessionId,
+		project: resolveProject(cwd),
+		cwd,
+		timestamp: (/* @__PURE__ */ new Date()).toISOString(),
+		data: {
+			tool_name: toolName,
+			tool_input: typeof toolInput === "string" ? toolInput.slice(0, 4e3) : JSON.stringify(toolInput ?? "").slice(0, 4e3),
+			error: typeof error === "string" ? error.slice(0, 4e3) : JSON.stringify(error ?? "").slice(0, 4e3)
+		}
+	}));
+	setTimeout(() => process.exit(0), 1e3).unref();
 }
 main().catch(() => process.exit(0));
 //#endregion

--- a/plugin/scripts/post-tool-use.mjs
+++ b/plugin/scripts/post-tool-use.mjs
@@ -32,19 +32,17 @@ function hookCwd(data) {
 }
 //#endregion
 //#region src/hooks/_post.ts
-async function postWithRetry(url, headers, body, opts = {}) {
-	const timeoutMs = opts.timeoutMs ?? 3e3;
-	const retryDelayMs = opts.retryDelayMs ?? 250;
+async function postWithRetry(url, headers, body, retryDelayMs = 250) {
 	for (let attempt = 0; attempt < 2; attempt++) {
+		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));
 		try {
 			if ((await fetch(url, {
 				method: "POST",
 				headers,
 				body,
-				signal: AbortSignal.timeout(timeoutMs)
+				signal: AbortSignal.timeout(3e3)
 			})).ok) return;
 		} catch {}
-		if (attempt === 0) await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
 	}
 }
 //#endregion

--- a/plugin/scripts/post-tool-use.mjs
+++ b/plugin/scripts/post-tool-use.mjs
@@ -33,7 +33,7 @@ function hookCwd(data) {
 //#endregion
 //#region src/hooks/_post.ts
 async function postWithRetry(url, headers, body, budgetMs = 1e3) {
-	const retryDelayMs = Math.floor(budgetMs / 8);
+	const retryDelayMs = Math.min(250, Math.floor(budgetMs / 8));
 	const attemptMs = Math.floor((budgetMs - retryDelayMs) / 2);
 	for (let attempt = 0; attempt < 2; attempt++) {
 		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));

--- a/plugin/scripts/post-tool-use.mjs
+++ b/plugin/scripts/post-tool-use.mjs
@@ -31,6 +31,23 @@ function hookCwd(data) {
 	if (projectDir && projectDir.trim()) return projectDir;
 }
 //#endregion
+//#region src/hooks/_post.ts
+async function postWithRetry(url, headers, body, opts = {}) {
+	const timeoutMs = opts.timeoutMs ?? 3e3;
+	const retryDelayMs = opts.retryDelayMs ?? 250;
+	for (let attempt = 0; attempt < 2; attempt++) {
+		try {
+			if ((await fetch(url, {
+				method: "POST",
+				headers,
+				body,
+				signal: AbortSignal.timeout(timeoutMs)
+			})).ok) return;
+		} catch {}
+		if (attempt === 0) await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+	}
+}
+//#endregion
 //#region src/hooks/post-tool-use.ts
 function isSdkChildContext(payload) {
 	if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -60,25 +77,20 @@ async function main() {
 	const toolInput = data.tool_input ?? data.toolArgs;
 	const { imageData, cleanOutput } = extractImageData(toolOutput(data));
 	const cwd = hookCwd(data) || process.cwd();
-	fetch(`${REST_URL}/agentmemory/observe`, {
-		method: "POST",
-		headers: authHeaders(),
-		body: JSON.stringify({
-			hookType: "post_tool_use",
-			sessionId,
-			project: resolveProject(cwd),
-			cwd,
-			timestamp: (/* @__PURE__ */ new Date()).toISOString(),
-			data: {
-				tool_name: toolName,
-				tool_input: toolInput,
-				tool_output: truncate(cleanOutput, 8e3),
-				...imageData ? { image_data: imageData } : {}
-			}
-		}),
-		signal: AbortSignal.timeout(3e3)
-	}).catch(() => {});
-	setTimeout(() => process.exit(0), 500).unref();
+	postWithRetry(`${REST_URL}/agentmemory/observe`, authHeaders(), JSON.stringify({
+		hookType: "post_tool_use",
+		sessionId,
+		project: resolveProject(cwd),
+		cwd,
+		timestamp: (/* @__PURE__ */ new Date()).toISOString(),
+		data: {
+			tool_name: toolName,
+			tool_input: toolInput,
+			tool_output: truncate(cleanOutput, 8e3),
+			...imageData ? { image_data: imageData } : {}
+		}
+	}));
+	setTimeout(() => process.exit(0), 1e3).unref();
 }
 function toolOutput(data) {
 	if (data.tool_response !== void 0) return data.tool_response;

--- a/plugin/scripts/post-tool-use.mjs
+++ b/plugin/scripts/post-tool-use.mjs
@@ -32,11 +32,10 @@ function hookCwd(data) {
 }
 //#endregion
 //#region src/hooks/_post.ts
-async function postWithRetry(url, headers, body, budgetMs = 1e3) {
-	const retryDelayMs = Math.min(250, Math.floor(budgetMs / 8));
-	const attemptMs = Math.floor((budgetMs - retryDelayMs) / 2);
+const RETRY_DELAY_MS = 100;
+async function postWithRetry(url, headers, body, attemptMs = 400) {
 	for (let attempt = 0; attempt < 2; attempt++) {
-		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));
+		if (attempt) await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
 		try {
 			if ((await fetch(url, {
 				method: "POST",

--- a/plugin/scripts/post-tool-use.mjs
+++ b/plugin/scripts/post-tool-use.mjs
@@ -33,7 +33,7 @@ function hookCwd(data) {
 //#endregion
 //#region src/hooks/_post.ts
 async function postWithRetry(url, headers, body, budgetMs = 1e3) {
-	const retryDelayMs = Math.min(250, Math.floor(budgetMs / 8));
+	const retryDelayMs = Math.floor(budgetMs / 8);
 	const attemptMs = Math.floor((budgetMs - retryDelayMs) / 2);
 	for (let attempt = 0; attempt < 2; attempt++) {
 		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));

--- a/plugin/scripts/post-tool-use.mjs
+++ b/plugin/scripts/post-tool-use.mjs
@@ -32,7 +32,9 @@ function hookCwd(data) {
 }
 //#endregion
 //#region src/hooks/_post.ts
-async function postWithRetry(url, headers, body, retryDelayMs = 250) {
+async function postWithRetry(url, headers, body, budgetMs = 1e3) {
+	const retryDelayMs = Math.min(250, Math.floor(budgetMs / 8));
+	const attemptMs = Math.floor((budgetMs - retryDelayMs) / 2);
 	for (let attempt = 0; attempt < 2; attempt++) {
 		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));
 		try {
@@ -40,9 +42,12 @@ async function postWithRetry(url, headers, body, retryDelayMs = 250) {
 				method: "POST",
 				headers,
 				body,
-				signal: AbortSignal.timeout(3e3)
+				signal: AbortSignal.timeout(attemptMs)
 			})).ok) return;
-		} catch {}
+		} catch (err) {
+			const name = err?.name;
+			if (name === "TimeoutError" || name === "AbortError") return;
+		}
 	}
 }
 //#endregion

--- a/plugin/scripts/post-tool-use.mjs
+++ b/plugin/scripts/post-tool-use.mjs
@@ -30,12 +30,9 @@ function hookCwd(data) {
 	const projectDir = process.env["DEVIN_PROJECT_DIR"] || process.env["CLAUDE_PROJECT_DIR"];
 	if (projectDir && projectDir.trim()) return projectDir;
 }
-//#endregion
-//#region src/hooks/_post.ts
-const RETRY_DELAY_MS = 100;
 async function postWithRetry(url, headers, body, attemptMs = 400) {
 	for (let attempt = 0; attempt < 2; attempt++) {
-		if (attempt) await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
+		if (attempt) await new Promise((r) => setTimeout(r, 100));
 		try {
 			if ((await fetch(url, {
 				method: "POST",

--- a/plugin/scripts/prompt-submit.mjs
+++ b/plugin/scripts/prompt-submit.mjs
@@ -32,19 +32,17 @@ function hookCwd(data) {
 }
 //#endregion
 //#region src/hooks/_post.ts
-async function postWithRetry(url, headers, body, opts = {}) {
-	const timeoutMs = opts.timeoutMs ?? 3e3;
-	const retryDelayMs = opts.retryDelayMs ?? 250;
+async function postWithRetry(url, headers, body, retryDelayMs = 250) {
 	for (let attempt = 0; attempt < 2; attempt++) {
+		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));
 		try {
 			if ((await fetch(url, {
 				method: "POST",
 				headers,
 				body,
-				signal: AbortSignal.timeout(timeoutMs)
+				signal: AbortSignal.timeout(3e3)
 			})).ok) return;
 		} catch {}
-		if (attempt === 0) await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
 	}
 }
 //#endregion

--- a/plugin/scripts/prompt-submit.mjs
+++ b/plugin/scripts/prompt-submit.mjs
@@ -33,7 +33,7 @@ function hookCwd(data) {
 //#endregion
 //#region src/hooks/_post.ts
 async function postWithRetry(url, headers, body, budgetMs = 1e3) {
-	const retryDelayMs = Math.floor(budgetMs / 8);
+	const retryDelayMs = Math.min(250, Math.floor(budgetMs / 8));
 	const attemptMs = Math.floor((budgetMs - retryDelayMs) / 2);
 	for (let attempt = 0; attempt < 2; attempt++) {
 		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));

--- a/plugin/scripts/prompt-submit.mjs
+++ b/plugin/scripts/prompt-submit.mjs
@@ -32,11 +32,10 @@ function hookCwd(data) {
 }
 //#endregion
 //#region src/hooks/_post.ts
-async function postWithRetry(url, headers, body, budgetMs = 1e3) {
-	const retryDelayMs = Math.min(250, Math.floor(budgetMs / 8));
-	const attemptMs = Math.floor((budgetMs - retryDelayMs) / 2);
+const RETRY_DELAY_MS = 100;
+async function postWithRetry(url, headers, body, attemptMs = 400) {
 	for (let attempt = 0; attempt < 2; attempt++) {
-		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));
+		if (attempt) await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
 		try {
 			if ((await fetch(url, {
 				method: "POST",

--- a/plugin/scripts/prompt-submit.mjs
+++ b/plugin/scripts/prompt-submit.mjs
@@ -31,6 +31,23 @@ function hookCwd(data) {
 	if (projectDir && projectDir.trim()) return projectDir;
 }
 //#endregion
+//#region src/hooks/_post.ts
+async function postWithRetry(url, headers, body, opts = {}) {
+	const timeoutMs = opts.timeoutMs ?? 3e3;
+	const retryDelayMs = opts.retryDelayMs ?? 250;
+	for (let attempt = 0; attempt < 2; attempt++) {
+		try {
+			if ((await fetch(url, {
+				method: "POST",
+				headers,
+				body,
+				signal: AbortSignal.timeout(timeoutMs)
+			})).ok) return;
+		} catch {}
+		if (attempt === 0) await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+	}
+}
+//#endregion
 //#region src/hooks/prompt-submit.ts
 function isSdkChildContext(payload) {
 	if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -57,20 +74,15 @@ async function main() {
 	if (isSdkChildContext(data)) return;
 	const sessionId = data.session_id || data.sessionId || data.conversation_id || "unknown";
 	const cwd = hookCwd(data) || process.cwd();
-	fetch(`${REST_URL}/agentmemory/observe`, {
-		method: "POST",
-		headers: authHeaders(),
-		body: JSON.stringify({
-			hookType: "prompt_submit",
-			sessionId,
-			project: resolveProject(cwd),
-			cwd,
-			timestamp: (/* @__PURE__ */ new Date()).toISOString(),
-			data: { prompt: data.prompt ?? data.userPrompt }
-		}),
-		signal: AbortSignal.timeout(3e3)
-	}).catch(() => {});
-	setTimeout(() => process.exit(0), 500).unref();
+	postWithRetry(`${REST_URL}/agentmemory/observe`, authHeaders(), JSON.stringify({
+		hookType: "prompt_submit",
+		sessionId,
+		project: resolveProject(cwd),
+		cwd,
+		timestamp: (/* @__PURE__ */ new Date()).toISOString(),
+		data: { prompt: data.prompt ?? data.userPrompt }
+	}));
+	setTimeout(() => process.exit(0), 1e3).unref();
 }
 main().catch(() => process.exit(0));
 //#endregion

--- a/plugin/scripts/prompt-submit.mjs
+++ b/plugin/scripts/prompt-submit.mjs
@@ -33,7 +33,7 @@ function hookCwd(data) {
 //#endregion
 //#region src/hooks/_post.ts
 async function postWithRetry(url, headers, body, budgetMs = 1e3) {
-	const retryDelayMs = Math.min(250, Math.floor(budgetMs / 8));
+	const retryDelayMs = Math.floor(budgetMs / 8);
 	const attemptMs = Math.floor((budgetMs - retryDelayMs) / 2);
 	for (let attempt = 0; attempt < 2; attempt++) {
 		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));

--- a/plugin/scripts/prompt-submit.mjs
+++ b/plugin/scripts/prompt-submit.mjs
@@ -32,7 +32,9 @@ function hookCwd(data) {
 }
 //#endregion
 //#region src/hooks/_post.ts
-async function postWithRetry(url, headers, body, retryDelayMs = 250) {
+async function postWithRetry(url, headers, body, budgetMs = 1e3) {
+	const retryDelayMs = Math.min(250, Math.floor(budgetMs / 8));
+	const attemptMs = Math.floor((budgetMs - retryDelayMs) / 2);
 	for (let attempt = 0; attempt < 2; attempt++) {
 		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));
 		try {
@@ -40,9 +42,12 @@ async function postWithRetry(url, headers, body, retryDelayMs = 250) {
 				method: "POST",
 				headers,
 				body,
-				signal: AbortSignal.timeout(3e3)
+				signal: AbortSignal.timeout(attemptMs)
 			})).ok) return;
-		} catch {}
+		} catch (err) {
+			const name = err?.name;
+			if (name === "TimeoutError" || name === "AbortError") return;
+		}
 	}
 }
 //#endregion

--- a/plugin/scripts/prompt-submit.mjs
+++ b/plugin/scripts/prompt-submit.mjs
@@ -30,12 +30,9 @@ function hookCwd(data) {
 	const projectDir = process.env["DEVIN_PROJECT_DIR"] || process.env["CLAUDE_PROJECT_DIR"];
 	if (projectDir && projectDir.trim()) return projectDir;
 }
-//#endregion
-//#region src/hooks/_post.ts
-const RETRY_DELAY_MS = 100;
 async function postWithRetry(url, headers, body, attemptMs = 400) {
 	for (let attempt = 0; attempt < 2; attempt++) {
-		if (attempt) await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
+		if (attempt) await new Promise((r) => setTimeout(r, 100));
 		try {
 			if ((await fetch(url, {
 				method: "POST",

--- a/plugin/scripts/session-end.mjs
+++ b/plugin/scripts/session-end.mjs
@@ -34,7 +34,7 @@ function hookCwd(data) {
 //#endregion
 //#region src/hooks/_post.ts
 async function postWithRetry(url, headers, body, budgetMs = 1e3) {
-	const retryDelayMs = Math.min(250, Math.floor(budgetMs / 8));
+	const retryDelayMs = Math.floor(budgetMs / 8);
 	const attemptMs = Math.floor((budgetMs - retryDelayMs) / 2);
 	for (let attempt = 0; attempt < 2; attempt++) {
 		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));

--- a/plugin/scripts/session-end.mjs
+++ b/plugin/scripts/session-end.mjs
@@ -33,19 +33,17 @@ function hookCwd(data) {
 }
 //#endregion
 //#region src/hooks/_post.ts
-async function postWithRetry(url, headers, body, opts = {}) {
-	const timeoutMs = opts.timeoutMs ?? 3e3;
-	const retryDelayMs = opts.retryDelayMs ?? 250;
+async function postWithRetry(url, headers, body, retryDelayMs = 250) {
 	for (let attempt = 0; attempt < 2; attempt++) {
+		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));
 		try {
 			if ((await fetch(url, {
 				method: "POST",
 				headers,
 				body,
-				signal: AbortSignal.timeout(timeoutMs)
+				signal: AbortSignal.timeout(3e3)
 			})).ok) return;
 		} catch {}
-		if (attempt === 0) await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
 	}
 }
 //#endregion

--- a/plugin/scripts/session-end.mjs
+++ b/plugin/scripts/session-end.mjs
@@ -32,6 +32,23 @@ function hookCwd(data) {
 	if (projectDir && projectDir.trim()) return projectDir;
 }
 //#endregion
+//#region src/hooks/_post.ts
+async function postWithRetry(url, headers, body, opts = {}) {
+	const timeoutMs = opts.timeoutMs ?? 3e3;
+	const retryDelayMs = opts.retryDelayMs ?? 250;
+	for (let attempt = 0; attempt < 2; attempt++) {
+		try {
+			if ((await fetch(url, {
+				method: "POST",
+				headers,
+				body,
+				signal: AbortSignal.timeout(timeoutMs)
+			})).ok) return;
+		} catch {}
+		if (attempt === 0) await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+	}
+}
+//#endregion
 //#region src/hooks/session-end.ts
 function isSdkChildContext(payload) {
 	if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -91,19 +108,14 @@ async function main() {
 		const cwd = hookCwd(data) || process.cwd();
 		const project = resolveProject(cwd);
 		const timestamp = (/* @__PURE__ */ new Date()).toISOString();
-		await Promise.allSettled(transcriptPrompts.map((prompt) => fetch(`${REST_URL}/agentmemory/observe`, {
-			method: "POST",
-			headers: authHeaders(),
-			body: JSON.stringify({
-				hookType: "prompt_submit",
-				sessionId,
-				project,
-				cwd,
-				timestamp,
-				data: { prompt }
-			}),
-			signal: AbortSignal.timeout(3e3)
-		})));
+		await Promise.allSettled(transcriptPrompts.map((prompt) => postWithRetry(`${REST_URL}/agentmemory/observe`, authHeaders(), JSON.stringify({
+			hookType: "prompt_submit",
+			sessionId,
+			project,
+			cwd,
+			timestamp,
+			data: { prompt }
+		}))));
 	}
 	fetch(`${REST_URL}/agentmemory/session/end`, {
 		method: "POST",

--- a/plugin/scripts/session-end.mjs
+++ b/plugin/scripts/session-end.mjs
@@ -33,7 +33,9 @@ function hookCwd(data) {
 }
 //#endregion
 //#region src/hooks/_post.ts
-async function postWithRetry(url, headers, body, retryDelayMs = 250) {
+async function postWithRetry(url, headers, body, budgetMs = 1e3) {
+	const retryDelayMs = Math.min(250, Math.floor(budgetMs / 8));
+	const attemptMs = Math.floor((budgetMs - retryDelayMs) / 2);
 	for (let attempt = 0; attempt < 2; attempt++) {
 		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));
 		try {
@@ -41,9 +43,12 @@ async function postWithRetry(url, headers, body, retryDelayMs = 250) {
 				method: "POST",
 				headers,
 				body,
-				signal: AbortSignal.timeout(3e3)
+				signal: AbortSignal.timeout(attemptMs)
 			})).ok) return;
-		} catch {}
+		} catch (err) {
+			const name = err?.name;
+			if (name === "TimeoutError" || name === "AbortError") return;
+		}
 	}
 }
 //#endregion
@@ -113,7 +118,7 @@ async function main() {
 			cwd,
 			timestamp,
 			data: { prompt }
-		}))));
+		}), 3e3)));
 	}
 	fetch(`${REST_URL}/agentmemory/session/end`, {
 		method: "POST",

--- a/plugin/scripts/session-end.mjs
+++ b/plugin/scripts/session-end.mjs
@@ -31,12 +31,9 @@ function hookCwd(data) {
 	const projectDir = process.env["DEVIN_PROJECT_DIR"] || process.env["CLAUDE_PROJECT_DIR"];
 	if (projectDir && projectDir.trim()) return projectDir;
 }
-//#endregion
-//#region src/hooks/_post.ts
-const RETRY_DELAY_MS = 100;
 async function postWithRetry(url, headers, body, attemptMs = 400) {
 	for (let attempt = 0; attempt < 2; attempt++) {
-		if (attempt) await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
+		if (attempt) await new Promise((r) => setTimeout(r, 100));
 		try {
 			if ((await fetch(url, {
 				method: "POST",

--- a/plugin/scripts/session-end.mjs
+++ b/plugin/scripts/session-end.mjs
@@ -33,11 +33,10 @@ function hookCwd(data) {
 }
 //#endregion
 //#region src/hooks/_post.ts
-async function postWithRetry(url, headers, body, budgetMs = 1e3) {
-	const retryDelayMs = Math.min(250, Math.floor(budgetMs / 8));
-	const attemptMs = Math.floor((budgetMs - retryDelayMs) / 2);
+const RETRY_DELAY_MS = 100;
+async function postWithRetry(url, headers, body, attemptMs = 400) {
 	for (let attempt = 0; attempt < 2; attempt++) {
-		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));
+		if (attempt) await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
 		try {
 			if ((await fetch(url, {
 				method: "POST",
@@ -53,6 +52,7 @@ async function postWithRetry(url, headers, body, budgetMs = 1e3) {
 }
 //#endregion
 //#region src/hooks/session-end.ts
+const OBSERVE_ATTEMPT_MS = 3e3;
 function isSdkChildContext(payload) {
 	if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
 	if (!payload || typeof payload !== "object") return false;
@@ -118,7 +118,7 @@ async function main() {
 			cwd,
 			timestamp,
 			data: { prompt }
-		}), 6250)));
+		}), OBSERVE_ATTEMPT_MS)));
 	}
 	fetch(`${REST_URL}/agentmemory/session/end`, {
 		method: "POST",
@@ -135,6 +135,6 @@ async function main() {
 }
 main().catch(() => process.exit(0));
 //#endregion
-export {};
+export { OBSERVE_ATTEMPT_MS };
 
 //# sourceMappingURL=session-end.mjs.map

--- a/plugin/scripts/session-end.mjs
+++ b/plugin/scripts/session-end.mjs
@@ -34,7 +34,7 @@ function hookCwd(data) {
 //#endregion
 //#region src/hooks/_post.ts
 async function postWithRetry(url, headers, body, budgetMs = 1e3) {
-	const retryDelayMs = Math.floor(budgetMs / 8);
+	const retryDelayMs = Math.min(250, Math.floor(budgetMs / 8));
 	const attemptMs = Math.floor((budgetMs - retryDelayMs) / 2);
 	for (let attempt = 0; attempt < 2; attempt++) {
 		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));
@@ -118,7 +118,7 @@ async function main() {
 			cwd,
 			timestamp,
 			data: { prompt }
-		}), 3e3)));
+		}), 6250)));
 	}
 	fetch(`${REST_URL}/agentmemory/session/end`, {
 		method: "POST",

--- a/plugin/scripts/subagent-start.mjs
+++ b/plugin/scripts/subagent-start.mjs
@@ -33,7 +33,7 @@ function hookCwd(data) {
 //#endregion
 //#region src/hooks/_post.ts
 async function postWithRetry(url, headers, body, budgetMs = 1e3) {
-	const retryDelayMs = Math.floor(budgetMs / 8);
+	const retryDelayMs = Math.min(250, Math.floor(budgetMs / 8));
 	const attemptMs = Math.floor((budgetMs - retryDelayMs) / 2);
 	for (let attempt = 0; attempt < 2; attempt++) {
 		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));

--- a/plugin/scripts/subagent-start.mjs
+++ b/plugin/scripts/subagent-start.mjs
@@ -32,11 +32,10 @@ function hookCwd(data) {
 }
 //#endregion
 //#region src/hooks/_post.ts
-async function postWithRetry(url, headers, body, budgetMs = 1e3) {
-	const retryDelayMs = Math.min(250, Math.floor(budgetMs / 8));
-	const attemptMs = Math.floor((budgetMs - retryDelayMs) / 2);
+const RETRY_DELAY_MS = 100;
+async function postWithRetry(url, headers, body, attemptMs = 400) {
 	for (let attempt = 0; attempt < 2; attempt++) {
-		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));
+		if (attempt) await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
 		try {
 			if ((await fetch(url, {
 				method: "POST",

--- a/plugin/scripts/subagent-start.mjs
+++ b/plugin/scripts/subagent-start.mjs
@@ -33,7 +33,7 @@ function hookCwd(data) {
 //#endregion
 //#region src/hooks/_post.ts
 async function postWithRetry(url, headers, body, budgetMs = 1e3) {
-	const retryDelayMs = Math.min(250, Math.floor(budgetMs / 8));
+	const retryDelayMs = Math.floor(budgetMs / 8);
 	const attemptMs = Math.floor((budgetMs - retryDelayMs) / 2);
 	for (let attempt = 0; attempt < 2; attempt++) {
 		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));

--- a/plugin/scripts/subagent-start.mjs
+++ b/plugin/scripts/subagent-start.mjs
@@ -32,7 +32,9 @@ function hookCwd(data) {
 }
 //#endregion
 //#region src/hooks/_post.ts
-async function postWithRetry(url, headers, body, retryDelayMs = 250) {
+async function postWithRetry(url, headers, body, budgetMs = 1e3) {
+	const retryDelayMs = Math.min(250, Math.floor(budgetMs / 8));
+	const attemptMs = Math.floor((budgetMs - retryDelayMs) / 2);
 	for (let attempt = 0; attempt < 2; attempt++) {
 		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));
 		try {
@@ -40,9 +42,12 @@ async function postWithRetry(url, headers, body, retryDelayMs = 250) {
 				method: "POST",
 				headers,
 				body,
-				signal: AbortSignal.timeout(3e3)
+				signal: AbortSignal.timeout(attemptMs)
 			})).ok) return;
-		} catch {}
+		} catch (err) {
+			const name = err?.name;
+			if (name === "TimeoutError" || name === "AbortError") return;
+		}
 	}
 }
 //#endregion

--- a/plugin/scripts/subagent-start.mjs
+++ b/plugin/scripts/subagent-start.mjs
@@ -31,6 +31,21 @@ function hookCwd(data) {
 	if (projectDir && projectDir.trim()) return projectDir;
 }
 //#endregion
+//#region src/hooks/_post.ts
+async function postWithRetry(url, headers, body, retryDelayMs = 250) {
+	for (let attempt = 0; attempt < 2; attempt++) {
+		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));
+		try {
+			if ((await fetch(url, {
+				method: "POST",
+				headers,
+				body,
+				signal: AbortSignal.timeout(3e3)
+			})).ok) return;
+		} catch {}
+	}
+}
+//#endregion
 //#region src/hooks/subagent-start.ts
 function isSdkChildContext(payload) {
 	if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -39,7 +54,6 @@ function isSdkChildContext(payload) {
 }
 const REST_URL = process.env["AGENTMEMORY_URL"] || "http://localhost:3111";
 const SECRET = process.env["AGENTMEMORY_SECRET"] || "";
-const TIMEOUT_MS = 800;
 function authHeaders() {
 	const h = { "Content-Type": "application/json" };
 	if (SECRET) h["Authorization"] = `Bearer ${SECRET}`;
@@ -60,23 +74,18 @@ async function main() {
 	const agentId = data.agent_id || data.agentName;
 	const agentType = data.agent_type || data.agentDisplayName || data.agentName;
 	const cwd = hookCwd(data) || process.cwd();
-	fetch(`${REST_URL}/agentmemory/observe`, {
-		method: "POST",
-		headers: authHeaders(),
-		body: JSON.stringify({
-			hookType: "subagent_start",
-			sessionId,
-			project: resolveProject(cwd),
-			cwd,
-			timestamp: (/* @__PURE__ */ new Date()).toISOString(),
-			data: {
-				agent_id: agentId,
-				agent_type: agentType
-			}
-		}),
-		signal: AbortSignal.timeout(TIMEOUT_MS)
-	}).catch(() => {});
-	setTimeout(() => process.exit(0), 500).unref();
+	postWithRetry(`${REST_URL}/agentmemory/observe`, authHeaders(), JSON.stringify({
+		hookType: "subagent_start",
+		sessionId,
+		project: resolveProject(cwd),
+		cwd,
+		timestamp: (/* @__PURE__ */ new Date()).toISOString(),
+		data: {
+			agent_id: agentId,
+			agent_type: agentType
+		}
+	}));
+	setTimeout(() => process.exit(0), 1e3).unref();
 }
 main().catch(() => process.exit(0));
 //#endregion

--- a/plugin/scripts/subagent-start.mjs
+++ b/plugin/scripts/subagent-start.mjs
@@ -30,12 +30,9 @@ function hookCwd(data) {
 	const projectDir = process.env["DEVIN_PROJECT_DIR"] || process.env["CLAUDE_PROJECT_DIR"];
 	if (projectDir && projectDir.trim()) return projectDir;
 }
-//#endregion
-//#region src/hooks/_post.ts
-const RETRY_DELAY_MS = 100;
 async function postWithRetry(url, headers, body, attemptMs = 400) {
 	for (let attempt = 0; attempt < 2; attempt++) {
-		if (attempt) await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
+		if (attempt) await new Promise((r) => setTimeout(r, 100));
 		try {
 			if ((await fetch(url, {
 				method: "POST",

--- a/plugin/scripts/subagent-stop.mjs
+++ b/plugin/scripts/subagent-stop.mjs
@@ -33,7 +33,7 @@ function hookCwd(data) {
 //#endregion
 //#region src/hooks/_post.ts
 async function postWithRetry(url, headers, body, budgetMs = 1e3) {
-	const retryDelayMs = Math.floor(budgetMs / 8);
+	const retryDelayMs = Math.min(250, Math.floor(budgetMs / 8));
 	const attemptMs = Math.floor((budgetMs - retryDelayMs) / 2);
 	for (let attempt = 0; attempt < 2; attempt++) {
 		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));

--- a/plugin/scripts/subagent-stop.mjs
+++ b/plugin/scripts/subagent-stop.mjs
@@ -32,11 +32,10 @@ function hookCwd(data) {
 }
 //#endregion
 //#region src/hooks/_post.ts
-async function postWithRetry(url, headers, body, budgetMs = 1e3) {
-	const retryDelayMs = Math.min(250, Math.floor(budgetMs / 8));
-	const attemptMs = Math.floor((budgetMs - retryDelayMs) / 2);
+const RETRY_DELAY_MS = 100;
+async function postWithRetry(url, headers, body, attemptMs = 400) {
 	for (let attempt = 0; attempt < 2; attempt++) {
-		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));
+		if (attempt) await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
 		try {
 			if ((await fetch(url, {
 				method: "POST",

--- a/plugin/scripts/subagent-stop.mjs
+++ b/plugin/scripts/subagent-stop.mjs
@@ -31,6 +31,21 @@ function hookCwd(data) {
 	if (projectDir && projectDir.trim()) return projectDir;
 }
 //#endregion
+//#region src/hooks/_post.ts
+async function postWithRetry(url, headers, body, retryDelayMs = 250) {
+	for (let attempt = 0; attempt < 2; attempt++) {
+		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));
+		try {
+			if ((await fetch(url, {
+				method: "POST",
+				headers,
+				body,
+				signal: AbortSignal.timeout(3e3)
+			})).ok) return;
+		} catch {}
+	}
+}
+//#endregion
 //#region src/hooks/subagent-stop.ts
 function isSdkChildContext(payload) {
 	if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -60,24 +75,19 @@ async function main() {
 	const agentType = data.agent_type || data.agentDisplayName || data.agentName;
 	const lastMsg = typeof data.last_assistant_message === "string" ? data.last_assistant_message.slice(0, 4e3) : "";
 	const cwd = hookCwd(data) || process.cwd();
-	fetch(`${REST_URL}/agentmemory/observe`, {
-		method: "POST",
-		headers: authHeaders(),
-		body: JSON.stringify({
-			hookType: "subagent_stop",
-			sessionId,
-			project: resolveProject(cwd),
-			cwd,
-			timestamp: (/* @__PURE__ */ new Date()).toISOString(),
-			data: {
-				agent_id: agentId,
-				agent_type: agentType,
-				last_message: lastMsg
-			}
-		}),
-		signal: AbortSignal.timeout(2e3)
-	}).catch(() => {});
-	setTimeout(() => process.exit(0), 500).unref();
+	postWithRetry(`${REST_URL}/agentmemory/observe`, authHeaders(), JSON.stringify({
+		hookType: "subagent_stop",
+		sessionId,
+		project: resolveProject(cwd),
+		cwd,
+		timestamp: (/* @__PURE__ */ new Date()).toISOString(),
+		data: {
+			agent_id: agentId,
+			agent_type: agentType,
+			last_message: lastMsg
+		}
+	}));
+	setTimeout(() => process.exit(0), 1e3).unref();
 }
 main().catch(() => process.exit(0));
 //#endregion

--- a/plugin/scripts/subagent-stop.mjs
+++ b/plugin/scripts/subagent-stop.mjs
@@ -33,7 +33,7 @@ function hookCwd(data) {
 //#endregion
 //#region src/hooks/_post.ts
 async function postWithRetry(url, headers, body, budgetMs = 1e3) {
-	const retryDelayMs = Math.min(250, Math.floor(budgetMs / 8));
+	const retryDelayMs = Math.floor(budgetMs / 8);
 	const attemptMs = Math.floor((budgetMs - retryDelayMs) / 2);
 	for (let attempt = 0; attempt < 2; attempt++) {
 		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));

--- a/plugin/scripts/subagent-stop.mjs
+++ b/plugin/scripts/subagent-stop.mjs
@@ -32,7 +32,9 @@ function hookCwd(data) {
 }
 //#endregion
 //#region src/hooks/_post.ts
-async function postWithRetry(url, headers, body, retryDelayMs = 250) {
+async function postWithRetry(url, headers, body, budgetMs = 1e3) {
+	const retryDelayMs = Math.min(250, Math.floor(budgetMs / 8));
+	const attemptMs = Math.floor((budgetMs - retryDelayMs) / 2);
 	for (let attempt = 0; attempt < 2; attempt++) {
 		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));
 		try {
@@ -40,9 +42,12 @@ async function postWithRetry(url, headers, body, retryDelayMs = 250) {
 				method: "POST",
 				headers,
 				body,
-				signal: AbortSignal.timeout(3e3)
+				signal: AbortSignal.timeout(attemptMs)
 			})).ok) return;
-		} catch {}
+		} catch (err) {
+			const name = err?.name;
+			if (name === "TimeoutError" || name === "AbortError") return;
+		}
 	}
 }
 //#endregion

--- a/plugin/scripts/subagent-stop.mjs
+++ b/plugin/scripts/subagent-stop.mjs
@@ -30,12 +30,9 @@ function hookCwd(data) {
 	const projectDir = process.env["DEVIN_PROJECT_DIR"] || process.env["CLAUDE_PROJECT_DIR"];
 	if (projectDir && projectDir.trim()) return projectDir;
 }
-//#endregion
-//#region src/hooks/_post.ts
-const RETRY_DELAY_MS = 100;
 async function postWithRetry(url, headers, body, attemptMs = 400) {
 	for (let attempt = 0; attempt < 2; attempt++) {
-		if (attempt) await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
+		if (attempt) await new Promise((r) => setTimeout(r, 100));
 		try {
 			if ((await fetch(url, {
 				method: "POST",

--- a/plugin/scripts/task-completed.mjs
+++ b/plugin/scripts/task-completed.mjs
@@ -33,7 +33,7 @@ function hookCwd(data) {
 //#endregion
 //#region src/hooks/_post.ts
 async function postWithRetry(url, headers, body, budgetMs = 1e3) {
-	const retryDelayMs = Math.floor(budgetMs / 8);
+	const retryDelayMs = Math.min(250, Math.floor(budgetMs / 8));
 	const attemptMs = Math.floor((budgetMs - retryDelayMs) / 2);
 	for (let attempt = 0; attempt < 2; attempt++) {
 		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));

--- a/plugin/scripts/task-completed.mjs
+++ b/plugin/scripts/task-completed.mjs
@@ -32,11 +32,10 @@ function hookCwd(data) {
 }
 //#endregion
 //#region src/hooks/_post.ts
-async function postWithRetry(url, headers, body, budgetMs = 1e3) {
-	const retryDelayMs = Math.min(250, Math.floor(budgetMs / 8));
-	const attemptMs = Math.floor((budgetMs - retryDelayMs) / 2);
+const RETRY_DELAY_MS = 100;
+async function postWithRetry(url, headers, body, attemptMs = 400) {
 	for (let attempt = 0; attempt < 2; attempt++) {
-		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));
+		if (attempt) await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
 		try {
 			if ((await fetch(url, {
 				method: "POST",

--- a/plugin/scripts/task-completed.mjs
+++ b/plugin/scripts/task-completed.mjs
@@ -33,7 +33,7 @@ function hookCwd(data) {
 //#endregion
 //#region src/hooks/_post.ts
 async function postWithRetry(url, headers, body, budgetMs = 1e3) {
-	const retryDelayMs = Math.min(250, Math.floor(budgetMs / 8));
+	const retryDelayMs = Math.floor(budgetMs / 8);
 	const attemptMs = Math.floor((budgetMs - retryDelayMs) / 2);
 	for (let attempt = 0; attempt < 2; attempt++) {
 		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));

--- a/plugin/scripts/task-completed.mjs
+++ b/plugin/scripts/task-completed.mjs
@@ -31,6 +31,21 @@ function hookCwd(data) {
 	if (projectDir && projectDir.trim()) return projectDir;
 }
 //#endregion
+//#region src/hooks/_post.ts
+async function postWithRetry(url, headers, body, retryDelayMs = 250) {
+	for (let attempt = 0; attempt < 2; attempt++) {
+		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));
+		try {
+			if ((await fetch(url, {
+				method: "POST",
+				headers,
+				body,
+				signal: AbortSignal.timeout(3e3)
+			})).ok) return;
+		} catch {}
+	}
+}
+//#endregion
 //#region src/hooks/task-completed.ts
 function isSdkChildContext(payload) {
 	if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -57,26 +72,21 @@ async function main() {
 	if (isSdkChildContext(data)) return;
 	const sessionId = data.session_id || data.sessionId || data.conversation_id || "unknown";
 	const cwd = hookCwd(data) || process.cwd();
-	fetch(`${REST_URL}/agentmemory/observe`, {
-		method: "POST",
-		headers: authHeaders(),
-		body: JSON.stringify({
-			hookType: "task_completed",
-			sessionId,
-			project: resolveProject(cwd),
-			cwd,
-			timestamp: (/* @__PURE__ */ new Date()).toISOString(),
-			data: {
-				task_id: data.task_id,
-				task_subject: data.task_subject,
-				task_description: typeof data.task_description === "string" ? data.task_description.slice(0, 2e3) : "",
-				teammate_name: data.teammate_name,
-				team_name: data.team_name
-			}
-		}),
-		signal: AbortSignal.timeout(2e3)
-	}).catch(() => {});
-	setTimeout(() => process.exit(0), 500).unref();
+	postWithRetry(`${REST_URL}/agentmemory/observe`, authHeaders(), JSON.stringify({
+		hookType: "task_completed",
+		sessionId,
+		project: resolveProject(cwd),
+		cwd,
+		timestamp: (/* @__PURE__ */ new Date()).toISOString(),
+		data: {
+			task_id: data.task_id,
+			task_subject: data.task_subject,
+			task_description: typeof data.task_description === "string" ? data.task_description.slice(0, 2e3) : "",
+			teammate_name: data.teammate_name,
+			team_name: data.team_name
+		}
+	}));
+	setTimeout(() => process.exit(0), 1e3).unref();
 }
 main().catch(() => process.exit(0));
 //#endregion

--- a/plugin/scripts/task-completed.mjs
+++ b/plugin/scripts/task-completed.mjs
@@ -32,7 +32,9 @@ function hookCwd(data) {
 }
 //#endregion
 //#region src/hooks/_post.ts
-async function postWithRetry(url, headers, body, retryDelayMs = 250) {
+async function postWithRetry(url, headers, body, budgetMs = 1e3) {
+	const retryDelayMs = Math.min(250, Math.floor(budgetMs / 8));
+	const attemptMs = Math.floor((budgetMs - retryDelayMs) / 2);
 	for (let attempt = 0; attempt < 2; attempt++) {
 		if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));
 		try {
@@ -40,9 +42,12 @@ async function postWithRetry(url, headers, body, retryDelayMs = 250) {
 				method: "POST",
 				headers,
 				body,
-				signal: AbortSignal.timeout(3e3)
+				signal: AbortSignal.timeout(attemptMs)
 			})).ok) return;
-		} catch {}
+		} catch (err) {
+			const name = err?.name;
+			if (name === "TimeoutError" || name === "AbortError") return;
+		}
 	}
 }
 //#endregion

--- a/plugin/scripts/task-completed.mjs
+++ b/plugin/scripts/task-completed.mjs
@@ -30,12 +30,9 @@ function hookCwd(data) {
 	const projectDir = process.env["DEVIN_PROJECT_DIR"] || process.env["CLAUDE_PROJECT_DIR"];
 	if (projectDir && projectDir.trim()) return projectDir;
 }
-//#endregion
-//#region src/hooks/_post.ts
-const RETRY_DELAY_MS = 100;
 async function postWithRetry(url, headers, body, attemptMs = 400) {
 	for (let attempt = 0; attempt < 2; attempt++) {
-		if (attempt) await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
+		if (attempt) await new Promise((r) => setTimeout(r, 100));
 		try {
 			if ((await fetch(url, {
 				method: "POST",

--- a/src/hooks/_post.ts
+++ b/src/hooks/_post.ts
@@ -2,14 +2,19 @@
 // swallowed the error and the process was gone before anything noticed.
 // Retries once on a bad status or a network error, and never rejects.
 //
-// A caller's exit timer has to outlast retryDelayMs plus both attempts, or it
-// kills the retry before it lands. The hooks use 1000ms against the 250ms here.
+// budgetMs is the caller's own exit deadline. Both attempts and the delay
+// between them are sized to fit inside it, because a per-attempt timeout
+// longer than the budget means a slow first attempt is killed by the exit
+// timer before the retry ever runs, which is the case the retry exists for.
 export async function postWithRetry(
   url: string,
   headers: Record<string, string>,
   body: string,
-  retryDelayMs = 250,
+  budgetMs = 1000,
 ): Promise<void> {
+  const retryDelayMs = Math.min(250, Math.floor(budgetMs / 8));
+  const attemptMs = Math.floor((budgetMs - retryDelayMs) / 2);
+
   for (let attempt = 0; attempt < 2; attempt++) {
     if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));
     try {
@@ -18,11 +23,17 @@ export async function postWithRetry(
         method: "POST",
         headers,
         body,
-        signal: AbortSignal.timeout(3000),
+        signal: AbortSignal.timeout(attemptMs),
       });
       if (res.ok) return;
-    } catch {
-      // Network error or timeout. Same handling as a bad status.
+    } catch (err) {
+      // A timeout or abort means the outcome is UNKNOWN: the server may have
+      // already written the observation and simply not answered in time. The
+      // dedup guard cannot help, because it records only after the write
+      // completes, so a retry here creates a second observation. Refusals,
+      // resets, and bad statuses are certain non-delivery, and retry safely.
+      const name = (err as { name?: string })?.name;
+      if (name === "TimeoutError" || name === "AbortError") return;
     }
   }
 }

--- a/src/hooks/_post.ts
+++ b/src/hooks/_post.ts
@@ -1,40 +1,28 @@
-// Hooks fire once per event and then exit, so a failed POST used to vanish:
-// the caller swallowed the error and the process was gone before anything
-// could notice. That loses the observation outright.
+// A hook fires once and exits, so a failed POST used to vanish: the caller
+// swallowed the error and the process was gone before anything noticed.
+// Retries once on a bad status or a network error, and never rejects.
 //
-// The loss is not hypothetical. The worker's connection to the engine drops
-// and reconnects periodically. A POST landing inside that window gets a 404,
-// because the route is briefly unregistered, or a 500, because an in-flight
-// state call died with the socket. Reconnect finishes in well under a second,
-// so a single retry recovers the event.
-//
-// Never rejects. A hook must not crash on a delivery failure, and a caller
-// that forgets to catch should still exit cleanly.
+// A caller's exit timer has to outlast retryDelayMs plus both attempts, or it
+// kills the retry before it lands. The hooks use 1000ms against the 250ms here.
 export async function postWithRetry(
   url: string,
   headers: Record<string, string>,
   body: string,
-  opts: { timeoutMs?: number; retryDelayMs?: number } = {},
+  retryDelayMs = 250,
 ): Promise<void> {
-  const timeoutMs = opts.timeoutMs ?? 3000;
-  const retryDelayMs = opts.retryDelayMs ?? 250;
-
   for (let attempt = 0; attempt < 2; attempt++) {
+    if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));
     try {
-      // A fresh signal per attempt. Reusing one would hand the retry a clock
-      // that is already spent, or already aborted.
+      // A fresh signal per attempt. A reused one arrives already spent.
       const res = await fetch(url, {
         method: "POST",
         headers,
         body,
-        signal: AbortSignal.timeout(timeoutMs),
+        signal: AbortSignal.timeout(3000),
       });
       if (res.ok) return;
     } catch {
       // Network error or timeout. Same handling as a bad status.
-    }
-    if (attempt === 0) {
-      await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
     }
   }
 }

--- a/src/hooks/_post.ts
+++ b/src/hooks/_post.ts
@@ -12,7 +12,7 @@ export async function postWithRetry(
   body: string,
   budgetMs = 1000,
 ): Promise<void> {
-  const retryDelayMs = Math.min(250, Math.floor(budgetMs / 8));
+  const retryDelayMs = Math.floor(budgetMs / 8);
   const attemptMs = Math.floor((budgetMs - retryDelayMs) / 2);
 
   for (let attempt = 0; attempt < 2; attempt++) {

--- a/src/hooks/_post.ts
+++ b/src/hooks/_post.ts
@@ -1,26 +1,18 @@
 // A hook fires once and exits, so a failed POST used to vanish: the caller
 // swallowed the error and the process was gone before anything noticed.
 // Retries once on a bad status or a network error, and never rejects.
-//
-// budgetMs is the caller's own exit deadline. Both attempts and the delay
-// between them are sized to fit inside it, because a per-attempt timeout
-// longer than the budget means a slow first attempt is killed by the exit
-// timer before the retry ever runs, which is the case the retry exists for.
+const RETRY_DELAY_MS = 100;
+
 export async function postWithRetry(
   url: string,
   headers: Record<string, string>,
   body: string,
-  budgetMs = 1000,
+  attemptMs = 400,
 ): Promise<void> {
-  // Capped: on a large budget an eighth is a long idle pause, and it eats the
-  // per-attempt share that a slow server actually needs.
-  const retryDelayMs = Math.min(250, Math.floor(budgetMs / 8));
-  const attemptMs = Math.floor((budgetMs - retryDelayMs) / 2);
-
   for (let attempt = 0; attempt < 2; attempt++) {
-    if (attempt) await new Promise((r) => setTimeout(r, retryDelayMs));
+    if (attempt) await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
     try {
-      // A fresh signal per attempt. A reused one arrives already spent.
+      // Fresh signal per attempt: a reused one arrives already spent.
       const res = await fetch(url, {
         method: "POST",
         headers,
@@ -29,11 +21,8 @@ export async function postWithRetry(
       });
       if (res.ok) return;
     } catch (err) {
-      // A timeout or abort means the outcome is UNKNOWN: the server may have
-      // already written the observation and simply not answered in time. The
-      // dedup guard cannot help, because it records only after the write
-      // completes, so a retry here creates a second observation. Refusals,
-      // resets, and bad statuses are certain non-delivery, and retry safely.
+      // A timeout leaves delivery UNKNOWN, so retrying it can duplicate.
+      // See the "does not retry after a client timeout" tests.
       const name = (err as { name?: string })?.name;
       if (name === "TimeoutError" || name === "AbortError") return;
     }

--- a/src/hooks/_post.ts
+++ b/src/hooks/_post.ts
@@ -1,0 +1,40 @@
+// Hooks fire once per event and then exit, so a failed POST used to vanish:
+// the caller swallowed the error and the process was gone before anything
+// could notice. That loses the observation outright.
+//
+// The loss is not hypothetical. The worker's connection to the engine drops
+// and reconnects periodically. A POST landing inside that window gets a 404,
+// because the route is briefly unregistered, or a 500, because an in-flight
+// state call died with the socket. Reconnect finishes in well under a second,
+// so a single retry recovers the event.
+//
+// Never rejects. A hook must not crash on a delivery failure, and a caller
+// that forgets to catch should still exit cleanly.
+export async function postWithRetry(
+  url: string,
+  headers: Record<string, string>,
+  body: string,
+  opts: { timeoutMs?: number; retryDelayMs?: number } = {},
+): Promise<void> {
+  const timeoutMs = opts.timeoutMs ?? 3000;
+  const retryDelayMs = opts.retryDelayMs ?? 250;
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      // A fresh signal per attempt. Reusing one would hand the retry a clock
+      // that is already spent, or already aborted.
+      const res = await fetch(url, {
+        method: "POST",
+        headers,
+        body,
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+      if (res.ok) return;
+    } catch {
+      // Network error or timeout. Same handling as a bad status.
+    }
+    if (attempt === 0) {
+      await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+    }
+  }
+}

--- a/src/hooks/_post.ts
+++ b/src/hooks/_post.ts
@@ -1,13 +1,19 @@
 // A hook fires once and exits, so a failed POST used to vanish: the caller
 // swallowed the error and the process was gone before anything noticed.
 // Retries once on a bad status or a network error, and never rejects.
-const RETRY_DELAY_MS = 100;
+//
+// Both attempts and the delay between them must fit inside the caller's exit
+// timer, or the process dies mid-retry and the retry silently stops existing.
+// The hooks arm 1000ms; 400 + 100 + 400 leaves 100ms of margin. A test pins
+// this, so raising either number without raising the timer fails the suite.
+export const RETRY_DELAY_MS = 100;
+export const DEFAULT_ATTEMPT_MS = 400;
 
 export async function postWithRetry(
   url: string,
   headers: Record<string, string>,
   body: string,
-  attemptMs = 400,
+  attemptMs = DEFAULT_ATTEMPT_MS,
 ): Promise<void> {
   for (let attempt = 0; attempt < 2; attempt++) {
     if (attempt) await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
@@ -22,7 +28,7 @@ export async function postWithRetry(
       if (res.ok) return;
     } catch (err) {
       // A timeout leaves delivery UNKNOWN, so retrying it can duplicate.
-      // See the "does not retry after a client timeout" tests.
+      // See the client-timeout cases in test/hook-post-retry.test.ts.
       const name = (err as { name?: string })?.name;
       if (name === "TimeoutError" || name === "AbortError") return;
     }

--- a/src/hooks/_post.ts
+++ b/src/hooks/_post.ts
@@ -12,7 +12,9 @@ export async function postWithRetry(
   body: string,
   budgetMs = 1000,
 ): Promise<void> {
-  const retryDelayMs = Math.floor(budgetMs / 8);
+  // Capped: on a large budget an eighth is a long idle pause, and it eats the
+  // per-attempt share that a slow server actually needs.
+  const retryDelayMs = Math.min(250, Math.floor(budgetMs / 8));
   const attemptMs = Math.floor((budgetMs - retryDelayMs) / 2);
 
   for (let attempt = 0; attempt < 2; attempt++) {

--- a/src/hooks/notification.ts
+++ b/src/hooks/notification.ts
@@ -57,7 +57,6 @@ async function main() {
         message: data.message,
       },
     }),
-    { timeoutMs: 2000 },
   );
   setTimeout(() => process.exit(0), 1000).unref();
 }

--- a/src/hooks/notification.ts
+++ b/src/hooks/notification.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { resolveProject, hookCwd } from "./_project.js";
+import { postWithRetry } from "./_post.js";
 
 function isSdkChildContext(payload: unknown): boolean {
   if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -41,10 +42,10 @@ async function main() {
 
   const cwd = hookCwd(data) || process.cwd();
 
-  fetch(`${REST_URL}/agentmemory/observe`, {
-    method: "POST",
-    headers: authHeaders(),
-    body: JSON.stringify({
+  postWithRetry(
+    `${REST_URL}/agentmemory/observe`,
+    authHeaders(),
+    JSON.stringify({
       hookType: "notification",
       sessionId,
       project: resolveProject(cwd),
@@ -56,9 +57,9 @@ async function main() {
         message: data.message,
       },
     }),
-    signal: AbortSignal.timeout(2000),
-  }).catch(() => {});
-  setTimeout(() => process.exit(0), 500).unref();
+    { timeoutMs: 2000 },
+  );
+  setTimeout(() => process.exit(0), 1000).unref();
 }
 
 main().catch(() => process.exit(0));

--- a/src/hooks/post-tool-failure.ts
+++ b/src/hooks/post-tool-failure.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { resolveProject, hookCwd } from "./_project.js";
+import { postWithRetry } from "./_post.js";
 
 function isSdkChildContext(payload: unknown): boolean {
   if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -40,10 +41,10 @@ async function main() {
 
   const cwd = hookCwd(data) || process.cwd();
 
-  fetch(`${REST_URL}/agentmemory/observe`, {
-    method: "POST",
-    headers: authHeaders(),
-    body: JSON.stringify({
+  postWithRetry(
+    `${REST_URL}/agentmemory/observe`,
+    authHeaders(),
+    JSON.stringify({
       hookType: "post_tool_failure",
       sessionId,
       project: resolveProject(cwd),
@@ -61,9 +62,8 @@ async function main() {
             : JSON.stringify(error ?? "").slice(0, 4000),
       },
     }),
-    signal: AbortSignal.timeout(3000),
-  }).catch(() => {});
-  setTimeout(() => process.exit(0), 500).unref();
+  );
+  setTimeout(() => process.exit(0), 1000).unref();
 }
 
 main().catch(() => process.exit(0));

--- a/src/hooks/post-tool-use.ts
+++ b/src/hooks/post-tool-use.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { resolveProject, hookCwd } from "./_project.js";
+import { postWithRetry } from "./_post.js";
 
 function isSdkChildContext(payload: unknown): boolean {
   if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -39,10 +40,10 @@ async function main() {
   const { imageData, cleanOutput } = extractImageData(toolOutput(data));
   const cwd = hookCwd(data) || process.cwd();
 
-  fetch(`${REST_URL}/agentmemory/observe`, {
-    method: "POST",
-    headers: authHeaders(),
-    body: JSON.stringify({
+  postWithRetry(
+    `${REST_URL}/agentmemory/observe`,
+    authHeaders(),
+    JSON.stringify({
       hookType: "post_tool_use",
       sessionId,
       project: resolveProject(cwd),
@@ -55,9 +56,12 @@ async function main() {
         ...(imageData ? { image_data: imageData } : {}),
       },
     }),
-    signal: AbortSignal.timeout(3000),
-  }).catch(() => {});
-  setTimeout(() => process.exit(0), 500).unref();
+  );
+  // The timer is unref'd, so it does not hold the process open and costs
+  // nothing when the POST succeeds. It only caps a request still in flight,
+  // and a retry needs room to land: a fast 404 plus the retry delay plus the
+  // second attempt runs past 500ms.
+  setTimeout(() => process.exit(0), 1000).unref();
 }
 
 function toolOutput(data: Record<string, unknown>): unknown {

--- a/src/hooks/post-tool-use.ts
+++ b/src/hooks/post-tool-use.ts
@@ -57,10 +57,6 @@ async function main() {
       },
     }),
   );
-  // The timer is unref'd, so it does not hold the process open and costs
-  // nothing when the POST succeeds. It only caps a request still in flight,
-  // and a retry needs room to land: a fast 404 plus the retry delay plus the
-  // second attempt runs past 500ms.
   setTimeout(() => process.exit(0), 1000).unref();
 }
 

--- a/src/hooks/prompt-submit.ts
+++ b/src/hooks/prompt-submit.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { resolveProject, hookCwd } from "./_project.js";
+import { postWithRetry } from "./_post.js";
 
 function isSdkChildContext(payload: unknown): boolean {
   if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -36,10 +37,10 @@ async function main() {
 
   const cwd = hookCwd(data) || process.cwd();
 
-  fetch(`${REST_URL}/agentmemory/observe`, {
-    method: "POST",
-    headers: authHeaders(),
-    body: JSON.stringify({
+  postWithRetry(
+    `${REST_URL}/agentmemory/observe`,
+    authHeaders(),
+    JSON.stringify({
       hookType: "prompt_submit",
       sessionId,
       project: resolveProject(cwd),
@@ -47,9 +48,8 @@ async function main() {
       timestamp: new Date().toISOString(),
       data: { prompt: data.prompt ?? data.userPrompt },
     }),
-    signal: AbortSignal.timeout(3000),
-  }).catch(() => {});
-  setTimeout(() => process.exit(0), 500).unref();
+  );
+  setTimeout(() => process.exit(0), 1000).unref();
 }
 
 main().catch(() => process.exit(0));

--- a/src/hooks/session-end.ts
+++ b/src/hooks/session-end.ts
@@ -87,6 +87,9 @@ async function main() {
             timestamp,
             data: { prompt },
           }),
+          // Awaited rather than raced against an exit timer, so this one can
+          // afford a longer per-request timeout than the other hooks.
+          3000,
         ),
       ),
     );

--- a/src/hooks/session-end.ts
+++ b/src/hooks/session-end.ts
@@ -3,6 +3,10 @@ import { readFileSync } from "node:fs";
 import { resolveProject, hookCwd } from "./_project.js";
 import { postWithRetry } from "./_post.js";
 
+// Exported so the regression test binds to the real value instead of a copy
+// that can silently drift back to a losing one.
+export const OBSERVE_ATTEMPT_MS = 3000;
+
 function isSdkChildContext(payload: unknown): boolean {
   if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
   if (!payload || typeof payload !== "object") return false;
@@ -87,12 +91,9 @@ async function main() {
             timestamp,
             data: { prompt },
           }),
-          // A budget, not a per-request timeout: postWithRetry splits it
-          // across two attempts and the delay between them. 6250 preserves
-          // the 3000ms per attempt this call had before the retry existed.
-          // These are awaited, and the exit timer below is armed after the
-          // await, so nothing else caps them.
-          6250,
+          // Awaited, and the exit timer below is armed after the await, so
+          // these keep the generous per-request timeout they had before.
+          OBSERVE_ATTEMPT_MS,
         ),
       ),
     );

--- a/src/hooks/session-end.ts
+++ b/src/hooks/session-end.ts
@@ -87,9 +87,12 @@ async function main() {
             timestamp,
             data: { prompt },
           }),
-          // Awaited rather than raced against an exit timer, so this one can
-          // afford a longer per-request timeout than the other hooks.
-          3000,
+          // A budget, not a per-request timeout: postWithRetry splits it
+          // across two attempts and the delay between them. 6250 preserves
+          // the 3000ms per attempt this call had before the retry existed.
+          // These are awaited, and the exit timer below is armed after the
+          // await, so nothing else caps them.
+          6250,
         ),
       ),
     );

--- a/src/hooks/session-end.ts
+++ b/src/hooks/session-end.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { readFileSync } from "node:fs";
 import { resolveProject, hookCwd } from "./_project.js";
+import { postWithRetry } from "./_post.js";
 
 function isSdkChildContext(payload: unknown): boolean {
   if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -75,10 +76,10 @@ async function main() {
     const timestamp = new Date().toISOString();
     await Promise.allSettled(
       transcriptPrompts.map((prompt) =>
-        fetch(`${REST_URL}/agentmemory/observe`, {
-          method: "POST",
-          headers: authHeaders(),
-          body: JSON.stringify({
+        postWithRetry(
+          `${REST_URL}/agentmemory/observe`,
+          authHeaders(),
+          JSON.stringify({
             hookType: "prompt_submit",
             sessionId,
             project,
@@ -86,8 +87,7 @@ async function main() {
             timestamp,
             data: { prompt },
           }),
-          signal: AbortSignal.timeout(3000),
-        }),
+        ),
       ),
     );
   }

--- a/src/hooks/subagent-start.ts
+++ b/src/hooks/subagent-start.ts
@@ -13,11 +13,6 @@ function isSdkChildContext(payload: unknown): boolean {
 const REST_URL = process.env["AGENTMEMORY_URL"] || "http://localhost:3111";
 const SECRET = process.env["AGENTMEMORY_SECRET"] || "";
 
-// Passive telemetry only — nothing reads the response, so the previous
-// `await` was pure latency. The exit timer below is the cap that keeps a
-// slow or unreachable server from stacking onto every concurrent subagent
-// startup (#221); postWithRetry sizes both attempts to fit inside it.
-
 function authHeaders(): Record<string, string> {
   const h: Record<string, string> = { "Content-Type": "application/json" };
   if (SECRET) h["Authorization"] = `Bearer ${SECRET}`;
@@ -61,6 +56,10 @@ async function main() {
       },
     }),
   );
+  // Passive telemetry: nothing reads the response, so this cap is what keeps
+  // a slow or unreachable server from stacking onto every concurrent subagent
+  // startup (#221). postWithRetry's attempts and delay must stay under it; the
+  // test in test/hook-post-retry.test.ts pins that.
   setTimeout(() => process.exit(0), 1000).unref();
 }
 

--- a/src/hooks/subagent-start.ts
+++ b/src/hooks/subagent-start.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { resolveProject, hookCwd } from "./_project.js";
+import { postWithRetry } from "./_post.js";
 
 // Inlined from ./sdk-guard so each hook bundles to a single self-contained
 // .mjs (matches the pattern used by every other hook entry in tsdown.config).
@@ -16,7 +17,6 @@ const SECRET = process.env["AGENTMEMORY_SECRET"] || "";
 // `await` was pure latency. Tightened from 2000ms to a defensive cap so a
 // slow/unreachable server can't stack onto every concurrent subagent
 // startup (#221).
-const TIMEOUT_MS = 800;
 
 function authHeaders(): Record<string, string> {
   const h: Record<string, string> = { "Content-Type": "application/json" };
@@ -46,10 +46,10 @@ async function main() {
 
   const cwd = hookCwd(data) || process.cwd();
 
-  fetch(`${REST_URL}/agentmemory/observe`, {
-    method: "POST",
-    headers: authHeaders(),
-    body: JSON.stringify({
+  postWithRetry(
+    `${REST_URL}/agentmemory/observe`,
+    authHeaders(),
+    JSON.stringify({
       hookType: "subagent_start",
       sessionId,
       project: resolveProject(cwd),
@@ -60,9 +60,8 @@ async function main() {
         agent_type: agentType,
       },
     }),
-    signal: AbortSignal.timeout(TIMEOUT_MS),
-  }).catch(() => {});
-  setTimeout(() => process.exit(0), 500).unref();
+  );
+  setTimeout(() => process.exit(0), 1000).unref();
 }
 
 main().catch(() => process.exit(0));

--- a/src/hooks/subagent-start.ts
+++ b/src/hooks/subagent-start.ts
@@ -14,9 +14,9 @@ const REST_URL = process.env["AGENTMEMORY_URL"] || "http://localhost:3111";
 const SECRET = process.env["AGENTMEMORY_SECRET"] || "";
 
 // Passive telemetry only — nothing reads the response, so the previous
-// `await` was pure latency. Tightened from 2000ms to a defensive cap so a
-// slow/unreachable server can't stack onto every concurrent subagent
-// startup (#221).
+// `await` was pure latency. The exit timer below is the cap that keeps a
+// slow or unreachable server from stacking onto every concurrent subagent
+// startup (#221); postWithRetry sizes both attempts to fit inside it.
 
 function authHeaders(): Record<string, string> {
   const h: Record<string, string> = { "Content-Type": "application/json" };

--- a/src/hooks/subagent-stop.ts
+++ b/src/hooks/subagent-stop.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { resolveProject, hookCwd } from "./_project.js";
+import { postWithRetry } from "./_post.js";
 
 function isSdkChildContext(payload: unknown): boolean {
   if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -42,10 +43,10 @@ async function main() {
 
   const cwd = hookCwd(data) || process.cwd();
 
-  fetch(`${REST_URL}/agentmemory/observe`, {
-    method: "POST",
-    headers: authHeaders(),
-    body: JSON.stringify({
+  postWithRetry(
+    `${REST_URL}/agentmemory/observe`,
+    authHeaders(),
+    JSON.stringify({
       hookType: "subagent_stop",
       sessionId,
       project: resolveProject(cwd),
@@ -57,9 +58,8 @@ async function main() {
         last_message: lastMsg,
       },
     }),
-    signal: AbortSignal.timeout(2000),
-  }).catch(() => {});
-  setTimeout(() => process.exit(0), 500).unref();
+  );
+  setTimeout(() => process.exit(0), 1000).unref();
 }
 
 main().catch(() => process.exit(0));

--- a/src/hooks/task-completed.ts
+++ b/src/hooks/task-completed.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { resolveProject, hookCwd } from "./_project.js";
+import { postWithRetry } from "./_post.js";
 
 function isSdkChildContext(payload: unknown): boolean {
   if (process.env["AGENTMEMORY_SDK_CHILD"] === "1") return true;
@@ -36,10 +37,10 @@ async function main() {
 
   const cwd = hookCwd(data) || process.cwd();
 
-  fetch(`${REST_URL}/agentmemory/observe`, {
-    method: "POST",
-    headers: authHeaders(),
-    body: JSON.stringify({
+  postWithRetry(
+    `${REST_URL}/agentmemory/observe`,
+    authHeaders(),
+    JSON.stringify({
       hookType: "task_completed",
       sessionId,
       project: resolveProject(cwd),
@@ -55,9 +56,8 @@ async function main() {
         team_name: data.team_name,
       },
     }),
-    signal: AbortSignal.timeout(2000),
-  }).catch(() => {});
-  setTimeout(() => process.exit(0), 500).unref();
+  );
+  setTimeout(() => process.exit(0), 1000).unref();
 }
 
 main().catch(() => process.exit(0));

--- a/test/hook-post-retry.test.ts
+++ b/test/hook-post-retry.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { postWithRetry } from "../src/hooks/_post.js";
+import {
+  postWithRetry,
+  DEFAULT_ATTEMPT_MS,
+  RETRY_DELAY_MS,
+} from "../src/hooks/_post.js";
 import { OBSERVE_ATTEMPT_MS } from "../src/hooks/session-end.js";
 
 const ENDPOINT = "http://localhost:3111/agentmemory/observe";
@@ -75,7 +79,6 @@ describe("postWithRetry", () => {
     expect(signals[0]).not.toBe(signals[1]);
   });
 
-
   // A timeout or abort leaves the outcome unknown: the server may have written
   // the observation and simply not answered in time. observe.ts records its
   // dedup hash only AFTER the write completes, so a retry here would create a
@@ -96,7 +99,7 @@ describe("postWithRetry", () => {
   // session-end value is imported, not copied, so lowering it back to a value
   // that loses observations under a slow server fails here.
   it.each([
-    ["the default", undefined, 400],
+    ["the default", undefined, DEFAULT_ATTEMPT_MS],
     ["session-end's", OBSERVE_ATTEMPT_MS, 3000],
   ])("uses %s per-attempt timeout on both attempts", async (_l, arg, want) => {
     const timeouts: number[] = [];
@@ -111,5 +114,12 @@ describe("postWithRetry", () => {
 
     expect(timeouts).toEqual([want, want]);
     vi.restoreAllMocks();
+  });
+
+  // The hooks arm a 1000ms exit timer. If the two attempts plus the delay
+  // exceed it the process dies mid-retry, which is how two earlier revisions
+  // of this file silently stopped retrying at all.
+  it("fits both attempts inside the hooks' exit timer", () => {
+    expect(DEFAULT_ATTEMPT_MS * 2 + RETRY_DELAY_MS).toBeLessThanOrEqual(1000);
   });
 });

--- a/test/hook-post-retry.test.ts
+++ b/test/hook-post-retry.test.ts
@@ -1,86 +1,59 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { postWithRetry } from "../src/hooks/_post.js";
 
-const URL = "http://localhost:3111/agentmemory/observe";
+const ENDPOINT = "http://localhost:3111/agentmemory/observe";
 
 afterEach(() => {
   vi.unstubAllGlobals();
 });
 
 function stubFetch(responses: Array<Response | Error>) {
-  const calls: string[] = [];
   let i = 0;
-  const fn = vi.fn(async (url: string) => {
-    calls.push(url);
+  const fn = vi.fn(async () => {
     const next = responses[Math.min(i, responses.length - 1)];
     i += 1;
     if (next instanceof Error) throw next;
     return next;
   });
   vi.stubGlobal("fetch", fn);
-  return { fn, calls };
+  return fn;
 }
 
 describe("postWithRetry", () => {
   it("sends once when the server accepts it", async () => {
-    const { fn } = stubFetch([new Response(null, { status: 201 })]);
+    const fn = stubFetch([new Response(null, { status: 201 })]);
 
-    await postWithRetry(URL, {}, "{}", { retryDelayMs: 1 });
+    await postWithRetry(ENDPOINT, {}, "{}", 1);
 
     expect(fn).toHaveBeenCalledTimes(1);
   });
 
   // The engine drops the worker socket periodically. During that window the
-  // route is briefly unregistered and POST /agentmemory/observe answers 404.
-  // Without a retry the observation is gone: the caller swallowed the error
-  // and the hook process exited.
-  it("retries a 404 and keeps the observation", async () => {
-    const { fn } = stubFetch([
-      new Response(null, { status: 404 }),
-      new Response(null, { status: 201 }),
-    ]);
+  // route is briefly unregistered and the POST answers 404, or an in-flight
+  // state call dies and it answers 500. Without a retry the observation is
+  // gone: the caller swallowed the error and the hook process exited.
+  it.each([
+    ["404", new Response(null, { status: 404 })],
+    ["500", new Response(null, { status: 500 })],
+    ["a network error", new Error("ECONNRESET")],
+  ])("retries %s and keeps the observation", async (_label, failure) => {
+    const fn = stubFetch([failure, new Response(null, { status: 201 })]);
 
-    await postWithRetry(URL, {}, "{}", { retryDelayMs: 1 });
-
-    expect(fn).toHaveBeenCalledTimes(2);
-  });
-
-  it("retries a 500", async () => {
-    const { fn } = stubFetch([
-      new Response(null, { status: 500 }),
-      new Response(null, { status: 201 }),
-    ]);
-
-    await postWithRetry(URL, {}, "{}", { retryDelayMs: 1 });
+    await postWithRetry(ENDPOINT, {}, "{}", 1);
 
     expect(fn).toHaveBeenCalledTimes(2);
   });
 
-  it("retries a network error", async () => {
-    const { fn } = stubFetch([
-      new Error("ECONNRESET"),
-      new Response(null, { status: 201 }),
-    ]);
+  // Both inputs are load-bearing. A throw-only case leaves an unbounded loop
+  // on a persistently bad status undetected, and vice versa.
+  it.each([
+    ["a bad status", new Response(null, { status: 500 })],
+    ["a network error", new Error("ECONNREFUSED")],
+  ])("stops after one retry and never rejects on %s", async (_l, failure) => {
+    const fn = stubFetch([failure]);
 
-    await postWithRetry(URL, {}, "{}", { retryDelayMs: 1 });
-
+    await expect(postWithRetry(ENDPOINT, {}, "{}", 1)).resolves.toBeUndefined();
     expect(fn).toHaveBeenCalledTimes(2);
-  });
-
-  it("gives up after one retry rather than looping", async () => {
-    const { fn } = stubFetch([new Response(null, { status: 500 })]);
-
-    await postWithRetry(URL, {}, "{}", { retryDelayMs: 1 });
-
-    expect(fn).toHaveBeenCalledTimes(2);
-  });
-
-  it("never rejects, so a caller cannot crash the hook", async () => {
-    stubFetch([new Error("ECONNREFUSED")]);
-
-    await expect(
-      postWithRetry(URL, {}, "{}", { retryDelayMs: 1 }),
-    ).resolves.toBeUndefined();
   });
 
   it("gives each attempt its own timeout signal", async () => {
@@ -93,7 +66,7 @@ describe("postWithRetry", () => {
       }),
     );
 
-    await postWithRetry(URL, {}, "{}", { retryDelayMs: 1 });
+    await postWithRetry(ENDPOINT, {}, "{}", 1);
 
     expect(signals).toHaveLength(2);
     expect(signals[0]).toBeDefined();

--- a/test/hook-post-retry.test.ts
+++ b/test/hook-post-retry.test.ts
@@ -111,4 +111,22 @@ describe("postWithRetry", () => {
     await expect(postWithRetry(ENDPOINT, {}, "{}", 8)).resolves.toBeUndefined();
     expect(fn).toHaveBeenCalledTimes(1);
   });
+
+  // budgetMs is a budget for BOTH attempts, not a per-request timeout. Passing
+  // a value that was previously a per-request timeout silently halves it, which
+  // is how session-end briefly dropped every observation under a slow server.
+  it("gives session-end's budget the per-request timeout it needs", async () => {
+    const timeouts: number[] = [];
+    const realTimeout = AbortSignal.timeout.bind(AbortSignal);
+    vi.spyOn(AbortSignal, "timeout").mockImplementation((ms: number) => {
+      timeouts.push(ms);
+      return realTimeout(ms);
+    });
+    stubFetch([new Response(null, { status: 500 })]);
+
+    await postWithRetry(ENDPOINT, {}, "{}", 6250);
+
+    expect(timeouts[0]).toBeGreaterThanOrEqual(3000);
+    vi.restoreAllMocks();
+  });
 });

--- a/test/hook-post-retry.test.ts
+++ b/test/hook-post-retry.test.ts
@@ -33,8 +33,7 @@ describe("postWithRetry", () => {
   // state call dies and it answers 500. Without a retry the observation is
   // gone: the caller swallowed the error and the hook process exited.
   it.each([
-    ["404", new Response(null, { status: 404 })],
-    ["500", new Response(null, { status: 500 })],
+    ["a bad status", new Response(null, { status: 404 })],
     ["a network error", new Error("ECONNRESET")],
   ])("retries %s and keeps the observation", async (_label, failure) => {
     const fn = stubFetch([failure, new Response(null, { status: 201 })]);
@@ -90,9 +89,10 @@ describe("postWithRetry", () => {
 
     await postWithRetry(ENDPOINT, {}, "{}", 1000);
 
-    expect(timeouts).toHaveLength(2);
-    const delay = Math.min(250, Math.floor(1000 / 8));
-    expect(timeouts[0] * 2 + delay).toBeLessThanOrEqual(1000);
+    // Literals, not the implementation's own formula: a test that recomputes
+    // what it checks passes against a wrong-but-self-consistent derivation.
+    expect(timeouts).toEqual([437, 437]);
+    expect(437 * 2 + 125).toBeLessThanOrEqual(1000);
     vi.restoreAllMocks();
   });
 

--- a/test/hook-post-retry.test.ts
+++ b/test/hook-post-retry.test.ts
@@ -23,7 +23,7 @@ describe("postWithRetry", () => {
   it("sends once when the server accepts it", async () => {
     const fn = stubFetch([new Response(null, { status: 201 })]);
 
-    await postWithRetry(ENDPOINT, {}, "{}", 1);
+    await postWithRetry(ENDPOINT, {}, "{}", 8);
 
     expect(fn).toHaveBeenCalledTimes(1);
   });
@@ -39,7 +39,7 @@ describe("postWithRetry", () => {
   ])("retries %s and keeps the observation", async (_label, failure) => {
     const fn = stubFetch([failure, new Response(null, { status: 201 })]);
 
-    await postWithRetry(ENDPOINT, {}, "{}", 1);
+    await postWithRetry(ENDPOINT, {}, "{}", 8);
 
     expect(fn).toHaveBeenCalledTimes(2);
   });
@@ -52,7 +52,7 @@ describe("postWithRetry", () => {
   ])("stops after one retry and never rejects on %s", async (_l, failure) => {
     const fn = stubFetch([failure]);
 
-    await expect(postWithRetry(ENDPOINT, {}, "{}", 1)).resolves.toBeUndefined();
+    await expect(postWithRetry(ENDPOINT, {}, "{}", 8)).resolves.toBeUndefined();
     expect(fn).toHaveBeenCalledTimes(2);
   });
 
@@ -66,12 +66,49 @@ describe("postWithRetry", () => {
       }),
     );
 
-    await postWithRetry(ENDPOINT, {}, "{}", 1);
+    await postWithRetry(ENDPOINT, {}, "{}", 8);
 
     expect(signals).toHaveLength(2);
     expect(signals[0]).toBeDefined();
     // A reused signal would already be counting down, or aborted, by the
     // time the second attempt runs.
     expect(signals[0]).not.toBe(signals[1]);
+  });
+
+  // Both attempts and the delay between them have to fit inside the caller's
+  // exit budget. A per-attempt timeout longer than the budget means a slow
+  // first attempt is killed by the exit timer before the retry can run, which
+  // is exactly the case the retry exists for.
+  it("fits both attempts inside the caller's budget", async () => {
+    const timeouts: number[] = [];
+    const realTimeout = AbortSignal.timeout.bind(AbortSignal);
+    vi.spyOn(AbortSignal, "timeout").mockImplementation((ms: number) => {
+      timeouts.push(ms);
+      return realTimeout(ms);
+    });
+    stubFetch([new Response(null, { status: 500 })]);
+
+    await postWithRetry(ENDPOINT, {}, "{}", 1000);
+
+    expect(timeouts).toHaveLength(2);
+    const delay = Math.min(250, Math.floor(1000 / 8));
+    expect(timeouts[0] * 2 + delay).toBeLessThanOrEqual(1000);
+    vi.restoreAllMocks();
+  });
+
+  // A timeout or abort leaves the outcome unknown: the server may have written
+  // the observation and simply not answered in time. observe.ts records its
+  // dedup hash only AFTER the write completes, so a retry here would create a
+  // second observation. Certain non-delivery retries; ambiguity does not.
+  it.each([
+    ["TimeoutError", "TimeoutError"],
+    ["AbortError", "AbortError"],
+  ])("does not retry after a client %s", async (_l, name) => {
+    const err = new Error("aborted");
+    err.name = name;
+    const fn = stubFetch([err]);
+
+    await expect(postWithRetry(ENDPOINT, {}, "{}", 8)).resolves.toBeUndefined();
+    expect(fn).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/hook-post-retry.test.ts
+++ b/test/hook-post-retry.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { postWithRetry } from "../src/hooks/_post.js";
+import { OBSERVE_ATTEMPT_MS } from "../src/hooks/session-end.js";
 
 const ENDPOINT = "http://localhost:3111/agentmemory/observe";
 
@@ -74,27 +75,6 @@ describe("postWithRetry", () => {
     expect(signals[0]).not.toBe(signals[1]);
   });
 
-  // Both attempts and the delay between them have to fit inside the caller's
-  // exit budget. A per-attempt timeout longer than the budget means a slow
-  // first attempt is killed by the exit timer before the retry can run, which
-  // is exactly the case the retry exists for.
-  it("fits both attempts inside the caller's budget", async () => {
-    const timeouts: number[] = [];
-    const realTimeout = AbortSignal.timeout.bind(AbortSignal);
-    vi.spyOn(AbortSignal, "timeout").mockImplementation((ms: number) => {
-      timeouts.push(ms);
-      return realTimeout(ms);
-    });
-    stubFetch([new Response(null, { status: 500 })]);
-
-    await postWithRetry(ENDPOINT, {}, "{}", 1000);
-
-    // Literals, not the implementation's own formula: a test that recomputes
-    // what it checks passes against a wrong-but-self-consistent derivation.
-    expect(timeouts).toEqual([437, 437]);
-    expect(437 * 2 + 125).toBeLessThanOrEqual(1000);
-    vi.restoreAllMocks();
-  });
 
   // A timeout or abort leaves the outcome unknown: the server may have written
   // the observation and simply not answered in time. observe.ts records its
@@ -112,21 +92,24 @@ describe("postWithRetry", () => {
     expect(fn).toHaveBeenCalledTimes(1);
   });
 
-  // budgetMs is a budget for BOTH attempts, not a per-request timeout. Passing
-  // a value that was previously a per-request timeout silently halves it, which
-  // is how session-end briefly dropped every observation under a slow server.
-  it("gives session-end's budget the per-request timeout it needs", async () => {
+  // Each attempt gets the full per-attempt timeout; the caller picks it. The
+  // session-end value is imported, not copied, so lowering it back to a value
+  // that loses observations under a slow server fails here.
+  it.each([
+    ["the default", undefined, 400],
+    ["session-end's", OBSERVE_ATTEMPT_MS, 3000],
+  ])("uses %s per-attempt timeout on both attempts", async (_l, arg, want) => {
     const timeouts: number[] = [];
-    const realTimeout = AbortSignal.timeout.bind(AbortSignal);
+    const real = AbortSignal.timeout.bind(AbortSignal);
     vi.spyOn(AbortSignal, "timeout").mockImplementation((ms: number) => {
       timeouts.push(ms);
-      return realTimeout(ms);
+      return real(ms);
     });
     stubFetch([new Response(null, { status: 500 })]);
 
-    await postWithRetry(ENDPOINT, {}, "{}", 6250);
+    await postWithRetry(ENDPOINT, {}, "{}", arg);
 
-    expect(timeouts[0]).toBeGreaterThanOrEqual(3000);
+    expect(timeouts).toEqual([want, want]);
     vi.restoreAllMocks();
   });
 });

--- a/test/hook-post-retry.test.ts
+++ b/test/hook-post-retry.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { postWithRetry } from "../src/hooks/_post.js";
+
+const URL = "http://localhost:3111/agentmemory/observe";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function stubFetch(responses: Array<Response | Error>) {
+  const calls: string[] = [];
+  let i = 0;
+  const fn = vi.fn(async (url: string) => {
+    calls.push(url);
+    const next = responses[Math.min(i, responses.length - 1)];
+    i += 1;
+    if (next instanceof Error) throw next;
+    return next;
+  });
+  vi.stubGlobal("fetch", fn);
+  return { fn, calls };
+}
+
+describe("postWithRetry", () => {
+  it("sends once when the server accepts it", async () => {
+    const { fn } = stubFetch([new Response(null, { status: 201 })]);
+
+    await postWithRetry(URL, {}, "{}", { retryDelayMs: 1 });
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  // The engine drops the worker socket periodically. During that window the
+  // route is briefly unregistered and POST /agentmemory/observe answers 404.
+  // Without a retry the observation is gone: the caller swallowed the error
+  // and the hook process exited.
+  it("retries a 404 and keeps the observation", async () => {
+    const { fn } = stubFetch([
+      new Response(null, { status: 404 }),
+      new Response(null, { status: 201 }),
+    ]);
+
+    await postWithRetry(URL, {}, "{}", { retryDelayMs: 1 });
+
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries a 500", async () => {
+    const { fn } = stubFetch([
+      new Response(null, { status: 500 }),
+      new Response(null, { status: 201 }),
+    ]);
+
+    await postWithRetry(URL, {}, "{}", { retryDelayMs: 1 });
+
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries a network error", async () => {
+    const { fn } = stubFetch([
+      new Error("ECONNRESET"),
+      new Response(null, { status: 201 }),
+    ]);
+
+    await postWithRetry(URL, {}, "{}", { retryDelayMs: 1 });
+
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("gives up after one retry rather than looping", async () => {
+    const { fn } = stubFetch([new Response(null, { status: 500 })]);
+
+    await postWithRetry(URL, {}, "{}", { retryDelayMs: 1 });
+
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("never rejects, so a caller cannot crash the hook", async () => {
+    stubFetch([new Error("ECONNREFUSED")]);
+
+    await expect(
+      postWithRetry(URL, {}, "{}", { retryDelayMs: 1 }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("gives each attempt its own timeout signal", async () => {
+    const signals: Array<AbortSignal | undefined> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init: RequestInit) => {
+        signals.push(init.signal as AbortSignal | undefined);
+        return new Response(null, { status: 500 });
+      }),
+    );
+
+    await postWithRetry(URL, {}, "{}", { retryDelayMs: 1 });
+
+    expect(signals).toHaveLength(2);
+    expect(signals[0]).toBeDefined();
+    // A reused signal would already be counting down, or aborted, by the
+    // time the second attempt runs.
+    expect(signals[0]).not.toBe(signals[1]);
+  });
+});


### PR DESCRIPTION
A hook sends one POST, swallows any error, and exits. A failed delivery leaves no trace and the observation is gone.

`src/hooks/post-tool-use.ts` before this change:

```js
  }).catch(() => {});
  setTimeout(() => process.exit(0), 500).unref();
```

There is no retry and no queue. Whatever that POST carried is lost.

## What this costs in a real deployment

On a self-hosted instance serving 20+ concurrent sessions, the worker's connection to the engine drops and reconnects about once a minute. I measured 12 consecutive intervals: 55 to 63 seconds apart. Each reconnect succeeds on the first attempt, so `livez` stays 200 and nothing alerts.

Requests that land in that window fail. Over 2,000 HTTP log lines:

```
201  1,823 (91.2%)
200    129 ( 6.5%)
500     31 ( 1.55%)
404     12 ( 0.60%)
```

The errors appear only in minutes that carry a reconnect. The worst burst sits on the one minute with double the usual reconnect count.

**All 12 of the 404s are `POST /agentmemory/observe`.** The route is briefly unregistered while the socket comes back. Each of those is an observation that no longer exists.

The 500s hit `/observe`, `/semantic`, `/summarize`, `/memories`, `/audit`, and `/relations`. Those are in-flight state calls dying with the socket.

## The change

`postWithRetry()` in `src/hooks/_post.ts`. It sends. On a bad status or a network error it waits, then sends once more. Reconnect completes in well under a second, so one retry recovers the event.

Three details that matter:

- **Both attempts are sized to fit the caller's exit budget.** A per-attempt timeout longer than the budget means a slow first attempt is killed by the exit timer before the retry can run, which is the case the retry exists for. A 1000 ms budget gives two 437 ms attempts around a 125 ms delay.
- **Each attempt gets a fresh `AbortSignal`.** A reused signal arrives already spent, or already aborted.
- **A timeout or abort does not retry.** That outcome is unknown rather than failed, and retrying it duplicates the observation.
- **It never rejects.** A hook must not crash on a delivery failure.
- **It stops after one retry.** A hook is not the place for a backoff ladder.

Eight hooks post observations and all now use it: `post-tool-use`, `post-tool-failure`, `prompt-submit`, `notification`, `session-end`, `subagent-start`, `subagent-stop`, and `task-completed`.

## Why the exit timer moves from 500 ms to 1000 ms

This part is load-bearing. A fast 404 plus the retry delay plus the second attempt runs past 500 ms. At the old value the retry gets killed before it lands, and the change does nothing.

**The happy path does not get slower.** The timer is `unref`'d, so it never holds the process open when the POST settles. Measured against a local stub, running the built `plugin/scripts/post-tool-use.mjs`:

| server behavior | requests sent | process exit |
|---|---|---|
| 201 | 1 | 126 ms |
| 404 then 201 | 2 | 258 ms |
| persistent 500 | 2 | 266 ms |
| never answers | 1 | 542 ms |

The last row is the abort rule working: one attempt, no duplicate, and the process still exits well inside the budget.

## Built plugin scripts are included

`plugin/scripts/*.mjs` are the bundled hooks Claude Code runs, and this repo tracks them. They are rebuilt here. Without them the plugin would keep the old behavior while the source said otherwise.

## Tests

`test/hook-post-retry.test.ts` covers a bad status, a network error, stopping after one retry, never rejecting, separate signals per attempt, that both attempts fit the budget, and that a `TimeoutError` or `AbortError` does not retry.

Mutation-checked rather than assumed. Removing the abort guard fails the two abort cases. Widening the per-attempt timeout to the whole budget fails the budget case. Widening the loop bound fails three.

`session-end` is the hook where a duplicate was reachable, so it was checked end to end: against a server answering at 3500 ms, 50 transcript prompts produce 50 observations.

## What this does not do

- **It only recovers fast failures.** Each attempt gets a share of the caller's exit budget, so with the 1000ms budget the hooks use, an attempt is capped near 437ms. A server that answers more slowly than that is aborted, and an abort deliberately does not retry (see below). The retry covers the fast 404s and connection resets a reconnect produces, not a degraded server.

- **It does not retry an ambiguous failure, so some loss remains.** A refusal, a reset, or a bad status is certain non-delivery and retries. A client-side timeout is not: the server may have written the observation and simply not answered in time. `mem::observe` records its dedup hash only after the write completes, so a retry after a timeout writes a second observation rather than being deduped. Choosing not to retry there trades a little recovery for no duplication.

- **It does not fix the reconnect itself.** I could not establish why the engine closes the socket, so I did not build on a guess. The retry helps whatever the cause turns out to be.

- **Pre-existing, and adjacent enough to mention:** `session-end` re-posts the transcript's `prompt_submit` observations on every session end, and the dedup TTL is five minutes. Any session longer than that already produces duplicates. That is not introduced here, but it is visible while reading this code.

- **`session-end` keeps its `/agentmemory/session/end` call unchanged.** Different endpoint, different timeout, outside the observation-loss problem this addresses.

## Verification

- `npm test`: 1,720 passed, 0 failed, 1 skipped.
- `npx tsc --noEmit`: 30 errors, the same count `main` reports in a clean worktree. None in the changed files.
- `npm run build`: clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved reliability when sending activity observations, task updates, and transcripts.
  - Requests may retry once after recoverable network or server errors.
  - Timeout and cancellation failures now stop promptly without unnecessary retries.
  - Request attempts and retry delays are constrained to the available completion time.
  - Increased completion wait time helps background updates finish before the process exits.
  - Transcript submissions can use a longer request window when additional time is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->