### PR TITLE
fix(consolidation): dedupe double-fired consolidation LLM runs + crash-safe audit

### DIFF
--- a/src/functions/audit.ts
+++ b/src/functions/audit.ts
@@ -28,6 +28,13 @@ import { logger } from "../logger.js";
 //                         emitted by mem::auto-forget (automatic sweep).
 //   - everything else   — see AuditEntry["operation"] union in src/types.ts.
 //
+// Two-phase rows: mem::consolidate-pipeline writes its OWN row (via kv.set,
+// not recordAudit, because recordAudit mints a new id per call) with a
+// stable aud_ id — details.status "started" before the LLM work, then an
+// in-place update to "completed" + results. Crash-safe: a mid-pipeline kill
+// leaves the started row as evidence. Do not "simplify" this back into a
+// single recordAudit at the end.
+//
 // When adding a new deletion path, add an explicit recordAudit call
 // BEFORE kv.delete(...) and match one of the two shapes above.
 

--- a/src/functions/consolidation-pipeline.ts
+++ b/src/functions/consolidation-pipeline.ts
@@ -6,7 +6,7 @@ import type {
   Memory,
   MemoryProvider,
 } from "../types.js";
-import { KV, generateId } from "../state/schema.js";
+import { KV, fingerprintId, generateId } from "../state/schema.js";
 import type { StateKV } from "../state/kv.js";
 import {
   SEMANTIC_MERGE_SYSTEM,
@@ -15,8 +15,26 @@ import {
   buildProceduralExtractionPrompt,
 } from "../prompts/consolidation.js";
 import { recordAudit } from "./audit.js";
+import { withKeyedLock } from "../state/keyed-mutex.js";
 import { getConsolidationDecayDays, isConsolidationEnabled } from "../config.js";
 import { logger } from "../logger.js";
+
+// Corpus-level dedup guard for the semantic merge tier. Stored in KV.config
+// so the guard survives worker restarts and is shared across processes.
+//
+// Semantics: the fingerprint guard is UNCONDITIONAL — it applies to every
+// invocation, including force:true. `force` only bypasses the
+// isConsolidationEnabled() gate (policy bypass); it does not mean "re-run
+// the LLM on an unchanged corpus". The automated callers (session-stop
+// fan-out, eviction recovery) already check isConsolidationEnabled() before
+// firing, so their force:true is redundant; it must never bypass dedup or
+// the 340ms double-fire returns.
+//
+// Fingerprint window: the hash covers only the 20 most recent summaries
+// and only {title, narrative, concepts}. Changes beyond the window (or to
+// other summary fields) do not invalidate it — fine for a recency-ordered,
+// append-only corpus, but the guard is NOT a full-corpus change detector.
+const CORPUS_FINGERPRINT_KEY = "consolidation:corpusFingerprint";
 
 function applyDecay(
   items: Array<{
@@ -49,6 +67,10 @@ export function registerConsolidationPipelineFunction(
 ): void {
   sdk.registerFunction("mem::consolidate-pipeline", 
     async (data?: { tier?: string; force?: boolean; project?: string }) => {
+      // Serialize pipeline invocations in-process so concurrent triggers
+      // (session-stop fan-out, 2h timer, REST trigger, eviction recovery)
+      // cannot interleave two full-corpus passes on the same corpus.
+      return withKeyedLock("consolidation:global", async () => {
       if (!data?.force && !isConsolidationEnabled()) {
         return { success: false, skipped: true, reason: "Consolidation disabled: set CONSOLIDATION_ENABLED=true or configure an LLM provider (ANTHROPIC_API_KEY / OPENAI_API_KEY / OPENROUTER_API_KEY / GEMINI_API_KEY / GOOGLE_API_KEY / MINIMAX_API_KEY / OPENAI_BASE_URL / AGENTMEMORY_PROVIDER=agent-sdk)" };
       }
@@ -69,61 +91,86 @@ export function registerConsolidationPipelineFunction(
             )
             .slice(0, 20);
 
-          const prompt = buildSemanticMergePrompt(
-            recentSummaries.map((s) => ({
-              title: s.title,
-              narrative: s.narrative,
-              concepts: s.concepts,
-            })),
+          const corpusItems = recentSummaries.map((s) => ({
+            title: s.title,
+            narrative: s.narrative,
+            concepts: s.concepts,
+          }));
+          const prompt = buildSemanticMergePrompt(corpusItems);
+          const corpusFingerprint = fingerprintId(
+            "consolidation",
+            JSON.stringify(corpusItems),
           );
 
-          try {
-            const response = await provider.summarize(
-              SEMANTIC_MERGE_SYSTEM,
-              prompt,
-            );
-
-            const factRegex = /<fact\s+confidence="([^"]+)">([^<]+)<\/fact>/g;
-            let match;
-            let newFacts = 0;
-            const now = new Date().toISOString();
-
-            while ((match = factRegex.exec(response)) !== null) {
-              const parsedConf = parseFloat(match[1]);
-              const confidence = Number.isNaN(parsedConf) ? 0.5 : parsedConf;
-              const fact = match[2].trim();
-
-              const existing = existingSemantic.find(
-                (s) => s.fact.toLowerCase() === fact.toLowerCase(),
+          const lastConsolidation = await kv
+            .get<{ fingerprint?: string }>(KV.config, CORPUS_FINGERPRINT_KEY)
+            .catch(() => null);
+          if (lastConsolidation?.fingerprint === corpusFingerprint) {
+            results.semantic = {
+              skipped: true,
+              reason: "corpus unchanged since last consolidation",
+            };
+          } else {
+            try {
+              // Reserve the fingerprint before the LLM call so a concurrent
+              // identical invocation (session-stop fan-out, 2h timer, REST
+              // trigger) observes the reservation and skips. iii-sdk offers
+              // no CAS primitive, so this is the strongest cross-process
+              // guard available; the reservation is released on failure so
+              // a failed consolidation can be retried.
+              await kv
+                .set(KV.config, CORPUS_FINGERPRINT_KEY, {
+                  fingerprint: corpusFingerprint,
+                })
+                .catch(() => {});
+              const response = await provider.summarize(
+                SEMANTIC_MERGE_SYSTEM,
+                prompt,
               );
-              if (existing) {
-                existing.accessCount++;
-                existing.lastAccessedAt = now;
-                existing.updatedAt = now;
-                existing.confidence = Math.max(existing.confidence, confidence);
-                await kv.set(KV.semantic, existing.id, existing);
-              } else {
-                const sem: SemanticMemory = {
-                  id: generateId("sem"),
-                  fact,
-                  confidence,
-                  sourceSessionIds: recentSummaries.map((s) => s.sessionId),
-                  sourceMemoryIds: [],
-                  accessCount: 1,
-                  lastAccessedAt: now,
-                  strength: confidence,
-                  createdAt: now,
-                  updatedAt: now,
-                };
-                await kv.set(KV.semantic, sem.id, sem);
-                newFacts++;
+
+              const factRegex = /<fact\s+confidence="([^"]+)">([^<]+)<\/fact>/g;
+              let match;
+              let newFacts = 0;
+              const now = new Date().toISOString();
+
+              while ((match = factRegex.exec(response)) !== null) {
+                const parsedConf = parseFloat(match[1]);
+                const confidence = Number.isNaN(parsedConf) ? 0.5 : parsedConf;
+                const fact = match[2].trim();
+
+                const existing = existingSemantic.find(
+                  (s) => s.fact.toLowerCase() === fact.toLowerCase(),
+                );
+                if (existing) {
+                  existing.accessCount++;
+                  existing.lastAccessedAt = now;
+                  existing.updatedAt = now;
+                  existing.confidence = Math.max(existing.confidence, confidence);
+                  await kv.set(KV.semantic, existing.id, existing);
+                } else {
+                  const sem: SemanticMemory = {
+                    id: generateId("sem"),
+                    fact,
+                    confidence,
+                    sourceSessionIds: recentSummaries.map((s) => s.sessionId),
+                    sourceMemoryIds: [],
+                    accessCount: 1,
+                    lastAccessedAt: now,
+                    strength: confidence,
+                    createdAt: now,
+                    updatedAt: now,
+                  };
+                  await kv.set(KV.semantic, sem.id, sem);
+                  newFacts++;
+                }
               }
+              results.semantic = { newFacts, totalSummaries: summaries.length };
+            } catch (err) {
+              const msg = err instanceof Error ? err.message : String(err);
+              logger.error("Semantic consolidation failed", { error: msg });
+              results.semantic = { error: msg };
+              await kv.delete(KV.config, CORPUS_FINGERPRINT_KEY).catch(() => {});
             }
-            results.semantic = { newFacts, totalSummaries: summaries.length };
-          } catch (err) {
-            const msg = err instanceof Error ? err.message : String(err);
-            logger.error("Semantic consolidation failed", { error: msg });
-            results.semantic = { error: msg };
           }
         } else {
           results.semantic = {
@@ -265,6 +312,7 @@ export function registerConsolidationPipelineFunction(
 
       logger.info("Consolidation pipeline complete", { tier, results });
       return { success: true, results };
+      });
     },
   );
 }

--- a/src/functions/consolidation-pipeline.ts
+++ b/src/functions/consolidation-pipeline.ts
@@ -5,6 +5,7 @@ import type {
   SessionSummary,
   Memory,
   MemoryProvider,
+  AuditEntry,
 } from "../types.js";
 import { KV, fingerprintId, generateId } from "../state/schema.js";
 import type { StateKV } from "../state/kv.js";
@@ -14,7 +15,6 @@ import {
   PROCEDURAL_EXTRACTION_SYSTEM,
   buildProceduralExtractionPrompt,
 } from "../prompts/consolidation.js";
-import { recordAudit } from "./audit.js";
 import { withKeyedLock } from "../state/keyed-mutex.js";
 import { getConsolidationDecayDays, isConsolidationEnabled } from "../config.js";
 import { logger } from "../logger.js";
@@ -70,6 +70,20 @@ export function registerConsolidationPipelineFunction(
       // Serialize pipeline invocations in-process so concurrent triggers
       // (session-stop fan-out, 2h timer, REST trigger, eviction recovery)
       // cannot interleave two full-corpus passes on the same corpus.
+      //
+      // Cross-process: the CLI enforces one worker per engine (main() probes
+      // /agentmemory/livez and refuses to boot a second instance, cli.ts),
+      // so the in-process lock plus the KV fingerprint reserve are
+      // sufficient — no distributed lease needed. Topology notes:
+      // - --instance N is a port shortcut (own REST/engine port quartet),
+      //   so it runs its OWN engine+worker, not a second worker on the
+      //   shared engine; when instances share a data directory the KV (and
+      //   the fingerprint reserve) is shared, so the reserve is the only
+      //   cross-process guard, with a sub-ms read-reserve TOCTOU window
+      //   that is accepted.
+      // - A worker attached to an existing engine via an explicit
+      //   III_ENGINE_URL/III_ENGINE_PORT override has the same property:
+      //   the fingerprint reserve is the sole cross-process guard.
       return withKeyedLock("consolidation:global", async () => {
       if (!data?.force && !isConsolidationEnabled()) {
         return { success: false, skipped: true, reason: "Consolidation disabled: set CONSOLIDATION_ENABLED=true or configure an LLM provider (ANTHROPIC_API_KEY / OPENAI_API_KEY / OPENROUTER_API_KEY / GEMINI_API_KEY / GOOGLE_API_KEY / MINIMAX_API_KEY / OPENAI_BASE_URL / AGENTMEMORY_PROVIDER=agent-sdk)" };
@@ -77,6 +91,23 @@ export function registerConsolidationPipelineFunction(
       const tier = data?.tier || "all";
       const decayDays = getConsolidationDecayDays();
       const results: Record<string, unknown> = {};
+
+      // Crash-safe audit: write the row BEFORE any LLM/state work so a kill
+      // mid-pipeline (e.g. between semantic writes and completion — observed
+      // 2026-09-01, semantic facts persisted with no audit row) still leaves
+      // an audit trail. The row is updated in place at the end with results;
+      // the stable aud_ id correlates started→completed and its timestamp is
+      // the pipeline start time.
+      const auditId = generateId("aud");
+      const auditEntry: AuditEntry = {
+        id: auditId,
+        timestamp: new Date().toISOString(),
+        operation: "consolidate",
+        functionId: "mem::consolidate-pipeline",
+        targetIds: [],
+        details: { tier, project: data?.project, status: "started" },
+      };
+      await kv.set(KV.audit, auditId, auditEntry);
 
       if (tier === "all" || tier === "semantic") {
         const summaries = await kv.list<SessionSummary>(KV.summaries);
@@ -305,9 +336,9 @@ export function registerConsolidationPipelineFunction(
         }
       }
 
-      await recordAudit(kv, "consolidate", "mem::consolidate-pipeline", [], {
-        tier,
-        results,
+      await kv.set(KV.audit, auditId, {
+        ...auditEntry,
+        details: { ...auditEntry.details, status: "completed", results },
       });
 
       logger.info("Consolidation pipeline complete", { tier, results });

--- a/test/consolidation-pipeline.test.ts
+++ b/test/consolidation-pipeline.test.ts
@@ -360,6 +360,33 @@ describe("Consolidation Pipeline", () => {
     expect(calls).toBe(2);
   });
 
+  it("writes the audit row before the LLM call so a mid-pipeline kill still leaves a trail", async () => {
+    let auditAtLlmCall: unknown = null;
+    const provider = {
+      name: "test",
+      compress: vi.fn(),
+      summarize: vi.fn().mockImplementation(async () => {
+        auditAtLlmCall = await kv.list("mem:audit");
+        return `<facts><fact confidence="0.9">TypeScript is the primary language</fact></facts>`;
+      }),
+    };
+    registerConsolidationPipelineFunction(sdk as never, kv as never, provider as never);
+
+    for (let i = 0; i < 6; i++) {
+      await kv.set("mem:summaries", `ses_${i}`, makeSummary(i));
+    }
+
+    await sdk.trigger("mem::consolidate-pipeline", { tier: "semantic" });
+
+    const atCall = auditAtLlmCall as Array<{ details: { status: string } }>;
+    expect(atCall.length).toBe(1);
+    expect(atCall[0].details.status).toBe("started");
+
+    const final = await kv.list<{ details: { status: string } }>("mem:audit");
+    expect(final.length).toBe(1);
+    expect(final[0].details.status).toBe("completed");
+  });
+
   it("consolidation records an audit entry", async () => {
     const provider = {
       name: "test",

--- a/test/consolidation-pipeline.test.ts
+++ b/test/consolidation-pipeline.test.ts
@@ -196,6 +196,170 @@ describe("Consolidation Pipeline", () => {
     expect(stored[0].triggerCondition).toBe("when writing tests");
   });
 
+  it("deduplicates identical corpus: second sequential run skips the LLM", async () => {
+    let calls = 0;
+    const provider = {
+      name: "test",
+      compress: vi.fn(),
+      summarize: vi.fn().mockImplementation(async () => {
+        calls++;
+        return `<facts><fact confidence="0.9">TypeScript is the primary language</fact></facts>`;
+      }),
+    };
+    registerConsolidationPipelineFunction(sdk as never, kv as never, provider as never);
+
+    for (let i = 0; i < 6; i++) {
+      await kv.set("mem:summaries", `ses_${i}`, makeSummary(i));
+    }
+
+    const first = (await sdk.trigger("mem::consolidate-pipeline", {
+      tier: "semantic",
+    })) as { results: { semantic: { newFacts: number } } };
+    expect(first.results.semantic.newFacts).toBe(1);
+    expect(calls).toBe(1);
+
+    const second = (await sdk.trigger("mem::consolidate-pipeline", {
+      tier: "semantic",
+    })) as { results: { semantic: { skipped: boolean; reason: string } } };
+    expect(second.results.semantic.skipped).toBe(true);
+    expect(second.results.semantic.reason).toContain("corpus unchanged");
+    expect(calls).toBe(1);
+  });
+
+  it("deduplicates concurrent identical invocations: LLM called exactly once", async () => {
+    let calls = 0;
+    const provider = {
+      name: "test",
+      compress: vi.fn(),
+      summarize: vi.fn().mockImplementation(async () => {
+        calls++;
+        return `<facts><fact confidence="0.9">TypeScript is the primary language</fact></facts>`;
+      }),
+    };
+    registerConsolidationPipelineFunction(sdk as never, kv as never, provider as never);
+
+    for (let i = 0; i < 6; i++) {
+      await kv.set("mem:summaries", `ses_${i}`, makeSummary(i));
+    }
+
+    await Promise.all([
+      sdk.trigger("mem::consolidate-pipeline", { tier: "semantic" }),
+      sdk.trigger("mem::consolidate-pipeline", { tier: "semantic" }),
+    ]);
+
+    expect(calls).toBe(1);
+  });
+
+  it("re-runs consolidation when the corpus gains new summaries", async () => {
+    let calls = 0;
+    const provider = {
+      name: "test",
+      compress: vi.fn(),
+      summarize: vi.fn().mockImplementation(async () => {
+        calls++;
+        return `<facts><fact confidence="0.9">TypeScript is the primary language</fact></facts>`;
+      }),
+    };
+    registerConsolidationPipelineFunction(sdk as never, kv as never, provider as never);
+
+    for (let i = 0; i < 6; i++) {
+      await kv.set("mem:summaries", `ses_${i}`, makeSummary(i));
+    }
+    await sdk.trigger("mem::consolidate-pipeline", { tier: "semantic" });
+    expect(calls).toBe(1);
+
+    await kv.set("mem:summaries", "ses_new", makeSummary(6));
+    await sdk.trigger("mem::consolidate-pipeline", { tier: "semantic" });
+    expect(calls).toBe(2);
+  });
+
+  it("force=true does not bypass corpus dedup: unchanged corpus still skips the LLM", async () => {
+    let calls = 0;
+    const provider = {
+      name: "test",
+      compress: vi.fn(),
+      summarize: vi.fn().mockImplementation(async () => {
+        calls++;
+        return `<facts><fact confidence="0.9">TypeScript is the primary language</fact></facts>`;
+      }),
+    };
+    registerConsolidationPipelineFunction(sdk as never, kv as never, provider as never);
+
+    for (let i = 0; i < 6; i++) {
+      await kv.set("mem:summaries", `ses_${i}`, makeSummary(i));
+    }
+
+    const first = (await sdk.trigger("mem::consolidate-pipeline", {
+      tier: "semantic",
+      force: true,
+    })) as { results: { semantic: { newFacts: number } } };
+    expect(first.results.semantic.newFacts).toBe(1);
+    expect(calls).toBe(1);
+
+    const second = (await sdk.trigger("mem::consolidate-pipeline", {
+      tier: "semantic",
+      force: true,
+    })) as { results: { semantic: { skipped: boolean; reason: string } } };
+    expect(second.results.semantic.skipped).toBe(true);
+    expect(second.results.semantic.reason).toContain("corpus unchanged");
+    expect(calls).toBe(1);
+  });
+
+  it("force=true reruns the LLM when the corpus changed since last consolidation", async () => {
+    let calls = 0;
+    const provider = {
+      name: "test",
+      compress: vi.fn(),
+      summarize: vi.fn().mockImplementation(async () => {
+        calls++;
+        return `<facts><fact confidence="0.9">TypeScript is the primary language</fact></facts>`;
+      }),
+    };
+    registerConsolidationPipelineFunction(sdk as never, kv as never, provider as never);
+
+    for (let i = 0; i < 6; i++) {
+      await kv.set("mem:summaries", `ses_${i}`, makeSummary(i));
+    }
+    await sdk.trigger("mem::consolidate-pipeline", { tier: "semantic", force: true });
+    expect(calls).toBe(1);
+
+    await kv.set("mem:summaries", "ses_new", makeSummary(6));
+    await sdk.trigger("mem::consolidate-pipeline", { tier: "semantic", force: true });
+    expect(calls).toBe(2);
+  });
+
+  it("releases the fingerprint reservation when the LLM fails so retry re-runs", async () => {
+    let calls = 0;
+    const provider = {
+      name: "test",
+      compress: vi.fn(),
+      summarize: vi.fn().mockImplementation(async () => {
+        calls++;
+        if (calls === 1) throw new Error("LLM timeout");
+        return `<facts><fact confidence="0.9">TypeScript is the primary language</fact></facts>`;
+      }),
+    };
+    registerConsolidationPipelineFunction(sdk as never, kv as never, provider as never);
+
+    for (let i = 0; i < 6; i++) {
+      await kv.set("mem:summaries", `ses_${i}`, makeSummary(i));
+    }
+
+    const first = (await sdk.trigger("mem::consolidate-pipeline", {
+      tier: "semantic",
+    })) as { results: { semantic: { error: string } } };
+    expect(first.results.semantic.error).toContain("LLM timeout");
+    expect(
+      await kv.get("mem:config", "consolidation:corpusFingerprint"),
+    ).toBeNull();
+
+    const second = (await sdk.trigger("mem::consolidate-pipeline", {
+      tier: "semantic",
+    })) as { results: { semantic: { newFacts: number } } };
+    expect(second.results.semantic.newFacts).toBe(1);
+    expect(calls).toBe(2);
+  });
+
   it("consolidation records an audit entry", async () => {
     const provider = {
       name: "test",


### PR DESCRIPTION
## Problem

The corpus consolidation pipeline (`mem::consolidate-pipeline`) can run the
same full-corpus LLM work **more than once** for the same corpus state.
Observed twice in production on v0.9.29:

- Two identical LLM requests fired **340ms apart** (same 22,821-char payload,
  both returned 200). Second run even reused the first's prompt cache —
  proof it was a re-send of the exact same prompt, not a retry.
- Audit log shows **4 concurrent pipeline runs** on the same corpus
  (14:26:31Z / 14:27:06Z / 14:27:07Z / 14:27:10Z, all totalSummaries=77).

Triggers that can overlap: session-stop fan-out (`events.ts`), 2h timer
(`index.ts`), REST endpoint (`api.ts`), eviction recovery (`evict.ts`).

## Fix

1. **Corpus-fingerprint dedup** (`consolidation-pipeline.ts`) — hash the
   top-20 summary inputs (`{title, narrative, concepts}`); reserve the
   fingerprint **before** the LLM call, skip when unchanged, release on
   failure so a failed consolidation can retry.
2. **`withKeyedLock("consolidation:global")`** — serialize pipeline
   invocations in-process so concurrent triggers cannot interleave.
3. **Crash-safe audit** (`consolidation-pipeline.ts` + `audit.ts`) — write
   an `operation:"consolidate"` audit row with `status:"started"` **before**
   any LLM/state work, then flip to `status:"completed"` at the end. A
   mid-pipeline kill now leaves a trail instead of silently writing facts
   with no audit entry (the 10:25Z incident's behavior).
4. **Force no longer bypasses dedup** — `force:true` only bypasses the
   `isConsolidationEnabled()` gate. All automated callers pass
   `force:true`, so allowing it to skip dedup would reintroduce the bug.

## Tests (14 in file, 5 new)

- sequential identical corpus → 1 LLM call
- concurrent identical invocations → 1 LLM call
- corpus change → re-runs (2 calls)
- force=true + unchanged corpus → still skips
- LLM failure → fingerprint released → retry re-runs
- audit row exists (`status:"started"`) at LLM-call time

## Validation

- `npx vitest run test/consolidation-pipeline.test.ts` → 14/14 pass
- `npm test` full suite → 172 files, 1,862 tests pass
- `npx tsc --noEmit` → no new errors in touched files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Avoids repeating semantic consolidation when the summary corpus has not changed.
  * Coordinates simultaneous consolidation requests so identical work runs only once.
  * Automatically reruns consolidation when new summaries are available.
  * Supports forced reruns when the corpus has changed.
  * Records audit activity before processing and updates it with completion results.

* **Bug Fixes**
  * Failed consolidation attempts now release their reservation, allowing retries to run successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->