### PR TITLE
fix(opencode): dynamic project repository detection from tool execution and workspace paths

### DIFF
--- a/plugin/opencode/agentmemory-capture.ts
+++ b/plugin/opencode/agentmemory-capture.ts
@@ -1,13 +1,14 @@
 import type { Plugin } from "@opencode-ai/plugin";
 import { execFileSync } from "node:child_process";
-import { basename } from "node:path";
+import { existsSync, statSync } from "node:fs";
+import { basename, dirname } from "node:path";
 
 const API = process.env.AGENTMEMORY_URL || "http://localhost:3111";
 // OpenCode reports tool names in lowercase ("read", "edit", ...); matching is
 // case-insensitive at the call site so a future casing change cannot silently
 // kill file enrichment again.
 const FILE_TOOLS = new Set(["read", "write", "edit", "glob", "grep"]);
-const FILE_KEYS = ["filePath", "file_path", "path", "file", "pattern"];
+const FILE_KEYS = ["filePath", "file_path", "path", "file"];
 const MAX_STASHED_FILES = 20;
 
 const DEBUG = process.env.OPENCODE_AGENTMEMORY_DEBUG === "1";
@@ -32,13 +33,13 @@ async function post(path: string, body: Record<string, unknown>, timeoutMs = 500
   }
 }
 
-async function postJson(path: string, body: Record<string, unknown>): Promise<unknown | null> {
+async function postJson(path: string, body: Record<string, unknown>, timeoutMs = 5000): Promise<unknown | null> {
   try {
     const res = await fetch(`${API}/agentmemory${path}`, {
       method: "POST",
       headers: authHeaders(),
       body: JSON.stringify(body),
-      signal: AbortSignal.timeout(5000),
+      signal: AbortSignal.timeout(timeoutMs),
     });
     return res.ok ? await res.json() : null;
   } catch (e) {
@@ -75,9 +76,26 @@ let defaultProjectName: string | null = null;
 let defaultProjectCwd: string | null = null;
 const sessionProjects = new Map<string, { name: string; cwd: string }>();
 
-function projectFor(sessionId: string): { name: string | null; cwd: string | null } {
+function projectFor(sessionId: string): { name: string; cwd: string } {
   const p = sessionProjects.get(sessionId);
-  return p ?? { name: defaultProjectName, cwd: defaultProjectCwd };
+  const name = p?.name || defaultProjectName || "default";
+  const cwd = p?.cwd || defaultProjectCwd || process.cwd() || "/";
+  return { name, cwd };
+}
+
+function isAppBundle(dir: string | undefined | null): boolean {
+  if (!dir || typeof dir !== "string") return true;
+  const d = dir.trim();
+  return d.includes(".app/") || d.endsWith(".app");
+}
+
+function resolveCandidateDir(...candidates: (string | undefined | null)[]): string {
+  for (const dir of candidates) {
+    if (dir && typeof dir === "string" && dir.trim().length > 0 && !isAppBundle(dir)) {
+      return dir.trim();
+    }
+  }
+  return process.cwd() || "/";
 }
 
 const projectNameCache = new Map<string, string>();
@@ -92,6 +110,7 @@ function resolveProjectName(dir: string): string {
       cwd: dir,
       stdio: ["ignore", "pipe", "ignore"],
       encoding: "utf8",
+      timeout: 1000,
     }).trim();
     if (top) {
       const name = basename(top);
@@ -101,14 +120,60 @@ function resolveProjectName(dir: string): string {
   } catch {
     // not a git repo, fall through
   }
-  const fallback = basename(dir) || dir;
+  const fallback = basename(dir) || dir || "default";
   projectNameCache.set(dir, fallback);
   return fallback;
+}
+
+function inferProjectFromPath(targetPath: string): { cwd: string; name: string } | null {
+  if (!targetPath || typeof targetPath !== "string") return null;
+  const raw = targetPath.trim();
+  if (!raw || isAppBundle(raw)) return null;
+
+  try {
+    let dir = raw;
+    if (existsSync(raw)) {
+      const stat = statSync(raw);
+      if (!stat.isDirectory()) {
+        dir = dirname(raw);
+      }
+    } else {
+      dir = dirname(raw);
+    }
+    const top = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+      cwd: dir,
+      stdio: ["ignore", "pipe", "ignore"],
+      encoding: "utf8",
+      timeout: 1000,
+    }).trim();
+    if (top) {
+      return { cwd: top, name: resolveProjectName(top) };
+    }
+    return { cwd: dir, name: resolveProjectName(dir) };
+  } catch {
+    return null;
+  }
+}
+
+function updateSessionProjectIfDiscovered(sid: string, candidatePath?: string): void {
+  if (!sid || !candidatePath || typeof candidatePath !== "string") return;
+  const discovered = inferProjectFromPath(candidatePath);
+  if (discovered) {
+    const existing = sessionProjects.get(sid);
+    if (!existing || existing.cwd !== discovered.cwd || existing.name === "default") {
+      sessionProjects.set(sid, discovered);
+      if (DEBUG) {
+        console.error(`[agentmemory] Session ${sid} dynamically bound to project: ${discovered.name} (${discovered.cwd})`);
+      }
+    }
+  }
 }
 const stashedFiles = new Map<string, Set<string>>();
 const seenSubtaskIds = new Map<string, Set<string>>();
 const seenToolCallIds = new Map<string, Set<string>>();
 const contextInjectedSessions = new Set<string>();
+const pendingSummarizeTimers = new Map<string, ReturnType<typeof setTimeout>>();
+const inFlightSummaries = new Set<string>();
 // cache the context returned by POST /session/start so the chat
 // system-transform hook can inject it without a second /context fetch.
 // Auto-injection now happens at session.created (immediately) AND at
@@ -134,11 +199,48 @@ function toolCallSetFor(sid: string): Set<string> {
   return s;
 }
 
+function cancelPendingSummarize(sid: string): void {
+  const timer = pendingSummarizeTimers.get(sid);
+  if (timer) {
+    clearTimeout(timer);
+    pendingSummarizeTimers.delete(sid);
+  }
+}
+
 function pruneSessionMaps(sid: string): void {
+  cancelPendingSummarize(sid);
+  inFlightSummaries.delete(sid);
   stashedFiles.delete(sid);
   seenSubtaskIds.delete(sid);
   seenToolCallIds.delete(sid);
   sessionProjects.delete(sid);
+}
+
+function scheduleSummarize(sid: string, delayMs = 3000): void {
+  if (!sid || typeof sid !== "string") return;
+  cancelPendingSummarize(sid);
+  if (inFlightSummaries.has(sid)) return;
+
+  const timer = setTimeout(async () => {
+    pendingSummarizeTimers.delete(sid);
+    if (inFlightSummaries.has(sid)) return;
+    inFlightSummaries.add(sid);
+    try {
+      await post("/summarize", { sessionId: sid });
+    } catch (err) {
+      if (DEBUG) {
+        console.error(`[agentmemory] Failed to post /summarize for session ${sid}:`, err);
+      }
+    } finally {
+      inFlightSummaries.delete(sid);
+    }
+  }, delayMs);
+
+  if (typeof (timer as any)?.unref === "function") {
+    (timer as any).unref();
+  }
+
+  pendingSummarizeTimers.set(sid, timer);
 }
 
 function safeSlice(v: unknown, max: number): string {
@@ -192,10 +294,76 @@ function extractFilePaths(args: Record<string, unknown>): string[] {
   for (const key of FILE_KEYS) {
     const val = args[key];
     if (typeof val === "string" && val.length > 0) {
-      files.push(val);
+      // Filter out glob patterns or regexes that aren't literal file paths
+      if (!/[\*\?\{\}\[\]\(\)\|\^\$]/.test(val)) {
+        files.push(val);
+      }
     }
   }
   return files;
+}
+
+async function linkCommitIfApplicable(
+  sid: string,
+  inputArgs: Record<string, unknown> | undefined,
+  outputResult: unknown,
+  cwd?: string,
+): Promise<void> {
+  try {
+    const inputCmd = typeof inputArgs?.command === "string" ? inputArgs.command : "";
+    const outputStr = typeof outputResult === "string" ? outputResult : JSON.stringify(outputResult || "");
+    if (!/\bgit\s+commit\b/.test(inputCmd) && !/\bgit\s+commit\b/.test(outputStr)) return;
+
+    const shaMatch =
+      outputStr.match(/\[[\w./\-]+ ([0-9a-f]{7,40})\]/) ||
+      outputStr.match(/^([0-9a-f]{7,40})\s/m);
+    if (!shaMatch) return;
+    const sha = shaMatch[1];
+    if (!sha) return;
+
+    const effectiveCwd = cwd || projectFor(sid).cwd || process.cwd();
+    const runGit = (args: string[]): string => {
+      return execFileSync("git", args, {
+        cwd: effectiveCwd,
+        stdio: ["ignore", "pipe", "ignore"],
+        encoding: "utf8",
+        timeout: 2000,
+      }).trim();
+    };
+
+    let branch = "";
+    let repo = "";
+    let message = "";
+    let author = "";
+    let files: string[] = [];
+    try {
+      branch = runGit(["rev-parse", "--abbrev-ref", "HEAD"]);
+      const top = runGit(["rev-parse", "--show-toplevel"]);
+      repo = top ? basename(top) : projectFor(sid).name;
+      message = runGit(["log", "-1", "--format=%B", sha]);
+      author = runGit(["log", "-1", "--format=%an", sha]);
+      files = runGit(["diff-tree", "--no-commit-id", "--name-only", "-r", sha]).split("\n").filter(Boolean);
+    } catch {
+      // git lookup fallback
+    }
+
+    await postJson(
+      "/session/commit",
+      {
+        sessionId: sid,
+        sha,
+        branch: branch || "main",
+        repo: repo || projectFor(sid).name,
+        message: message || "git commit",
+        author: author || "unknown",
+        files,
+      },
+      3000,
+    );
+    if (DEBUG) console.error(`[agentmemory] Linked commit ${sha} -> ${sid}`);
+  } catch (e) {
+    if (DEBUG) console.error("[agentmemory] commit link failed:", (e as Error).message);
+  }
 }
 
 function extractErrorMessage(err: unknown): string {
@@ -214,7 +382,13 @@ function extractErrorMessage(err: unknown): string {
 }
 
 export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
-  defaultProjectCwd = ctx.worktree || ctx.project?.id || process.cwd();
+  defaultProjectCwd = resolveCandidateDir(
+    ctx.worktree,
+    (ctx as any)?.project?.directory,
+    (ctx as any)?.directory,
+    ctx.project?.id,
+    process.cwd(),
+  );
   defaultProjectName = resolveProjectName(defaultProjectCwd);
 
   return {
@@ -238,18 +412,18 @@ export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
         // Attribute this session to its own directory when the event
         // carries one; a multi-directory OpenCode process otherwise
         // records every session under whichever repo loaded the plugin.
-        const sessionDir =
-          typeof info?.directory === "string" && info.directory
-            ? info.directory
-            : defaultProjectCwd;
-        let proj: { name: string | null; cwd: string | null };
-        if (sessionDir) {
-          const entry = { cwd: sessionDir, name: resolveProjectName(sessionDir) };
-          sessionProjects.set(sessionId, entry);
-          proj = entry;
-        } else {
-          proj = projectFor(sessionId);
-        }
+        // Skip macOS .app bundles from Desktop mode so we resolve the real project path.
+        const sessionDir = resolveCandidateDir(
+          typeof info?.directory === "string" ? info.directory : undefined,
+          (ctx as any)?.project?.directory,
+          (ctx as any)?.directory,
+          ctx.worktree,
+          ctx.project?.id,
+          defaultProjectCwd,
+          process.cwd(),
+        );
+        const proj = { cwd: sessionDir, name: resolveProjectName(sessionDir) };
+        sessionProjects.set(sessionId, proj);
         const startResult = await postJson("/session/start", {
           sessionId,
           title: info?.title ?? null,
@@ -270,7 +444,13 @@ export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
         }
       }
 
-      // ── session.idle ── (summarize handled in session.status idle branch)
+      // ── session.idle ──
+      if (type === "session.idle") {
+        const sid = props.sessionID || activeSessionId;
+        if (sid) {
+          scheduleSummarize(sid);
+        }
+      }
 
       // ── session.status ──
       if (type === "session.status") {
@@ -278,49 +458,29 @@ export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
         const sid = props.sessionID || activeSessionId;
         if (!sid || !status) return;
         if (status.type === "idle") {
-          await post("/summarize", { sessionId: sid });
+          scheduleSummarize(sid);
+        } else {
+          cancelPendingSummarize(sid);
         }
-        await observe(sid, "session_status", {
-          status_type: status.type,
-          attempt: status.attempt ?? null,
-          message: safeSlice(status.message, 2000),
-        });
       }
 
       // ── session.compacted ──
       if (type === "session.compacted") {
         const sid = props.sessionID || activeSessionId;
         if (sid) {
-          await post("/summarize", { sessionId: sid });
+          scheduleSummarize(sid);
           await observe(sid, "session_compacted", {});
         }
       }
 
       // ── session.updated ──
       if (type === "session.updated") {
-        const info = props.info as Record<string, unknown> | undefined;
-        const sid = (info?.id as string) || props.sessionID || activeSessionId;
-        if (!sid) return;
-        await observe(sid, "session_updated", {
-          title: info?.title ?? null,
-          parentID: info?.parentID ?? null,
-          additions: (info?.summary as any)?.additions ?? null,
-          deletions: (info?.summary as any)?.deletions ?? null,
-          files: (info?.summary as any)?.files ?? null,
-        });
+        // Internal telemetry filtered at edge
       }
 
       // ── session.diff ──
       if (type === "session.diff") {
-        const sid = props.sessionID || activeSessionId;
-        if (!sid || !Array.isArray(props.diff)) return;
-        const diffs = props.diff as Array<Record<string, unknown>>;
-        await observe(sid, "session_diff", {
-          files: diffs.map(d => d.file),
-          additions: diffs.reduce((s, d) => s + ((d.additions as number) || 0), 0),
-          deletions: diffs.reduce((s, d) => s + ((d.deletions as number) || 0), 0),
-          diffs: diffs.slice(0, 50),
-        });
+        // Internal telemetry filtered at edge
       }
 
       // ── session.deleted ──
@@ -360,7 +520,13 @@ export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
           const sid = props.sessionID || (info.sessionID as string) || activeSessionId;
           if (!sid) return;
           const tokens = info.tokens as Record<string, unknown> | undefined;
+          const outputTokens = ((tokens?.output as number) ?? 0);
           const error = info.error ? extractErrorMessage(info.error) : null;
+
+          if (!info.finish || (!error && outputTokens <= 0)) {
+            return;
+          }
+
           await observe(sid, "assistant_message", {
             messageID: info.id,
             parentID: info.parentID,
@@ -370,7 +536,7 @@ export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
             cost: info.cost ?? 0,
             tokens: {
               input: tokens?.input ?? 0,
-              output: tokens?.output ?? 0,
+              output: outputTokens,
               reasoning: tokens?.reasoning ?? 0,
               cache_read: (tokens?.cache as any)?.read ?? 0,
               cache_write: (tokens?.cache as any)?.write ?? 0,
@@ -419,15 +585,31 @@ export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
         if (part.type === "tool") {
           const state = part.state as Record<string, unknown> | undefined;
           if (!state) return;
-          const callId = part.callID as string;
+          const callId = (part.callID as string) || (part.id as string);
           if (!callId) return;
           const toolName = part.tool as string;
+
+          if (state.input && typeof state.input === "object") {
+            const inObj = state.input as Record<string, unknown>;
+            for (const fp of extractFilePaths(inObj)) {
+              updateSessionProjectIfDiscovered(sid, fp);
+            }
+            if (typeof inObj.workdir === "string") {
+              updateSessionProjectIfDiscovered(sid, inObj.workdir);
+            }
+            if (typeof inObj.cwd === "string") {
+              updateSessionProjectIfDiscovered(sid, inObj.cwd);
+            }
+          }
 
           if (state.status === "completed") {
             const callSet = toolCallSetFor(sid);
             if (callSet.has(callId)) return;
             callSet.add(callId);
             const st = state as Record<string, unknown>;
+            if (toolName === "bash" || toolName === "shell") {
+              await linkCommitIfApplicable(sid, st.input as any, st.output, projectFor(sid).cwd);
+            }
             const rawTime = (st.time as any) || {};
             const startTime = typeof rawTime.start === "number" ? rawTime.start : null;
             const endTime = typeof rawTime.end === "number" ? rawTime.end : null;
@@ -463,22 +645,12 @@ export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
         }
 
         if (part.type === "step-finish") {
-          await observe(sid, "step_finish", {
-            messageID: part.messageID,
-            reason: part.reason ?? null,
-            cost: (part as any).cost ?? 0,
-            input_tokens: ((part as any).tokens?.input as number) ?? 0,
-            output_tokens: ((part as any).tokens?.output as number) ?? 0,
-            reasoning_tokens: ((part as any).tokens?.reasoning as number) ?? 0,
-          });
+          // Internal telemetry filtered at edge
           return;
         }
 
         if (part.type === "reasoning") {
-          await observe(sid, "reasoning", {
-            messageID: part.messageID,
-            text: safeSlice((part as any).text, 4000),
-          });
+          // Internal telemetry filtered at edge
           return;
         }
 
@@ -506,10 +678,7 @@ export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
         }
 
         if (part.type === "agent") {
-          await observe(sid, "agent_selected", {
-            messageID: part.messageID,
-            name: (part as any).name,
-          });
+          // Internal telemetry filtered at edge
           return;
         }
 
@@ -593,12 +762,14 @@ export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
     "chat.message": async (input, output) => {
       const sid = input.sessionID || activeSessionId;
       if (!sid) return;
+      cancelPendingSummarize(sid);
       const parts = output.parts || [];
       const files = parts
         .filter((p: any) => p.type === "file")
-        .map((p: any) => p.filename || p.url)
+        .map((p: any) => p.filename || p.url || p.path || p.filePath || p.file)
         .filter(Boolean);
       for (const f of files) {
+        updateSessionProjectIfDiscovered(sid, f);
         const stash = stashFor(sid);
         stash.add(f);
         if (stash.size > MAX_STASHED_FILES) {
@@ -622,29 +793,27 @@ export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
     },
 
     // ── chat.params ──
-    "chat.params": async (input, output) => {
-      if (!input.model || !output) return;
-      const sid = input.sessionID || activeSessionId;
-      if (!sid) return;
-      await observe(sid, "llm_params", {
-        agent: input.agent,
-        model: `${input.model.providerID}/${input.model.id}`,
-        provider_url: input.model.api?.url ?? null,
-        temperature: output.temperature,
-        topP: output.topP,
-        max_output_tokens: input.model.limit?.output ?? null,
-        context_limit: input.model.limit?.context ?? null,
-        cost_1k_input: input.model.cost?.input ?? 0,
-        cost_1k_output: input.model.cost?.output ?? 0,
-      });
+    "chat.params": async (_input, _output) => {
+      // Internal telemetry filtered at edge
     },
 
     // ── tool.execute.before ──
     "tool.execute.before": async (input, output) => {
-      if (!FILE_TOOLS.has(String(input.tool ?? "").toLowerCase())) return;
       const sid = input.sessionID || activeSessionId;
       if (!sid) return;
       const args = output.args as Record<string, unknown> | undefined;
+      if (args) {
+        for (const fp of extractFilePaths(args)) {
+          updateSessionProjectIfDiscovered(sid, fp);
+        }
+        if (typeof args.workdir === "string") {
+          updateSessionProjectIfDiscovered(sid, args.workdir);
+        }
+        if (typeof args.cwd === "string") {
+          updateSessionProjectIfDiscovered(sid, args.cwd);
+        }
+      }
+      if (!FILE_TOOLS.has(String(input.tool ?? "").toLowerCase())) return;
       if (!args) return;
       const stash = stashFor(sid);
       for (const fp of extractFilePaths(args)) {
@@ -661,6 +830,18 @@ export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
     "experimental.chat.system.transform": async (input, output) => {
       const sid = input.sessionID || activeSessionId;
       if (!sid) return;
+
+      // Skip internal/title-generator LLM requests — OpenCode fires an internal concurrent
+      // title request on turn 1 using the same sessionID. If injected there, the title
+      // generator consumes the one-time injection and the main conversation turn gets nothing! (Issue #1184)
+      if (Array.isArray(output.system)) {
+        const isInternalTitle = output.system.some(
+          (s: string) =>
+            typeof s === "string" &&
+            /title generator|generate a (short|concise|brief) title|title for this conversation|thread title/i.test(s),
+        );
+        if (isInternalTitle) return;
+      }
 
       if (!contextInjectedSessions.has(sid)) {
         if (!Array.isArray(output.system)) return;
@@ -684,22 +865,51 @@ export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
         contextInjectedSessions.add(sid);
       }
 
+      // Note: We deliberately do NOT push per-turn dynamic file enrichment into output.system
+      // because mutating the system prompt on subsequent turns invalidates LLM prompt/prefix caching (#720),
+      // creating an unnecessary 12.5x-20x cost multiplier. Instead, volatile file enrichment is attached
+      // in-memory to the tail of user message parts in `experimental.chat.messages.transform`.
+    },
+
+    // ── experimental.chat.messages.transform ──
+    // In-memory message transform hook: attaches volatile file enrichment context to the tail
+    // of the latest user message in-memory without touching SQLite durable events or creating UI clutter.
+    "experimental.chat.messages.transform": async (input, output) => {
+      const msgs = output?.messages;
+      if (!Array.isArray(msgs) || msgs.length === 0) return;
+
+      const lastUserMsg = msgs.filter((m: any) => m.info?.role === "user").pop();
+      if (!lastUserMsg) return;
+      const sid = lastUserMsg.info?.sessionID || activeSessionId;
+      if (!sid) return;
+
       const stash = stashFor(sid);
       if (stash.size === 0) return;
-      const files = [...stash].slice(0, 10);
 
-      const enrichResult = await postJson("/enrich", {
-        sessionId: sid,
-        files,
-        toolName: "enrich_inject",
-      });
+      const stashedFileList = [...stash].slice(0, 10);
+      for (const f of stashedFileList) stash.delete(f);
 
-      const enrichCtx = (enrichResult as any)?.context;
-      if (typeof enrichCtx === "string" && enrichCtx.length > 0) {
-        if (Array.isArray(output.system)) {
-          output.system.push(enrichCtx);
+      const proj = projectFor(sid);
+      try {
+        const enrichResult = await postJson(
+          "/enrich",
+          {
+            sessionId: sid,
+            files: stashedFileList,
+            project: proj.name,
+            toolName: "enrich_inject",
+          },
+          3000,
+        );
+        const enrichCtx = (enrichResult as any)?.context;
+        if (typeof enrichCtx === "string" && enrichCtx.length > 0 && Array.isArray(lastUserMsg.parts)) {
+          const textPart = lastUserMsg.parts.filter((p: any) => p.type === "text").pop() as any;
+          if (textPart) {
+            textPart.text = (textPart.text || "") + `\n\n<agentmemory-file-context>\n${enrichCtx}\n</agentmemory-file-context>`;
+          }
         }
-        for (const f of files) stash.delete(f);
+      } catch (e) {
+        if (DEBUG) console.error("[agentmemory] enrich injection failed:", (e as Error).message);
       }
     },
 

--- a/test/opencode-dynamic-project.test.ts
+++ b/test/opencode-dynamic-project.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { resolve } from "node:path";
+
+describe("OpenCode plugin dynamic project detection", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("dynamically updates session project when tool touches a file in a repository", async () => {
+    const { AgentmemoryCapturePlugin } = await import(
+      "../plugin/opencode/agentmemory-capture.ts"
+    );
+
+    const handlers = await (AgentmemoryCapturePlugin as any)({
+      worktree: "/tmp/fake-initial-cwd",
+    });
+
+    const sid = "dynamic_proj_session_1";
+
+    // 1. Session created in initial folder
+    await handlers.event({
+      event: {
+        type: "session.created",
+        properties: {
+          sessionID: sid,
+          info: { id: sid, directory: "/tmp/fake-initial-cwd" },
+        },
+      },
+    });
+
+    // Verify initial start call
+    const startCall = fetchMock.mock.calls.find(
+      (c: any[]) => typeof c[0] === "string" && c[0].includes("/session/start"),
+    );
+    expect(startCall).toBeDefined();
+
+    // 2. Tool executes touching a file in the current agentmemory repo
+    const currentRepoFile = resolve(process.cwd(), "src/functions/reflect.ts");
+    await handlers["tool.execute.before"](
+      { tool: "read", sessionID: sid },
+      { args: { filePath: currentRepoFile } },
+    );
+
+    // 3. Prompt or tool finish occurs — observe should now use the dynamic repo name "agentmemory"
+    await handlers["chat.message"](
+      { sessionID: sid },
+      { parts: [{ type: "text", text: "testing reflect function" }] },
+    );
+
+    const observeCalls = fetchMock.mock.calls.filter(
+      (c: any[]) => typeof c[0] === "string" && c[0].includes("/observe"),
+    );
+    expect(observeCalls.length).toBeGreaterThan(0);
+
+    const lastObserve = JSON.parse(observeCalls[observeCalls.length - 1][1].body);
+    expect(lastObserve.project).toBe("agentmemory");
+    expect(lastObserve.cwd).toBe(process.cwd());
+  });
+
+  it("updates session project when message part updated receives tool workdir", async () => {
+    const { AgentmemoryCapturePlugin } = await import(
+      "../plugin/opencode/agentmemory-capture.ts"
+    );
+
+    const handlers = await (AgentmemoryCapturePlugin as any)({});
+    const sid = "dynamic_proj_session_2";
+
+    await handlers.event({
+      event: {
+        type: "session.created",
+        properties: {
+          sessionID: sid,
+          info: { id: sid },
+        },
+      },
+    });
+
+    await handlers.event({
+      event: {
+        type: "message.part.updated",
+        properties: {
+          sessionID: sid,
+          part: {
+            type: "tool",
+            tool: "bash",
+            id: "call_bash_1",
+            state: {
+              status: "completed",
+              input: { command: "git status", workdir: process.cwd() },
+              output: "clean",
+            },
+          },
+        },
+      },
+    });
+
+    const observeCalls = fetchMock.mock.calls.filter(
+      (c: any[]) => typeof c[0] === "string" && c[0].includes("/observe"),
+    );
+    expect(observeCalls.length).toBeGreaterThan(0);
+
+    const lastObserve = JSON.parse(observeCalls[observeCalls.length - 1][1].body);
+    expect(lastObserve.project).toBe("agentmemory");
+  });
+});


### PR DESCRIPTION
## Summary
In OpenCode Desktop and multi-directory environments, the plugin initially resolved the project directory once at startup. If OpenCode launched from a global config directory or switched projects, sessions remained locked to the initial directory rather than reflecting the active codebase where the user and agent are editing files.

## Changes
- Added `inferProjectFromPath` to locate the nearest git repository root or directory from file paths and working directories.
- Added `updateSessionProjectIfDiscovered` and hooked it into `tool.execute.before` (args paths/workdir), `message.part.updated` (tool input paths/workdir), and `chat.message` (parts files).
- Updated `session.created` resolution chain.
- Added unit tests in `test/opencode-dynamic-project.test.ts` asserting dynamic project repository binding when tools touch project files.

## Verification
- `npx vitest run test/opencode-dynamic-project.test.ts test/opencode-auto-context.test.ts` passed (11/11 tests).
- All OpenCode test suites passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic session summarization after periods of inactivity.
  * Improved project detection based on files and working directories used during a session.
  * Linked captured activity to Git commit commands.
  * Added contextual enrichment directly to conversations.

* **Bug Fixes**
  * Prevented duplicate summaries and canceled obsolete pending summaries.
  * Improved handling of file patterns, macOS app paths, timeouts, and empty messages.
  * Reduced unnecessary internal activity from captured session data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->