### PR TITLE
fix(graph): bound sourceObservationIds in temporal graph node and edge creation and merge (#1171)

### DIFF
--- a/src/functions/temporal-graph.ts
+++ b/src/functions/temporal-graph.ts
@@ -45,7 +45,9 @@ Rules:
 - Capture reasoning/motivation behind each relationship
 - Weight relationships by directness: 1.0 = explicit statement, 0.5 = inferred, 0.1 = speculative`;
 
-function parseTemporalGraphXml(
+export const GRAPH_MAX_SOURCE_OBSERVATION_IDS = 20;
+
+export function parseTemporalGraphXml(
   xml: string,
   observationIds: string[],
 ): { nodes: GraphNode[]; edges: GraphEdge[] } {
@@ -79,7 +81,9 @@ function parseTemporalGraphXml(
       type,
       name,
       properties,
-      sourceObservationIds: observationIds,
+      sourceObservationIds: (observationIds || []).slice(
+        -GRAPH_MAX_SOURCE_OBSERVATION_IDS,
+      ),
       createdAt: now,
       aliases: aliases.length > 0 ? aliases : undefined,
     });
@@ -132,7 +136,9 @@ function parseTemporalGraphXml(
         sourceNodeId: sourceNode.id,
         targetNodeId: targetNode.id,
         weight: Math.max(0, Math.min(1, weight)),
-        sourceObservationIds: observationIds,
+        sourceObservationIds: (observationIds || []).slice(
+          -GRAPH_MAX_SOURCE_OBSERVATION_IDS,
+        ),
         createdAt: now,
         tcommit: now,
         tvalid:
@@ -201,10 +207,10 @@ export function registerTemporalGraphFunctions(
               ...existing,
               sourceObservationIds: [
                 ...new Set([
-                  ...existing.sourceObservationIds,
+                  ...(existing.sourceObservationIds || []),
                   ...obsIds,
                 ]),
-              ],
+              ].slice(-GRAPH_MAX_SOURCE_OBSERVATION_IDS),
               properties: { ...existing.properties, ...node.properties },
               updatedAt: new Date().toISOString(),
               aliases: [

--- a/test/temporal-graph.test.ts
+++ b/test/temporal-graph.test.ts
@@ -372,4 +372,97 @@ describe("TemporalGraph", () => {
     expect(result.success).toBe(false);
     expect(result.error).toBe("No observations provided");
   });
+
+  it("caps sourceObservationIds at 20 in parseTemporalGraphXml", async () => {
+    const { parseTemporalGraphXml, GRAPH_MAX_SOURCE_OBSERVATION_IDS } = await import(
+      "../src/functions/temporal-graph.js"
+    );
+    expect(GRAPH_MAX_SOURCE_OBSERVATION_IDS).toBe(20);
+
+    const xml = `<temporal_graph>
+  <entities>
+    <entity type="person" name="Alice">
+      <property key="role">engineer</property>
+    </entity>
+    <entity type="organization" name="Acme Corp">
+      <property key="industry">tech</property>
+    </entity>
+  </entities>
+  <relationships>
+    <relationship type="works_at" source="Alice" target="Acme Corp" weight="0.9" valid_from="2024-01-01" valid_to="current">
+      <reasoning>Alice joined Acme Corp</reasoning>
+    </relationship>
+  </relationships>
+</temporal_graph>`;
+
+    const obsIds = Array.from({ length: 25 }, (_, i) => `obs_${i + 1}`);
+    const { nodes, edges } = parseTemporalGraphXml(xml, obsIds);
+
+    expect(nodes.length).toBe(2);
+    expect(nodes[0].sourceObservationIds.length).toBe(20);
+    expect(nodes[0].sourceObservationIds[0]).toBe("obs_6");
+    expect(nodes[0].sourceObservationIds[19]).toBe("obs_25");
+
+    expect(edges.length).toBe(1);
+    expect(edges[0].sourceObservationIds.length).toBe(20);
+    expect(edges[0].sourceObservationIds[0]).toBe("obs_6");
+    expect(edges[0].sourceObservationIds[19]).toBe("obs_25");
+  });
+
+  it("caps sourceObservationIds at 20 on node merge in temporal-graph-extract", async () => {
+    const { registerTemporalGraphFunctions } = await import(
+      "../src/functions/temporal-graph.js"
+    );
+
+    const existingNode: GraphNode = {
+      id: "gn_alice",
+      type: "person",
+      name: "Alice",
+      properties: { role: "engineer" },
+      sourceObservationIds: Array.from({ length: 15 }, (_, i) => `old_obs_${i + 1}`),
+      createdAt: "2024-01-01T00:00:00Z",
+    };
+
+    const response = `<temporal_graph>
+  <entities>
+    <entity type="person" name="Alice">
+      <property key="level">senior</property>
+    </entity>
+  </entities>
+  <relationships></relationships>
+</temporal_graph>`;
+
+    const provider: MemoryProvider = {
+      name: "test",
+      compress: vi.fn().mockResolvedValue(response),
+      summarize: vi.fn().mockResolvedValue(response),
+    };
+
+    const sdk = mockSdk();
+    const kv = mockKV([existingNode]);
+    registerTemporalGraphFunctions(sdk as never, kv as never, provider);
+
+    const newObservations = Array.from({ length: 10 }, (_, i) => ({
+      id: `new_obs_${i + 1}`,
+      title: `Observation ${i + 1}`,
+      narrative: `Narrative ${i + 1}`,
+      concepts: [],
+      files: [],
+      type: "conversation",
+      timestamp: "2024-02-01T00:00:00Z",
+    }));
+
+    const result = (await sdk.trigger("mem::temporal-graph-extract", {
+      observations: newObservations,
+    })) as any;
+
+    expect(result.success).toBe(true);
+
+    const nodes = await kv.list<GraphNode>("mem:graph:nodes");
+    const aliceNode = nodes.find((n) => n.name === "Alice");
+    expect(aliceNode).toBeDefined();
+    expect(aliceNode?.sourceObservationIds.length).toBe(20);
+    expect(aliceNode?.sourceObservationIds[0]).toBe("old_obs_6");
+    expect(aliceNode?.sourceObservationIds[19]).toBe("new_obs_10");
+  });
 });


### PR DESCRIPTION
## Summary
Fixes #1171.

In long-running sessions, hot graph nodes and edges repeatedly re-union `sourceObservationIds` on each extraction without bounding, causing node records to grow past worker and KV payload limits (up to ~256 KB / 8,750 IDs per node, accounting for 97% of node payload size).

## Changes
- Export `GRAPH_MAX_SOURCE_OBSERVATION_IDS = 20` in `src/functions/temporal-graph.ts`.
- Bound `sourceObservationIds` in `parseTemporalGraphXml` for node and edge creation to the 20 most recent IDs using `.slice(-GRAPH_MAX_SOURCE_OBSERVATION_IDS)`.
- Bound `sourceObservationIds` on node merge in `mem::temporal-graph-extract` to the 20 most recent IDs.
- Added comprehensive unit tests in `test/temporal-graph.test.ts` verifying that creation and merges preserve the freshest IDs and strictly cap at 20.

## Verification
- `npx vitest run test/temporal-graph.test.ts` passed (9/9 tests).
- Full test suite passed (165 test files, 1,788 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Temporal graph records now retain only the 20 most recent source observation IDs.
  * Merged graph nodes consistently apply the same 20-ID limit.

* **Tests**
  * Added coverage verifying observation ID limits during parsing and node merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->