### PR TITLE
fix(opencode): inject agentmemory context on every turn, not just turn 1

### DIFF
--- a/plugin/opencode/agentmemory-capture.ts
+++ b/plugin/opencode/agentmemory-capture.ts
@@ -662,44 +662,45 @@ export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
       const sid = input.sessionID || activeSessionId;
       if (!sid) return;
 
-      if (!contextInjectedSessions.has(sid)) {
-        if (!Array.isArray(output.system)) return;
-        output.system.push(AGENTMEMORY_INSTRUCTIONS);
-        // prefer the context already fetched at session.created;
-        // fall back to a fresh /context call if the cache missed (e.g.
-        // session resumed across plugin reloads).
-        let ctx = startContextCache.get(sid);
-        if (typeof ctx !== "string" || ctx.length === 0) {
-          const result = await postJson("/context", {
-            sessionId: sid,
-            project: projectFor(sid).name,
-          });
-          ctx = (result as any)?.context;
-        } else {
-          startContextCache.delete(sid);
-        }
-        if (typeof ctx === "string" && ctx.length > 0) {
-          output.system.push(ctx);
-        }
-        contextInjectedSessions.add(sid);
+      // Skip internal utility requests (title generator, compaction, subagent summaries)
+      if (
+        (input as any)?.agent === "title" ||
+        (input as any)?.agent === "compaction" ||
+        (input as any)?.small === true
+      ) {
+        return;
+      }
+      if (Array.isArray(output.system)) {
+        const isInternalTitle = output.system.some(
+          (s: string) =>
+            typeof s === "string" &&
+            /title generator|generate a (short|concise|brief) title|title for this conversation|thread title/i.test(s),
+        );
+        if (isInternalTitle) return;
       }
 
-      const stash = stashFor(sid);
-      if (stash.size === 0) return;
-      const files = [...stash].slice(0, 10);
+      if (!Array.isArray(output.system)) return;
 
-      const enrichResult = await postJson("/enrich", {
-        sessionId: sid,
-        files,
-        toolName: "enrich_inject",
-      });
+      // Inject instructions and frozen start context on EVERY regular chat step of the session.
+      // Because startContext and AGENTMEMORY_INSTRUCTIONS are identical across all turns of this session,
+      // LLM prefix caching is 100% preserved (#720), while ensuring the model maintains memory context
+      // throughout multi-turn conversations and across tool execution steps.
+      output.system.push(AGENTMEMORY_INSTRUCTIONS);
 
-      const enrichCtx = (enrichResult as any)?.context;
-      if (typeof enrichCtx === "string" && enrichCtx.length > 0) {
-        if (Array.isArray(output.system)) {
-          output.system.push(enrichCtx);
+      let ctx = startContextCache.get(sid);
+      if (typeof ctx !== "string" || ctx.length === 0) {
+        const result = await postJson("/context", {
+          sessionId: sid,
+          project: projectFor(sid).name,
+        });
+        ctx = (result as any)?.context;
+        if (typeof ctx === "string" && ctx.length > 0) {
+          startContextCache.set(sid, ctx);
         }
-        for (const f of files) stash.delete(f);
+      }
+
+      if (typeof ctx === "string" && ctx.length > 0) {
+        output.system.push(ctx);
       }
     },
 

--- a/plugin/opencode/agentmemory-capture.ts
+++ b/plugin/opencode/agentmemory-capture.ts
@@ -108,12 +108,10 @@ function resolveProjectName(dir: string): string {
 const stashedFiles = new Map<string, Set<string>>();
 const seenSubtaskIds = new Map<string, Set<string>>();
 const seenToolCallIds = new Map<string, Set<string>>();
-const contextInjectedSessions = new Set<string>();
 // cache the context returned by POST /session/start so the chat
 // system-transform hook can inject it without a second /context fetch.
-// Auto-injection now happens at session.created (immediately) AND at
-// the first prompt_submit (fallback for older OpenCode builds that
-// don't implement experimental.chat.system.transform).
+// Auto-injection happens at session.created (immediately) and cached
+// startContext is injected on every chat turn to preserve LLM prefix caching (#720).
 const startContextCache = new Map<string, string>();
 
 function stashFor(sid: string): Set<string> {
@@ -187,6 +185,18 @@ memory_consolidate — Run the 4-tier memory consolidation pipeline.
 All memory tools start with \`agentmemory_memory_\`. Use the exact names as they appear in your tool list. Tool results are JSON. Always check what was returned before presenting to the user.
 </agentmemory-instructions>`;
 
+// Upstream @opencode-ai/plugin types omit runtime agent and model parameters (#1184)
+interface OpenCodeChatTransformInput {
+  sessionID?: string;
+  model?: unknown;
+  agent?: string;
+  small?: boolean;
+}
+
+interface OpenCodeContextResponse {
+  context?: string;
+}
+
 function extractFilePaths(args: Record<string, unknown>): string[] {
   const files: string[] = [];
   for (const key of FILE_KEYS) {
@@ -230,7 +240,6 @@ export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
         stashedFiles.set(activeSessionId, new Set());
         seenSubtaskIds.delete(activeSessionId);
         seenToolCallIds.delete(activeSessionId);
-        contextInjectedSessions.delete(activeSessionId);
         // Snapshot the session id locally — `activeSessionId` is mutable
         // and another `session.created` event during the await could
         // rebind it, causing context to be cached against the wrong key.
@@ -336,7 +345,6 @@ export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
         if (sid === activeSessionId) activeSessionId = null;
         pruneSessionMaps(sid);
         startContextCache.delete(sid);
-        contextInjectedSessions.delete(sid);
       }
 
       // ── session.error ──
@@ -660,26 +668,28 @@ export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
     // ── experimental.chat.system.transform ──
     "experimental.chat.system.transform": async (input, output) => {
       const sid = input.sessionID || activeSessionId;
-      if (!sid) return;
+      if (!sid || !Array.isArray(output.system)) return;
 
-      // Skip internal utility requests (title generator, compaction, subagent summaries)
+      // Type assertion: upstream @opencode-ai/plugin types omit runtime agent and small model flags (#1184)
+      const chatInput = input as OpenCodeChatTransformInput;
+
+      // Skip internal utility requests (e.g. background auto-title generation #1184 or compaction)
+      // which share the session ID but do not participate in the interactive chat stream.
       if (
-        (input as any)?.agent === "title" ||
-        (input as any)?.agent === "compaction" ||
-        (input as any)?.small === true
+        chatInput.agent === "title" ||
+        chatInput.agent === "compaction" ||
+        chatInput.small === true
       ) {
         return;
       }
-      if (Array.isArray(output.system)) {
-        const isInternalTitle = output.system.some(
-          (s: string) =>
-            typeof s === "string" &&
-            /title generator|generate a (short|concise|brief) title|title for this conversation|thread title/i.test(s),
-        );
-        if (isInternalTitle) return;
-      }
 
-      if (!Array.isArray(output.system)) return;
+      // Fallback for OpenCode runtimes where chatInput.agent is not populated on internal prompts.
+      const isInternalTitle = output.system.some(
+        (s: string) =>
+          typeof s === "string" &&
+          /title generator|generate a (short|concise|brief) title|title for this conversation|thread title/i.test(s),
+      );
+      if (isInternalTitle) return;
 
       // Inject instructions and frozen start context on EVERY regular chat step of the session.
       // Because startContext and AGENTMEMORY_INSTRUCTIONS are identical across all turns of this session,
@@ -693,7 +703,7 @@ export const AgentmemoryCapturePlugin: Plugin = async (ctx) => {
           sessionId: sid,
           project: projectFor(sid).name,
         });
-        ctx = (result as any)?.context;
+        ctx = (result as OpenCodeContextResponse)?.context;
         if (typeof ctx === "string" && ctx.length > 0) {
           startContextCache.set(sid, ctx);
         }

--- a/test/opencode-auto-context.test.ts
+++ b/test/opencode-auto-context.test.ts
@@ -24,10 +24,9 @@ describe("OpenCode plugin auto-context injection (#431)", () => {
     );
   });
 
-  it("chat.system.transform reads cached context first, falls back to /context", () => {
+  it("chat.system.transform reads cached context on every turn and falls back to /context", () => {
     expect(plugin).toMatch(/startContextCache\.get\(sid\)/);
     expect(plugin).toMatch(/postJson\(["']\/context["']/);
-    expect(plugin).toMatch(/startContextCache\.delete\(sid\)/);
   });
 
   it("session.deleted clears the cache to avoid stale entries", () => {

--- a/test/opencode-auto-context.test.ts
+++ b/test/opencode-auto-context.test.ts
@@ -1,37 +1,173 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { readFileSync } from "node:fs";
 
-// OpenCode plugin needs zero-config memory injection. Plugin
-// already wires experimental.chat.system.transform; this PR threads
-// the /session/start context through a cache so injection happens
-// without a second /context fetch and is documented as the
-// SessionStart-equivalent behaviour.
-describe("OpenCode plugin auto-context injection (#431)", () => {
+describe("OpenCode plugin auto-context injection (#431, #720, #1184)", () => {
   const plugin = readFileSync(
     "plugin/opencode/agentmemory-capture.ts",
     "utf-8",
   );
 
-  it("captures context returned by POST /session/start", () => {
+  it("captures and caches session context at initialization", () => {
     expect(plugin).toMatch(/startContextCache\s*=\s*new Map<string,\s*string>/);
-    expect(plugin).toMatch(
-      /postJson\(["']\/session\/start["']/,
-    );
-    // Snapshot `activeSessionId` into a local before the await so the cached
-    // context binds to the session that opened it, not a later one.
+    expect(plugin).toMatch(/postJson\(["']\/session\/start["']/);
     expect(plugin).toMatch(
       /const\s+sessionId\s*=\s*activeSessionId[\s\S]*?startContextCache\.set\(sessionId/,
     );
   });
 
-  it("chat.system.transform reads cached context on every turn and falls back to /context", () => {
-    expect(plugin).toMatch(/startContextCache\.get\(sid\)/);
-    expect(plugin).toMatch(/postJson\(["']\/context["']/);
+  it("injects frozen context on every conversational turn without deleting cached entries", () => {
+    const transformBlock = plugin.slice(
+      plugin.indexOf('"experimental.chat.system.transform"'),
+      plugin.indexOf('"experimental.session.compacting"'),
+    );
+    expect(transformBlock).toMatch(/startContextCache\.get\(sid\)/);
+    expect(transformBlock).toMatch(/postJson\(["']\/context["']/);
+    expect(transformBlock).not.toContain("startContextCache.delete(sid)");
   });
 
-  it("session.deleted clears the cache to avoid stale entries", () => {
+  it("clears cached session state upon session deletion", () => {
     const deletedBlock = plugin.slice(plugin.indexOf("session.deleted"));
     expect(deletedBlock).toMatch(/startContextCache\.delete\(sid\)/);
+  });
+});
+
+describe("OpenCode plugin system prompt transformation behavior", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ context: "<agentmemory-context project=\"demo\">mock data</agentmemory-context>" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  async function getPluginHooks(ctx: Record<string, unknown> = { worktree: "/repo/demo" }) {
+    const { AgentmemoryCapturePlugin } = await import(
+      "../plugin/opencode/agentmemory-capture.ts"
+    );
+    return (AgentmemoryCapturePlugin as (c: unknown) => Promise<{
+      event: (msg: unknown) => Promise<void>;
+      "experimental.chat.system.transform": (
+        input: { sessionID?: string; agent?: string; small?: boolean },
+        output: { system?: string[] },
+      ) => Promise<void>;
+    }>)(ctx);
+  }
+
+  it("preserves identical memory context across multi-turn chat interactions", async () => {
+    const hooks = await getPluginHooks();
+
+    // 1. Session created -> fetches and caches start context
+    await hooks.event({
+      event: { type: "session.created", properties: { info: { id: "ses_multi_turn" } } },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // 2. Turn 1
+    const turn1Output: { system: string[] } = { system: [] };
+    await hooks["experimental.chat.system.transform"](
+      { sessionID: "ses_multi_turn" },
+      turn1Output,
+    );
+    expect(turn1Output.system).toHaveLength(2);
+    expect(turn1Output.system[0]).toContain("<agentmemory-instructions>");
+    expect(turn1Output.system[1]).toContain("<agentmemory-context project=\"demo\">mock data</agentmemory-context>");
+    // Should NOT have made an extra network call (used cached start context)
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // 3. Turn 2 (OpenCode creates a fresh output.system array)
+    const turn2Output: { system: string[] } = { system: [] };
+    await hooks["experimental.chat.system.transform"](
+      { sessionID: "ses_multi_turn" },
+      turn2Output,
+    );
+    expect(turn2Output.system).toHaveLength(2);
+    expect(turn2Output.system[0]).toBe(turn1Output.system[0]);
+    expect(turn2Output.system[1]).toBe(turn1Output.system[1]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // 4. Turn 3
+    const turn3Output: { system: string[] } = { system: [] };
+    await hooks["experimental.chat.system.transform"](
+      { sessionID: "ses_multi_turn" },
+      turn3Output,
+    );
+    expect(turn3Output.system[0]).toBe(turn1Output.system[0]);
+    expect(turn3Output.system[1]).toBe(turn1Output.system[1]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips internal utility requests such as title generation and compaction", async () => {
+    const hooks = await getPluginHooks();
+    await hooks.event({
+      event: { type: "session.created", properties: { info: { id: "ses_internal_guard" } } },
+    });
+
+    // Internal title agent request
+    const titleOutput: { system: string[] } = { system: [] };
+    await hooks["experimental.chat.system.transform"](
+      { sessionID: "ses_internal_guard", agent: "title" },
+      titleOutput,
+    );
+    expect(titleOutput.system).toEqual([]);
+
+    // Compaction agent request
+    const compactionOutput: { system: string[] } = { system: [] };
+    await hooks["experimental.chat.system.transform"](
+      { sessionID: "ses_internal_guard", agent: "compaction" },
+      compactionOutput,
+    );
+    expect(compactionOutput.system).toEqual([]);
+
+    // Small model request
+    const smallOutput: { system: string[] } = { system: [] };
+    await hooks["experimental.chat.system.transform"](
+      { sessionID: "ses_internal_guard", small: true },
+      smallOutput,
+    );
+    expect(smallOutput.system).toEqual([]);
+
+    // Legacy title prompt regex fallback when agent metadata is missing
+    const legacyTitleOutput: { system: string[] } = {
+      system: ["You are a title generator. Output only a short title."],
+    };
+    await hooks["experimental.chat.system.transform"](
+      { sessionID: "ses_internal_guard" },
+      legacyTitleOutput,
+    );
+    expect(legacyTitleOutput.system).toHaveLength(1);
+    expect(legacyTitleOutput.system[0]).not.toContain("<agentmemory-instructions>");
+  });
+
+  it("fetches and re-caches context on cache miss for resumed sessions", async () => {
+    const hooks = await getPluginHooks();
+
+    // Directly call transform without prior session.created event
+    const output: { system: string[] } = { system: [] };
+    await hooks["experimental.chat.system.transform"](
+      { sessionID: "ses_resumed_session" },
+      output,
+    );
+
+    expect(output.system).toHaveLength(2);
+    expect(output.system[0]).toContain("<agentmemory-instructions>");
+    expect(output.system[1]).toContain("<agentmemory-context project=\"demo\">mock data</agentmemory-context>");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Second turn on resumed session should now hit the cache
+    const secondTurnOutput: { system: string[] } = { system: [] };
+    await hooks["experimental.chat.system.transform"](
+      { sessionID: "ses_resumed_session" },
+      secondTurnOutput,
+    );
+    expect(secondTurnOutput.system).toHaveLength(2);
+    expect(fetchMock).toHaveBeenCalledTimes(1); // No new network call
   });
 });
 


### PR DESCRIPTION
## Problem

OpenCode's `<agentmemory-context>` injection only lands on **turn 1 step 0**; every subsequent step/turn in the session silently loses memory context.

Live call-log analysis across all sessions (OmniRoute gateway):
- Request 1: `sysInst=true | sysCtx=true`
- **Requests 2..N (100%): `sysInst=false | sysCtx=false`**

Root cause: OpenCode builds a **fresh `output.system` array on every LLM step**. The plugin gated injection on `contextInjectedSessions.has(sid)` + `startContextCache.delete(sid)` after first use — so step 0 consumes the injection and all later turns get nothing.

## Fix (`plugin/opencode/agentmemory-capture.ts`)

1. **Robust internal-request skip** — check `(input as any)?.agent === "title" | "compaction"` and `input?.small === true`, keeping the brittle title-regex as fallback. (Supersedes the fragile string-match-only guard.)
2. **Inject on EVERY regular chat step** — push `AGENTMEMORY_INSTRUCTIONS` + cached `startContext` (fall back to `/context` and re-cache, don't delete). Identical bytes per turn → **prefix cache 100% preserved (#720)**.
3. Volatile file enrichment stays in `messages.transform` (message tail) — never touches `output.system`.

## Validation

Live E2E (fresh session, `opencode run`):
- Title generator call: context **skipped** (correct)
- Turn 1: `inst=true | ctx=true`
- **Turn 2: `inst=true | ctx=true`** (previously impossible)
- Turn 2 token usage: `cache.read=60672` — prefix cache hit confirmed
- Compression calls: no context (correct)

`npm test`: 159 files, 1,718 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Chat context is now refreshed on every regular conversation turn, preserving context across multi-turn sessions.
  * Resumed sessions can recover context when cached data is unavailable.
  * Internal utility requests and title-generation prompts no longer receive regular chat memory instructions.
  * Automatic file enrichment during context injection has been removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->