### PR TITLE
fix(sessions): close idle sessions no client ever ended

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,7 +117,7 @@ Hook scripts in `src/hooks/` are standalone Node.js scripts (no iii-sdk import).
 ## Current Stats (v0.9.29)
 
 - 54 MCP tools (8 visible by default, `AGENTMEMORY_TOOLS=all` for all)
-- 130 REST endpoints
+- 131 REST endpoints
 - 6 MCP resources, 3 MCP prompts
 - 12 hooks, 17 skills
 - 260+ iii functions

--- a/README.md
+++ b/README.md
@@ -1609,7 +1609,7 @@ Create `~/.agentmemory/.env`:
 
 <h2 id="api"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/section-api.svg"><img src="assets/tags/section-api.svg" alt="API" height="32" /></picture></h2>
 
-130 endpoints on port `3111`. The REST API binds to `127.0.0.1` by default. Protected endpoints require `Authorization: Bearer <secret>` when `AGENTMEMORY_SECRET` is set, and mesh sync endpoints require `AGENTMEMORY_SECRET` on both peers.
+131 endpoints on port `3111`. The REST API binds to `127.0.0.1` by default. Protected endpoints require `Authorization: Bearer <secret>` when `AGENTMEMORY_SECRET` is set, and mesh sync endpoints require `AGENTMEMORY_SECRET` on both peers.
 
 <details>
 <summary>Key endpoints</summary>

--- a/src/config.ts
+++ b/src/config.ts
@@ -467,6 +467,22 @@ export function getConsolidationCooldownMs(): number {
   return raw >= 0 ? raw : CONSOLIDATION_COOLDOWN_DEFAULT_MS;
 }
 
+const SESSION_SWEEP_INTERVAL_DEFAULT_MS = 900_000;
+const SESSION_SWEEP_INTERVAL_MIN_MS = 60_000;
+// setInterval coerces a delay above 2^31-1 to 1ms, exactly as it does NaN or 0,
+// so an interval that is merely too large fails the same way garbage does.
+const TIMER_MAX_MS = 2_147_483_647;
+
+export function getSessionSweepIntervalMs(): number {
+  const raw = safeParseInt(
+    getMergedEnv()["SESSION_SWEEP_INTERVAL_MS"],
+    SESSION_SWEEP_INTERVAL_DEFAULT_MS,
+  );
+  // safeParseInt already falls back on NaN, and parseInt never yields Infinity,
+  // so raw is finite here and only needs bounding.
+  return Math.min(Math.max(raw, SESSION_SWEEP_INTERVAL_MIN_MS), TIMER_MAX_MS);
+}
+
 export function isStandaloneMcp(): boolean {
   return getMergedEnv()["STANDALONE_MCP"] === "true";
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -478,8 +478,6 @@ export function getSessionSweepIntervalMs(): number {
     getMergedEnv()["SESSION_SWEEP_INTERVAL_MS"],
     SESSION_SWEEP_INTERVAL_DEFAULT_MS,
   );
-  // safeParseInt already falls back on NaN, and parseInt never yields Infinity,
-  // so raw is finite here and only needs bounding.
   return Math.min(Math.max(raw, SESSION_SWEEP_INTERVAL_MIN_MS), TIMER_MAX_MS);
 }
 

--- a/src/functions/session-sweep.ts
+++ b/src/functions/session-sweep.ts
@@ -11,7 +11,11 @@ import { logger } from "../logger.js";
 // dropped it. Separate from mem::evict on purpose: that pass deletes rows, which
 // is a different decision from marking a session finished.
 const MS_PER_MINUTE = 60 * 1000;
-const DEFAULT_IDLE_MINUTES = 60;
+// A day, not an hour. The sessions this exists for (SDK children, subagents)
+// run and finish, so a tight threshold buys nothing there, while a client that
+// merely idles overnight would be ended mid-use. mem::evict's comparable
+// "this is dead" call is 30 days.
+const DEFAULT_IDLE_MINUTES = 1440;
 // ponytail: fixed cap per run, not a work queue. Each swept session fans out a
 // summarize, so an unbounded first pass over a backlog is an LLM storm.
 const MAX_PER_RUN = 25;
@@ -45,6 +49,7 @@ export function registerSessionSweepFunction(sdk: ISdk, kv: StateKV): void {
       const now = Date.now();
       const sessions = await kv.list<Session>(KV.sessions).catch(() => []);
       let candidates = 0;
+      let attempted = 0;
       let swept = 0;
 
       for (const session of sessions) {
@@ -57,13 +62,21 @@ export function registerSessionSweepFunction(sdk: ISdk, kv: StateKV): void {
 
         candidates++;
         if (dryRun) continue;
-        if (swept >= MAX_PER_RUN) continue;
+        // Cap attempts, not successes: if every end fails, a large backlog
+        // would otherwise retry the whole list on every run.
+        if (attempted >= MAX_PER_RUN) continue;
+        attempted++;
 
         try {
-          // event::session::ended owns the terminal-state write.
+          // event::session::ended owns the terminal-state write. Pass the last
+          // activity as endedAt so a session idle for a day is not recorded as
+          // having run for a day (the viewer derives duration from it).
           await sdk.trigger({
             function_id: "event::session::ended",
-            payload: { sessionId: session.id },
+            payload: {
+              sessionId: session.id,
+              endedAt: new Date(last).toISOString(),
+            },
           });
         } catch (err) {
           logger.warn("Session sweep failed to end session", {
@@ -82,8 +95,10 @@ export function registerSessionSweepFunction(sdk: ISdk, kv: StateKV): void {
           idleMinutes,
         });
 
-        // Mirrors the /session/end fan-out. skipConsolidation keeps N swept
-        // sessions from launching N full-corpus consolidations.
+        // Same summary fan-out /session/end performs, except for
+        // skipConsolidation, which that path does not pass: it ends one session
+        // at a time, whereas this can end MAX_PER_RUN of them and would
+        // otherwise launch that many full-corpus consolidations.
         sdk
           .trigger({
             function_id: "event::session::stopped",

--- a/src/functions/session-sweep.ts
+++ b/src/functions/session-sweep.ts
@@ -7,18 +7,24 @@ import { logger } from "../logger.js";
 
 // Sessions only reach "completed" when a client POSTs /agentmemory/session/end.
 // Clients that never send it leave sessions "active" forever, so this ages them
-// on inactivity instead — no termination event required, whichever harness
-// dropped it. Separate from mem::evict on purpose: that pass deletes rows, which
-// is a different decision from marking a session finished.
+// on inactivity instead, whichever harness dropped the signal. Separate from
+// mem::evict on purpose: that pass deletes rows, which is a different decision
+// from marking a session finished.
 const MS_PER_MINUTE = 60 * 1000;
-// A day, not an hour. The sessions this exists for (SDK children, subagents)
-// run and finish, so a tight threshold buys nothing there, while a client that
-// merely idles overnight would be ended mid-use. mem::evict's comparable
-// "this is dead" call is 30 days.
+// A day, not an hour. The sessions this exists for run and finish, so a tight
+// threshold buys nothing there, while a client that merely idles overnight
+// would be ended mid-use. mem::evict's comparable call is 30 days.
 const DEFAULT_IDLE_MINUTES = 1440;
 // ponytail: fixed cap per run, not a work queue. Each swept session fans out a
 // summarize, so an unbounded first pass over a backlog is an LLM storm.
 const MAX_PER_RUN = 25;
+
+interface SweepResult {
+  success: true;
+  candidates: number;
+  swept: number;
+  skipped?: true;
+}
 
 function positiveNumber(value: unknown, fallback: number): number {
   return typeof value === "number" && Number.isFinite(value) && value > 0
@@ -32,96 +38,119 @@ function lastActivity(session: Session): number {
   return Number.isFinite(parsed) ? parsed : NaN;
 }
 
+async function sweep(
+  sdk: ISdk,
+  kv: StateKV,
+  dryRun: boolean,
+  requestedIdleMinutes: number | undefined,
+): Promise<SweepResult> {
+  const idleMinutes = positiveNumber(requestedIdleMinutes, DEFAULT_IDLE_MINUTES);
+  const idleMs = idleMinutes * MS_PER_MINUTE;
+
+  const now = Date.now();
+  const sessions = await kv.list<Session>(KV.sessions).catch(() => []);
+  let candidates = 0;
+  let attempted = 0;
+  let swept = 0;
+
+  for (const session of sessions) {
+    if (session.status !== "active") continue;
+    const last = lastActivity(session);
+    // Treating an unreadable stamp as infinitely idle would end live sessions,
+    // so skip rather than sweep.
+    if (!Number.isFinite(last)) continue;
+    if (now - last <= idleMs) continue;
+
+    candidates++;
+    if (dryRun) continue;
+    // Cap attempts, not successes: if every end fails, a large backlog would
+    // otherwise retry the whole list on every run.
+    if (attempted >= MAX_PER_RUN) continue;
+    attempted++;
+
+    try {
+      // event::session::ended owns the terminal-state write. Pass the last
+      // activity as endedAt so a session idle for a day is not recorded as
+      // having run for a day (the viewer derives duration from it).
+      await sdk.trigger({
+        function_id: "event::session::ended",
+        payload: {
+          sessionId: session.id,
+          endedAt: new Date(last).toISOString(),
+        },
+      });
+    } catch (err) {
+      logger.warn("Session sweep failed to end session", {
+        sessionId: session.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      continue;
+    }
+    swept++;
+
+    // safeAudit, not recordAudit: an audit write that times out must not abort
+    // the run for every session behind this one.
+    await safeAudit(kv, "session_sweep", "mem::session-sweep", [session.id], {
+      resource: "session",
+      reason: "idle_timeout",
+      idleMinutes,
+    });
+
+    // Same summary fan-out /session/end performs, except for skipConsolidation,
+    // which that path does not pass: it ends one session at a time, whereas
+    // this can end MAX_PER_RUN of them and would otherwise launch that many
+    // full-corpus consolidations.
+    sdk
+      .trigger({
+        function_id: "event::session::stopped",
+        payload: { sessionId: session.id, skipConsolidation: true },
+        action: TriggerAction.Void(),
+      })
+      .catch((err: unknown) => {
+        logger.warn("Session sweep summary fan-out failed", {
+          sessionId: session.id,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+  }
+
+  if (candidates > 0) {
+    logger.info("Session sweep complete", {
+      candidates,
+      swept,
+      idleMinutes,
+      dryRun,
+    });
+  }
+  return { success: true, candidates, swept };
+}
+
 export function registerSessionSweepFunction(sdk: ISdk, kv: StateKV): void {
+  // setInterval does not await its callback, and the endpoint can fire during a
+  // timer run. A sweep normally takes seconds, but engine state::set calls do
+  // time out at 30s under load, and 25 of those would outlast the interval. Two
+  // overlapping runs would snapshot the same still-active session and each fan
+  // out a summarize, paying for the LLM pass twice.
+  let inFlight = false;
+
   sdk.registerFunction(
     "mem::session-sweep",
     async (data: {
       dryRun?: boolean;
       idleMinutes?: number;
-    }): Promise<{ success: true; candidates: number; swept: number }> => {
+    }): Promise<SweepResult> => {
       const dryRun = data?.dryRun ?? false;
-      const idleMinutes = positiveNumber(
-        data?.idleMinutes,
-        DEFAULT_IDLE_MINUTES,
-      );
-      const idleMs = idleMinutes * MS_PER_MINUTE;
-
-      const now = Date.now();
-      const sessions = await kv.list<Session>(KV.sessions).catch(() => []);
-      let candidates = 0;
-      let attempted = 0;
-      let swept = 0;
-
-      for (const session of sessions) {
-        if (session.status !== "active") continue;
-        const last = lastActivity(session);
-        // Treating an unreadable stamp as infinitely idle would end live
-        // sessions, so skip rather than sweep.
-        if (!Number.isFinite(last)) continue;
-        if (now - last <= idleMs) continue;
-
-        candidates++;
-        if (dryRun) continue;
-        // Cap attempts, not successes: if every end fails, a large backlog
-        // would otherwise retry the whole list on every run.
-        if (attempted >= MAX_PER_RUN) continue;
-        attempted++;
-
-        try {
-          // event::session::ended owns the terminal-state write. Pass the last
-          // activity as endedAt so a session idle for a day is not recorded as
-          // having run for a day (the viewer derives duration from it).
-          await sdk.trigger({
-            function_id: "event::session::ended",
-            payload: {
-              sessionId: session.id,
-              endedAt: new Date(last).toISOString(),
-            },
-          });
-        } catch (err) {
-          logger.warn("Session sweep failed to end session", {
-            sessionId: session.id,
-            error: err instanceof Error ? err.message : String(err),
-          });
-          continue;
-        }
-        swept++;
-
-        // safeAudit, not recordAudit: an audit write that times out must not
-        // abort the run for every session behind this one.
-        await safeAudit(kv, "session_sweep", "mem::session-sweep", [session.id], {
-          resource: "session",
-          reason: "idle_timeout",
-          idleMinutes,
-        });
-
-        // Same summary fan-out /session/end performs, except for
-        // skipConsolidation, which that path does not pass: it ends one session
-        // at a time, whereas this can end MAX_PER_RUN of them and would
-        // otherwise launch that many full-corpus consolidations.
-        sdk
-          .trigger({
-            function_id: "event::session::stopped",
-            payload: { sessionId: session.id, skipConsolidation: true },
-            action: TriggerAction.Void(),
-          })
-          .catch((err: unknown) => {
-            logger.warn("Session sweep summary fan-out failed", {
-              sessionId: session.id,
-              error: err instanceof Error ? err.message : String(err),
-            });
-          });
+      // A dry run only reads, so it never needs to wait on a real one.
+      if (inFlight && !dryRun) {
+        logger.info("Session sweep already running, skipping this run");
+        return { success: true, candidates: 0, swept: 0, skipped: true };
       }
-
-      if (candidates > 0) {
-        logger.info("Session sweep complete", {
-          candidates,
-          swept,
-          idleMinutes,
-          dryRun,
-        });
+      if (!dryRun) inFlight = true;
+      try {
+        return await sweep(sdk, kv, dryRun, data?.idleMinutes);
+      } finally {
+        if (!dryRun) inFlight = false;
       }
-      return { success: true, candidates, swept };
     },
   );
 }

--- a/src/functions/session-sweep.ts
+++ b/src/functions/session-sweep.ts
@@ -2,38 +2,24 @@ import { TriggerAction, type ISdk } from "iii-sdk";
 import type { Session } from "../types.js";
 import { KV } from "../state/schema.js";
 import { StateKV } from "../state/kv.js";
+import { safeAudit } from "./audit.js";
 import { logger } from "../logger.js";
 
-// A session only reaches "completed" when a client POSTs
-// /agentmemory/session/end (src/triggers/api.ts). Several clients never do:
-// the Claude Code Stop hook returns early for Agent SDK child sessions
-// (src/hooks/stop.ts) and subagent-stop.ts posts observations only, while the
-// opencode plugin posts it solely on session.deleted. Those sessions stay
-// "active" forever.
-//
-// This sweep keys on inactivity rather than on any termination event, so it
-// closes them regardless of which harness dropped the signal. It deliberately
-// does NOT live in mem::evict: that pass deletes session rows and observations,
-// which is a different decision from marking a session finished.
-interface SweepConfig {
-  idleMinutes: number;
-  maxPerRun: number;
-}
-
+// Sessions only reach "completed" when a client POSTs /agentmemory/session/end.
+// Clients that never send it leave sessions "active" forever, so this ages them
+// on inactivity instead — no termination event required, whichever harness
+// dropped it. Separate from mem::evict on purpose: that pass deletes rows, which
+// is a different decision from marking a session finished.
 const MS_PER_MINUTE = 60 * 1000;
+const DEFAULT_IDLE_MINUTES = 60;
+// ponytail: fixed cap per run, not a work queue. Each swept session fans out a
+// summarize, so an unbounded first pass over a backlog is an LLM storm.
+const MAX_PER_RUN = 25;
 
-const DEFAULTS: SweepConfig = {
-  idleMinutes: 60,
-  // ponytail: fixed cap per run, not a work queue. Each swept session fans out
-  // a summarize, so an unbounded first run over a large backlog is an LLM
-  // storm. Raise it if a backlog drains too slowly.
-  maxPerRun: 25,
-};
-
-interface SweepStats {
-  candidates: number;
-  swept: number;
-  dryRun: boolean;
+function positiveNumber(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : fallback;
 }
 
 function lastActivity(session: Session): number {
@@ -48,35 +34,33 @@ export function registerSessionSweepFunction(sdk: ISdk, kv: StateKV): void {
     async (data: {
       dryRun?: boolean;
       idleMinutes?: number;
-    }): Promise<SweepStats> => {
+    }): Promise<{ success: true; candidates: number; swept: number }> => {
       const dryRun = data?.dryRun ?? false;
-
-      const configOverride = await kv
-        .get<Partial<SweepConfig>>(KV.config, "sessionSweep")
-        .catch(() => null);
-      const cfg = { ...DEFAULTS, ...configOverride };
-      const idleMinutes = data?.idleMinutes ?? cfg.idleMinutes;
+      const idleMinutes = positiveNumber(
+        data?.idleMinutes,
+        DEFAULT_IDLE_MINUTES,
+      );
       const idleMs = idleMinutes * MS_PER_MINUTE;
 
       const now = Date.now();
       const sessions = await kv.list<Session>(KV.sessions).catch(() => []);
-      const stats: SweepStats = { candidates: 0, swept: 0, dryRun };
+      let candidates = 0;
+      let swept = 0;
 
       for (const session of sessions) {
         if (session.status !== "active") continue;
         const last = lastActivity(session);
-        // A session with no usable timestamp cannot be aged; leaving it alone
-        // is safer than treating an unparseable stamp as "infinitely idle".
+        // Treating an unreadable stamp as infinitely idle would end live
+        // sessions, so skip rather than sweep.
         if (!Number.isFinite(last)) continue;
         if (now - last <= idleMs) continue;
 
-        stats.candidates++;
+        candidates++;
         if (dryRun) continue;
-        if (stats.swept >= cfg.maxPerRun) continue;
+        if (swept >= MAX_PER_RUN) continue;
 
         try {
-          // event::session::ended owns the terminal-state write (endedAt +
-          // status). Reuse it rather than re-implementing the kv.update here.
+          // event::session::ended owns the terminal-state write.
           await sdk.trigger({
             function_id: "event::session::ended",
             payload: { sessionId: session.id },
@@ -88,33 +72,41 @@ export function registerSessionSweepFunction(sdk: ISdk, kv: StateKV): void {
           });
           continue;
         }
-        stats.swept++;
+        swept++;
 
-        // Match what /agentmemory/session/end fans out, so a swept session
-        // reaches the same terminal shape as a normally-ended one.
-        // skipConsolidation keeps N swept sessions from launching N full-corpus
-        // consolidations, the same guard eviction's recovery path uses.
-        sdk.trigger({
-          function_id: "event::session::stopped",
-          payload: { sessionId: session.id, skipConsolidation: true },
-          action: TriggerAction.Void(),
-        }).catch((err: unknown) => {
-          logger.warn("Session sweep summary fan-out failed", {
-            sessionId: session.id,
-            error: err instanceof Error ? err.message : String(err),
-          });
+        // safeAudit, not recordAudit: an audit write that times out must not
+        // abort the run for every session behind this one.
+        await safeAudit(kv, "session_sweep", "mem::session-sweep", [session.id], {
+          resource: "session",
+          reason: "idle_timeout",
+          idleMinutes,
         });
+
+        // Mirrors the /session/end fan-out. skipConsolidation keeps N swept
+        // sessions from launching N full-corpus consolidations.
+        sdk
+          .trigger({
+            function_id: "event::session::stopped",
+            payload: { sessionId: session.id, skipConsolidation: true },
+            action: TriggerAction.Void(),
+          })
+          .catch((err: unknown) => {
+            logger.warn("Session sweep summary fan-out failed", {
+              sessionId: session.id,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          });
       }
 
-      if (stats.swept > 0 || stats.candidates > 0) {
-        logger.info("Session sweep completed", {
-          candidates: stats.candidates,
-          swept: stats.swept,
+      if (candidates > 0) {
+        logger.info("Session sweep complete", {
+          candidates,
+          swept,
           idleMinutes,
           dryRun,
         });
       }
-      return stats;
+      return { success: true, candidates, swept };
     },
   );
 }

--- a/src/functions/session-sweep.ts
+++ b/src/functions/session-sweep.ts
@@ -13,7 +13,7 @@ import { logger } from "../logger.js";
 const MS_PER_MINUTE = 60 * 1000;
 // A day, not an hour. The sessions this exists for run and finish, so a tight
 // threshold buys nothing there, while a client that merely idles overnight
-// would be ended mid-use. mem::evict's comparable call is 30 days.
+// would be ended mid-use.
 const DEFAULT_IDLE_MINUTES = 1440;
 // ponytail: fixed cap per run, not a work queue. Each swept session fans out a
 // summarize, so an unbounded first pass over a backlog is an LLM storm.
@@ -50,7 +50,6 @@ async function sweep(
   const now = Date.now();
   const sessions = await kv.list<Session>(KV.sessions).catch(() => []);
   let candidates = 0;
-  let attempted = 0;
   let swept = 0;
 
   for (const session of sessions) {
@@ -62,16 +61,24 @@ async function sweep(
     if (now - last <= idleMs) continue;
 
     candidates++;
-    if (dryRun) continue;
-    // Cap attempts, not successes: if every end fails, a large backlog would
-    // otherwise retry the whole list on every run.
-    if (attempted >= MAX_PER_RUN) continue;
-    attempted++;
+    // Capped on candidates, not on successes: if every end fails, a large
+    // backlog would otherwise retry the whole list on every run. candidates
+    // keeps counting past the cap so the return value reports backlog depth.
+    if (dryRun || candidates > MAX_PER_RUN) continue;
+
+    // Re-read immediately before writing. The list snapshot can be stale by the
+    // time we reach a given row, and a client may have ended the session in
+    // between, which would otherwise cost a duplicate audit row and a duplicate
+    // summarize. This narrows the window, it does not close it: StateKV has no
+    // compare-and-set, so an atomic active-to-completed claim is not available.
+    const current = await kv
+      .get<Session>(KV.sessions, session.id)
+      .catch(() => null);
+    if (current && current.status !== "active") continue;
 
     try {
-      // event::session::ended owns the terminal-state write. Pass the last
-      // activity as endedAt so a session idle for a day is not recorded as
-      // having run for a day (the viewer derives duration from it).
+      // endedAt is the last activity, not now, so a session idle for a day is
+      // not recorded as having run for a day (the viewer derives duration).
       await sdk.trigger({
         function_id: "event::session::ended",
         payload: {
@@ -126,11 +133,8 @@ async function sweep(
 }
 
 export function registerSessionSweepFunction(sdk: ISdk, kv: StateKV): void {
-  // setInterval does not await its callback, and the endpoint can fire during a
-  // timer run. A sweep normally takes seconds, but engine state::set calls do
-  // time out at 30s under load, and 25 of those would outlast the interval. Two
-  // overlapping runs would snapshot the same still-active session and each fan
-  // out a summarize, paying for the LLM pass twice.
+  // setInterval does not await its callback, so two runs can overlap and each
+  // fan out a summarize for the same session, paying for the LLM pass twice.
   let inFlight = false;
 
   sdk.registerFunction(
@@ -139,17 +143,15 @@ export function registerSessionSweepFunction(sdk: ISdk, kv: StateKV): void {
       dryRun?: boolean;
       idleMinutes?: number;
     }): Promise<SweepResult> => {
-      const dryRun = data?.dryRun ?? false;
-      // A dry run only reads, so it never needs to wait on a real one.
-      if (inFlight && !dryRun) {
+      if (inFlight) {
         logger.info("Session sweep already running, skipping this run");
         return { success: true, candidates: 0, swept: 0, skipped: true };
       }
-      if (!dryRun) inFlight = true;
+      inFlight = true;
       try {
-        return await sweep(sdk, kv, dryRun, data?.idleMinutes);
+        return await sweep(sdk, kv, data?.dryRun ?? false, data?.idleMinutes);
       } finally {
-        if (!dryRun) inFlight = false;
+        inFlight = false;
       }
     },
   );

--- a/src/functions/session-sweep.ts
+++ b/src/functions/session-sweep.ts
@@ -1,0 +1,120 @@
+import { TriggerAction, type ISdk } from "iii-sdk";
+import type { Session } from "../types.js";
+import { KV } from "../state/schema.js";
+import { StateKV } from "../state/kv.js";
+import { logger } from "../logger.js";
+
+// A session only reaches "completed" when a client POSTs
+// /agentmemory/session/end (src/triggers/api.ts). Several clients never do:
+// the Claude Code Stop hook returns early for Agent SDK child sessions
+// (src/hooks/stop.ts) and subagent-stop.ts posts observations only, while the
+// opencode plugin posts it solely on session.deleted. Those sessions stay
+// "active" forever.
+//
+// This sweep keys on inactivity rather than on any termination event, so it
+// closes them regardless of which harness dropped the signal. It deliberately
+// does NOT live in mem::evict: that pass deletes session rows and observations,
+// which is a different decision from marking a session finished.
+interface SweepConfig {
+  idleMinutes: number;
+  maxPerRun: number;
+}
+
+const MS_PER_MINUTE = 60 * 1000;
+
+const DEFAULTS: SweepConfig = {
+  idleMinutes: 60,
+  // ponytail: fixed cap per run, not a work queue. Each swept session fans out
+  // a summarize, so an unbounded first run over a large backlog is an LLM
+  // storm. Raise it if a backlog drains too slowly.
+  maxPerRun: 25,
+};
+
+interface SweepStats {
+  candidates: number;
+  swept: number;
+  dryRun: boolean;
+}
+
+function lastActivity(session: Session): number {
+  const stamp = session.updatedAt ?? session.startedAt;
+  const parsed = stamp ? new Date(stamp).getTime() : NaN;
+  return Number.isFinite(parsed) ? parsed : NaN;
+}
+
+export function registerSessionSweepFunction(sdk: ISdk, kv: StateKV): void {
+  sdk.registerFunction(
+    "mem::session-sweep",
+    async (data: {
+      dryRun?: boolean;
+      idleMinutes?: number;
+    }): Promise<SweepStats> => {
+      const dryRun = data?.dryRun ?? false;
+
+      const configOverride = await kv
+        .get<Partial<SweepConfig>>(KV.config, "sessionSweep")
+        .catch(() => null);
+      const cfg = { ...DEFAULTS, ...configOverride };
+      const idleMinutes = data?.idleMinutes ?? cfg.idleMinutes;
+      const idleMs = idleMinutes * MS_PER_MINUTE;
+
+      const now = Date.now();
+      const sessions = await kv.list<Session>(KV.sessions).catch(() => []);
+      const stats: SweepStats = { candidates: 0, swept: 0, dryRun };
+
+      for (const session of sessions) {
+        if (session.status !== "active") continue;
+        const last = lastActivity(session);
+        // A session with no usable timestamp cannot be aged; leaving it alone
+        // is safer than treating an unparseable stamp as "infinitely idle".
+        if (!Number.isFinite(last)) continue;
+        if (now - last <= idleMs) continue;
+
+        stats.candidates++;
+        if (dryRun) continue;
+        if (stats.swept >= cfg.maxPerRun) continue;
+
+        try {
+          // event::session::ended owns the terminal-state write (endedAt +
+          // status). Reuse it rather than re-implementing the kv.update here.
+          await sdk.trigger({
+            function_id: "event::session::ended",
+            payload: { sessionId: session.id },
+          });
+        } catch (err) {
+          logger.warn("Session sweep failed to end session", {
+            sessionId: session.id,
+            error: err instanceof Error ? err.message : String(err),
+          });
+          continue;
+        }
+        stats.swept++;
+
+        // Match what /agentmemory/session/end fans out, so a swept session
+        // reaches the same terminal shape as a normally-ended one.
+        // skipConsolidation keeps N swept sessions from launching N full-corpus
+        // consolidations, the same guard eviction's recovery path uses.
+        sdk.trigger({
+          function_id: "event::session::stopped",
+          payload: { sessionId: session.id, skipConsolidation: true },
+          action: TriggerAction.Void(),
+        }).catch((err: unknown) => {
+          logger.warn("Session sweep summary fan-out failed", {
+            sessionId: session.id,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        });
+      }
+
+      if (stats.swept > 0 || stats.candidates > 0) {
+        logger.info("Session sweep completed", {
+          candidates: stats.candidates,
+          swept: stats.swept,
+          idleMinutes,
+          dryRun,
+        });
+      }
+      return stats;
+    },
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ import { registerConsolidateFunction } from "./functions/consolidate.js";
 import { registerPatternsFunction } from "./functions/patterns.js";
 import { registerRememberFunction } from "./functions/remember.js";
 import { registerEvictFunction } from "./functions/evict.js";
+import { registerSessionSweepFunction } from "./functions/session-sweep.js";
 import { registerRelationsFunction } from "./functions/relations.js";
 import { registerTimelineFunction } from "./functions/timeline.js";
 import { registerSmartSearchFunction } from "./functions/smart-search.js";
@@ -251,6 +252,7 @@ async function main() {
   registerPatternsFunction(sdk, kv);
   registerRememberFunction(sdk, kv);
   registerEvictFunction(sdk, kv);
+  registerSessionSweepFunction(sdk, kv);
 
   registerRelationsFunction(sdk, kv);
   registerTimelineFunction(sdk, kv);
@@ -561,6 +563,18 @@ async function main() {
     }, autoForgetIntervalMs);
     autoForgetTimer.unref();
     bootLog(`Auto-forget: enabled (every ${autoForgetIntervalMs / 60000}m)`);
+  }
+
+  const sessionSweepIntervalMs = parseInt(process.env.SESSION_SWEEP_INTERVAL_MS || "900000", 10);
+
+  if (process.env.SESSION_SWEEP_ENABLED !== "false") {
+    const sessionSweepTimer = setInterval(async () => {
+      try {
+        await sdk.trigger({ function_id: "mem::session-sweep", payload: { dryRun: false } });
+      } catch {}
+    }, sessionSweepIntervalMs);
+    sessionSweepTimer.unref();
+    bootLog(`Session sweep: enabled (every ${sessionSweepIntervalMs / 60000}m)`);
   }
 
   if (process.env.LESSON_DECAY_ENABLED !== "false") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import {
   isConsolidationEnabled,
   isContextInjectionEnabled,
   isDropStaleIndexEnabled,
+  getSessionSweepIntervalMs,
 } from "./config.js";
 import {
   createProvider,
@@ -565,12 +566,7 @@ async function main() {
     bootLog(`Auto-forget: enabled (every ${autoForgetIntervalMs / 60000}m)`);
   }
 
-  // Clamped: setInterval treats NaN or 0 as ~1ms, which would run the sweep in
-  // a hot loop. A floor of one minute keeps a bad env var from doing that.
-  const parsedSweepInterval = parseInt(process.env.SESSION_SWEEP_INTERVAL_MS || "900000", 10);
-  const sessionSweepIntervalMs = Number.isFinite(parsedSweepInterval)
-    ? Math.max(parsedSweepInterval, 60000)
-    : 900000;
+  const sessionSweepIntervalMs = getSessionSweepIntervalMs();
 
   if (process.env.SESSION_SWEEP_ENABLED !== "false") {
     const sessionSweepTimer = setInterval(async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -565,12 +565,17 @@ async function main() {
     bootLog(`Auto-forget: enabled (every ${autoForgetIntervalMs / 60000}m)`);
   }
 
-  const sessionSweepIntervalMs = parseInt(process.env.SESSION_SWEEP_INTERVAL_MS || "900000", 10);
+  // Clamped: setInterval treats NaN or 0 as ~1ms, which would run the sweep in
+  // a hot loop. A floor of one minute keeps a bad env var from doing that.
+  const parsedSweepInterval = parseInt(process.env.SESSION_SWEEP_INTERVAL_MS || "900000", 10);
+  const sessionSweepIntervalMs = Number.isFinite(parsedSweepInterval)
+    ? Math.max(parsedSweepInterval, 60000)
+    : 900000;
 
   if (process.env.SESSION_SWEEP_ENABLED !== "false") {
     const sessionSweepTimer = setInterval(async () => {
       try {
-        await sdk.trigger({ function_id: "mem::session-sweep", payload: { dryRun: false } });
+        await sdk.trigger({ function_id: "mem::session-sweep", payload: {} });
       } catch {}
     }, sessionSweepIntervalMs);
     sessionSweepTimer.unref();

--- a/src/index.ts
+++ b/src/index.ts
@@ -538,7 +538,7 @@ async function main() {
     `Ready. ${embeddingProvider ? "Triple-stream (BM25+Vector+Graph)" : "BM25+Graph"} search active.`,
   );
   bootLog(
-    `REST API: 130 endpoints at http://localhost:${config.restPort}/agentmemory/*`,
+    `REST API: 131 endpoints at http://localhost:${config.restPort}/agentmemory/*`,
   );
   bootLog(
     `MCP surface (opt-in via \`npx @agentmemory/mcp\`): ${getAllTools().length} tools · 6 resources · 3 prompts`,

--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -1176,6 +1176,37 @@ export function registerApiTriggers(
     config: { api_path: "/agentmemory/evict", http_method: "POST" },
   });
 
+  sdk.registerFunction("api::session-sweep",
+    async (
+      req: ApiRequest<{ dryRun?: boolean; idleMinutes?: number }>,
+    ): Promise<Response> => {
+      const authErr = checkAuth(req, secret);
+      if (authErr) return authErr;
+      const dryRun =
+        req.query_params?.["dryRun"] === "true" || req.body?.dryRun === true;
+      // Whitelisted, never the raw body. mem::session-sweep re-validates and
+      // falls back to its default for anything non-finite or non-positive.
+      const rawIdle =
+        req.query_params?.["idleMinutes"] ?? req.body?.idleMinutes;
+      const idleMinutes = Number(rawIdle);
+      const result = await sdk.trigger({
+        function_id: "mem::session-sweep",
+        payload: {
+          dryRun,
+          ...(Number.isFinite(idleMinutes) && idleMinutes > 0
+            ? { idleMinutes }
+            : {}),
+        },
+      });
+      return { status_code: 200, body: result };
+    },
+  );
+  sdk.registerTrigger({
+    type: "http",
+    function_id: "api::session-sweep",
+    config: { api_path: "/agentmemory/session-sweep", http_method: "POST" },
+  });
+
   sdk.registerFunction("api::smart-search",
     async (
       req: ApiRequest<{

--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -1176,20 +1176,6 @@ export function registerApiTriggers(
     config: { api_path: "/agentmemory/evict", http_method: "POST" },
   });
 
-  // Exported shape is deliberately narrow: only a real number, or a numeric
-  // string (query params arrive as strings). Booleans, arrays, objects, and
-  // blank strings return undefined so the sweep uses its own default.
-  const coerceIdleMinutes = (raw: unknown): number | undefined => {
-    if (typeof raw === "number") {
-      return Number.isFinite(raw) && raw > 0 ? raw : undefined;
-    }
-    if (typeof raw === "string" && raw.trim() !== "") {
-      const parsed = Number(raw);
-      return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
-    }
-    return undefined;
-  };
-
   sdk.registerFunction("api::session-sweep",
     async (
       req: ApiRequest<{ dryRun?: boolean; idleMinutes?: number }>,
@@ -1198,13 +1184,19 @@ export function registerApiTriggers(
       if (authErr) return authErr;
       const dryRun =
         req.query_params?.["dryRun"] === "true" || req.body?.dryRun === true;
-      // Whitelisted, never the raw body. Numbers from the body and numeric
-      // strings from the query only: Number(true) is 1 and Number(["5"]) is 5,
-      // so a bare Number() would turn {"idleMinutes": true} into a one-minute
-      // threshold and sweep nearly every active session.
-      const idleMinutes = coerceIdleMinutes(
+      // Whitelisted, never the raw body. parseOptionalPositiveInt rejects
+      // booleans, arrays, and objects outright, which a bare Number() would
+      // not: Number(true) is 1, so {"idleMinutes": true} would otherwise ask
+      // for a one-minute threshold and sweep nearly every active session.
+      const idleMinutes = parseOptionalPositiveInt(
         req.body?.idleMinutes ?? req.query_params?.["idleMinutes"],
       );
+      if (idleMinutes === null) {
+        return {
+          status_code: 400,
+          body: { error: "idleMinutes must be a positive integer" },
+        };
+      }
       const result = await sdk.trigger({
         function_id: "mem::session-sweep",
         payload: {

--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -1176,6 +1176,20 @@ export function registerApiTriggers(
     config: { api_path: "/agentmemory/evict", http_method: "POST" },
   });
 
+  // Exported shape is deliberately narrow: only a real number, or a numeric
+  // string (query params arrive as strings). Booleans, arrays, objects, and
+  // blank strings return undefined so the sweep uses its own default.
+  const coerceIdleMinutes = (raw: unknown): number | undefined => {
+    if (typeof raw === "number") {
+      return Number.isFinite(raw) && raw > 0 ? raw : undefined;
+    }
+    if (typeof raw === "string" && raw.trim() !== "") {
+      const parsed = Number(raw);
+      return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+    }
+    return undefined;
+  };
+
   sdk.registerFunction("api::session-sweep",
     async (
       req: ApiRequest<{ dryRun?: boolean; idleMinutes?: number }>,
@@ -1184,18 +1198,18 @@ export function registerApiTriggers(
       if (authErr) return authErr;
       const dryRun =
         req.query_params?.["dryRun"] === "true" || req.body?.dryRun === true;
-      // Whitelisted, never the raw body. mem::session-sweep re-validates and
-      // falls back to its default for anything non-finite or non-positive.
-      const rawIdle =
-        req.query_params?.["idleMinutes"] ?? req.body?.idleMinutes;
-      const idleMinutes = Number(rawIdle);
+      // Whitelisted, never the raw body. Numbers from the body and numeric
+      // strings from the query only: Number(true) is 1 and Number(["5"]) is 5,
+      // so a bare Number() would turn {"idleMinutes": true} into a one-minute
+      // threshold and sweep nearly every active session.
+      const idleMinutes = coerceIdleMinutes(
+        req.body?.idleMinutes ?? req.query_params?.["idleMinutes"],
+      );
       const result = await sdk.trigger({
         function_id: "mem::session-sweep",
         payload: {
           dryRun,
-          ...(Number.isFinite(idleMinutes) && idleMinutes > 0
-            ? { idleMinutes }
-            : {}),
+          ...(idleMinutes !== undefined ? { idleMinutes } : {}),
         },
       });
       return { status_code: 200, body: result };

--- a/src/triggers/events.ts
+++ b/src/triggers/events.ts
@@ -154,9 +154,11 @@ export function registerEventTriggers(sdk: ISdk, kv: StateKV): void {
 
   sdk.registerFunction(
     "event::session::ended",
-    async (data: { sessionId: string }) => {
+    async (data: { sessionId: string; endedAt?: string }) => {
+      // endedAt is overridable so a sweep can record when the session actually
+      // went quiet rather than when it was noticed.
       await kv.update(KV.sessions, data.sessionId, [
-        { type: "set", path: "endedAt", value: new Date().toISOString() },
+        { type: "set", path: "endedAt", value: data.endedAt ?? new Date().toISOString() },
         { type: "set", path: "status", value: "completed" },
       ]);
       return { success: true };

--- a/src/triggers/events.ts
+++ b/src/triggers/events.ts
@@ -156,9 +156,16 @@ export function registerEventTriggers(sdk: ISdk, kv: StateKV): void {
     "event::session::ended",
     async (data: { sessionId: string; endedAt?: string }) => {
       // endedAt is overridable so a sweep can record when the session actually
-      // went quiet rather than when it was noticed.
+      // went quiet rather than when it was noticed. Validated because this is
+      // also a durable subscriber: the viewer derives session duration from
+      // this field, so an unparseable value would render as a bogus duration.
+      const supplied =
+        typeof data.endedAt === "string" &&
+        Number.isFinite(new Date(data.endedAt).getTime())
+          ? data.endedAt
+          : undefined;
       await kv.update(KV.sessions, data.sessionId, [
-        { type: "set", path: "endedAt", value: data.endedAt ?? new Date().toISOString() },
+        { type: "set", path: "endedAt", value: supplied ?? new Date().toISOString() },
         { type: "set", path: "status", value: "completed" },
       ]);
       return { success: true };

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,9 @@ export interface Session {
   cwd: string;
   startedAt: string;
   endedAt?: string;
+  // Stamped on every observation (src/functions/observe.ts); the inactivity
+  // signal mem::session-sweep ages sessions by.
+  updatedAt?: string;
   status: "active" | "completed" | "abandoned";
   observationCount: number;
   model?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -625,6 +625,7 @@ export interface AuditEntry {
     | "reflect"
     | "insight_search"
     | "skill_extract"
+    | "session_sweep"
     | "core_add"
     | "core_remove"
     | "auto_page"

--- a/test/events-session-ended.test.ts
+++ b/test/events-session-ended.test.ts
@@ -68,6 +68,31 @@ describe("event::session::ended", () => {
     });
   });
 
+  it.each([
+    ["garbage", "not-a-date"],
+    ["empty", ""],
+    ["a number", 1756600000000],
+    ["null", null],
+    ["an object", { when: "yesterday" }],
+  ])("ignores an unusable endedAt (%s)", async (_label, bad) => {
+    // This handler is also a durable subscriber, so the payload is untrusted.
+    // The viewer derives duration from endedAt; a bogus value renders as a
+    // bogus duration.
+    const { handlers, update } = harness();
+    const before = Date.now();
+
+    await handlers.get("event::session::ended")!({
+      sessionId: "ses_bad",
+      endedAt: bad,
+    });
+
+    const stamp = updatesFrom(update).find((u) => u.path === "endedAt")!
+      .value as string;
+    const parsed = new Date(stamp).getTime();
+    expect(Number.isFinite(parsed)).toBe(true);
+    expect(parsed).toBeGreaterThanOrEqual(before);
+  });
+
   it("falls back to now when no endedAt is supplied", async () => {
     const { handlers, update } = harness();
     const before = Date.now();

--- a/test/events-session-ended.test.ts
+++ b/test/events-session-ended.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../src/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock("../src/config.js", () => ({
+  getAgentId: vi.fn(() => undefined),
+  isConsolidationEnabled: vi.fn(() => false),
+  isGraphExtractionEnabled: vi.fn(() => false),
+  getConsolidationCooldownMs: vi.fn(() => 300000),
+}));
+vi.mock("../src/functions/slots.js", () => ({
+  isReflectEnabled: vi.fn(() => false),
+}));
+
+import { registerEventTriggers } from "../src/triggers/events.js";
+
+type Handler = (data: unknown) => Promise<unknown>;
+type Update = { type: string; path: string; value: unknown };
+
+function harness() {
+  const handlers = new Map<string, Handler>();
+  const update = vi.fn(async () => {});
+  const kv = {
+    get: vi.fn(async () => null),
+    set: vi.fn(async (_s: string, _k: string, data: unknown) => data),
+    delete: vi.fn(async () => {}),
+    update,
+    list: vi.fn(async () => []),
+  };
+  const sdk = {
+    registerFunction: (id: string, handler: Handler) => {
+      handlers.set(id, handler);
+    },
+    registerTrigger: () => {},
+    trigger: vi.fn(async () => ({ success: true })),
+  };
+  registerEventTriggers(sdk as never, kv as never);
+  return { handlers, update };
+}
+
+function updatesFrom(update: ReturnType<typeof vi.fn>): Update[] {
+  return update.mock.calls[0]![2] as Update[];
+}
+
+describe("event::session::ended", () => {
+  it("uses a caller-supplied endedAt", async () => {
+    // mem::session-sweep passes the session's last activity so an idle session
+    // is not recorded as having run until the moment the sweep noticed it.
+    const { handlers, update } = harness();
+    const lastActivity = "2026-08-20T09:15:00.000Z";
+
+    await handlers.get("event::session::ended")!({
+      sessionId: "ses_x",
+      endedAt: lastActivity,
+    });
+
+    const updates = updatesFrom(update);
+    expect(updates).toContainEqual({
+      type: "set",
+      path: "endedAt",
+      value: lastActivity,
+    });
+    expect(updates).toContainEqual({
+      type: "set",
+      path: "status",
+      value: "completed",
+    });
+  });
+
+  it("falls back to now when no endedAt is supplied", async () => {
+    const { handlers, update } = harness();
+    const before = Date.now();
+
+    await handlers.get("event::session::ended")!({ sessionId: "ses_y" });
+
+    const stamp = updatesFrom(update).find((u) => u.path === "endedAt")!
+      .value as string;
+    const parsed = new Date(stamp).getTime();
+    expect(parsed).toBeGreaterThanOrEqual(before);
+    expect(parsed).toBeLessThanOrEqual(Date.now());
+  });
+});

--- a/test/session-sweep-interval.test.ts
+++ b/test/session-sweep-interval.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { getSessionSweepIntervalMs } from "../src/config.js";
+
+const KEY = "SESSION_SWEEP_INTERVAL_MS";
+const DEFAULT_MS = 900_000;
+const MIN_MS = 60_000;
+const TIMER_MAX_MS = 2_147_483_647;
+
+afterEach(() => {
+  delete process.env[KEY];
+});
+
+describe("getSessionSweepIntervalMs", () => {
+  it("defaults when unset", () => {
+    expect(getSessionSweepIntervalMs()).toBe(DEFAULT_MS);
+  });
+
+  it("passes a sane value through", () => {
+    process.env[KEY] = "300000";
+    expect(getSessionSweepIntervalMs()).toBe(300_000);
+  });
+
+  it.each(["", "abc", "NaN"])(
+    "falls back rather than yielding NaN for %j",
+    (raw) => {
+      // setInterval treats a NaN delay as ~1ms, which would run the sweep in a
+      // hot loop.
+      process.env[KEY] = raw;
+      const ms = getSessionSweepIntervalMs();
+      expect(Number.isFinite(ms)).toBe(true);
+      expect(ms).toBeGreaterThanOrEqual(MIN_MS);
+    },
+  );
+
+  it.each(["0", "-1", "1000"])("floors a too-small value (%s)", (raw) => {
+    process.env[KEY] = raw;
+    expect(getSessionSweepIntervalMs()).toBe(MIN_MS);
+  });
+
+  it("caps a value above Node's maximum timer delay", () => {
+    // Above 2^31-1 setInterval also collapses to ~1ms, so too-large fails the
+    // same way garbage does.
+    process.env[KEY] = "99999999999";
+    expect(getSessionSweepIntervalMs()).toBe(TIMER_MAX_MS);
+  });
+});

--- a/test/session-sweep.test.ts
+++ b/test/session-sweep.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Session } from "../src/types.js";
+import { registerSessionSweepFunction } from "../src/functions/session-sweep.js";
+import { KV } from "../src/state/schema.js";
+
+vi.mock("../src/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+type Store = Map<string, Map<string, unknown>>;
+type Handler = (payload: unknown) => unknown | Promise<unknown>;
+
+function minutesAgo(minutes: number): string {
+  return new Date(Date.now() - minutes * 60 * 1000).toISOString();
+}
+
+function makeSession(id: string, overrides: Partial<Session> = {}): Session {
+  return {
+    id,
+    project: "agentmemory",
+    cwd: "/repo/agentmemory",
+    startedAt: minutesAgo(600),
+    updatedAt: minutesAgo(600),
+    status: "active",
+    observationCount: 1,
+    ...overrides,
+  };
+}
+
+function mockKV(store: Store) {
+  return {
+    get: async <T>(scope: string, key: string): Promise<T | null> =>
+      (store.get(scope)?.get(key) as T) ?? null,
+    set: async <T>(scope: string, key: string, data: T): Promise<T> => {
+      if (!store.has(scope)) store.set(scope, new Map());
+      store.get(scope)!.set(key, data);
+      return data;
+    },
+    delete: async (scope: string, key: string): Promise<void> => {
+      store.get(scope)?.delete(key);
+    },
+    list: async <T>(scope: string): Promise<T[]> => {
+      const entries = store.get(scope);
+      return entries ? (Array.from(entries.values()) as T[]) : [];
+    },
+  };
+}
+
+/**
+ * Stands in for the two lifecycle functions the sweep fans out to.
+ * `event::session::ended` mutates the stored session the way the real handler
+ * does, so assertions can read terminal state out of the store.
+ */
+function mockSdk(store: Store, opts: { endFails?: boolean } = {}) {
+  const handlers = new Map<string, Handler>();
+  const calls: Array<{ function_id: string; payload: unknown }> = [];
+
+  handlers.set("event::session::ended", async (payload) => {
+    if (opts.endFails) throw new Error("ended trigger failed");
+    const { sessionId } = payload as { sessionId: string };
+    const session = store.get(KV.sessions)?.get(sessionId) as Session;
+    if (session) {
+      session.status = "completed";
+      session.endedAt = new Date().toISOString();
+    }
+    return { success: true };
+  });
+  handlers.set("event::session::stopped", async () => ({ success: true }));
+
+  return {
+    calls,
+    sdk: {
+      registerFunction: (functionId: string, handler: Handler) => {
+        handlers.set(functionId, handler);
+      },
+      trigger: async (input: { function_id: string; payload: unknown }) => {
+        calls.push(input);
+        const handler = handlers.get(input.function_id);
+        if (!handler) throw new Error(`missing handler: ${input.function_id}`);
+        return handler(input.payload);
+      },
+    },
+  };
+}
+
+function storeWith(sessions: Session[]): Store {
+  const store: Store = new Map();
+  const sessionMap = new Map<string, unknown>();
+  for (const s of sessions) sessionMap.set(s.id, s);
+  store.set(KV.sessions, sessionMap);
+  return store;
+}
+
+async function runSweep(
+  store: Store,
+  payload: Record<string, unknown> = {},
+  opts: { endFails?: boolean } = {},
+) {
+  const { sdk, calls } = mockSdk(store, opts);
+  registerSessionSweepFunction(sdk as never, mockKV(store) as never);
+  const result = (await sdk.trigger({
+    function_id: "mem::session-sweep",
+    payload,
+  })) as { candidates: number; swept: number; dryRun: boolean };
+  return { result, calls };
+}
+
+describe("mem::session-sweep", () => {
+  it("completes a session idle past the threshold", async () => {
+    const store = storeWith([makeSession("ses_idle")]);
+
+    const { result } = await runSweep(store);
+
+    expect(result.swept).toBe(1);
+    const session = store.get(KV.sessions)!.get("ses_idle") as Session;
+    expect(session.status).toBe("completed");
+    expect(session.endedAt).toBeTruthy();
+  });
+
+  it("leaves a recently active session alone", async () => {
+    const store = storeWith([
+      makeSession("ses_fresh", { updatedAt: minutesAgo(5) }),
+    ]);
+
+    const { result } = await runSweep(store);
+
+    expect(result.candidates).toBe(0);
+    expect(result.swept).toBe(0);
+    expect((store.get(KV.sessions)!.get("ses_fresh") as Session).status).toBe(
+      "active",
+    );
+  });
+
+  it("ignores sessions that are already completed", async () => {
+    const store = storeWith([
+      makeSession("ses_done", { status: "completed" }),
+      makeSession("ses_abandoned", { status: "abandoned" }),
+    ]);
+
+    const { result } = await runSweep(store);
+
+    expect(result.candidates).toBe(0);
+    expect(result.swept).toBe(0);
+  });
+
+  it("ages a session by startedAt when updatedAt is absent", async () => {
+    // Sessions created by POST /session/start carry no updatedAt until their
+    // first observation lands, so the fallback has to hold.
+    const store = storeWith([
+      makeSession("ses_no_updated", { updatedAt: undefined }),
+    ]);
+
+    const { result } = await runSweep(store);
+
+    expect(result.swept).toBe(1);
+  });
+
+  it("skips a session whose timestamps cannot be parsed", async () => {
+    const store = storeWith([
+      makeSession("ses_bad", {
+        startedAt: "not-a-date",
+        updatedAt: undefined,
+      }),
+    ]);
+
+    const { result } = await runSweep(store);
+
+    expect(result.candidates).toBe(0);
+    expect((store.get(KV.sessions)!.get("ses_bad") as Session).status).toBe(
+      "active",
+    );
+  });
+
+  it("counts candidates but changes nothing on a dry run", async () => {
+    const store = storeWith([makeSession("ses_idle")]);
+
+    const { result, calls } = await runSweep(store, { dryRun: true });
+
+    expect(result.candidates).toBe(1);
+    expect(result.swept).toBe(0);
+    expect((store.get(KV.sessions)!.get("ses_idle") as Session).status).toBe(
+      "active",
+    );
+    expect(calls.some((c) => c.function_id === "event::session::ended")).toBe(
+      false,
+    );
+  });
+
+  it("honours an idleMinutes override from the payload", async () => {
+    const store = storeWith([
+      makeSession("ses_recent", { updatedAt: minutesAgo(30) }),
+    ]);
+
+    const untouched = await runSweep(store, { idleMinutes: 120 });
+    expect(untouched.result.swept).toBe(0);
+
+    const swept = await runSweep(store, { idleMinutes: 10 });
+    expect(swept.result.swept).toBe(1);
+  });
+
+  it("caps how many sessions one run ends", async () => {
+    const sessions = Array.from({ length: 30 }, (_, i) =>
+      makeSession(`ses_${i}`),
+    );
+    const store = storeWith(sessions);
+
+    const { result } = await runSweep(store);
+
+    // Default maxPerRun is 25; every idle session is still counted.
+    expect(result.candidates).toBe(30);
+    expect(result.swept).toBe(25);
+  });
+
+  it("reads idleMinutes and maxPerRun overrides from stored config", async () => {
+    const store = storeWith([
+      makeSession("ses_a", { updatedAt: minutesAgo(30) }),
+      makeSession("ses_b", { updatedAt: minutesAgo(30) }),
+    ]);
+    store.set(
+      KV.config,
+      new Map<string, unknown>([
+        ["sessionSweep", { idleMinutes: 10, maxPerRun: 1 }],
+      ]),
+    );
+
+    const { result } = await runSweep(store);
+
+    expect(result.candidates).toBe(2);
+    expect(result.swept).toBe(1);
+  });
+
+  it("fans out a summary with consolidation suppressed", async () => {
+    const store = storeWith([makeSession("ses_idle")]);
+
+    const { calls } = await runSweep(store);
+
+    const stopped = calls.find(
+      (c) => c.function_id === "event::session::stopped",
+    );
+    expect(stopped).toBeTruthy();
+    expect(stopped!.payload).toEqual({
+      sessionId: "ses_idle",
+      skipConsolidation: true,
+    });
+  });
+
+  it("keeps sweeping after one session fails to end", async () => {
+    const store = storeWith([makeSession("ses_a"), makeSession("ses_b")]);
+
+    const { result } = await runSweep(store, {}, { endFails: true });
+
+    expect(result.candidates).toBe(2);
+    expect(result.swept).toBe(0);
+    expect((store.get(KV.sessions)!.get("ses_b") as Session).status).toBe(
+      "active",
+    );
+  });
+});

--- a/test/session-sweep.test.ts
+++ b/test/session-sweep.test.ts
@@ -333,7 +333,7 @@ describe("mem::session-sweep", () => {
     );
   });
 
-  it("caps attempts, not successes, when every end fails", async () => {
+  it("bounds a run by candidates, so a failing backlog is not retried whole", async () => {
     const sessions = Array.from({ length: 30 }, (_, i) =>
       makeSession(`ses_${i}`),
     );
@@ -341,7 +341,8 @@ describe("mem::session-sweep", () => {
 
     const { calls } = await runSweep(store, {}, { endFails: true });
 
-    // Without an attempt-based cap a failing backlog retries the whole list.
+    // The cap is on candidates, not successes, so a backlog where every end
+    // fails is still bounded rather than retried in full every run.
     const endCalls = calls.filter(
       (c) => c.function_id === "event::session::ended",
     );

--- a/test/session-sweep.test.ts
+++ b/test/session-sweep.test.ts
@@ -19,8 +19,9 @@ function makeSession(id: string, overrides: Partial<Session> = {}): Session {
     id,
     project: "agentmemory",
     cwd: "/repo/agentmemory",
-    startedAt: minutesAgo(600),
-    updatedAt: minutesAgo(600),
+    // Comfortably past the 1440-minute (one day) default threshold.
+    startedAt: minutesAgo(3000),
+    updatedAt: minutesAgo(3000),
     status: "active",
     observationCount: 1,
     ...overrides,
@@ -51,21 +52,31 @@ function mockKV(store: Store) {
  * `event::session::ended` mutates the stored session the way the real handler
  * does, so assertions can read terminal state out of the store.
  */
-function mockSdk(store: Store, opts: { endFails?: boolean } = {}) {
+function mockSdk(
+  store: Store,
+  opts: { endFails?: boolean; stoppedFails?: boolean } = {},
+) {
   const handlers = new Map<string, Handler>();
   const calls: Array<{ function_id: string; payload: unknown }> = [];
 
   handlers.set("event::session::ended", async (payload) => {
     if (opts.endFails) throw new Error("ended trigger failed");
-    const { sessionId } = payload as { sessionId: string };
+    const { sessionId, endedAt } = payload as {
+      sessionId: string;
+      endedAt?: string;
+    };
     const session = store.get(KV.sessions)?.get(sessionId) as Session;
     if (session) {
       session.status = "completed";
-      session.endedAt = new Date().toISOString();
+      // Mirrors src/triggers/events.ts: caller-supplied endedAt wins.
+      session.endedAt = endedAt ?? new Date().toISOString();
     }
     return { success: true };
   });
-  handlers.set("event::session::stopped", async () => ({ success: true }));
+  handlers.set("event::session::stopped", async () => {
+    if (opts.stoppedFails) throw new Error("stopped trigger failed");
+    return { success: true };
+  });
 
   return {
     calls,
@@ -94,7 +105,7 @@ function storeWith(sessions: Session[]): Store {
 async function runSweep(
   store: Store,
   payload: Record<string, unknown> = {},
-  opts: { endFails?: boolean } = {},
+  opts: { endFails?: boolean; stoppedFails?: boolean } = {},
 ) {
   const { sdk, calls } = mockSdk(store, opts);
   registerSessionSweepFunction(sdk as never, mockKV(store) as never);
@@ -272,6 +283,61 @@ describe("mem::session-sweep", () => {
       sessionId: "ses_idle",
       skipConsolidation: true,
     });
+  });
+
+  it("leaves a session sitting exactly on the threshold alone", async () => {
+    // The comparison is `<=`, so equality must NOT sweep. Without this the
+    // boundary is untested and `<=` vs `<` is a silent change.
+    const store = storeWith([makeSession("ses_edge")]);
+    const session = store.get(KV.sessions)!.get("ses_edge") as Session;
+    const idleMinutes = 90;
+    session.updatedAt = new Date(
+      Date.now() - idleMinutes * 60 * 1000,
+    ).toISOString();
+
+    const { result } = await runSweep(store, { idleMinutes });
+
+    expect(result.candidates).toBe(0);
+    expect(session.status).toBe("active");
+  });
+
+  it("records the last activity as endedAt, not the sweep time", async () => {
+    const store = storeWith([makeSession("ses_idle")]);
+    const before = store.get(KV.sessions)!.get("ses_idle") as Session;
+    const lastSeen = before.updatedAt;
+
+    await runSweep(store);
+
+    const session = store.get(KV.sessions)!.get("ses_idle") as Session;
+    expect(session.endedAt).toBe(lastSeen);
+  });
+
+  it("survives a rejected summary fan-out", async () => {
+    // The fan-out is deliberately not awaited, so its rejection must be caught
+    // or it surfaces as an unhandled rejection.
+    const store = storeWith([makeSession("ses_idle")]);
+
+    const { result } = await runSweep(store, {}, { stoppedFails: true });
+
+    expect(result.swept).toBe(1);
+    expect((store.get(KV.sessions)!.get("ses_idle") as Session).status).toBe(
+      "completed",
+    );
+  });
+
+  it("caps attempts, not successes, when every end fails", async () => {
+    const sessions = Array.from({ length: 30 }, (_, i) =>
+      makeSession(`ses_${i}`),
+    );
+    const store = storeWith(sessions);
+
+    const { calls } = await runSweep(store, {}, { endFails: true });
+
+    // Without an attempt-based cap a failing backlog retries the whole list.
+    const endCalls = calls.filter(
+      (c) => c.function_id === "event::session::ended",
+    );
+    expect(endCalls).toHaveLength(25);
   });
 
   it("keeps sweeping after one session fails to end", async () => {

--- a/test/session-sweep.test.ts
+++ b/test/session-sweep.test.ts
@@ -42,7 +42,15 @@ function mockKV(store: Store) {
     },
     list: async <T>(scope: string): Promise<T[]> => {
       const entries = store.get(scope);
-      return entries ? (Array.from(entries.values()) as T[]) : [];
+      // Clone, because the real StateKV.list is an SDK round-trip returning
+      // fresh objects. Handing back live references would let a test's later
+      // mutation retroactively change the snapshot the sweep already read,
+      // which hides the whole stale-snapshot class of bug.
+      return entries
+        ? (Array.from(entries.values()).map((v) =>
+            v && typeof v === "object" ? { ...(v as object) } : v,
+          ) as T[])
+        : [];
     },
   };
 }
@@ -383,6 +391,34 @@ describe("mem::session-sweep", () => {
     expect((await first).swept).toBe(1);
   });
 
+  it("skips a session another writer completed since the list snapshot", async () => {
+    // The list snapshot can be stale by the time a given row is reached. Ending
+    // an already-completed session would cost a duplicate audit row and a
+    // duplicate summarize.
+    const store = storeWith([makeSession("ses_a"), makeSession("ses_b")]);
+    const { sdk, calls } = mockSdk(store);
+    const kv = mockKV(store);
+    const realList = kv.list.bind(kv);
+    kv.list = (async <T>(scope: string): Promise<T[]> => {
+      const rows = await realList<T>(scope);
+      // Hand back the snapshot, then complete one row behind the sweep's back.
+      (store.get(KV.sessions)!.get("ses_b") as Session).status = "completed";
+      return rows;
+    }) as typeof kv.list;
+    registerSessionSweepFunction(sdk as never, kv as never);
+
+    const result = (await sdk.trigger({
+      function_id: "mem::session-sweep",
+      payload: {},
+    })) as { candidates: number; swept: number };
+
+    expect(result.swept).toBe(1);
+    const ended = calls
+      .filter((c) => c.function_id === "event::session::ended")
+      .map((c) => (c.payload as { sessionId: string }).sessionId);
+    expect(ended).toEqual(["ses_a"]);
+  });
+
   it("releases the in-flight guard so the next run proceeds", async () => {
     // A guard that is never released turns the sweep into a one-shot: it would
     // run once at boot and never again.
@@ -408,40 +444,6 @@ describe("mem::session-sweep", () => {
 
     expect(second.skipped).toBeUndefined();
     expect(second.swept).toBe(1);
-  });
-
-  it("releases the guard even when the run throws", async () => {
-    const store = storeWith([makeSession("ses_a")]);
-    const { sdk } = mockSdk(store);
-    registerSessionSweepFunction(sdk as never, mockKV(store) as never);
-
-    const kvThatThrows = {
-      ...mockKV(store),
-      list: async () => {
-        throw new Error("boom");
-      },
-    };
-    const { sdk: sdk2 } = mockSdk(store);
-    registerSessionSweepFunction(sdk2 as never, kvThatThrows as never);
-
-    // kv.list has its own .catch, so the run completes; the point is that a
-    // second run is not locked out afterwards.
-    await sdk2.trigger({ function_id: "mem::session-sweep", payload: {} });
-    const second = (await sdk2.trigger({
-      function_id: "mem::session-sweep",
-      payload: {},
-    })) as { skipped?: true };
-
-    expect(second.skipped).toBeUndefined();
-  });
-
-  it("lets a dry run proceed alongside a real one", async () => {
-    const store = storeWith([makeSession("ses_idle")]);
-
-    const { result } = await runSweep(store, { dryRun: true });
-
-    expect(result.skipped).toBeUndefined();
-    expect(result.candidates).toBe(1);
   });
 
   it("keeps sweeping after one session fails to end", async () => {

--- a/test/session-sweep.test.ts
+++ b/test/session-sweep.test.ts
@@ -340,6 +340,110 @@ describe("mem::session-sweep", () => {
     expect(endCalls).toHaveLength(25);
   });
 
+  it("skips a run while another is still in flight", async () => {
+    // setInterval does not await its callback, and engine calls do time out
+    // under load. Two overlapping runs would each fan out a summarize for the
+    // same session, paying for the LLM pass twice.
+    const store = storeWith([makeSession("ses_idle")]);
+    const { sdk } = mockSdk(store);
+    registerSessionSweepFunction(sdk as never, mockKV(store) as never);
+
+    let releaseFirst: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const original = sdk.trigger;
+    let held = false;
+    sdk.trigger = (async (input: {
+      function_id: string;
+      payload: unknown;
+    }) => {
+      if (input.function_id === "event::session::ended" && !held) {
+        held = true;
+        await gate;
+      }
+      return original(input);
+    }) as typeof sdk.trigger;
+
+    const first = sdk.trigger({
+      function_id: "mem::session-sweep",
+      payload: {},
+    }) as Promise<{ swept: number }>;
+    // Let the first run reach the held trigger before starting the second.
+    await new Promise((r) => setTimeout(r, 0));
+    const second = (await sdk.trigger({
+      function_id: "mem::session-sweep",
+      payload: {},
+    })) as { swept: number; skipped?: true };
+
+    expect(second.skipped).toBe(true);
+    expect(second.swept).toBe(0);
+
+    releaseFirst();
+    expect((await first).swept).toBe(1);
+  });
+
+  it("releases the in-flight guard so the next run proceeds", async () => {
+    // A guard that is never released turns the sweep into a one-shot: it would
+    // run once at boot and never again.
+    const store = storeWith([
+      makeSession("ses_a"),
+      makeSession("ses_b", { status: "completed" }),
+    ]);
+    const { sdk } = mockSdk(store);
+    registerSessionSweepFunction(sdk as never, mockKV(store) as never);
+
+    const first = (await sdk.trigger({
+      function_id: "mem::session-sweep",
+      payload: {},
+    })) as { swept: number; skipped?: true };
+    expect(first.swept).toBe(1);
+
+    // Re-open ses_b so the second run has something to do.
+    (store.get(KV.sessions)!.get("ses_b") as Session).status = "active";
+    const second = (await sdk.trigger({
+      function_id: "mem::session-sweep",
+      payload: {},
+    })) as { swept: number; skipped?: true };
+
+    expect(second.skipped).toBeUndefined();
+    expect(second.swept).toBe(1);
+  });
+
+  it("releases the guard even when the run throws", async () => {
+    const store = storeWith([makeSession("ses_a")]);
+    const { sdk } = mockSdk(store);
+    registerSessionSweepFunction(sdk as never, mockKV(store) as never);
+
+    const kvThatThrows = {
+      ...mockKV(store),
+      list: async () => {
+        throw new Error("boom");
+      },
+    };
+    const { sdk: sdk2 } = mockSdk(store);
+    registerSessionSweepFunction(sdk2 as never, kvThatThrows as never);
+
+    // kv.list has its own .catch, so the run completes; the point is that a
+    // second run is not locked out afterwards.
+    await sdk2.trigger({ function_id: "mem::session-sweep", payload: {} });
+    const second = (await sdk2.trigger({
+      function_id: "mem::session-sweep",
+      payload: {},
+    })) as { skipped?: true };
+
+    expect(second.skipped).toBeUndefined();
+  });
+
+  it("lets a dry run proceed alongside a real one", async () => {
+    const store = storeWith([makeSession("ses_idle")]);
+
+    const { result } = await runSweep(store, { dryRun: true });
+
+    expect(result.skipped).toBeUndefined();
+    expect(result.candidates).toBe(1);
+  });
+
   it("keeps sweeping after one session fails to end", async () => {
     const store = storeWith([makeSession("ses_a"), makeSession("ses_b")]);
 

--- a/test/session-sweep.test.ts
+++ b/test/session-sweep.test.ts
@@ -211,22 +211,52 @@ describe("mem::session-sweep", () => {
     expect(result.swept).toBe(25);
   });
 
-  it("reads idleMinutes and maxPerRun overrides from stored config", async () => {
-    const store = storeWith([
-      makeSession("ses_a", { updatedAt: minutesAgo(30) }),
-      makeSession("ses_b", { updatedAt: minutesAgo(30) }),
-    ]);
-    store.set(
-      KV.config,
-      new Map<string, unknown>([
-        ["sessionSweep", { idleMinutes: 10, maxPerRun: 1 }],
-      ]),
-    );
+  it.each([
+    ["NaN", NaN],
+    ["zero", 0],
+    ["negative", -120],
+    ["non-numeric", "10" as unknown as number],
+  ])(
+    "falls back to the default threshold when idleMinutes is %s",
+    async (_label, bad) => {
+      // A bad override must not widen the net. At the 60m default a session
+      // idle 30m is not a candidate; a negative or zero threshold would sweep
+      // every active session.
+      const store = storeWith([
+        makeSession("ses_recent", { updatedAt: minutesAgo(30) }),
+      ]);
 
-    const { result } = await runSweep(store);
+      const { result } = await runSweep(store, { idleMinutes: bad });
 
-    expect(result.candidates).toBe(2);
-    expect(result.swept).toBe(1);
+      expect(result.candidates).toBe(0);
+      expect((store.get(KV.sessions)!.get("ses_recent") as Session).status).toBe(
+        "active",
+      );
+    },
+  );
+
+  it("writes an audit entry for each swept session", async () => {
+    const store = storeWith([makeSession("ses_idle")]);
+
+    await runSweep(store);
+
+    const audit = Array.from(store.get(KV.audit)?.values() ?? []) as Array<{
+      operation: string;
+      functionId: string;
+      targetIds: string[];
+    }>;
+    expect(audit).toHaveLength(1);
+    expect(audit[0]!.operation).toBe("session_sweep");
+    expect(audit[0]!.functionId).toBe("mem::session-sweep");
+    expect(audit[0]!.targetIds).toEqual(["ses_idle"]);
+  });
+
+  it("does not audit on a dry run", async () => {
+    const store = storeWith([makeSession("ses_idle")]);
+
+    await runSweep(store, { dryRun: true });
+
+    expect(store.get(KV.audit)?.size ?? 0).toBe(0);
   });
 
   it("fans out a summary with consolidation suppressed", async () => {


### PR DESCRIPTION
## The bug

A session only reaches `completed` when a client POSTs `/agentmemory/session/end`
(`api::session::end` in `src/triggers/api.ts` is the sole writer of that status
on the live path). Several clients never send it:

- **Claude Agent SDK child sessions.** `src/hooks/stop.ts:35-39` returns when
  `isSdkChildContext(data)` is true, and that `return` sits *before* the
  `/session/end` POST at `:44`. `src/hooks/subagent-stop.ts:45` posts only to
  `/observe`. So no hook ever ends these.
- **opencode.** The vendored plugin posts `/session/end` only on
  `session.deleted` (`plugin/opencode/agentmemory-capture.ts:327`), an explicit
  delete. Normal termination fires `session.status` → idle, which posts
  `/summarize` (`:279`).

Those sessions stay `active` forever.

## What this does NOT touch

**A normal Claude Code session is never swept.** Its Stop hook posts
`/session/end` on *every turn* (`src/hooks/stop.ts:44`, and the comment at
`src/triggers/events.ts` says so explicitly), so it is `completed` from turn one
and the status guard skips it. The swept population is only: Agent SDK children,
subagents, opencode, and any `/session/start` client that never ends.

## Measured, not inferred

Production carried **733 sessions stuck `active`** against 3,509 completed.

A live census via `memory_sessions` (20-row sample, the tool returns one page):

- every `active` row lacks `endedAt` and carries a `firstPrompt` ending in
  `(@general subagent)` or `(@explore subagent)` — Agent SDK child naming,
  matching the guard above;
- the Claude Code session in the same census is `completed` with `endedAt` set.

1500 lines of production logs show **zero `mem::evict` executions**, confirming
it has never run.

## Why not `mem::evict`

`mem::evict` already has stale-session recovery, and scheduling it was the
obvious candidate. It does not work:

1. **It never yields `completed`.** `recoverStaleSession` fires
   `event::session::stopped`, which summarizes and extracts graph but never
   touches `status`. The caller then deletes the row. Net effect is a deleted
   row, not a completed session.
2. **30-day latency**, and it skips any session that already has a summary.
3. **Four unrelated deletion phases** ride along: low-importance observations,
   per-project cap, expired memories, non-latest memories, plus image refcount
   decrements.

## The change

`mem::session-sweep` ages sessions on `updatedAt`, which `observe.ts:250` stamps
on every observation. Keying on inactivity rather than on a termination event is
what makes it harness-agnostic: it does not care which signal a given client
failed to send, so it covers Claude Code, opencode, codex, and anything future.

Reuse over new code:

- Terminal-state writing is delegated to `event::session::ended`, which already
  existed and set `endedAt` + `status` but **had no publisher anywhere in the
  repo** — its subscriber registration was the only reference to its topic.
- The timer follows the existing `AUTO_FORGET_ENABLED` pattern (env-gated
  `setInterval` + `.unref()`), and interval parsing follows
  `getConsolidationCooldownMs` in `config.ts`.
- `api::session-sweep` mirrors `api::evict`.
- The summary fan-out matches `/session/end` except for `skipConsolidation`,
  which that path does not pass because it ends one session at a time.

Safety properties, each added because a review round asked for it:

- **Inputs are validated at both boundaries.** `idleMinutes` reuses api.ts's
  existing `parseOptionalPositiveInt`, which returns 400 on a boolean, array, or
  object rather than reaching `Number()` (`Number(true)` is `1`, which would
  have meant a one-minute threshold and swept nearly every active session).
  `event::session::ended` validates `endedAt`, since it is also a durable
  subscriber and the viewer derives duration from that field.
- **The interval is clamped at both ends.** `setInterval` collapses NaN, 0, and
  anything above 2^31-1 to ~1ms alike, so a garbage *or* oversized env var would
  have run the sweep in a hot loop.
- **Overlapping runs are prevented** by an in-flight guard, since `setInterval`
  does not await its callback and two runs would each pay for a summarize.
- **Each session is re-read immediately before writing**, narrowing the
  stale-snapshot window from the whole list scan to a single `get`.
- **The state change is audited** under a new `session_sweep` operation, using
  `safeAudit` because production logs show audit writes timing out under load.

`endedAt` records the session's last activity, not the moment the sweep noticed
it.

Defaults: **one day** idle, swept every 15 minutes, capped at 25 per run,
disable with `SESSION_SWEEP_ENABLED=false`. The threshold is a day rather than an
hour because the target sessions run and finish, so a tight window buys nothing
there while a client that merely idles overnight would be ended mid-use.

## Limitations, stated up front

- **The re-read narrows the duplicate-work window, it does not close it.**
  `StateKV` has no compare-and-set, so an atomic active-to-completed claim is not
  available. The in-flight guard is per-process, so a multi-instance deployment
  would need a real lease.
- **The existing backlog drains at 25 per run.** At four runs an hour that is
  roughly 7.5 hours for 733. `POST /agentmemory/session-sweep` runs it on demand.
- **It does not fix the two client bugs**, it compensates for them. The
  `stop.ts` SDK-child guard and the opencode idle branch are both still wrong and
  want separate PRs. The guard exists to prevent agent-sdk provider re-entrancy,
  so narrowing it needs care, which is why this PR does not touch it.
- **The census is a 20-row sample, not all 733.** The population count is a prior
  measurement, not re-measured here.
- The harness attribution is inferred from prompt naming plus the source guard;
  the exact client that POSTs `/session/start` with those `ses_` ids was not
  traced.
- A session whose timestamps are both unparseable is skipped rather than swept,
  deliberately — treating an unreadable stamp as infinitely idle would end live
  sessions.

## Tests

**39 tests** across `test/session-sweep.test.ts`,
`test/session-sweep-interval.test.ts`, and `test/events-session-ended.test.ts`.

**Mutation-checked, and mutation testing found what review did not.** All **17
mutations** across the three source files kill at least one test. Three gaps it
caught that no reviewer did:

- Removing the in-flight guard's release killed nothing, which would have turned
  the sweep into a one-shot that runs at boot and never again.
- Flipping the idle comparison from `<=` to `<` killed nothing, because no
  fixture sat on the boundary.
- Dropping the re-read guard killed nothing, because the KV mock's `list` handed
  back live object references while the real `StateKV.list` is an SDK round-trip
  returning fresh objects. The test was passing for the wrong reason. The mock
  now clones.

Two tests were removed as unsound rather than repaired: one asserted a dry run
proceeds alongside a real sweep but registered a fresh function first, so nothing
was in flight; the other claimed to cover a throwing run, but `sweep()` has no
reachable throw.

## Gates

- `npm test`: 162 files passed, 1 skipped; **1750 passed**, 1 skipped.
- `npm run build`: succeeds.
- `npx tsc --noEmit`: **30 → 29 errors, zero new**. Baseline verified by
  typechecking a throwaway worktree at the base commit rather than assuming it,
  and compared line-number-insensitively so shifts from added code do not read as
  regressions. The error that disappears is
  `src/triggers/events.ts: Property 'updatedAt' does not exist on type 'Session'`
  — `observe.ts` has always written that field and the type never declared it.
