### PR TITLE
fix(viewer): pause canvas graph simulation and background polling when tab is hidden

### DIFF
--- a/src/viewer/index.html
+++ b/src/viewer/index.html
@@ -1415,6 +1415,10 @@
       if (state.activeTab === 'replay' && tab !== 'replay' && typeof stopReplayTimer === 'function') {
         stopReplayTimer();
       }
+      if (tab !== 'graph' && graphSim.raf) {
+        cancelAnimationFrame(graphSim.raf);
+        graphSim.raf = null;
+      }
       if (!opts.skipRoute) {
         updateTabRoute(tab, !!opts.replaceRoute);
       }
@@ -1432,6 +1436,13 @@
         v.classList.toggle('active', v.id === 'view-' + tab);
       });
       if (state.flagsConfig) renderFlagBanners(state.flagsConfig);
+      if (tab === 'graph') {
+        if (graphSim.running && graphSim.quietTicks <= 30) {
+          wakeGraphSim();
+        } else if (graphSim.canvas) {
+          renderGraph();
+        }
+      }
       loadTab(tab);
     }
 
@@ -1787,6 +1798,7 @@
     function startDashboardAutoRefresh() {
       if (dashboardTimer) clearInterval(dashboardTimer);
       dashboardTimer = setInterval(function() {
+        if (document.hidden) return;
         if (pollTimer) return;
         if (state.activeTab === 'dashboard') refreshDashboard();
       }, 30000);
@@ -3797,6 +3809,7 @@
       setWsStatus('polling · ' + (POLL_INTERVAL_MS / 1000) + 's', 'disconnected');
       var tick = 0;
       pollTimer = setInterval(function() {
+        if (document.hidden) return;
         tick++;
         if (state.activeTab === 'dashboard') {
           state.dashboard.loaded = false;
@@ -4507,9 +4520,13 @@
     })();
     startDashboardAutoRefresh();
 
+    var ditherInterval = null;
+    var startDitherLoop = function() {};
+    var stopDitherLoop = function() {};
+
     // Ambient background: an ordered-dither dot field that drifts very
     // slowly — the print-halftone cousin of the old static dot grid.
-    // Renders at quarter resolution and ~12fps; a single static frame
+    // Renders at quarter resolution and ~8fps; a single static frame
     // under prefers-reduced-motion.
     (function ditherField() {
       var cv = document.getElementById('bg-dither');
@@ -4554,19 +4571,48 @@
         }
       }
 
-      draw();
-      if (!reduced) {
-        setInterval(function () {
+      startDitherLoop = function() {
+        if (reduced || ditherInterval) return;
+        ditherInterval = setInterval(function () {
           t++;
           draw();
-        }, 85);
-      }
+        }, 120);
+      };
+
+      stopDitherLoop = function() {
+        if (ditherInterval) {
+          clearInterval(ditherInterval);
+          ditherInterval = null;
+        }
+      };
+
+      draw();
+      startDitherLoop();
       window.addEventListener('resize', draw);
       new MutationObserver(draw).observe(document.documentElement, {
         attributes: true,
         attributeFilter: ['data-theme']
       });
     })();
+
+    document.addEventListener('visibilitychange', function() {
+      if (document.hidden) {
+        if (graphSim.raf) {
+          cancelAnimationFrame(graphSim.raf);
+          graphSim.raf = null;
+        }
+        stopDitherLoop();
+      } else {
+        startDitherLoop();
+        if (state.activeTab === 'graph') {
+          if (graphSim.running && graphSim.quietTicks <= 30) {
+            wakeGraphSim();
+          } else if (graphSim.canvas) {
+            renderGraph();
+          }
+        }
+      }
+    });
   </script>
 </body>
 </html>

--- a/test/viewer-safari-optimization.test.ts
+++ b/test/viewer-safari-optimization.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+
+describe("viewer safari CPU/RAM optimization", () => {
+  const viewer = readFileSync("src/viewer/index.html", "utf-8");
+
+  it("handles Page Visibility API by cancelling graph RAF and pausing dither loop on hidden", () => {
+    expect(viewer).toContain("document.addEventListener('visibilitychange'");
+    expect(viewer).toContain("if (document.hidden)");
+    expect(viewer).toContain("cancelAnimationFrame(graphSim.raf)");
+    expect(viewer).toContain("stopDitherLoop()");
+  });
+
+  it("resumes dither loop and repaints or wakes graph when visible", () => {
+    expect(viewer).toContain("startDitherLoop()");
+    expect(viewer).toContain("if (state.activeTab === 'graph')");
+    expect(viewer).toContain("wakeGraphSim()");
+    expect(viewer).toContain("renderGraph()");
+  });
+
+  it("cancels graph animation frames when switching away from graph tab", () => {
+    expect(viewer).toContain("if (tab !== 'graph' && graphSim.raf)");
+    expect(viewer).toContain("graphSim.raf = null");
+  });
+
+  it("guards auto-refresh dashboard and polling intervals when document is hidden", () => {
+    expect(viewer).toContain("function startDashboardAutoRefresh()");
+    expect(viewer).toContain("if (document.hidden) return;");
+  });
+});


### PR DESCRIPTION
## Summary
In WebKit (Safari) and Chromium browsers, backgrounded or inactive dashboard tabs continue running the 60fps Canvas Graph physics animation loop, ambient dither interval, and active polling timers, causing high CPU load and browser memory footprint (~600MB+ in Safari Web Content).

## Changes
- Added Page Visibility API (`visibilitychange`) listener in `src/viewer/index.html` to cancel active `graphSim.raf` animation frames and clear the ambient dither interval when `document.hidden` is true.
- Automatically wake simulation or repaint canvas when the page becomes visible again on the `graph` tab.
- Automatically cancel `graphSim.raf` when navigating away from the `graph` tab in `switchTab(tab)`.
- Added `if (document.hidden) return;` guards to `dashboardTimer` and `pollTimer` callbacks to prevent background wakeups.
- Refactored ambient background dither loop into `startDitherLoop()` / `stopDitherLoop()` helpers with a 120ms interval (~8fps).
- Added unit tests in `test/viewer-safari-optimization.test.ts`.

## Verification
- `npx vitest run test/viewer-safari-optimization.test.ts` passed (4/4 tests).
- All viewer tests passed (`62 passed` across 6 test files).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Reduced background CPU and memory usage when the viewer tab is hidden.
  - Paused dashboard refreshes, polling, graph animation, and background effects when inactive.
  - Automatically resumed relevant updates and refreshed the graph when returning to the tab.
  - Reduced the background effect’s animation frequency for improved efficiency.

- **Tests**
  - Added coverage to verify background work pauses and resumes correctly across tab visibility and viewer tab changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->