### PR TITLE
fix(memory): reject leaked tool-call args in remember

### DIFF
--- a/src/functions/remember.ts
+++ b/src/functions/remember.ts
@@ -55,8 +55,14 @@ export function registerRememberFunction(sdk: ISdk, kv: StateKV): void {
       // not schema-invalid: it saves, with type/concepts/files/project silently
       // left at their defaults and the markup embedded in the memory. Refuse it
       // so the caller resends instead. More than one marker is required, so
-      // content that legitimately mentions one of these tags still saves.
-      if (ARG_LEAK_PATTERNS.filter((p) => p.test(data.content)).length > 1) {
+      // content that legitimately mentions one of these tags still saves. Count
+      // occurrences, not matched categories, so two leaked <type> tags trip this
+      // as surely as one <type> plus one <concepts>.
+      const markerCount = ARG_LEAK_PATTERNS.reduce(
+        (count, p) => count + (data.content.match(new RegExp(p.source, p.flags + "g"))?.length ?? 0),
+        0,
+      );
+      if (markerCount > 1) {
         return {
           success: false,
           error:

--- a/src/functions/remember.ts
+++ b/src/functions/remember.ts
@@ -19,6 +19,19 @@ function safeSlice(text: string, length: number): string {
   return /[\uD800-\uDBFF]$/.test(sliced) ? sliced.slice(0, -1) : sliced;
 }
 
+// Signs that a caller mis-encoded its tool call and the arguments after content
+// were absorbed into content as literal text. Matching the argument names of the
+// save tools keeps this specific to that failure. No /g flag: these are reused
+// across calls, and a stateful lastIndex would make matching intermittent.
+const ARG_LEAK_PATTERNS = [
+  /<\/(?:[a-z]+:)?(?:parameter|invoke|function_calls)>/i,
+  /<\/content>/i,
+  /<type>\s*\S/i,
+  /<concepts>\s*\S/i,
+  /<files>\s*\S/i,
+  /<project>\s*\S/i,
+];
+
 export function registerRememberFunction(sdk: ISdk, kv: StateKV): void {
   sdk.registerFunction("mem::remember", 
     async (data: {
@@ -37,6 +50,20 @@ export function registerRememberFunction(sdk: ISdk, kv: StateKV): void {
         !data.content.trim()
       ) {
         return { success: false, error: "content is required" };
+      }
+      // content is free-form, so a call whose later arguments leaked into it is
+      // not schema-invalid: it saves, with type/concepts/files/project silently
+      // left at their defaults and the markup embedded in the memory. Refuse it
+      // so the caller resends instead. More than one marker is required, so
+      // content that legitimately mentions one of these tags still saves.
+      if (ARG_LEAK_PATTERNS.filter((p) => p.test(data.content)).length > 1) {
+        return {
+          success: false,
+          error:
+            "content contains tool-call markup, so the arguments after it were " +
+            "probably absorbed into content. Resend with one parameter per " +
+            "argument: content, type, concepts, files, project.",
+        };
       }
       if (data.files && !Array.isArray(data.files)) {
         return { success: false, error: "files must be an array" };

--- a/src/functions/remember.ts
+++ b/src/functions/remember.ts
@@ -55,9 +55,7 @@ export function registerRememberFunction(sdk: ISdk, kv: StateKV): void {
       // not schema-invalid: it saves, with type/concepts/files/project silently
       // left at their defaults and the markup embedded in the memory. Refuse it
       // so the caller resends instead. More than one marker is required, so
-      // content that legitimately mentions one of these tags still saves. Count
-      // occurrences, not matched categories, so two leaked <type> tags trip this
-      // as surely as one <type> plus one <concepts>.
+      // content that legitimately mentions one of these tags still saves.
       const markerCount = ARG_LEAK_PATTERNS.reduce(
         (count, p) => count + (data.content.match(new RegExp(p.source, p.flags + "g"))?.length ?? 0),
         0,

--- a/test/remember-arg-leak.test.ts
+++ b/test/remember-arg-leak.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+vi.mock("../src/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("../src/state/keyed-mutex.js", () => ({
+  withKeyedLock: <T>(_key: string, fn: () => Promise<T>) => fn(),
+}));
+
+vi.mock("iii-sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("iii-sdk")>();
+  return {
+    ...actual,
+    TriggerAction: {
+      ...actual.TriggerAction,
+      Void: vi.fn(() => ({ type: "void" })),
+    },
+  };
+});
+
+import { vi } from "vitest";
+import { registerRememberFunction } from "../src/functions/remember.js";
+import { getSearchIndex, setIndexPersistence } from "../src/functions/search.js";
+
+function mockKV() {
+  const store = new Map<string, Map<string, unknown>>();
+  return {
+    get: async <T>(scope: string, key: string): Promise<T | null> =>
+      (store.get(scope)?.get(key) as T) ?? null,
+    set: async <T>(scope: string, key: string, data: T): Promise<T> => {
+      if (!store.has(scope)) store.set(scope, new Map());
+      store.get(scope)!.set(key, data);
+      return data;
+    },
+    delete: async (scope: string, key: string): Promise<void> => {
+      store.get(scope)?.delete(key);
+    },
+    list: async <T>(scope: string): Promise<T[]> => {
+      const entries = store.get(scope);
+      return entries ? (Array.from(entries.values()) as T[]) : [];
+    },
+  };
+}
+
+function mockSdk() {
+  const functions = new Map<string, Function>();
+  return {
+    registerFunction: (id: string, handler: Function) => {
+      functions.set(id, handler);
+    },
+    registerTrigger: () => {},
+    trigger: async (input: { function_id: string; payload: unknown }) => {
+      const fn = functions.get(input.function_id);
+      if (!fn) return {};
+      return fn(input.payload);
+    },
+  };
+}
+
+async function remember(payload: unknown) {
+  const sdk = mockSdk();
+  const kv = mockKV();
+  registerRememberFunction(sdk as never, kv as never);
+
+  const result = (await sdk.trigger({
+    function_id: "mem::remember",
+    payload,
+  })) as { success: boolean; error?: string; memory?: { id: string; type: string } };
+
+  return { result, kv };
+}
+
+describe("mem::remember — mis-encoded tool call arguments", () => {
+  beforeEach(() => {
+    getSearchIndex().clear();
+    setIndexPersistence(null);
+  });
+
+  afterEach(() => {
+    setIndexPersistence(null);
+  });
+
+  // Verbatim shape of a real mis-encoded save: the caller closed content with a
+  // tag and wrote the remaining arguments as text, so only content arrived.
+  const leaked = [
+    "porter export handler: the 413 size-limit precedence is MaxBytesError first.",
+    "</content>",
+    "<type>bug</type>",
+    "<concepts>porter, export handler</concepts>",
+    "<files>internal/porter/handler/export/export.go</files>",
+    "<project>porter</project>",
+    "</invoke>",
+  ].join("\n");
+
+  it("refuses content carrying the arguments that followed it", async () => {
+    const { result, kv } = await remember({ content: leaked });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("one parameter per argument");
+
+    // The point of failing here is that the alternative is a silent save: the
+    // markup persisted and every field after content lost.
+    expect(await kv.list("mem:memories")).toHaveLength(0);
+  });
+
+  it("refuses it even when the other arguments are also sent", async () => {
+    // The leaked text is still wrong when type and project happen to arrive, so
+    // the guard cannot key off their absence.
+    const { result } = await remember({
+      content: leaked,
+      type: "bug",
+      project: "porter",
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("saves content that merely mentions one of the argument tags", async () => {
+    const { result } = await remember({
+      content: "The MCP schema names the field <project>; pass it as its own argument.",
+      type: "fact",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.memory?.type).toBe("fact");
+  });
+
+  it("saves prose about closing tags in general", async () => {
+    const { result } = await remember({
+      content: "Reader.Close() must run before the </html> is written, or the body truncates.",
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("keeps matching on repeated calls, so the check is not stateful", async () => {
+    for (let i = 0; i < 3; i++) {
+      const { result } = await remember({ content: leaked });
+      expect(result.success).toBe(false);
+    }
+  });
+});

--- a/test/remember-arg-leak.test.ts
+++ b/test/remember-arg-leak.test.ts
@@ -134,6 +134,17 @@ describe("mem::remember — mis-encoded tool call arguments", () => {
     expect(result.success).toBe(true);
   });
 
+  it("refuses content carrying the same marker twice", async () => {
+    // Two occurrences of one marker must trip the guard as surely as two
+    // different markers, so the check counts occurrences, not categories.
+    const { result } = await remember({
+      content: "<type>bug</type>\nmore text\n<type>fact</type>",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("one parameter per argument");
+  });
+
   it("keeps matching on repeated calls, so the check is not stateful", async () => {
     for (let i = 0; i < 3; i++) {
       const { result } = await remember({ content: leaked });


### PR DESCRIPTION
A caller that mis-encodes its tool call can close the content argument with a tag and write the arguments that follow it as literal text, so only content arrives. content is free-form, so nothing is schema-invalid: the save succeeded with the markup embedded in the memory and type, concepts, files and project silently left at their defaults.

mem::remember now refuses that content, since it is the single point every save path funnels through: the MCP server, the stdio package, and the trigger API. More than one marker is required, so content that legitimately mentions one of the argument tags still saves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented malformed memory saves when tool-call argument markup is unintentionally included in content.
  * Added clear guidance to resend each value as a separate parameter.
  * Preserved valid content that merely references argument tags or closing-tag wording.
  * Ensured entries with repeated leaked markers are rejected and not persisted.
  * Kept validation consistent across repeated save attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->