### PR TITLE
fix(reflect): bound sourceMemoryIds in reflect concept cluster insights (#1168)

### DIFF
--- a/src/functions/reflect.ts
+++ b/src/functions/reflect.ts
@@ -13,6 +13,8 @@ import type {
 import { recordAudit } from "./audit.js";
 import { REFLECT_SYSTEM, buildReflectPrompt } from "../prompts/reflect.js";
 
+export const INSIGHT_MAX_SOURCE_IDS = 20;
+
 interface ConceptCluster {
   concepts: string[];
   facts: Array<{ fact: string; confidence: number }>;
@@ -292,9 +294,9 @@ export function registerReflectFunctions(
                 confidence,
                 reinforcements: 0,
                 sourceConceptCluster: conceptNames,
-                sourceMemoryIds: cluster.factIds,
-                sourceLessonIds: cluster.lessonIds,
-                sourceCrystalIds: cluster.crystalIds,
+                sourceMemoryIds: (cluster.factIds || []).slice(-INSIGHT_MAX_SOURCE_IDS),
+                sourceLessonIds: (cluster.lessonIds || []).slice(-INSIGHT_MAX_SOURCE_IDS),
+                sourceCrystalIds: (cluster.crystalIds || []).slice(-INSIGHT_MAX_SOURCE_IDS),
                 project: data?.project,
                 tags: conceptNames,
                 createdAt: now,

--- a/test/reflect.test.ts
+++ b/test/reflect.test.ts
@@ -4,7 +4,7 @@ vi.mock("../src/logger.js", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
-import { registerReflectFunctions } from "../src/functions/reflect.js";
+import { registerReflectFunctions, INSIGHT_MAX_SOURCE_IDS } from "../src/functions/reflect.js";
 import type { Insight, GraphNode, GraphEdge, SemanticMemory, Lesson, Crystal } from "../src/types.js";
 
 function mockKV() {
@@ -250,6 +250,61 @@ describe("Reflect", () => {
 
       expect(result.success).toBe(true);
       expect(result.newInsights).toBe(0);
+    });
+
+    it("caps sourceMemoryIds, sourceLessonIds, and sourceCrystalIds at 20 preserving freshest items", async () => {
+      expect(INSIGHT_MAX_SOURCE_IDS).toBe(20);
+
+      await kv.set("mem:graph:nodes", "node_security", makeConceptNode("security"));
+      await kv.set("mem:graph:nodes", "node_validation", makeConceptNode("validation"));
+      await kv.set("mem:graph:edges", "edge_1", makeEdge("security", "validation"));
+
+      for (let i = 0; i < 25; i++) {
+        const pad = i.toString().padStart(2, "0");
+        await kv.set(
+          "mem:semantic",
+          `sem_${pad}`,
+          makeSemantic(`security fact ${pad}`, `sem_${pad}`),
+        );
+        await kv.set(
+          "mem:lessons",
+          `lsn_${pad}`,
+          {
+            ...makeLesson(`security lesson ${pad}`, ["security"]),
+            id: `lsn_${pad}`,
+          },
+        );
+        await kv.set(
+          "mem:crystals",
+          `crys_${pad}`,
+          {
+            ...makeCrystal(`crystal narrative ${pad}`, [`security topic ${pad}`]),
+            id: `crys_${pad}`,
+          },
+        );
+      }
+
+      const result = (await sdk.trigger("mem::reflect", {})) as {
+        success: boolean;
+        newInsights: number;
+      };
+
+      expect(result.success).toBe(true);
+      expect(result.newInsights).toBeGreaterThan(0);
+
+      const insights = await kv.list<Insight>("mem:insights");
+      expect(insights.length).toBeGreaterThan(0);
+      for (const ins of insights) {
+        expect(ins.sourceMemoryIds.length).toBe(20);
+        expect(ins.sourceLessonIds.length).toBe(20);
+        expect(ins.sourceCrystalIds.length).toBe(20);
+        expect(ins.sourceMemoryIds[0]).toBe("sem_05");
+        expect(ins.sourceMemoryIds[19]).toBe("sem_24");
+        expect(ins.sourceLessonIds[0]).toBe("lsn_05");
+        expect(ins.sourceLessonIds[19]).toBe("lsn_24");
+        expect(ins.sourceCrystalIds[0]).toBe("crys_05");
+        expect(ins.sourceCrystalIds[19]).toBe("crys_24");
+      }
     });
   });
 


### PR DESCRIPTION
## Summary
Fixes #1168.

In mature repositories, `mem::reflect` groups facts across concept clusters and attaches unbounded arrays of fact IDs to each synthesized Insight (`sourceMemoryIds: cluster.factIds`), causing insight records to bloat rapidly.

## Changes
- Export `INSIGHT_MAX_SOURCE_IDS = 20` in `src/functions/reflect.ts`.
- Bound `sourceMemoryIds`, `sourceLessonIds`, and `sourceCrystalIds` to the 20 most recent IDs using `.slice(-INSIGHT_MAX_SOURCE_IDS)`.
- Added unit tests in `test/reflect.test.ts` verifying that insight creation bounds source ID arrays at 20 while preserving the freshest IDs.

## Verification
- `npx vitest run test/reflect.test.ts` passed (14/14 tests).
- Full test suite passed (165 test files, 1,788 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Insights now retain only the 20 most recent source references for memories, lessons, and crystals.
  * This keeps insight data more focused and manageable while preserving the freshest supporting items.
* **Bug Fixes**
  * Added safeguards for missing source lists so insight creation continues reliably with empty reference collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->