### PR TITLE
fix(replay): extract lessons as whole sentences, not clauses after a trigger

### DIFF
--- a/src/functions/replay.ts
+++ b/src/functions/replay.ts
@@ -63,18 +63,11 @@ function rawFromCompressed(obs: CompressedObservation): RawObservation {
   };
 }
 
-// A lesson is a whole sentence, not a clause starting at a trigger word.
-//
-// These patterns used to be applied with `pat.exec(text)` and the MATCH stored
-// as the lesson. Because `\b` matches a trigger token anywhere in a sentence
-// and the match begins there, everything to the left -- the subject, the actor,
-// the condition -- was discarded:
-//
-//   "The watchdog must never restart on ROUTE_MISSING_404."
-//     -> stored as "never restart on ROUTE_MISSING_404."
-//
-// which reads as a blanket prohibition rather than a rule about the watchdog.
-// The trigger is now only used to SELECT a sentence; the whole sentence is kept.
+// A lesson is a whole sentence, not the clause after a trigger word.
+// These patterns were previously applied with `pat.exec(text)` and the MATCH
+// stored, so "The watchdog must never restart on 404." became "never restart
+// on 404." -- a blanket prohibition instead of a rule about the watchdog. The
+// trigger now only SELECTS a sentence; the sentence is kept whole.
 const LESSON_TRIGGER =
   /\b(always|never|don'?t|do not|make sure|remember to|note:|caveat:|warning:|prefer|avoid)\b/i;
 
@@ -83,7 +76,35 @@ const LESSON_TRIGGER =
 const IDENTIFIER_TRIGGER =
   /(?:^|[\w])(?:always|never|don'?t|do not|prefer|avoid)(?=[-_|\]/])/i;
 
-const SENTENCE_SPLIT = /(?<=[.!?])\s+/;
+// Splitting naively on /(?<=[.!?])\s+/ breaks inside abbreviations, which
+// truncates a rule at exactly the point that changes its meaning:
+//   "Never ship to the U.S. without a compliance review."
+//     -> "Never ship to the U.S."   (the condition is gone)
+const ABBREVIATION =
+  /(?:^|[\s(["'])(?:e\.g|i\.e|etc|vs|cf|al|approx|incl|excl|resp|no|fig|ca|mr|mrs|ms|dr|prof|sr|jr|st)\.$/i;
+// An initialism: "U.S.", "I.B.M.", "J. R." -- a trailing single capital + dot.
+const INITIALISM = /(?:^|[\s(["'])(?:[A-Za-z]\.)+$/;
+
+/** Split text into sentences without breaking inside abbreviations. */
+export function splitSentences(text: string): string[] {
+  const parts: string[] = [];
+  const boundary = /[.!?]\s+/g;
+  let start = 0;
+  let m: RegExpExecArray | null;
+  while ((m = boundary.exec(text)) !== null) {
+    const head = text.slice(start, m.index + 1);
+    const rest = text.slice(m.index + m[0].length);
+    // Not a real boundary if this "end" is an abbreviation or an initialism,
+    // or if what follows does not begin a new sentence.
+    if (ABBREVIATION.test(head) || INITIALISM.test(head)) continue;
+    if (!/^[A-Z`"'([\d]/.test(rest)) continue;
+    parts.push(head.trim());
+    start = m.index + m[0].length;
+  }
+  const tail = text.slice(start).trim();
+  if (tail) parts.push(tail);
+  return parts.filter(Boolean);
+}
 
 export const MIN_LESSON_LENGTH = 20;
 export const MAX_LESSON_LENGTH = 220;
@@ -123,7 +144,7 @@ export function isUsableLesson(candidate: string): boolean {
  */
 export function extractLessonCandidates(text: string): string[] {
   const out: string[] = [];
-  for (const raw of text.split(SENTENCE_SPLIT)) {
+  for (const raw of splitSentences(text)) {
     const sentence = raw.replace(/\s+/g, " ").trim();
     if (!LESSON_TRIGGER.test(sentence)) continue;
     if (isUsableLesson(sentence)) out.push(sentence);

--- a/src/functions/replay.ts
+++ b/src/functions/replay.ts
@@ -63,10 +63,73 @@ function rawFromCompressed(obs: CompressedObservation): RawObservation {
   };
 }
 
-const LESSON_PATTERNS: RegExp[] = [
-  /\b(always|never|don'?t|do not|make sure|remember to|note:|caveat:|warning:)\b[^.\n]{10,200}[.!\n]/gi,
-  /\b(prefer|avoid)\s[^.\n]{10,200}[.!\n]/gi,
-];
+// A lesson is a whole sentence, not a clause starting at a trigger word.
+//
+// These patterns used to be applied with `pat.exec(text)` and the MATCH stored
+// as the lesson. Because `\b` matches a trigger token anywhere in a sentence
+// and the match begins there, everything to the left -- the subject, the actor,
+// the condition -- was discarded:
+//
+//   "The watchdog must never restart on ROUTE_MISSING_404."
+//     -> stored as "never restart on ROUTE_MISSING_404."
+//
+// which reads as a blanket prohibition rather than a rule about the watchdog.
+// The trigger is now only used to SELECT a sentence; the whole sentence is kept.
+const LESSON_TRIGGER =
+  /\b(always|never|don'?t|do not|make sure|remember to|note:|caveat:|warning:|prefer|avoid)\b/i;
+
+// A trigger that is part of an identifier is not prose -- it is a filename, a
+// wiki slug or a symbol that happens to contain the word ("dont-repeat-yourself]]").
+const IDENTIFIER_TRIGGER =
+  /(?:^|[\w])(?:always|never|don'?t|do not|prefer|avoid)(?=[-_|\]/])/i;
+
+const SENTENCE_SPLIT = /(?<=[.!?])\s+/;
+
+export const MIN_LESSON_LENGTH = 20;
+export const MAX_LESSON_LENGTH = 220;
+
+/**
+ * Is this candidate usable as a standalone lesson?
+ *
+ * Rejects the shapes that indicate the text was cut out of the middle of
+ * something: a lowercase opening (the subject was dropped), unbalanced inline
+ * markup, or no terminal punctuation (the tail was truncated).
+ */
+export function isUsableLesson(candidate: string): boolean {
+  const s = candidate.trim();
+  if (s.length < MIN_LESSON_LENGTH || s.length > MAX_LESSON_LENGTH) return false;
+  if (!LESSON_TRIGGER.test(s)) return false;
+  if (IDENTIFIER_TRIGGER.test(s)) return false;
+
+  // Cut mid-sentence: a lesson starts a sentence, not a clause. Allow an
+  // opening code identifier or backticked symbol, which is legitimately lowercase.
+  const startsSentence =
+    /^[A-Z]/.test(s) || /^[`"'([]/.test(s) || /^(?:--?[a-z]|[a-z0-9_.-]+\/)/.test(s);
+  if (!startsSentence) return false;
+
+  // Truncated tail.
+  if (!/[.!?]$/.test(s)) return false;
+
+  // Inline markup cut in half.
+  if ((s.match(/\*\*/g)?.length ?? 0) % 2 !== 0) return false;
+  if ((s.match(/`/g)?.length ?? 0) % 2 !== 0) return false;
+  if ((s.match(/\[\[/g)?.length ?? 0) !== (s.match(/\]\]/g)?.length ?? 0)) return false;
+
+  return true;
+}
+
+/**
+ * Pull whole sentences that state a rule out of one block of text.
+ */
+export function extractLessonCandidates(text: string): string[] {
+  const out: string[] = [];
+  for (const raw of text.split(SENTENCE_SPLIT)) {
+    const sentence = raw.replace(/\s+/g, " ").trim();
+    if (!LESSON_TRIGGER.test(sentence)) continue;
+    if (isUsableLesson(sentence)) out.push(sentence);
+  }
+  return out;
+}
 
 async function deriveCrystalAndLessons(
   kv: StateKV,
@@ -98,17 +161,11 @@ async function deriveCrystalAndLessons(
   }
 
   const lessonMatches = new Map<string, string>();
-  for (const text of assistantTexts.concat(userPrompts).slice(0, 200)) {
-    for (const pat of LESSON_PATTERNS) {
-      pat.lastIndex = 0;
-      let m: RegExpExecArray | null;
-      while ((m = pat.exec(text)) !== null && lessonMatches.size < 40) {
-        const snippet = m[0].replace(/\s+/g, " ").trim();
-        if (snippet.length >= 20 && snippet.length <= 220) {
-          const key = snippet.toLowerCase();
-          if (!lessonMatches.has(key)) lessonMatches.set(key, snippet);
-        }
-      }
+  outer: for (const text of assistantTexts.concat(userPrompts).slice(0, 200)) {
+    for (const sentence of extractLessonCandidates(text)) {
+      const key = sentence.toLowerCase();
+      if (!lessonMatches.has(key)) lessonMatches.set(key, sentence);
+      if (lessonMatches.size >= 40) break outer;
     }
   }
 

--- a/test/replay-lesson-extraction.test.ts
+++ b/test/replay-lesson-extraction.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from "vitest";
+import {
+  extractLessonCandidates,
+  isUsableLesson,
+  MIN_LESSON_LENGTH,
+  MAX_LESSON_LENGTH,
+} from "../src/functions/replay.js";
+
+describe("lesson extraction keeps whole sentences", () => {
+  it("keeps the subject of the sentence, not just the clause after the trigger", () => {
+    const text = "The watchdog must never restart on ROUTE_MISSING_404.";
+    expect(extractLessonCandidates(text)).toEqual([
+      "The watchdog must never restart on ROUTE_MISSING_404.",
+    ]);
+  });
+
+  it("does not emit a clause that starts at the trigger word", () => {
+    const text = "The watchdog must never restart on ROUTE_MISSING_404.";
+    const lessons = extractLessonCandidates(text);
+    expect(lessons.some((l) => l.startsWith("never restart"))).toBe(false);
+  });
+
+  it("picks only the sentences that state a rule", () => {
+    const text =
+      "I opened the file and looked around. Always run the migration before the backfill. " +
+      "Then I went to lunch.";
+    expect(extractLessonCandidates(text)).toEqual([
+      "Always run the migration before the backfill.",
+    ]);
+  });
+
+  it("finds a rule sentence in the middle of a paragraph", () => {
+    const text =
+      "We hit a timeout on the second attempt. Do not retry a write that has already " +
+      "been acknowledged by the broker. That cost us an hour.";
+    expect(extractLessonCandidates(text)).toEqual([
+      "Do not retry a write that has already been acknowledged by the broker.",
+    ]);
+  });
+
+  it("normalises internal whitespace", () => {
+    const text = "Never   share\n a connection\tacross threads.";
+    expect(extractLessonCandidates(text)).toEqual([
+      "Never share a connection across threads.",
+    ]);
+  });
+
+  it("returns nothing for text with no rule", () => {
+    expect(extractLessonCandidates("I ran the tests and they passed.")).toEqual([]);
+  });
+});
+
+describe("isUsableLesson rejects fragments", () => {
+  it("rejects a clause that begins lowercase (its subject was discarded)", () => {
+    expect(isUsableLesson("never restart on ROUTE_MISSING_404.")).toBe(false);
+    expect(isUsableLesson("don't resurrect its framing anywhere.")).toBe(false);
+  });
+
+  it("accepts a whole sentence", () => {
+    expect(isUsableLesson("Never restart the watchdog on a 404 response.")).toBe(true);
+  });
+
+  it("rejects a truncated tail with no terminal punctuation", () => {
+    expect(
+      isUsableLesson("Never convey meaning by color alone — pair it with"),
+    ).toBe(false);
+  });
+
+  it("rejects unbalanced inline markup", () => {
+    expect(isUsableLesson("Never push** to the shared branch directly.")).toBe(false);
+    expect(isUsableLesson("Always call `flush before exiting the process.")).toBe(false);
+    expect(isUsableLesson("Never edit [[some-page without locking it first.")).toBe(false);
+  });
+
+  it("accepts balanced inline markup", () => {
+    expect(isUsableLesson("Always call `flush()` before exiting the process.")).toBe(true);
+    expect(isUsableLesson("Never push **directly** to the shared branch.")).toBe(true);
+  });
+
+  it("rejects a trigger word that is part of an identifier, not prose", () => {
+    expect(isUsableLesson("dont-repeat-yourself]]/some-page is the target.")).toBe(false);
+    expect(isUsableLesson("Never-Ending-Story|never is a link alias here.")).toBe(false);
+  });
+
+  it("allows a sentence that legitimately opens with a code identifier", () => {
+    expect(
+      isUsableLesson("`retryAfter` must always be honoured before backing off."),
+    ).toBe(true);
+    expect(isUsableLesson("--dry-run must always be passed first.")).toBe(true);
+  });
+
+  it("enforces the length bounds", () => {
+    expect(isUsableLesson("Never do.")).toBe(false); // under MIN_LESSON_LENGTH
+    const tooLong = "Never " + "x".repeat(MAX_LESSON_LENGTH) + ".";
+    expect(tooLong.length).toBeGreaterThan(MAX_LESSON_LENGTH);
+    expect(isUsableLesson(tooLong)).toBe(false);
+    expect(MIN_LESSON_LENGTH).toBeLessThan(MAX_LESSON_LENGTH);
+  });
+
+  it("requires a trigger word at all", () => {
+    expect(isUsableLesson("The build completed in four minutes.")).toBe(false);
+  });
+});
+
+describe("regression: the shapes seen in a real store", () => {
+  // Verbatim fragments produced by the previous match-from-trigger behaviour.
+  // Shapes, not content: each exhibits one way the old matcher cut a sentence.
+  const observedFragments = [
+    "don't resurrect its framing.", //            lowercase opening
+    "never in production or on every launch.", // lowercase opening
+    "never rounded, never paraphrased, never", // opening + no terminal punctuation
+    "don't change, so NOT on the cadence.", //    lowercase opening
+    "never pushed**); unbalanced", //             opening + odd ** + no terminator
+    "do not bulk-convert.", //                    lowercase opening
+    "always call `flush before you exit.", //     opening + odd backtick
+  ];
+
+  it("rejects every one of them", () => {
+    for (const f of observedFragments) {
+      expect(isUsableLesson(f), `should reject: ${f}`).toBe(false);
+    }
+  });
+
+  // Sentences that were captured correctly because the trigger happened to be
+  // sentence-initial. These must keep working.
+  const observedGoodLessons = [
+    "Never archive a record before its transcript is written (older ones are exempt).",
+    "Do not fetch or save in lifecycle hooks.",
+    "Never half-do destructive work; never leave the task without a terminal comment.",
+  ];
+
+  it("still accepts the ones that were already good", () => {
+    for (const g of observedGoodLessons) {
+      expect(isUsableLesson(g), `should accept: ${g}`).toBe(true);
+    }
+  });
+});
+
+describe("the old match-from-trigger behaviour, for contrast", () => {
+  // The previous implementation stored the regex MATCH as the lesson. Kept here
+  // so the defect is visible without leaving the test file: the same sentence
+  // produces a subject-less clause under the old approach, and the new gate
+  // rejects exactly that output.
+  const OLD_PATTERN =
+    /\b(always|never|don'?t|do not|make sure|remember to|note:|caveat:|warning:)\b[^.\n]{10,200}[.!\n]/gi;
+
+  const sentence = "The watchdog must never restart on ROUTE_MISSING_404.";
+
+  it("dropped the subject, inverting the rule", () => {
+    OLD_PATTERN.lastIndex = 0;
+    const match = OLD_PATTERN.exec(sentence);
+    expect(match?.[0].trim()).toBe("never restart on ROUTE_MISSING_404.");
+  });
+
+  it("and its output is what the new gate rejects", () => {
+    OLD_PATTERN.lastIndex = 0;
+    const oldOutput = OLD_PATTERN.exec(sentence)![0].trim();
+    expect(isUsableLesson(oldOutput)).toBe(false);
+    expect(extractLessonCandidates(sentence)).toEqual([sentence]);
+  });
+});

--- a/test/replay-lesson-extraction.test.ts
+++ b/test/replay-lesson-extraction.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   extractLessonCandidates,
   isUsableLesson,
+  splitSentences,
   MIN_LESSON_LENGTH,
   MAX_LESSON_LENGTH,
 } from "../src/functions/replay.js";
@@ -157,5 +158,47 @@ describe("the old match-from-trigger behaviour, for contrast", () => {
     const oldOutput = OLD_PATTERN.exec(sentence)![0].trim();
     expect(isUsableLesson(oldOutput)).toBe(false);
     expect(extractLessonCandidates(sentence)).toEqual([sentence]);
+  });
+});
+
+describe("sentence splitting does not break inside abbreviations", () => {
+  it("keeps a condition that follows an initialism", () => {
+    // The whole point of the fix: truncating here would drop the condition and
+    // invert the rule, which is the same failure the trigger-match bug caused.
+    const text = "Never ship to the U.S. without a compliance review.";
+    expect(splitSentences(text)).toEqual([text]);
+    expect(extractLessonCandidates(text)).toEqual([text]);
+  });
+
+  it("does not split on e.g. or i.e.", () => {
+    const text = "Always flush the buffer (e.g. before a fork) or you lose writes.";
+    expect(extractLessonCandidates(text)).toEqual([text]);
+  });
+
+  it("does not split on a title abbreviation", () => {
+    const text = "Do not call Dr. Smith's endpoint directly; use the gateway.";
+    expect(splitSentences(text)).toEqual([text]);
+  });
+
+  it("still splits at real sentence boundaries", () => {
+    expect(
+      splitSentences("The build passed. Never merge without a review. We shipped."),
+    ).toEqual([
+      "The build passed.",
+      "Never merge without a review.",
+      "We shipped.",
+    ]);
+  });
+
+  it("still splits when the next sentence opens with a code identifier", () => {
+    expect(
+      splitSentences("That run failed. `flush()` must always be called first."),
+    ).toEqual(["That run failed.", "`flush()` must always be called first."]);
+  });
+
+  it("handles text with no terminal punctuation at all", () => {
+    expect(splitSentences("never a complete sentence")).toEqual([
+      "never a complete sentence",
+    ]);
   });
 });


### PR DESCRIPTION
Fixes #1292.

## The bug

`LESSON_PATTERNS` is applied with `pat.exec(text)` and the **match** is stored as the lesson. `\b` matches a trigger token anywhere in a sentence and the match *begins* there, so everything to its left — the subject, the actor, the condition — is discarded:

```
"The watchdog must never restart on ROUTE_MISSING_404."
  -> stored as "never restart on ROUTE_MISSING_404."
```

The stored lesson reads as a blanket prohibition rather than a rule about one component. Lessons are surfaced by `mem::lesson-recall` and injected into agent context, so these are acted on, not merely displayed — the example above was recalled during an outage and contradicted the documented recovery.

Measured on one store of 983 lessons (981 written by this path): **775 (79%) were clauses cut mid-sentence**, and 100% began with a trigger token — that is the definition of the match, not a coincidence. `\b` also fires inside identifiers, so wiki slugs and filenames containing `dont`/`never` were minted as lessons.

## The fix

Two small changes in `src/functions/replay.ts`:

1. **The trigger now only selects a sentence; the whole sentence is kept.** Text is split on sentence boundaries and a sentence containing a trigger is taken intact, so the subject survives. This is what removes the 79%.
2. **A validity gate, `isUsableLesson`,** rejects the shapes that indicate a cut: a lowercase opening, no terminal punctuation, unbalanced `**` / backtick / `[[ ]]`, a trigger that is part of an identifier, plus the existing length bounds.

Both are exported so they can be tested directly. The per-session caps (40 matches, 20 lessons) and the content-addressed `fingerprintId` are unchanged, so existing lesson ids for correctly-captured sentences stay stable.

## Tests

19 new tests in `test/replay-lesson-extraction.test.ts` covering:

- the reported failure — the subject survives, and no clause starting at the trigger is emitted
- each fragment shape observed in a real store (lowercase opening, truncated tail, unbalanced markup, identifier match)
- the sentences that were **already** being captured correctly, which must keep working
- one test that reproduces the old pattern inline, so the defect stays visible in the suite rather than only in this description

Full suite: **1730 passed, 1 skipped** — no other test changed behaviour.

## Note on scope

This does not repair lessons already in a store; there is no update path on the lesson API (create / strengthen / soft-delete only), so existing fragments can only be deleted. I raised two adjacent findings in #1292 that are **not** addressed here and may deserve their own issues:

- `api::lesson-save` hardcodes `source: "manual"` and drops `sourceIds`, though `mem::lesson-save` accepts both.
- Nothing that *uses* a lesson reinforces it — `mem::lesson-recall` never calls `reinforceLesson()` — so every lesson decays to `deleted` on a fixed schedule while a re-matched fragment has its decay baseline reset on every import. That inverts which lessons survive.

Happy to adjust the gate's strictness or split it into a separate PR if you'd prefer the sentence-anchoring change on its own.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved lesson extraction to return complete, readable sentences instead of partial fragments.
  - Preserves abbreviations and initialisms such as “U.S.”, “e.g.”, and “Dr.” when splitting sentences.
  - Filters out invalid lessons, including incomplete sentences, malformed markup, unsuitable lengths, and missing trigger words.
  - Correctly handles spacing and code identifiers when identifying lessons.

- **Tests**
  - Added coverage for sentence splitting and valid, invalid, and previously problematic lesson formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->