### PR TITLE
fix(replay): reinforce lesson confidence on JSONL re-import

### DIFF
--- a/src/functions/lessons.ts
+++ b/src/functions/lessons.ts
@@ -52,7 +52,12 @@ async function ensureLessonIndex(kv: StateKV): Promise<SearchIndex> {
   return lessonIndex ?? ensureLessonIndex(kv);
 }
 
-function reinforceLesson(lesson: Lesson): void {
+/**
+ * Applies one reinforcement step: bumps the counter and moves confidence
+ * asymptotically towards 1.0. Exported so the JSONL import path in replay.ts
+ * reinforces lessons through the same formula instead of duplicating it.
+ */
+export function reinforceLesson(lesson: Lesson): void {
   const now = new Date().toISOString();
   lesson.reinforcements++;
   lesson.confidence = Math.min(

--- a/src/functions/replay.ts
+++ b/src/functions/replay.ts
@@ -13,7 +13,7 @@ import { importOrigin } from "../types.js";
 import type { StateKV } from "../state/kv.js";
 import { KV, generateId, fingerprintId } from "../state/schema.js";
 import { parseJsonlText } from "../replay/jsonl-parser.js";
-import { resetLessonIndex } from "./lessons.js";
+import { reinforceLesson, resetLessonIndex } from "./lessons.js";
 import { projectTimeline, type Timeline } from "../replay/timeline.js";
 import { safeAudit } from "./audit.js";
 import { buildSyntheticCompression } from "./compress-synthetic.js";
@@ -68,7 +68,7 @@ const LESSON_PATTERNS: RegExp[] = [
   /\b(prefer|avoid)\s[^.\n]{10,200}[.!\n]/gi,
 ];
 
-async function deriveCrystalAndLessons(
+export async function deriveCrystalAndLessons(
   kv: StateKV,
   sessionId: string,
   project: string,
@@ -134,10 +134,13 @@ async function deriveCrystalAndLessons(
           ...existing,
           sourceIds: mergedSources,
           tags: mergedTags,
-          reinforcements: (existing.reinforcements || 0) + 1,
           updatedAt: createdAt,
           lastReinforcedAt: createdAt,
         };
+        // Bumps reinforcements AND confidence. Doing it by hand here used to
+        // increment the counter only, so re-imported lessons stayed pinned at
+        // their initial 0.4 no matter how often they recurred.
+        reinforceLesson(merged);
         await kv.set(KV.lessons, lessonId, merged);
       } else {
         const lesson: Lesson = {

--- a/test/replay-lesson-reinforce.test.ts
+++ b/test/replay-lesson-reinforce.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../src/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { deriveCrystalAndLessons } from "../src/functions/replay.js";
+import { KV } from "../src/state/schema.js";
+import type { StateKV } from "../src/state/kv.js";
+import type { Lesson, RawObservation } from "../src/types.js";
+
+function mockKV() {
+  const store = new Map<string, Map<string, unknown>>();
+  return {
+    get: async <T>(scope: string, key: string): Promise<T | null> =>
+      (store.get(scope)?.get(key) as T) ?? null,
+    set: async <T>(scope: string, key: string, data: T): Promise<T> => {
+      if (!store.has(scope)) store.set(scope, new Map());
+      store.get(scope)!.set(key, data);
+      return data;
+    },
+    delete: async (scope: string, key: string): Promise<void> => {
+      store.get(scope)?.delete(key);
+    },
+    list: async <T>(scope: string): Promise<T[]> => {
+      const entries = store.get(scope);
+      return entries ? (Array.from(entries.values()) as T[]) : [];
+    },
+  } as unknown as StateKV;
+}
+
+// Matches LESSON_PATTERNS ("always ..." clause, 20-220 chars).
+const ASSISTANT_TEXT =
+  "Always run the migration before restarting the worker, or the index rebuild silently drops rows.";
+
+const rawObs = (sessionId: string): RawObservation[] =>
+  [
+    {
+      id: `${sessionId}-1`,
+      sessionId,
+      timestamp: new Date().toISOString(),
+      hookType: "stop",
+      assistantResponse: ASSISTANT_TEXT,
+    },
+  ] as unknown as RawObservation[];
+
+async function importSession(kv: StateKV, sessionId: string): Promise<void> {
+  await deriveCrystalAndLessons(kv, sessionId, "proj", rawObs(sessionId), [], undefined);
+}
+
+describe("deriveCrystalAndLessons lesson reinforcement", () => {
+  it("raises confidence when the same lesson is imported again", async () => {
+    const kv = mockKV();
+
+    await importSession(kv, "sess-1");
+    const first = (await kv.list<Lesson>(KV.lessons))[0];
+    expect(first).toBeDefined();
+    expect(first.confidence).toBe(0.4);
+    expect(first.reinforcements).toBe(0);
+
+    await importSession(kv, "sess-2");
+    const second = (await kv.list<Lesson>(KV.lessons))[0];
+    expect(second.id).toBe(first.id);
+    expect(second.reinforcements).toBe(1);
+    // 0.4 + 0.1 * (1 - 0.4)
+    expect(second.confidence).toBeCloseTo(0.46, 10);
+
+    await importSession(kv, "sess-3");
+    const third = (await kv.list<Lesson>(KV.lessons))[0];
+    expect(third.reinforcements).toBe(2);
+    expect(third.confidence).toBeCloseTo(0.514, 10);
+  });
+
+  it("keeps confidence and reinforcements in step over many imports", async () => {
+    const kv = mockKV();
+    for (let i = 0; i < 10; i++) await importSession(kv, `sess-${i}`);
+    const lesson = (await kv.list<Lesson>(KV.lessons))[0];
+    expect(lesson.reinforcements).toBe(9);
+    // 1 - (1 - 0.4) * 0.9 ** 9
+    expect(lesson.confidence).toBeCloseTo(1 - 0.6 * 0.9 ** 9, 10);
+    expect(lesson.confidence).toBeLessThan(1);
+  });
+});


### PR DESCRIPTION
## The bug

`deriveCrystalAndLessons` in `src/functions/replay.ts` hand-rolls the merge when an imported lesson already exists. It increments `reinforcements` and stamps `lastReinforcedAt`, but never touches `confidence`:

```ts
const merged: Lesson = {
  ...existing,
  sourceIds: mergedSources,
  tags: mergedTags,
  reinforcements: (existing.reinforcements || 0) + 1,  // counter moves
  updatedAt: createdAt,
  lastReinforcedAt: createdAt,                          // confidence does not
};
```

The other entry point, `mem::lesson-save`, calls `reinforceLesson()` instead, which applies `confidence + 0.1 * (1 - confidence)`. So the same event — "this lesson came up again" — raises confidence through one path and not the other.

## Why it matters

Every lesson created by `import-jsonl` gets `confidence: 0.4` and can never leave it, no matter how often it recurs.

On one install after importing a `~/.claude/projects` tree, all **788** imported lessons sat at exactly `0.4`. **142** of them had `reinforcements >= 1`; the distribution went up to 27:

| reinforcements | lessons | confidence | should have been |
|---|---|---|---|
| 1 | 98 | 0.4 | 0.46 |
| 3 | 11 | 0.4 | 0.563 |
| 15 | 4 | 0.4 | 0.876 |
| 27 | 1 | 0.4 | 0.965 |

`mem::lesson-recall` ranks by `confidence * relevance * recencyBoost`, so with every value identical, confidence degenerates to a constant and contributes nothing to ordering. A lesson seen 27 times ranks exactly like one seen once. The decay sweep is unaffected, but it means an auto-imported lesson only ever moves downward.

## The fix

Export `reinforceLesson` and call it from the import path, so both paths share a single formula rather than duplicating it a second time. `reinforcements` keeps incrementing exactly once per merge, since `reinforceLesson` owns that too.

`deriveCrystalAndLessons` is exported for the test, matching what `isSensitive` already does in the same module.

## Tests

`test/replay-lesson-reinforce.test.ts` uses the `mockKV()` pattern from `test/lessons.test.ts` and asserts that repeated imports of the same lesson text move confidence `0.4 -> 0.46 -> 0.514`, and that after 10 imports confidence equals `1 - 0.6 * 0.9 ** 9` with `reinforcements === 9`.

Verified it fails on `main` without the change:

```
AssertionError: expected 0.4 to be close to 0.46
AssertionError: expected 0.4 to be close to 0.7675477065999999
```

`vitest run` over `lessons`, `replay`, `replay-sensitive`, `context-lessons`, `lesson-index-recall` and the new file: 61 passed.

`tsc --noEmit` reports 30 errors, all pre-existing on a clean checkout of `main` and none in the touched files.

## Note for existing installs

Already-imported lessons stay pinned at 0.4 after upgrading — the fix only applies to subsequent merges. Backfilling means replaying the formula `n` times per lesson from its initial 0.4. Happy to add a migration to this PR if you would like one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lesson reinforcement when importing repeated sessions.
  * Lesson confidence now updates consistently alongside reinforcement counts.
  * Preserved lesson identity across multiple imports.

* **Tests**
  * Added coverage verifying repeated imports, reinforcement counts, and confidence updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->