### PR TITLE
fix(compression): guard empty compression prompts and watermark summarization

### DIFF
--- a/src/functions/compress-synthetic.ts
+++ b/src/functions/compress-synthetic.ts
@@ -80,8 +80,9 @@ export function buildSyntheticCompression(
   const inputStr = stringifyForNarrative(raw.toolInput);
   const outputStr = stringifyForNarrative(raw.toolOutput);
   const promptStr = raw.userPrompt ?? "";
+  const contentStr = raw.content ?? "";
 
-  const narrativeParts = [promptStr, inputStr, outputStr].filter(
+  const narrativeParts = [promptStr, inputStr, outputStr, contentStr].filter(
     (s) => s.length > 0,
   );
 

--- a/src/functions/compress.ts
+++ b/src/functions/compress.ts
@@ -13,6 +13,7 @@ import {
   COMPRESSION_SYSTEM,
   buildCompressionPrompt,
 } from "../prompts/compression.js";
+import { buildSyntheticCompression } from "./compress-synthetic.js";
 import { VISION_DESCRIPTION_PROMPT } from "../prompts/vision.js";
 import { getXmlTag, getXmlChildren } from "../prompts/xml.js";
 import { getSearchIndex, vectorIndexAddGuarded } from "./search.js";
@@ -117,7 +118,81 @@ export function registerCompressFunction(
           : data.raw.toolOutput,
         userPrompt: data.raw.userPrompt,
         timestamp: data.raw.timestamp,
+        content: data.raw.content,
       });
+
+      if (!prompt) {
+        const synthetic = buildSyntheticCompression(data.raw);
+        await kv.set(
+          KV.observations(data.sessionId),
+          data.observationId,
+          synthetic,
+        );
+
+        try {
+          getSearchIndex().add(synthetic);
+        } catch (err) {
+          logger.warn("Failed to index synthetic observation into BM25", {
+            obsId: synthetic.id,
+            sessionId: synthetic.sessionId,
+            title: synthetic.title,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+
+        await vectorIndexAddGuarded(
+          synthetic.id,
+          synthetic.sessionId,
+          synthetic.title + " " + (synthetic.narrative || ""),
+          { kind: "synthetic", logId: synthetic.id },
+        );
+
+        const streamResults = await Promise.allSettled([
+          sdk.trigger({
+            function_id: "stream::set",
+            payload: {
+              stream_name: STREAM.name,
+              group_id: STREAM.group(data.sessionId),
+              item_id: data.observationId,
+              data: { type: "compressed", observation: synthetic },
+            },
+          }),
+          sdk.trigger({
+            function_id: "stream::send",
+            payload: {
+              stream_name: STREAM.name,
+              group_id: STREAM.viewerGroup,
+              id: `compressed-${data.observationId}`,
+              type: "compressed_observation",
+              data: {
+                type: "compressed",
+                observation: synthetic,
+                sessionId: data.sessionId,
+              },
+            },
+            action: TriggerAction.Void(),
+          }),
+        ]);
+        for (const result of streamResults) {
+          if (result.status === "rejected") {
+            logger.warn("Non-fatal stream publish failure after compress", {
+              sessionId: data.sessionId,
+              observationId: data.observationId,
+              error:
+                result.reason instanceof Error
+                  ? result.reason.message
+                  : String(result.reason),
+            });
+          }
+        }
+
+        return {
+          success: true,
+          skipped_llm: true,
+          observation: synthetic,
+          compressed: synthetic,
+        };
+      }
 
       try {
         const validator = (response: string) => {

--- a/src/functions/summarize.ts
+++ b/src/functions/summarize.ts
@@ -100,6 +100,8 @@ async function produceSummaryXml(
   compressed: CompressedObservation[],
   sessionId: string,
   project: string,
+  kv?: StateKV,
+  force?: boolean,
 ): Promise<{
   response: string;
   mode: "single" | "chunked";
@@ -137,7 +139,17 @@ async function produceSummaryXml(
     await Promise.all(
       batch.map(async (chunk, j) => {
         const idx = batchStart + j;
-        partialByIdx[idx] = await summarizeChunkWithRetry(
+        if (!force && chunk.length === chunkSize && kv) {
+          const cached = await kv.get<SessionSummary>(
+            KV.summaryPartials(sessionId),
+            String(idx),
+          );
+          if (cached && cached.observationCount === chunk.length) {
+            partialByIdx[idx] = cached;
+            return;
+          }
+        }
+        const partial = await summarizeChunkWithRetry(
           provider,
           chunk,
           sessionId,
@@ -145,6 +157,10 @@ async function produceSummaryXml(
           idx,
           chunks.length,
         );
+        partialByIdx[idx] = partial;
+        if (partial && chunk.length === chunkSize && kv) {
+          await kv.set(KV.summaryPartials(sessionId), String(idx), partial);
+        }
       }),
     );
   }
@@ -233,12 +249,13 @@ export function registerSummarizeFunction(
   metricsStore?: MetricsStore,
 ): void {
   sdk.registerFunction("mem::summarize", 
-    async (data: { sessionId: string } | undefined) => {
+    async (data: { sessionId: string; force?: boolean } | undefined) => {
       const startMs = Date.now();
       if (!data || typeof data.sessionId !== "string" || !data.sessionId.trim()) {
         return { success: false, error: "sessionId is required" };
       }
       const sessionId = data.sessionId.trim();
+      const force = Boolean(data.force);
 
       const session = await kv.get<Session>(KV.sessions, sessionId);
       if (!session) {
@@ -258,6 +275,23 @@ export function registerSummarizeFunction(
           sessionId,
         });
         return { success: false, error: "no_observations" };
+      }
+
+      if (!force) {
+        const existingSummary = await kv.get<SessionSummary>(
+          KV.summaries,
+          sessionId,
+        );
+        if (
+          existingSummary &&
+          existingSummary.observationCount === compressed.length
+        ) {
+          logger.info("Summarize zero-delta unchanged, returning cached summary", {
+            sessionId,
+            observationCount: compressed.length,
+          });
+          return { success: true, summary: existingSummary, cached: true };
+        }
       }
 
       if (provider.name === "noop") {
@@ -288,6 +322,8 @@ export function registerSummarizeFunction(
             compressed,
             sessionId,
             session.project,
+            kv,
+            force,
           );
           response = produced.response;
           mode = produced.mode;

--- a/src/prompts/compression.ts
+++ b/src/prompts/compression.ts
@@ -27,6 +27,16 @@ Rules:
 - Concepts should be reusable search terms (e.g., "React hooks", "SQL migration", "auth middleware")
 - Strip any secrets, tokens, or credentials from the output`;
 
+function hasValue(val: unknown): boolean {
+  if (val === undefined || val === null) return false;
+  if (typeof val === "string") return val.trim().length > 0;
+  if (typeof val === "object") {
+    if (Array.isArray(val)) return val.length > 0;
+    return Object.keys(val).length > 0;
+  }
+  return true;
+}
+
 export function buildCompressionPrompt(observation: {
   hookType: string;
   toolName?: string;
@@ -34,29 +44,44 @@ export function buildCompressionPrompt(observation: {
   toolOutput?: unknown;
   userPrompt?: string;
   timestamp: string;
-}): string {
+  content?: string;
+}): string | null {
+  const hasSubstantive =
+    hasValue(observation.toolName) ||
+    hasValue(observation.toolInput) ||
+    hasValue(observation.toolOutput) ||
+    hasValue(observation.userPrompt) ||
+    hasValue(observation.content);
+
+  if (!hasSubstantive) {
+    return null;
+  }
+
   const parts = [
     `Timestamp: ${observation.timestamp}`,
     `Hook: ${observation.hookType}`,
   ];
 
-  if (observation.toolName) parts.push(`Tool: ${observation.toolName}`);
-  if (observation.toolInput) {
+  if (hasValue(observation.toolName)) parts.push(`Tool: ${observation.toolName}`);
+  if (hasValue(observation.toolInput)) {
     const input =
       typeof observation.toolInput === "string"
         ? observation.toolInput
         : JSON.stringify(observation.toolInput, null, 2);
     parts.push(`Input:\n${truncate(input, 4000)}`);
   }
-  if (observation.toolOutput) {
+  if (hasValue(observation.toolOutput)) {
     const output =
       typeof observation.toolOutput === "string"
         ? observation.toolOutput
         : JSON.stringify(observation.toolOutput, null, 2);
     parts.push(`Output:\n${truncate(output, 4000)}`);
   }
-  if (observation.userPrompt) {
-    parts.push(`User prompt:\n${truncate(observation.userPrompt, 2000)}`);
+  if (hasValue(observation.userPrompt)) {
+    parts.push(`User prompt:\n${truncate(observation.userPrompt!, 2000)}`);
+  }
+  if (hasValue(observation.content)) {
+    parts.push(`Content:\n${truncate(observation.content!, 4000)}`);
   }
 
   return parts.join("\n\n");

--- a/src/state/schema.ts
+++ b/src/state/schema.ts
@@ -6,6 +6,7 @@ export const KV = {
   observations: (sessionId: string) => `mem:obs:${sessionId}`,
   memories: "mem:memories",
   summaries: "mem:summaries",
+  summaryPartials: (sessionId: string) => `mem:summary_partials:${sessionId}`,
   config: "mem:config",
   metrics: "mem:metrics",
   health: "mem:health",

--- a/src/triggers/api.ts
+++ b/src/triggers/api.ts
@@ -696,14 +696,16 @@ export function registerApiTriggers(
   });
 
   sdk.registerFunction("api::summarize", 
-    async (req: ApiRequest<{ sessionId: string }>): Promise<Response> => {
-      const sessionId = asNonEmptyString((req.body as Record<string, unknown>)?.sessionId);
+    async (req: ApiRequest<{ sessionId: string; force?: boolean }>): Promise<Response> => {
+      const body = (req.body ?? {}) as Record<string, unknown>;
+      const sessionId = asNonEmptyString(body?.sessionId);
       if (!sessionId) {
         return { status_code: 400, body: { error: "sessionId is required" } };
       }
+      const force = Boolean(body?.force);
       const result = await sdk.trigger({
         function_id: "mem::summarize",
-        payload: { sessionId },
+        payload: { sessionId, ...(force ? { force: true } : {}) },
       });
       return { status_code: 200, body: result };
     },

--- a/src/triggers/events.ts
+++ b/src/triggers/events.ts
@@ -114,7 +114,10 @@ export function registerEventTriggers(sdk: ISdk, kv: StateKV): void {
       );
       const compressed = observations.filter((o) => o.title);
       if (compressed.length > 0) {
-        fireVoid("mem::graph-extract", { observations: compressed });
+        fireVoid("mem::graph-extract", {
+          observations: compressed,
+          sessionId: data.sessionId,
+        });
       }
     } catch (err) {
       logger.warn("graph-extract trigger failed", {

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ export interface Session {
   cwd: string;
   startedAt: string;
   endedAt?: string;
+  updatedAt?: string;
   status: "active" | "completed" | "abandoned";
   observationCount: number;
   model?: string;
@@ -53,6 +54,7 @@ export interface RawObservation {
   toolInput?: unknown;
   toolOutput?: unknown;
   userPrompt?: string;
+  content?: string;
   assistantResponse?: string;
   raw: unknown;
   modality?: "text" | "image" | "mixed";

--- a/test/compression-guard.test.ts
+++ b/test/compression-guard.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { buildCompressionPrompt } from "../src/prompts/compression.js";
+import { registerCompressFunction } from "../src/functions/compress.js";
+import type { RawObservation, MemoryProvider } from "../src/types.js";
+
+const mockAddSearch = vi.fn();
+const mockVectorIndexAddGuarded = vi.fn().mockResolvedValue(true);
+
+vi.mock("../src/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("../src/functions/search.js", () => ({
+  getSearchIndex: () => ({
+    add: mockAddSearch,
+  }),
+  vectorIndexAddGuarded: (...args: unknown[]) => mockVectorIndexAddGuarded(...args),
+}));
+
+function mockKV() {
+  const store = new Map<string, Map<string, unknown>>();
+  return {
+    store,
+    get: async <T>(scope: string, key: string): Promise<T | null> => {
+      return (store.get(scope)?.get(key) as T) ?? null;
+    },
+    set: async <T>(scope: string, key: string, data: T): Promise<T> => {
+      if (!store.has(scope)) store.set(scope, new Map());
+      store.get(scope)!.set(key, data);
+      return data;
+    },
+    delete: async (scope: string, key: string): Promise<void> => {
+      store.get(scope)?.delete(key);
+    },
+    list: async <T>(scope: string): Promise<T[]> => {
+      if (!store.has(scope)) return [];
+      return Array.from(store.get(scope)!.values()) as T[];
+    },
+  };
+}
+
+function mockSdk() {
+  const fns = new Map<string, Function>();
+  const triggered: Array<{ id: string; data: unknown }> = [];
+  return {
+    fns,
+    triggered,
+    registerFunction: (
+      idOrOpts: string | { id: string },
+      fn: Function,
+    ) => {
+      const id = typeof idOrOpts === "string" ? idOrOpts : idOrOpts.id;
+      fns.set(id, fn);
+    },
+    trigger: async (
+      idOrInput:
+        | string
+        | { function_id: string; payload: unknown; action?: unknown },
+      data?: unknown,
+    ) => {
+      const id =
+        typeof idOrInput === "string" ? idOrInput : idOrInput.function_id;
+      const payload =
+        typeof idOrInput === "string" ? data : idOrInput.payload;
+      triggered.push({ id, data: payload });
+      const fn = fns.get(id);
+      if (fn) return fn(payload);
+      return null;
+    },
+  };
+}
+
+const VALID_COMPRESS_XML = `<observation>
+  <type>file_read</type>
+  <title>Read src/foo.ts</title>
+  <narrative>Read the file contents for analysis.</narrative>
+  <facts>
+    <fact>File src/foo.ts exists</fact>
+  </facts>
+  <concepts>
+    <concept>typescript</concept>
+  </concepts>
+  <files>
+    <file>src/foo.ts</file>
+  </files>
+  <importance>4</importance>
+</observation>`;
+
+describe("Prompt Guardrails & Empty Payload Skip (Issue #1270)", () => {
+  let sdk: ReturnType<typeof mockSdk>;
+  let kv: ReturnType<typeof mockKV>;
+  let provider: MemoryProvider;
+  let compressFn: Function;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sdk = mockSdk();
+    kv = mockKV();
+    provider = {
+      name: "test-provider",
+      compress: vi.fn().mockResolvedValue(VALID_COMPRESS_XML),
+      summarize: vi.fn().mockResolvedValue("summary"),
+    };
+    registerCompressFunction(sdk as never, kv as never, provider);
+    compressFn = sdk.fns.get("mem::compress")!;
+  });
+
+  describe("buildCompressionPrompt", () => {
+    it("returns null for empty observation / lifecycle hooks without content", () => {
+      expect(
+        buildCompressionPrompt({
+          hookType: "session_status",
+          timestamp: "2026-08-30T00:00:00.000Z",
+        }),
+      ).toBeNull();
+
+      expect(
+        buildCompressionPrompt({
+          hookType: "step_finish",
+          timestamp: "2026-08-30T00:00:00.000Z",
+          toolInput: {},
+          toolOutput: "",
+          userPrompt: "   ",
+        }),
+      ).toBeNull();
+    });
+
+    it("formats valid tool observation prompt", () => {
+      const prompt = buildCompressionPrompt({
+        hookType: "post_tool_use",
+        toolName: "Read",
+        toolInput: { file_path: "src/index.ts" },
+        toolOutput: "export const foo = 1;",
+        timestamp: "2026-08-30T00:00:00.000Z",
+      });
+
+      expect(prompt).not.toBeNull();
+      expect(prompt).toContain("Hook: post_tool_use");
+      expect(prompt).toContain("Tool: Read");
+      expect(prompt).toContain("src/index.ts");
+      expect(prompt).toContain("export const foo = 1;");
+    });
+
+    it("formats user prompt and content when present", () => {
+      const promptFromUser = buildCompressionPrompt({
+        hookType: "prompt_submit",
+        userPrompt: "Refactor auth middleware",
+        timestamp: "2026-08-30T00:00:00.000Z",
+      });
+      expect(promptFromUser).not.toBeNull();
+      expect(promptFromUser).toContain("User prompt:\nRefactor auth middleware");
+
+      const promptFromContent = buildCompressionPrompt({
+        hookType: "custom",
+        content: "Important architectural note",
+        timestamp: "2026-08-30T00:00:00.000Z",
+      });
+      expect(promptFromContent).not.toBeNull();
+      expect(promptFromContent).toContain("Content:\nImportant architectural note");
+    });
+  });
+
+  describe("mem::compress LLM bypass and lossless indexing", () => {
+    it("Test 1: Empty observation / lifecycle hook returns null prompt and does NOT call LLM provider", async () => {
+      const raw: RawObservation = {
+        id: "obs_empty",
+        sessionId: "ses_1",
+        timestamp: new Date().toISOString(),
+        hookType: "session_status" as never,
+        raw: {},
+      };
+
+      const result = await compressFn({
+        observationId: raw.id,
+        sessionId: raw.sessionId,
+        raw,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.skipped_llm).toBe(true);
+      expect(result.observation).toBeDefined();
+      expect(provider.compress).not.toHaveBeenCalled();
+
+      const stored = await kv.get("mem:obs:ses_1", raw.id);
+      expect(stored).toBeDefined();
+    });
+
+    it("Test 2: Valid tool observation produces valid prompt and calls LLM provider", async () => {
+      const raw: RawObservation = {
+        id: "obs_tool",
+        sessionId: "ses_1",
+        timestamp: new Date().toISOString(),
+        hookType: "post_tool_use",
+        toolName: "Read",
+        toolInput: { file_path: "src/foo.ts" },
+        toolOutput: "file contents",
+        raw: {},
+      };
+
+      const result = await compressFn({
+        observationId: raw.id,
+        sessionId: raw.sessionId,
+        raw,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.skipped_llm).toBeUndefined();
+      expect(provider.compress).toHaveBeenCalledTimes(1);
+      expect(result.compressed.title).toBe("Read src/foo.ts");
+    });
+
+    it("Test 3: User prompt or content without tool produces valid prompt and calls LLM provider", async () => {
+      const rawPrompt: RawObservation = {
+        id: "obs_prompt",
+        sessionId: "ses_1",
+        timestamp: new Date().toISOString(),
+        hookType: "prompt_submit",
+        userPrompt: "Optimize database queries",
+        raw: {},
+      };
+
+      const resultPrompt = await compressFn({
+        observationId: rawPrompt.id,
+        sessionId: rawPrompt.sessionId,
+        raw: rawPrompt,
+      });
+
+      expect(resultPrompt.success).toBe(true);
+      expect(provider.compress).toHaveBeenCalledTimes(1);
+
+      const rawContent: RawObservation = {
+        id: "obs_content",
+        sessionId: "ses_1",
+        timestamp: new Date().toISOString(),
+        hookType: "conversation" as never,
+        content: "Custom system log message",
+        raw: {},
+      };
+
+      const resultContent = await compressFn({
+        observationId: rawContent.id,
+        sessionId: rawContent.sessionId,
+        raw: rawContent,
+      });
+
+      expect(resultContent.success).toBe(true);
+      expect(provider.compress).toHaveBeenCalledTimes(2);
+    });
+
+    it("Test 4: Search index and vector index are updated even when LLM is bypassed (lossless guarantee)", async () => {
+      const raw: RawObservation = {
+        id: "obs_lossless",
+        sessionId: "ses_lossless",
+        timestamp: new Date().toISOString(),
+        hookType: "step_finish" as never,
+        raw: {},
+      };
+
+      const result = await compressFn({
+        observationId: raw.id,
+        sessionId: raw.sessionId,
+        raw,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.skipped_llm).toBe(true);
+      expect(result.observation).toBeDefined();
+
+      expect(mockAddSearch).toHaveBeenCalledWith(result.observation);
+      expect(mockVectorIndexAddGuarded).toHaveBeenCalledWith(
+        result.observation.id,
+        result.observation.sessionId,
+        expect.stringContaining(result.observation.title),
+        { kind: "synthetic", logId: result.observation.id },
+      );
+    });
+  });
+});

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -13,6 +13,11 @@ describe('KV', () => {
   it('has correct summaries scope', () => {
     expect(KV.summaries).toBe('mem:summaries')
   })
+
+  it('generates summaryPartials scope with session ID', () => {
+    expect(KV.summaryPartials('ses_123')).toBe('mem:summary_partials:ses_123')
+  })
+
 })
 
 describe('STREAM', () => {

--- a/test/summarize.test.ts
+++ b/test/summarize.test.ts
@@ -8,6 +8,7 @@ vi.mock("../src/state/schema.js", () => ({
   KV: {
     sessions: "sessions",
     summaries: "summaries",
+    summaryPartials: (sessionId: string) => `summary_partials:${sessionId}`,
     observations: (sessionId: string) => `obs:${sessionId}`,
     audit: "audit",
   },
@@ -478,5 +479,125 @@ describe("mem::summarize chunking", () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toBe("parse_failed");
+  });
+
+  it("zero-delta unchanged guard returns cached summary with 0 LLM calls", async () => {
+    const provider = makeProvider([
+      summaryXml({
+        title: "Initial summary",
+        decisions: ["decision 1"],
+        files: ["src/index.ts"],
+        concepts: ["initial"],
+      }),
+    ]);
+    const { handler } = await setupHandler({
+      sessionId: "ses_zero_delta",
+      obsCount: 5,
+      provider,
+    });
+
+    const firstResult: any = await handler({ sessionId: "ses_zero_delta" });
+    expect(firstResult.success).toBe(true);
+    expect(firstResult.summary.title).toBe("Initial summary");
+    expect(provider.calls).toHaveLength(1);
+
+    // Second summarize on unchanged observations returns cached: true with 0 new provider calls
+    const secondResult: any = await handler({ sessionId: "ses_zero_delta" });
+    expect(secondResult.success).toBe(true);
+    expect(secondResult.cached).toBe(true);
+    expect(secondResult.summary.title).toBe("Initial summary");
+    expect(provider.calls).toHaveLength(1);
+  });
+
+  it("chunk partial memoization reuses earlier chunk partials when delta observations are added", async () => {
+    process.env.SUMMARIZE_CHUNK_SIZE = "100";
+    process.env.SUMMARIZE_CHUNK_CONCURRENCY = "1";
+
+    const provider = makeProvider([
+      summaryXml({ title: "Chunk 1 summary" }),
+      summaryXml({ title: "Reduce 1" }),
+      summaryXml({ title: "Chunk 2 summary" }),
+      summaryXml({ title: "Reduce 2" }),
+    ]);
+
+    const sdk = mockSdk();
+    const kv = mockKV();
+    const session: Session = {
+      id: "ses_memo",
+      project: "test-project",
+      cwd: "/tmp",
+      startedAt: new Date().toISOString(),
+      status: "completed",
+      observationCount: 100,
+    };
+    await kv.set("sessions", "ses_memo", session);
+    for (let i = 0; i < 100; i++) {
+      const o = makeObs(i, "ses_memo");
+      await kv.set("obs:ses_memo", o.id, o);
+    }
+    registerSummarizeFunction(sdk as any, kv as any, provider);
+    const handler = sdk.functions.get("mem::summarize")!;
+
+    // Turn 1: 100 observations (1 full chunk) -> single-call path (since 100 <= chunkSize 100)
+    const turn1Result: any = await handler({ sessionId: "ses_memo" });
+    expect(turn1Result.success).toBe(true);
+    expect(provider.calls).toHaveLength(1);
+
+    // Now add 50 more observations (total 150 -> 2 chunks: chunk 0 has 100, chunk 1 has 50)
+    for (let i = 100; i < 150; i++) {
+      const o = makeObs(i, "ses_memo");
+      await kv.set("obs:ses_memo", o.id, o);
+    }
+
+    // Turn 2: Run chunked summarize.
+    // Chunk 0 (full chunk of 100) will be computed and cached.
+    // Chunk 1 (tail chunk of 50) will be computed.
+    // Plus reduce.
+    const turn2Result: any = await handler({ sessionId: "ses_memo" });
+    expect(turn2Result.success).toBe(true);
+    // Provider calls: 1 (from turn 1) + 1 (chunk 0) + 1 (chunk 1) + 1 (reduce) = 4
+    expect(provider.calls).toHaveLength(4);
+
+    // Now add 20 more observations (total 170 -> 2 chunks: chunk 0 has 100, chunk 1 has 70)
+    for (let i = 150; i < 170; i++) {
+      const o = makeObs(i, "ses_memo");
+      await kv.set("obs:ses_memo", o.id, o);
+    }
+
+    // Provider response for turn 3: only chunk 1 (tail chunk) and reduce should be called!
+    (provider as any).summarize = async (system: string, user: string) => {
+      provider.calls.push({ system, user });
+      if (system.includes("merging")) return summaryXml({ title: "Reduce 3" });
+      return summaryXml({ title: "Chunk 2 updated" });
+    };
+
+    const turn3Result: any = await handler({ sessionId: "ses_memo" });
+    expect(turn3Result.success).toBe(true);
+    // Calls added in turn 3: exactly 2 (chunk 1 + reduce), chunk 0 was reused from KV cache!
+    expect(provider.calls).toHaveLength(6);
+  });
+
+  it("forced re-summarization with force: true bypasses cache and re-runs", async () => {
+    const provider = makeProvider([
+      summaryXml({ title: "First run" }),
+      summaryXml({ title: "Forced second run" }),
+    ]);
+    const { handler } = await setupHandler({
+      sessionId: "ses_forced",
+      obsCount: 5,
+      provider,
+    });
+
+    const firstResult: any = await handler({ sessionId: "ses_forced" });
+    expect(firstResult.success).toBe(true);
+    expect(firstResult.summary.title).toBe("First run");
+    expect(provider.calls).toHaveLength(1);
+
+    // Second summarize with force: true bypasses zero-delta cache
+    const secondResult: any = await handler({ sessionId: "ses_forced", force: true });
+    expect(secondResult.success).toBe(true);
+    expect(secondResult.cached).toBeUndefined();
+    expect(secondResult.summary.title).toBe("Forced second run");
+    expect(provider.calls).toHaveLength(2);
   });
 });


### PR DESCRIPTION
Empty observations produced empty compression prompts (Facts:/Files: blocks with no content) and summarization re-ran on unchanged observation counts. Graph extraction had no delta deduplication.

Fix:
- compression: buildCompressionPrompt returns null when no substantive fields (toolName/toolInput/toolOutput/userPrompt/content); registerCompressFunction falls back to buildSyntheticCompression and publishes synthetic observation when prompt is null.
- prompts/compression: hasValue helper gates each section; content field added.
- compress-synthetic: include raw.content in narrativeParts.
- schema: KV.summaryPartials per session for chunk memoization.
- summarize: produceSummaryXml caches per-chunk partials in KV.summaryPartials; registerSummarizeFunction adds force param, zero-delta guard (returns cached summary when observationCount unchanged), and chunk partial reuse.
- triggers/api: api::summarize accepts force param.
- triggers/events: graph-extract trigger passes sessionId.
- types/schema: Session.updatedAt, RawObservation.content.

Tests: test/compression-guard.test.ts, test/summarize.test.ts watermark/force/zero-delta/partial-memoization. Split from 01881b4; telemetry filter parts excluded as superseded by telemetry branch (fix/observe-telemetry-semantic-fields).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for including raw observation content in compression.
  - Empty observations are stored without invoking language-model processing while remaining searchable.
  - Added cached summary reuse with optional forced re-summarization.
  - The summarization API now accepts an optional `force` option.
  - Session identifiers are now included in graph extraction events.

- **Tests**
  - Added coverage for compression guardrails, indexing, summary caching, and forced refreshes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->