### PR TITLE
fix(mcp): stop masking tool errors as unknown-tool fallback

### DIFF
--- a/src/mcp/rest-proxy.ts
+++ b/src/mcp/rest-proxy.ts
@@ -15,6 +15,20 @@ function forceProxy(): boolean {
   return raw === "1" || raw === "true";
 }
 
+// Thrown when the server was reached and responded, but the response was an
+// HTTP error — i.e. the tool executed and failed, as opposed to a network
+// failure. Callers must not treat this like a connectivity problem (no
+// invalidateHandle/local-fallback): the real error is in `message`.
+export class ProxyHttpError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+  ) {
+    super(message);
+    this.name = "ProxyHttpError";
+  }
+}
+
 export interface ProxyHandle {
   mode: "proxy";
   baseUrl: string;
@@ -147,8 +161,17 @@ export async function resolveHandle(): Promise<Handle> {
             signal: AbortSignal.timeout(CALL_TIMEOUT_MS),
           });
           if (!res.ok) {
-            throw new Error(
-              `${init?.method || "GET"} ${path} -> ${res.status} ${res.statusText}`,
+            const bodyText = await res.text().catch(() => "");
+            let detail = "";
+            try {
+              const parsed = bodyText ? JSON.parse(bodyText) : null;
+              if (parsed && typeof parsed.error === "string") detail = parsed.error;
+            } catch {
+              detail = bodyText;
+            }
+            throw new ProxyHttpError(
+              `${init?.method || "GET"} ${path} -> ${res.status} ${res.statusText}${detail ? `: ${detail}` : ""}`,
+              res.status,
             );
           }
           const text = await res.text();

--- a/src/mcp/rest-proxy.ts
+++ b/src/mcp/rest-proxy.ts
@@ -15,10 +15,8 @@ function forceProxy(): boolean {
   return raw === "1" || raw === "true";
 }
 
-// Thrown when the server was reached and responded, but the response was an
-// HTTP error — i.e. the tool executed and failed, as opposed to a network
-// failure. Callers must not treat this like a connectivity problem (no
-// invalidateHandle/local-fallback): the real error is in `message`.
+// Server reached and tool ran but failed — not a connectivity problem, so
+// callers must not invalidate the handle or fall back to local.
 export class ProxyHttpError extends Error {
   constructor(
     message: string,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1278,11 +1278,11 @@ export function registerMcpEndpoints(
               body: { error: `Unknown tool: ${name}` },
             };
         }
-      } catch (err) {
+      } catch {
         return {
           status_code: 500,
           body: {
-            error: err instanceof Error ? err.message : String(err),
+            error: "Internal error",
           },
         };
       }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1282,7 +1282,7 @@ export function registerMcpEndpoints(
         return {
           status_code: 500,
           body: {
-            error: "Internal error",
+            error: err instanceof Error ? err.message : String(err),
           },
         };
       }

--- a/src/mcp/standalone.ts
+++ b/src/mcp/standalone.ts
@@ -9,6 +9,7 @@ import { generateId } from "../state/schema.js";
 import {
   resolveHandle,
   invalidateHandle,
+  ProxyHttpError,
   type Handle,
   type ProxyHandle,
 } from "./rest-proxy.js";
@@ -390,7 +391,10 @@ export async function handleToolCall(
         process.stderr.write(
           `[@agentmemory/mcp] proxy call failed for ${toolName}: ${err instanceof Error ? err.message : String(err)}\n`,
         );
-        invalidateHandle();
+        // A ProxyHttpError means the server was reached and the tool ran but
+        // errored — that's not a connectivity problem, so keep the handle
+        // valid and surface the real error instead of falling back to local.
+        if (!(err instanceof ProxyHttpError)) invalidateHandle();
         throw err;
       }
     }
@@ -404,6 +408,10 @@ export async function handleToolCall(
     try {
       return await handleProxy(validated, handle);
     } catch (err) {
+      // A ProxyHttpError means the tool actually ran on the server and
+      // failed. Falling back to local KV here would silently paper over
+      // that failure with a fake success, so surface the real error instead.
+      if (err instanceof ProxyHttpError) throw err;
       process.stderr.write(
         `[@agentmemory/mcp] proxy call failed for ${toolName}: ${err instanceof Error ? err.message : String(err)}; invalidating handle and falling back to local KV\n`,
       );

--- a/src/mcp/standalone.ts
+++ b/src/mcp/standalone.ts
@@ -391,9 +391,6 @@ export async function handleToolCall(
         process.stderr.write(
           `[@agentmemory/mcp] proxy call failed for ${toolName}: ${err instanceof Error ? err.message : String(err)}\n`,
         );
-        // A ProxyHttpError means the server was reached and the tool ran but
-        // errored — that's not a connectivity problem, so keep the handle
-        // valid and surface the real error instead of falling back to local.
         if (!(err instanceof ProxyHttpError)) invalidateHandle();
         throw err;
       }
@@ -408,9 +405,6 @@ export async function handleToolCall(
     try {
       return await handleProxy(validated, handle);
     } catch (err) {
-      // A ProxyHttpError means the tool actually ran on the server and
-      // failed. Falling back to local KV here would silently paper over
-      // that failure with a fake success, so surface the real error instead.
       if (err instanceof ProxyHttpError) throw err;
       process.stderr.write(
         `[@agentmemory/mcp] proxy call failed for ${toolName}: ${err instanceof Error ? err.message : String(err)}; invalidating handle and falling back to local KV\n`,

--- a/test/mcp-standalone-proxy.test.ts
+++ b/test/mcp-standalone-proxy.test.ts
@@ -210,7 +210,7 @@ describe("@agentmemory/mcp standalone — server proxy (issue #159)", () => {
     expect(out.results[0].content).toBe("local only");
   });
 
-  it("invalidates the handle on proxy failure, so the next call re-probes", async () => {
+  it("invalidates the handle on a connectivity failure, so the next call re-probes", async () => {
     let probeCount = 0;
     let serverUp = true;
     installFetch((url) => {
@@ -218,7 +218,9 @@ describe("@agentmemory/mcp standalone — server proxy (issue #159)", () => {
         probeCount++;
         return serverUp ? new Response("ok", { status: 200 }) : new Response("", { status: 500 });
       }
-      return new Response("boom", { status: 500, statusText: "Internal Server Error" });
+      // Connection dropped mid-request — a real connectivity failure, distinct
+      // from an HTTP error response where the tool actually ran and failed.
+      throw new Error("ECONNRESET");
     });
     const localKv = new InMemoryKV(undefined);
     await handleToolCall("memory_save", { content: "first fallback" }, localKv);
@@ -226,6 +228,21 @@ describe("@agentmemory/mcp standalone — server proxy (issue #159)", () => {
     serverUp = false;
     await handleToolCall("memory_save", { content: "second fallback" }, localKv);
     expect(probeCount).toBe(2);
+  });
+
+  it("surfaces a real tool-execution error instead of masking it as a fallback", async () => {
+    installFetch((url) => {
+      if (url.endsWith("/agentmemory/livez")) return new Response("ok", { status: 200 });
+      return new Response(JSON.stringify({ error: "disk full" }), {
+        status: 500,
+        statusText: "Internal Server Error",
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const localKv = new InMemoryKV(undefined);
+    await expect(
+      handleToolCall("memory_save", { content: "should not fall back" }, localKv),
+    ).rejects.toThrow(/disk full/);
   });
 
   it("forwards non-essential tools to /agentmemory/mcp/call (#234)", async () => {
@@ -373,7 +390,10 @@ describe("@agentmemory/mcp standalone — server proxy (issue #159)", () => {
         probeStarted++;
         return new Response("ok", { status: 200 });
       }
-      return new Response("not found", { status: 404 });
+      return new Response(JSON.stringify({ id: "mem-1" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
     });
     try {
       const localKv = new InMemoryKV(undefined);


### PR DESCRIPTION
Proxy failures were treated identically whether the server was unreachable or the tool actually ran and errored. Any non-ok HTTP response invalidated the handle and either fell back to local KV (silently hiding the real failure) or, for tools the local fallback doesn't implement, surfaced a misleading "Unknown tool" message on the next call within the 30s local-mode window.

Tag HTTP error responses with ProxyHttpError so callers can tell a genuine tool-execution error (server reached, tool ran, failed) apart from a connectivity error (server unreachable) - only the latter should invalidate the handle and fall back to local. Also stop discarding the real error message on the server's dispatch catch-all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - HTTP error responses now provide clearer context, including status and response details.
  - Server-side tool failures are surfaced directly instead of being mistaken for connectivity issues or replaced by local fallback behavior.
  - Temporary connection failures continue to trigger recovery and fallback handling appropriately.

- **Tests**
  - Expanded coverage for connection drops, server tool failures, and probe responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->