### PR TITLE
feat(graph): delta graph extraction

### DIFF
--- a/src/functions/graph.ts
+++ b/src/functions/graph.ts
@@ -685,17 +685,63 @@ export function registerGraphFunction(
   provider: MemoryProvider,
 ): void {
   sdk.registerFunction("mem::graph-extract",
-    async (data: { observations: CompressedObservation[] }) => {
-      if (!data.observations || data.observations.length === 0) {
+    async (data: {
+      observations: CompressedObservation[];
+      sessionId?: string;
+      force?: boolean;
+    }) => {
+      if (!data || !data.observations || data.observations.length === 0) {
         return { success: false, error: "No observations provided" };
       }
 
-      const obsIds = data.observations.map((o) => o.id);
+      const sessionId =
+        (typeof data.sessionId === "string" && data.sessionId.trim()) ||
+        data.observations[0]?.sessionId;
+
+      let targetObs = data.observations;
+      if (!data.force && sessionId) {
+        const extractedSet = new Set<string>();
+        try {
+          const extractedList = await kv.list<
+            { id?: string; obsId?: string } | string
+          >(KV.graphExtracted(sessionId));
+          for (const item of extractedList) {
+            if (typeof item === "string") {
+              extractedSet.add(item);
+            } else if (item && typeof item === "object") {
+              if (typeof item.id === "string") extractedSet.add(item.id);
+              else if (typeof item.obsId === "string") extractedSet.add(item.obsId);
+            }
+          }
+        } catch (err) {
+          logger.warn("failed to read graph extracted observations", {
+            sessionId,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+
+        targetObs = data.observations.filter((o) => !extractedSet.has(o.id));
+        if (targetObs.length === 0) {
+          logger.info("Graph extraction skipped — all observations already extracted", {
+            sessionId,
+            count: data.observations.length,
+          });
+          return {
+            success: true,
+            nodesAdded: 0,
+            edgesAdded: 0,
+            cached: true,
+            skipped: true,
+          };
+        }
+      }
+
+      const obsIds = targetObs.map((o) => o.id);
 
       let nodes: GraphNode[] = [];
       let edges: GraphEdge[] = [];
       try {
-        const heuristic = extractGraphHeuristics(data.observations);
+        const heuristic = extractGraphHeuristics(targetObs);
         nodes = heuristic.nodes;
         edges = heuristic.edges;
       } catch (err) {
@@ -709,7 +755,7 @@ export function registerGraphFunction(
       let llmError: string | undefined;
       if (llmEnabled) {
         const prompt = buildGraphExtractionPrompt(
-          data.observations.map((o) => ({
+          targetObs.map((o) => ({
             title: o.title,
             narrative: o.narrative,
             concepts: o.concepts,
@@ -732,9 +778,20 @@ export function registerGraphFunction(
       }
 
       if (nodes.length === 0 && edges.length === 0) {
-        return llmError
-          ? { success: false, error: llmError }
-          : { success: true, nodesAdded: 0, edgesAdded: 0 };
+        if (llmError) {
+          return { success: false, error: llmError };
+        }
+        if (sessionId) {
+          await Promise.all(
+            targetObs.map((o) =>
+              kv.set(KV.graphExtracted(sessionId), o.id, {
+                id: o.id,
+                extractedAt: new Date().toISOString(),
+              }),
+            ),
+          );
+        }
+        return { success: true, nodesAdded: 0, edgesAdded: 0 };
       }
 
       try {
@@ -744,6 +801,17 @@ export function registerGraphFunction(
           edges,
           obsIds,
         );
+
+        if (sessionId) {
+          await Promise.all(
+            targetObs.map((o) =>
+              kv.set(KV.graphExtracted(sessionId), o.id, {
+                id: o.id,
+                extractedAt: new Date().toISOString(),
+              }),
+            ),
+          );
+        }
 
         await recordAudit(kv, "observe", "mem::graph-extract", obsIds, {
           nodesExtracted: nodes.length,

--- a/src/state/schema.ts
+++ b/src/state/schema.ts
@@ -6,6 +6,7 @@ export const KV = {
   observations: (sessionId: string) => `mem:obs:${sessionId}`,
   memories: "mem:memories",
   summaries: "mem:summaries",
+  graphExtracted: (sessionId: string) => `mem:graph_extracted:${sessionId}`,
   config: "mem:config",
   metrics: "mem:metrics",
   health: "mem:health",

--- a/test/graph-heuristic-extract.test.ts
+++ b/test/graph-heuristic-extract.test.ts
@@ -111,7 +111,7 @@ describe("keyless graph extraction wiring", () => {
 
   it("mem::graph-extract gates the LLM pass, not the heuristic pass", () => {
     const graph = readFileSync("src/functions/graph.ts", "utf-8");
-    expect(graph).toMatch(/extractGraphHeuristics\(data\.observations\)/);
+    expect(graph).toMatch(/extractGraphHeuristics\((?:data\.observations|targetObs)\)/);
     expect(graph).toMatch(
       /isGraphExtractionEnabled\(\) && !provider\.name\.includes\("noop"\)/,
     );

--- a/test/graph.test.ts
+++ b/test/graph.test.ts
@@ -738,5 +738,164 @@ describe("Graph Functions", () => {
       expect(result.success).toBe(true);
       expect(listCalls).toBe(0);
     });
+
+    it("deduplication / zero-delta: calling mem::graph-extract twice skips on second call with 0 LLM calls", async () => {
+      const localKv = mockKV();
+      const localSdk = mockSdk();
+      const compressMock = vi.fn().mockResolvedValue(`<entities>
+<entity type="file" name="src/a.ts"/>
+</entities>
+<relationships/>`);
+      const provider = {
+        name: "test-provider",
+        compress: compressMock,
+        summarize: vi.fn(),
+      };
+      registerGraphFunction(localSdk as never, localKv as never, provider as never);
+
+      const obs: CompressedObservation = {
+        id: "obs_dedup_1",
+        sessionId: "ses_dedup",
+        timestamp: "2026-02-01T10:00:00Z",
+        type: "file_edit",
+        title: "Obs 1",
+        facts: [],
+        narrative: "Obs 1 narrative",
+        concepts: [],
+        files: [],
+        importance: 5,
+      };
+
+      const result1 = (await localSdk.trigger("mem::graph-extract", {
+        observations: [obs],
+        sessionId: "ses_dedup",
+      })) as any;
+      expect(result1.success).toBe(true);
+      expect(result1.nodesAdded).toBe(1);
+      expect(compressMock).toHaveBeenCalledTimes(1);
+
+      // Second call with same observation
+      const result2 = (await localSdk.trigger("mem::graph-extract", {
+        observations: [obs],
+        sessionId: "ses_dedup",
+      })) as any;
+      expect(result2.success).toBe(true);
+      expect(result2.cached).toBe(true);
+      expect(result2.skipped).toBe(true);
+      expect(result2.nodesAdded).toBe(0);
+      expect(result2.edgesAdded).toBe(0);
+      expect(compressMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("delta processing: passing previously-extracted along with new observation only processes new observation", async () => {
+      const localKv = mockKV();
+      const localSdk = mockSdk();
+      const compressMock = vi.fn().mockImplementation(async (_sys, prompt) => {
+        if (prompt.includes("Obs 2 narrative")) {
+          return `<entities>
+<entity type="file" name="src/b.ts"/>
+</entities>
+<relationships/>`;
+        }
+        return `<entities>
+<entity type="file" name="src/a.ts"/>
+</entities>
+<relationships/>`;
+      });
+      const provider = {
+        name: "test-provider",
+        compress: compressMock,
+        summarize: vi.fn(),
+      };
+      registerGraphFunction(localSdk as never, localKv as never, provider as never);
+
+      const obs1: CompressedObservation = {
+        id: "obs_delta_1",
+        sessionId: "ses_delta",
+        timestamp: "2026-02-01T10:00:00Z",
+        type: "file_edit",
+        title: "Obs 1",
+        facts: [],
+        narrative: "Obs 1 narrative",
+        concepts: [],
+        files: [],
+        importance: 5,
+      };
+      const obs2: CompressedObservation = {
+        id: "obs_delta_2",
+        sessionId: "ses_delta",
+        timestamp: "2026-02-01T10:01:00Z",
+        type: "file_edit",
+        title: "Obs 2",
+        facts: [],
+        narrative: "Obs 2 narrative",
+        concepts: [],
+        files: [],
+        importance: 5,
+      };
+
+      await localSdk.trigger("mem::graph-extract", {
+        observations: [obs1],
+        sessionId: "ses_delta",
+      });
+      expect(compressMock).toHaveBeenCalledTimes(1);
+
+      // Now pass both obs1 and obs2
+      const result2 = (await localSdk.trigger("mem::graph-extract", {
+        observations: [obs1, obs2],
+        sessionId: "ses_delta",
+      })) as any;
+      expect(result2.success).toBe(true);
+      expect(result2.nodesAdded).toBe(1);
+      expect(compressMock).toHaveBeenCalledTimes(2);
+
+      const promptArg = compressMock.mock.calls[1][1];
+      expect(promptArg).toContain("Obs 2 narrative");
+      expect(promptArg).not.toContain("Obs 1 narrative");
+    });
+
+    it("force bypass: passing force: true re-extracts even if previously recorded", async () => {
+      const localKv = mockKV();
+      const localSdk = mockSdk();
+      const compressMock = vi.fn().mockResolvedValue(`<entities>
+<entity type="file" name="src/forced.ts"/>
+</entities>
+<relationships/>`);
+      const provider = {
+        name: "test-provider",
+        compress: compressMock,
+        summarize: vi.fn(),
+      };
+      registerGraphFunction(localSdk as never, localKv as never, provider as never);
+
+      const obs: CompressedObservation = {
+        id: "obs_force_1",
+        sessionId: "ses_force",
+        timestamp: "2026-02-01T10:00:00Z",
+        type: "file_edit",
+        title: "Obs Force",
+        facts: [],
+        narrative: "Obs Force narrative",
+        concepts: [],
+        files: [],
+        importance: 5,
+      };
+
+      await localSdk.trigger("mem::graph-extract", {
+        observations: [obs],
+        sessionId: "ses_force",
+      });
+      expect(compressMock).toHaveBeenCalledTimes(1);
+
+      const result2 = (await localSdk.trigger("mem::graph-extract", {
+        observations: [obs],
+        sessionId: "ses_force",
+        force: true,
+      })) as any;
+      expect(result2.success).toBe(true);
+      expect(result2.cached).toBeUndefined();
+      expect(result2.skipped).toBeUndefined();
+      expect(compressMock).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -13,6 +13,10 @@ describe('KV', () => {
   it('has correct summaries scope', () => {
     expect(KV.summaries).toBe('mem:summaries')
   })
+
+  it('generates graphExtracted scope with session ID', () => {
+    expect(KV.graphExtracted('ses_123')).toBe('mem:graph_extracted:ses_123')
+  })
 })
 
 describe('STREAM', () => {


### PR DESCRIPTION
Graph extraction was re-running on all observations every trigger, duplicating nodes/edges and wasting LLM calls.

Fix:
- schema: add KV.graphExtracted per session to track already-extracted observation ids.
- graph: before extraction, filter observations against graphExtracted; skip when all already extracted (cached:true); after extraction (even on empty result), persist ids to graphExtracted so subsequent triggers only process new observations.

Tests: test/graph.test.ts delta cases + heuristic extract.

Split from 01881b4; telemetry filter parts excluded as superseded by telemetry branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Graph extraction now skips observations already processed in the same session.
  * Added support for forcing extraction when a fresh analysis is needed.
  * Incremental extraction processes only newly added observations.

* **Bug Fixes**
  * Improved handling of extraction failures and empty results.

* **Tests**
  * Added coverage for cached, incremental, forced, and session-scoped graph extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->