### PR TITLE
feat: Kimi Code CLI plugin support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ agentmemory is a persistent memory system for AI coding agents, built on iii-eng
 6. `README.md` — tool counts (search for "MCP tools")
 7. `plugin/.claude-plugin/plugin.json` — tool count in description
 8. `plugin/plugin.json` and `plugin/.mcp.copilot.json` (when present) — tool count or MCP exposure
+9. `plugin/kimi.plugin.json` — tool count in description
 
 **When adding REST endpoints, you MUST update:**
 1. `src/triggers/api.ts` — endpoint registration
@@ -34,6 +35,7 @@ agentmemory is a persistent memory system for AI coding agents, built on iii-eng
 5. `test/export-import.test.ts` — version assertion
 6. `plugin/.claude-plugin/plugin.json` — version field
 7. `plugin/plugin.json` (when present) — version field
+8. `plugin/kimi.plugin.json` — version field
 
 **When adding new KV scopes:**
 1. `src/state/schema.ts` — add to the KV object

--- a/README.md
+++ b/README.md
@@ -629,6 +629,25 @@ agentmemory connect codex --with-hooks
 
 This adds an idempotent block to `~/.codex/hooks.json` referencing absolute paths to the bundled scripts (no `${CLAUDE_PLUGIN_ROOT}` expansion needed at user-scope). Re-run the same command after upgrading agentmemory to refresh paths. User entries in the same file are preserved; only previous agentmemory entries are replaced.
 
+### Kimi Code CLI
+
+```bash
+# 1. start the memory server in a separate terminal
+npx -y @agentmemory/agentmemory@latest
+
+# 2. install the plugin from a local checkout, then reload
+/plugins install ./plugin
+/reload
+```
+
+The Kimi Code plugin ships from the same `plugin/` directory via `plugin/kimi.plugin.json`. It registers:
+
+- `@agentmemory/mcp` as an MCP server (proxies all 54 tools when `AGENTMEMORY_URL` points at a running agentmemory server; falls back to a reduced local tool set when no server is reachable)
+- 10 lifecycle hooks: `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `PreCompact`, `SubagentStart`, `SubagentStop`, `Stop`, `SessionEnd` — the same host-agnostic scripts as the Claude Code plugin; Kimi Code runs plugin hooks with the plugin root as the working directory, so commands use `./scripts/...` paths and no `${CLAUDE_PLUGIN_ROOT}` placeholder
+- 17 invocable + reference skills
+
+`Notification` and `TaskCompleted` are not registered for Kimi Code: both scripts gate on Claude-Code-specific payload fields and would be no-ops. Session-end transcript replay is skipped automatically because Kimi Code does not pass a `transcript_path`; the session is still closed out via `/session/end`. Manage the plugin's MCP server with `/plugins mcp enable|disable agentmemory agentmemory`.
+
 ### GitHub Copilot CLI
 
 ```bash
@@ -740,6 +759,7 @@ The agentmemory entry is the **same MCP server block** across every host that us
 | **OpenClaw** | OpenClaw MCP config | Same `mcpServers` block. Deeper: `openclaw plugins install ./integrations/openclaw` claims OpenClaw's memory slot (auto-switches from `memory-core`); set `plugins.entries.agentmemory.hooks.allowConversationAccess=true` or turn capture is silently blocked. See [`integrations/openclaw`](integrations/openclaw/). |
 | **Codex CLI (MCP only)** | `.codex/config.toml` | TOML shape: `codex mcp add agentmemory -- npx -y @agentmemory/mcp`, or add `[mcp_servers.agentmemory]` manually. |
 | **Codex CLI (full plugin)** | Codex plugin marketplace | `codex plugin marketplace add rohitg00/agentmemory` then `codex plugin add agentmemory@agentmemory`. Registers MCP + 6 lifecycle hooks (SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, PreCompact, Stop) + 17 skills. On Codex Desktop, also run `agentmemory connect codex --with-hooks` until [openai/codex#16430](https://github.com/openai/codex/issues/16430) lands; plugin hooks are currently silent there. |
+| **Kimi Code CLI (full plugin)** | `plugin/kimi.plugin.json` | `/plugins install ./plugin` from a checkout, then `/reload`. Registers MCP + 10 lifecycle hooks (SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, PostToolUseFailure, PreCompact, SubagentStart, SubagentStop, Stop, SessionEnd) + 17 skills. Plugins install per-user and apply to all projects. |
 | **OpenCode (MCP only)** | `opencode.json` | Different shape: top-level `mcp` key, command as array: `{"mcp": {"agentmemory": {"type": "local", "command": ["npx", "-y", "@agentmemory/mcp"], "enabled": true}}}`. |
 | **OpenCode (full plugin)** | `plugin/opencode/` | 22 auto-capture hooks covering session lifecycle, messages, tools, errors. Project attribution is per-session, so one OpenCode process spanning several repositories files each session under its own project. Two slash commands (`/recall`, `/remember`). Copy `plugin/opencode/` into your OpenCode workspace and add the plugin entry to `opencode.json`. See [`plugin/opencode/README.md`](plugin/opencode/README.md) for the full hook table + gap analysis. |
 | **pi** | `~/.pi/agent/extensions/agentmemory` | `agentmemory connect pi` installs the bundled extension into pi's auto-discovery directory (recall on agent start, capture on agent end, `memory_search` / `memory_save` / `memory_health` tools, `/agentmemory-status`). `/reload` in a running pi picks it up. [`integrations/pi`](integrations/pi/) is also a pi package (`pi install ./integrations/pi` from a checkout). |

--- a/plugin/kimi.plugin.json
+++ b/plugin/kimi.plugin.json
@@ -1,0 +1,81 @@
+{
+  "name": "agentmemory",
+  "version": "0.9.29",
+  "description": "Persistent memory for AI coding agents -- captures tool usage, compresses via LLM, injects context into future sessions. 10 hooks, 54 MCP tools, 17 skills, real-time viewer.",
+  "author": {
+    "name": "Rohit Ghumare",
+    "url": "https://github.com/rohitg00"
+  },
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/rohitg00/agentmemory",
+  "keywords": ["memory", "agent-memory", "mcp", "context", "hooks"],
+  "interface": {
+    "displayName": "AgentMemory",
+    "shortDescription": "Persistent memory for coding agents: recall, lessons, handoffs, session history"
+  },
+  "skills": "./skills/",
+  "mcpServers": {
+    "agentmemory": {
+      "command": "npx",
+      "args": ["-y", "@agentmemory/mcp"],
+      "env": {
+        "AGENTMEMORY_URL": "${AGENTMEMORY_URL:-http://localhost:3111}",
+        "AGENTMEMORY_SECRET": "${AGENTMEMORY_SECRET:-}",
+        "AGENTMEMORY_TOOLS": "${AGENTMEMORY_TOOLS:-all}"
+      }
+    }
+  },
+  "hooks": [
+    {
+      "event": "SessionStart",
+      "command": "node ./scripts/session-start.mjs",
+      "timeout": 15
+    },
+    {
+      "event": "UserPromptSubmit",
+      "command": "node ./scripts/prompt-submit.mjs",
+      "timeout": 5
+    },
+    {
+      "event": "PreToolUse",
+      "matcher": "Edit|Write|Read|Glob|Grep",
+      "command": "node ./scripts/pre-tool-use.mjs",
+      "timeout": 10
+    },
+    {
+      "event": "PostToolUse",
+      "command": "node ./scripts/post-tool-use.mjs",
+      "timeout": 5
+    },
+    {
+      "event": "PostToolUseFailure",
+      "command": "node ./scripts/post-tool-failure.mjs",
+      "timeout": 5
+    },
+    {
+      "event": "PreCompact",
+      "command": "node ./scripts/pre-compact.mjs",
+      "timeout": 15
+    },
+    {
+      "event": "SubagentStart",
+      "command": "node ./scripts/subagent-start.mjs",
+      "timeout": 5
+    },
+    {
+      "event": "SubagentStop",
+      "command": "node ./scripts/subagent-stop.mjs",
+      "timeout": 5
+    },
+    {
+      "event": "Stop",
+      "command": "node ./scripts/stop.mjs",
+      "timeout": 10
+    },
+    {
+      "event": "SessionEnd",
+      "command": "node ./scripts/session-end.mjs",
+      "timeout": 10
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds `plugin/kimi.plugin.json` so the existing `plugin/` directory installs natively as a [Kimi Code CLI](https://www.kimi.com/code/docs/en/kimi-code-cli/customization/plugins.html) plugin:

```bash
/plugins install ./plugin   # from a checkout, then /reload
```

## What the manifest registers

- **10 lifecycle hooks** — the same host-agnostic scripts (`plugin/scripts/*.mjs`) as the Claude Code plugin: `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `PreCompact`, `SubagentStart`, `SubagentStop`, `Stop`, `SessionEnd`. Kimi Code runs plugin hooks with the plugin root as the working directory, so commands use `./scripts/...` paths and no `${CLAUDE_PLUGIN_ROOT}` placeholder is needed.
- **`mcpServers`** — the `@agentmemory/mcp` stdio shim, declared inline (Kimi manifests cannot reference an external `.mcp.json`). The shim already tolerates hosts that don't expand `${VAR:-default}` placeholders, so the env block matches the existing `.mcp.json` verbatim.
- **`skills: ./skills/`** — all 17 skills work unchanged (standard `SKILL.md` format).

## Compatibility notes (verified against the hook scripts)

- `Notification` and `TaskCompleted` are intentionally **not** registered: `notification.mjs` gates on Claude's `permission_prompt` type and `task-completed.mjs` reads Claude-only fields — both would be silent no-ops under Kimi Code.
- Session-end transcript replay degrades gracefully: Kimi Code does not pass `transcript_path`, so `session-end.mjs` skips replay and still closes the session via `/session/end`.
- All other scripts read only shared fields (`session_id`, `cwd`, `tool_name`, `tool_input`, `prompt`) present in Kimi Code's hook payloads, and all degrade gracefully on missing fields (fail-open, no stdout except the three context-injecting hooks which emit plain text — matching Kimi Code's stdout semantics).

## Test plan

- [x] Manifest parses as valid JSON; all 10 referenced hook scripts exist; 17 skill dirs each contain `SKILL.md`
- [x] Installed into a real Kimi Code CLI (`~/.kimi-code/plugins/managed/agentmemory`, `installed.json` entry) — loads as an enabled plugin
- [ ] Maintainer: `/plugins info agentmemory` shows no diagnostics after install

🤖 Generated with [Kimi Code](https://www.kimi.com/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Kimi Code CLI integration for agentmemory.
  - Added support for MCP connectivity, lifecycle hooks, skills, and transcript replay.
  - Added a full-plugin configuration option for Kimi Code.

- **Documentation**
  - Added setup and local installation instructions for Kimi Code.
  - Documented plugin reload steps, MCP management commands, supported capabilities, and unsupported events.
  - Updated maintenance guidance for keeping Kimi Code integration details current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->