### PR TITLE
fix(health): measure heap saturation against the heap ceiling, not heapTotal

### DIFF
--- a/src/health/monitor.ts
+++ b/src/health/monitor.ts
@@ -1,3 +1,4 @@
+import { getHeapStatistics } from "node:v8";
 import type { ISdk } from "iii-sdk";
 import type { HealthSnapshot } from "../types.js";
 import type { StateKV } from "../state/kv.js";
@@ -71,6 +72,7 @@ export function registerHealthMonitor(
         heapTotal: mem.heapTotal,
         rss: mem.rss,
         external: mem.external,
+        heapSizeLimit: getHeapStatistics().heap_size_limit,
       },
       cpu: {
         userMicros: currentCpu.user,

--- a/src/health/thresholds.ts
+++ b/src/health/thresholds.ts
@@ -59,10 +59,17 @@ export function evaluateHealth(
     degraded = true;
   }
 
+  // Saturation must be measured against the heap ceiling, not against
+  // heapTotal. heapTotal is only the heap V8 has committed so far, and V8
+  // deliberately keeps it close to the live set, so heapUsed/heapTotal sits at
+  // 80-95% in any healthy process under load. Fall back to heapTotal for
+  // snapshots written before heapSizeLimit existed.
+  const memCeiling =
+    snapshot.memory.heapSizeLimit && snapshot.memory.heapSizeLimit > 0
+      ? snapshot.memory.heapSizeLimit
+      : snapshot.memory.heapTotal;
   const memPercent =
-    snapshot.memory.heapTotal > 0
-      ? (snapshot.memory.heapUsed / snapshot.memory.heapTotal) * 100
-      : 0;
+    memCeiling > 0 ? (snapshot.memory.heapUsed / memCeiling) * 100 : 0;
   const rss = snapshot.memory.rss ?? 0;
   const rssAboveFloor = rss >= cfg.memoryRssFloorBytes;
   const memMb = Math.round(rss / (1024 * 1024));

--- a/src/health/thresholds.ts
+++ b/src/health/thresholds.ts
@@ -59,11 +59,9 @@ export function evaluateHealth(
     degraded = true;
   }
 
-  // Saturation must be measured against the heap ceiling, not against
-  // heapTotal. heapTotal is only the heap V8 has committed so far, and V8
-  // deliberately keeps it close to the live set, so heapUsed/heapTotal sits at
-  // 80-95% in any healthy process under load. Fall back to heapTotal for
-  // snapshots written before heapSizeLimit existed.
+  // heapTotal is the heap V8 has committed so far, not a ceiling: V8 keeps it
+  // close to the live set, so heapUsed/heapTotal reads 80-95% in any healthy
+  // process under load. Measuring saturation against it is what produced #158.
   const memCeiling =
     snapshot.memory.heapSizeLimit && snapshot.memory.heapSizeLimit > 0
       ? snapshot.memory.heapSizeLimit

--- a/src/types.ts
+++ b/src/types.ts
@@ -227,8 +227,7 @@ export interface HealthSnapshot {
     heapTotal: number;
     rss: number;
     external: number;
-    /** V8 heap ceiling (`v8.getHeapStatistics().heap_size_limit`). Optional so
-     *  snapshots persisted by older versions still deserialise. */
+    /** Optional: snapshots persisted before this field existed must still deserialise. */
     heapSizeLimit?: number;
   };
   cpu: { userMicros: number; systemMicros: number; percent: number };

--- a/src/types.ts
+++ b/src/types.ts
@@ -227,6 +227,9 @@ export interface HealthSnapshot {
     heapTotal: number;
     rss: number;
     external: number;
+    /** V8 heap ceiling (`v8.getHeapStatistics().heap_size_limit`). Optional so
+     *  snapshots persisted by older versions still deserialise. */
+    heapSizeLimit?: number;
   };
   cpu: { userMicros: number; systemMicros: number; percent: number };
   eventLoopLagMs: number;

--- a/test/health-thresholds.test.ts
+++ b/test/health-thresholds.test.ts
@@ -95,3 +95,50 @@ describe("evaluateHealth memory severity", () => {
     expect(strict.status).toBe("healthy");
   });
 });
+
+describe("evaluateHealth memory saturation uses the heap ceiling", () => {
+  it("stays healthy when heapUsed/heapTotal is high but the ceiling is far away", () => {
+    // Real reading from a --max-old-space-size=8192 server doing bulk work:
+    // 92% of the committed heap, but only 3.5% of the ceiling it may grow into.
+    const s = snap({
+      memory: {
+        heapUsed: 290 * 1024 * 1024,
+        heapTotal: 314 * 1024 * 1024,
+        rss: 690 * 1024 * 1024,
+        external: 140 * 1024 * 1024,
+        heapSizeLimit: 8240 * 1024 * 1024,
+      },
+    });
+    const { status, alerts, notes } = evaluateHealth(s);
+    expect(status).toBe("healthy");
+    expect(alerts).toEqual([]);
+    expect(notes.find((n) => n.startsWith("memory_heap_tight_"))).toBeUndefined();
+  });
+
+  it("still goes critical when the ceiling itself is nearly exhausted", () => {
+    const s = snap({
+      memory: {
+        heapUsed: 7900 * 1024 * 1024,
+        heapTotal: 8000 * 1024 * 1024,
+        rss: 8300 * 1024 * 1024,
+        external: 0,
+        heapSizeLimit: 8240 * 1024 * 1024,
+      },
+    });
+    const { status, alerts } = evaluateHealth(s);
+    expect(status).toBe("critical");
+    expect(alerts.some((a) => a.startsWith("memory_critical_"))).toBe(true);
+  });
+
+  it("falls back to heapTotal when heapSizeLimit is absent (older snapshots)", () => {
+    const s = snap({
+      memory: {
+        heapUsed: 970 * 1024 * 1024,
+        heapTotal: 1000 * 1024 * 1024,
+        rss: 1100 * 1024 * 1024,
+        external: 0,
+      },
+    });
+    expect(evaluateHealth(s).status).toBe("critical");
+  });
+});


### PR DESCRIPTION
### 🚀 Summary

- **Fix:** `evaluateHealth` measured memory saturation as `heapUsed / heapTotal`. `heapTotal` is the heap V8 has committed so far, not a ceiling, and V8 keeps it close to the live set — so the ratio reads 80-95% in any healthy process under load. Now measured against `v8.getHeapStatistics().heap_size_limit`.
- **Impact:** On a `--max-old-space-size=8192` server during bulk import: **92% reported** (`memory_critical`) vs **3.5% actual**, with RSS 690 MB on a 125 GB host, event-loop lag 0.05 ms, CPU 0.6%. The `memoryRssFloorBytes` gate from #158 masks this only while RSS stays under the floor; the denominator was still wrong.
- **Compat:** `HealthSnapshot.memory.heapSizeLimit` is optional and falls back to `heapTotal`, so snapshots persisted by older versions still evaluate and the 5 existing threshold tests pass unchanged.
- **Test:** 3 cases added — distant ceiling stays healthy, exhausted ceiling still goes critical, absent field falls back. Suite: 1714 passed, 1 skipped. `tsc --noEmit`: same 30 pre-existing errors before and after, none in the touched files.
