### PR TITLE
fix(viewer): render object session summaries as readable text

### DIFF
--- a/src/viewer/index.html
+++ b/src/viewer/index.html
@@ -1268,13 +1268,13 @@
     // narrative, and list fields. Interpolating the object form directly
     // rendered "[object Object]" (#1229); serialize both shapes to text.
     function sessionSummaryText(s) {
-      var sum = s && s.summary;
-      if (!sum) return '';
       try {
+        var sum = s && s.summary;
+        if (!sum) return '';
         if (typeof sum === 'string') {
           // Trim so a whitespace-only legacy summary yields '' and the
           // render paths' truthiness guards fall through cleanly.
-          return sum.trim();
+          return hasVisibleText(sum) ? sum.trim() : '';
         }
         if (typeof sum !== 'object') return '';
         var parts = [];
@@ -1302,14 +1302,20 @@
     // Summary list fields are typed string[] but arrive unvalidated from
     // stored summaries (the import path accepts hand-edited dumps), so a
     // non-string entry stringified into "[object Object]" and re-created
-    // the defect sessionSummaryText exists to prevent. Keep scalar
-    // strings only; skip everything else.
-    function isNonEmptyString(value) {
-      return typeof value === 'string' && value.trim();
+    // the defect sessionSummaryText exists to prevent. Keep visible scalar
+    // strings only (trim alone does not catch zero-width characters);
+    // skip everything else.
+    var INVISIBLE_CHARS = /[\s\u200b-\u200f\u2060\uFEFF]/g;
+    function hasVisibleText(value) {
+      return typeof value === 'string' && !!value.replace(INVISIBLE_CHARS, '');
     }
     function summaryList(values) {
+      if (typeof values === 'string') values = [values];
       if (!Array.isArray(values)) return '';
-      return values.filter(isNonEmptyString).join(', ');
+      return values
+        .filter(hasVisibleText)
+        .map(function (value) { return value.trim(); })
+        .join(', ');
     }
     function debounce(fn, ms) {
       var t;
@@ -3219,7 +3225,12 @@
           html += '<div class="session-item' + (selected ? ' selected' : '') + '"' + (id ? ' data-action="select-session" data-session-id="' + esc(id) + '" role="button" tabindex="0" aria-expanded="' + (selected ? 'true' : 'false') + '"' : '') + '>';
           html += '<div class="session-top"><span class="session-project">' + esc(sessionDisplayName(s)) + '</span>';
           html += '<span class="badge ' + statusBadge + '">' + esc(s.status) + '</span></div>';
-          var preview = s.firstPrompt || sessionSummaryText(s) || '';
+          // String-type-and-visible test on every chain term: a non-string
+          // firstPrompt (unvalidated import) or an invisible-char-only one
+          // would otherwise win the truthy chain and render "[object
+          // Object]" or blank out the preview.
+          var preview = hasVisibleText(s.firstPrompt) ? s.firstPrompt.trim() : '';
+          if (!preview) preview = sessionSummaryText(s);
           if (preview) {
             html += '<div class="session-preview" style="font-size:13px;color:var(--ink);margin:4px 0;line-height:1.4;">' + esc(truncate(preview, 140)) + '</div>';
           }
@@ -3275,15 +3286,19 @@
         var tool = o.title || o.toolName;
         if (tool && t !== 'conversation') toolCounts[tool] = (toolCounts[tool] || 0) + 1;
         (o.files || []).forEach(function(f) { fileSet.add(f); });
-        if (!firstPromptFromObs && (o.userPrompt || (o.type === 'conversation' && o.narrative))) {
-          firstPromptFromObs = o.userPrompt || o.narrative || '';
+        if (!firstPromptFromObs && (hasVisibleText(o.userPrompt) || (o.type === 'conversation' && hasVisibleText(o.narrative)))) {
+          firstPromptFromObs = hasVisibleText(o.userPrompt) ? o.userPrompt : o.narrative;
         }
       });
 
       var durationMs = s.endedAt ? new Date(s.endedAt).getTime() - new Date(s.startedAt).getTime() : 0;
       var durationLabel = durationMs > 0 ? (durationMs < 60000 ? (durationMs / 1000).toFixed(1) + 's' : (durationMs / 60000).toFixed(1) + 'm') : '-';
 
-      var preview = s.firstPrompt || sessionSummaryText(s) || firstPromptFromObs || '';
+      // Same visible-string guard as the list preview: non-string or
+      // invisible-char chain terms must fall through, not render garbage.
+      var preview = hasVisibleText(s.firstPrompt) ? s.firstPrompt.trim() : '';
+      if (!preview) preview = sessionSummaryText(s);
+      if (!preview) preview = hasVisibleText(firstPromptFromObs) ? firstPromptFromObs.trim() : '';
 
       var html = '<div class="detail-panel">';
       html += '<div style="display:flex;justify-content:space-between;align-items:flex-start;margin-bottom:12px;">';

--- a/src/viewer/index.html
+++ b/src/viewer/index.html
@@ -1270,22 +1270,31 @@
     function sessionSummaryText(s) {
       var sum = s && s.summary;
       if (!sum) return '';
-      if (typeof sum === 'string') return sum;
-      if (typeof sum !== 'object') return '';
-      var parts = [];
-      var title = typeof sum.title === 'string' ? sum.title.trim() : '';
-      var narrative = typeof sum.narrative === 'string' ? sum.narrative.trim() : '';
-      if (title) parts.push(sum.title);
-      // Trim before comparing so a whitespace-variant duplicate does not
-      // render the same text twice.
-      if (narrative && narrative !== title) parts.push(sum.narrative);
-      var keyDecisions = summaryList(sum.keyDecisions);
-      if (keyDecisions) parts.push('Key decisions: ' + keyDecisions);
-      var files = summaryList(sum.filesModified);
-      if (files) parts.push('Files: ' + files);
-      var concepts = summaryList(sum.concepts);
-      if (concepts) parts.push('Concepts: ' + concepts);
-      return parts.join(' — ');
+      try {
+        if (typeof sum === 'string') {
+          // Trim so a whitespace-only legacy summary yields '' and the
+          // render paths' truthiness guards fall through cleanly.
+          return sum.trim();
+        }
+        if (typeof sum !== 'object') return '';
+        var parts = [];
+        var title = typeof sum.title === 'string' ? sum.title.trim() : '';
+        var narrative = typeof sum.narrative === 'string' ? sum.narrative.trim() : '';
+        if (title) parts.push(sum.title);
+        // Trim before comparing so a whitespace-variant duplicate does not
+        // render the same text twice.
+        if (narrative && narrative !== title) parts.push(sum.narrative);
+        var keyDecisions = summaryList(sum.keyDecisions);
+        if (keyDecisions) parts.push('Key decisions: ' + keyDecisions);
+        var files = summaryList(sum.filesModified);
+        if (files) parts.push('Files: ' + files);
+        var concepts = summaryList(sum.concepts);
+        if (concepts) parts.push('Concepts: ' + concepts);
+        return parts.join(' — ');
+      } catch (_) {
+        // A hostile property getter must not take down the render pass.
+        return '';
+      }
     }
     // Summary list fields are typed string[] but arrive unvalidated from
     // stored summaries (the import path accepts hand-edited dumps), so a

--- a/src/viewer/index.html
+++ b/src/viewer/index.html
@@ -1277,16 +1277,24 @@
       if (typeof sum.narrative === 'string' && sum.narrative.trim() && sum.narrative !== sum.title) {
         parts.push(sum.narrative);
       }
-      if (Array.isArray(sum.keyDecisions) && sum.keyDecisions.length) {
-        parts.push('Key decisions: ' + sum.keyDecisions.map(String).join(', '));
-      }
-      if (Array.isArray(sum.filesModified) && sum.filesModified.length) {
-        parts.push('Files: ' + sum.filesModified.map(String).join(', '));
-      }
-      if (Array.isArray(sum.concepts) && sum.concepts.length) {
-        parts.push('Concepts: ' + sum.concepts.map(String).join(', '));
-      }
+      var keyDecisions = summaryList(sum.keyDecisions);
+      if (keyDecisions) parts.push('Key decisions: ' + keyDecisions);
+      var files = summaryList(sum.filesModified);
+      if (files) parts.push('Files: ' + files);
+      var concepts = summaryList(sum.concepts);
+      if (concepts) parts.push('Concepts: ' + concepts);
       return parts.join(' — ');
+    }
+    // Summary list fields are typed string[] but arrive unvalidated from
+    // stored summaries (the import path accepts hand-edited dumps), so a
+    // non-string entry stringified into "[object Object]" and re-created
+    // the defect sessionSummaryText exists to prevent. Keep scalar
+    // strings only; skip everything else.
+    function summaryList(values) {
+      if (!Array.isArray(values)) return '';
+      return values
+        .filter(function (value) { return typeof value === 'string' && value.trim(); })
+        .join(', ');
     }
     function debounce(fn, ms) {
       var t;

--- a/src/viewer/index.html
+++ b/src/viewer/index.html
@@ -1273,10 +1273,12 @@
       if (typeof sum === 'string') return sum;
       if (typeof sum !== 'object') return '';
       var parts = [];
-      if (typeof sum.title === 'string' && sum.title.trim()) parts.push(sum.title);
-      if (typeof sum.narrative === 'string' && sum.narrative.trim() && sum.narrative !== sum.title) {
-        parts.push(sum.narrative);
-      }
+      var title = typeof sum.title === 'string' ? sum.title.trim() : '';
+      var narrative = typeof sum.narrative === 'string' ? sum.narrative.trim() : '';
+      if (title) parts.push(sum.title);
+      // Trim before comparing so a whitespace-variant duplicate does not
+      // render the same text twice.
+      if (narrative && narrative !== title) parts.push(sum.narrative);
       var keyDecisions = summaryList(sum.keyDecisions);
       if (keyDecisions) parts.push('Key decisions: ' + keyDecisions);
       var files = summaryList(sum.filesModified);

--- a/src/viewer/index.html
+++ b/src/viewer/index.html
@@ -1278,8 +1278,8 @@
         }
         if (typeof sum !== 'object') return '';
         var parts = [];
-        var title = typeof sum.title === 'string' ? sum.title.trim() : '';
-        var narrative = typeof sum.narrative === 'string' ? sum.narrative.trim() : '';
+        var title = hasVisibleText(sum.title) ? sum.title.trim() : '';
+        var narrative = hasVisibleText(sum.narrative) ? sum.narrative.trim() : '';
         // Push the trimmed forms so object summaries render like the
         // string path (which returns trimmed text) instead of leaking
         // hand-edited padding into the preview.

--- a/src/viewer/index.html
+++ b/src/viewer/index.html
@@ -1280,10 +1280,13 @@
         var parts = [];
         var title = typeof sum.title === 'string' ? sum.title.trim() : '';
         var narrative = typeof sum.narrative === 'string' ? sum.narrative.trim() : '';
-        if (title) parts.push(sum.title);
+        // Push the trimmed forms so object summaries render like the
+        // string path (which returns trimmed text) instead of leaking
+        // hand-edited padding into the preview.
+        if (title) parts.push(title);
         // Trim before comparing so a whitespace-variant duplicate does not
         // render the same text twice.
-        if (narrative && narrative !== title) parts.push(sum.narrative);
+        if (narrative && narrative !== title) parts.push(narrative);
         var keyDecisions = summaryList(sum.keyDecisions);
         if (keyDecisions) parts.push('Key decisions: ' + keyDecisions);
         var files = summaryList(sum.filesModified);
@@ -1301,11 +1304,12 @@
     // non-string entry stringified into "[object Object]" and re-created
     // the defect sessionSummaryText exists to prevent. Keep scalar
     // strings only; skip everything else.
+    function isNonEmptyString(value) {
+      return typeof value === 'string' && value.trim();
+    }
     function summaryList(values) {
       if (!Array.isArray(values)) return '';
-      return values
-        .filter(function (value) { return typeof value === 'string' && value.trim(); })
-        .join(', ');
+      return values.filter(isNonEmptyString).join(', ');
     }
     function debounce(fn, ms) {
       var t;

--- a/src/viewer/index.html
+++ b/src/viewer/index.html
@@ -1262,6 +1262,32 @@
       var name = sessionDisplayName(s);
       return id ? name + ' (' + id + ')' : name + ' (missing id)';
     }
+    // GET /agentmemory/sessions merges each session's SessionSummary object
+    // into `summary` (api::sessions), so the field is either a plain string
+    // (legacy title slice from session/start) or an object with title,
+    // narrative, and list fields. Interpolating the object form directly
+    // rendered "[object Object]" (#1229); serialize both shapes to text.
+    function sessionSummaryText(s) {
+      var sum = s && s.summary;
+      if (!sum) return '';
+      if (typeof sum === 'string') return sum;
+      if (typeof sum !== 'object') return '';
+      var parts = [];
+      if (typeof sum.title === 'string' && sum.title.trim()) parts.push(sum.title);
+      if (typeof sum.narrative === 'string' && sum.narrative.trim() && sum.narrative !== sum.title) {
+        parts.push(sum.narrative);
+      }
+      if (Array.isArray(sum.keyDecisions) && sum.keyDecisions.length) {
+        parts.push('Key decisions: ' + sum.keyDecisions.map(String).join(', '));
+      }
+      if (Array.isArray(sum.filesModified) && sum.filesModified.length) {
+        parts.push('Files: ' + sum.filesModified.map(String).join(', '));
+      }
+      if (Array.isArray(sum.concepts) && sum.concepts.length) {
+        parts.push('Concepts: ' + sum.concepts.map(String).join(', '));
+      }
+      return parts.join(' — ');
+    }
     function debounce(fn, ms) {
       var t;
       return function() {
@@ -3170,7 +3196,7 @@
           html += '<div class="session-item' + (selected ? ' selected' : '') + '"' + (id ? ' data-action="select-session" data-session-id="' + esc(id) + '" role="button" tabindex="0" aria-expanded="' + (selected ? 'true' : 'false') + '"' : '') + '>';
           html += '<div class="session-top"><span class="session-project">' + esc(sessionDisplayName(s)) + '</span>';
           html += '<span class="badge ' + statusBadge + '">' + esc(s.status) + '</span></div>';
-          var preview = s.firstPrompt || s.summary || '';
+          var preview = s.firstPrompt || sessionSummaryText(s) || '';
           if (preview) {
             html += '<div class="session-preview" style="font-size:13px;color:var(--ink);margin:4px 0;line-height:1.4;">' + esc(truncate(preview, 140)) + '</div>';
           }
@@ -3234,7 +3260,7 @@
       var durationMs = s.endedAt ? new Date(s.endedAt).getTime() - new Date(s.startedAt).getTime() : 0;
       var durationLabel = durationMs > 0 ? (durationMs < 60000 ? (durationMs / 1000).toFixed(1) + 's' : (durationMs / 60000).toFixed(1) + 'm') : '-';
 
-      var preview = s.firstPrompt || s.summary || firstPromptFromObs || '';
+      var preview = s.firstPrompt || sessionSummaryText(s) || firstPromptFromObs || '';
 
       var html = '<div class="detail-panel">';
       html += '<div style="display:flex;justify-content:space-between;align-items:flex-start;margin-bottom:12px;">';

--- a/test/viewer-session-summary.test.ts
+++ b/test/viewer-session-summary.test.ts
@@ -517,6 +517,12 @@ describe("viewer session summary rendering", () => {
     expect(
       sandbox.sessionSummaryText({ summary: "\u200b\u200b " }),
     ).toBe("");
+    // Zero-width-only object fields are invisible too, not just strings.
+    expect(
+      sandbox.sessionSummaryText({
+        summary: { title: "\u200b", narrative: "\u200b", filesModified: ["f.ts"] } as unknown as object,
+      }),
+    ).toBe("Files: f.ts");
   });
 
   it("falls through a non-string firstPrompt to the serialized summary", () => {

--- a/test/viewer-session-summary.test.ts
+++ b/test/viewer-session-summary.test.ts
@@ -14,7 +14,8 @@ function htmlEscape(value: string): string {
   return value
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
+    .replace(/>/g, "&gt;")
+    .replace(/\u00a0/g, "&nbsp;");
 }
 function loadViewerSandbox() {
   const rendered = renderViewerDocument();

--- a/test/viewer-session-summary.test.ts
+++ b/test/viewer-session-summary.test.ts
@@ -26,6 +26,9 @@ function loadViewerSandbox() {
   expect(scriptMatch).not.toBeNull();
   if (!scriptMatch) throw new Error("viewer script not found");
 
+  // `any` mirrors the sibling loader in test/viewer-session-id.test.ts:
+  // tests assign and read untyped state off the vm sandbox, and tsconfig
+  // excludes test/ so the compiler cannot check these shapes.
   const elements = new Map<string, any>();
   const createMockElement = (id = "") => {
     const attributes = new Map<string, string>();
@@ -117,6 +120,8 @@ function loadViewerSandbox() {
   };
 
   const sandbox: Record<string, any> = {
+    // `any` here too: the vm sandbox globals are intentionally loose and
+    // match the sibling loader's typing (see the comment above).
     console: { log: () => {}, warn: () => {}, error: () => {} },
     document,
     window: {
@@ -333,8 +338,9 @@ describe("viewer session summary rendering", () => {
     const html = getElement("view-sessions").innerHTML;
     expect(html).not.toContain("[object Object]");
     // Title is numeric: it must be dropped, not stringified into the preview.
-    // The exact preview pins this: only the surviving Files entry renders.
-    expect(html).toContain('>Files: still/works.ts</div>');
+    // The bare-string keyDecisions field coerces to a one-element list, and
+    // the exact preview pins both behaviors.
+    expect(html).toContain('>Key decisions: not-an-array — Files: still/works.ts</div>');
     // A numeric narrative must likewise never leak into the text.
     expect(
       sandbox.sessionSummaryText({
@@ -464,5 +470,105 @@ describe("viewer session summary rendering", () => {
     });
 
     expect(sandbox.sessionSummaryText({ summary: hostile })).toBe("");
+  });
+
+  it("escapes summary markup through both render paths", async () => {
+    const { sandbox, getElement } = loadViewerSandbox();
+    const hostileText = {
+      title: "<script>alert(1)</script>",
+      narrative: 'a & b </div> "quoted"',
+      keyDecisions: ["<img src=x>"],
+    };
+    sandbox.state.sessions.items = [
+      baseSession({ summary: hostileText as unknown as object }),
+      baseSession({
+        id: "20260904_escape_str",
+        summary: "<b>bold</b> & more",
+      }),
+    ];
+    sandbox.state.sessions.selectedId = "20260811_113447_ba4a38";
+
+    sandbox.renderSessions();
+    const listHtml = getElement("view-sessions").innerHTML;
+    expect(listHtml).not.toContain("<script>");
+    expect(listHtml).not.toContain("<img");
+    expect(listHtml).toContain("&lt;script&gt;");
+    expect(listHtml).toContain("&amp;");
+
+    await sandbox.renderSessionDetail();
+    const detailHtml = getElement("session-detail").innerHTML;
+    expect(detailHtml).not.toContain("<script>alert(1)</script>");
+    expect(detailHtml).not.toContain("</div> \"quoted\"");
+    expect(detailHtml).toContain("&lt;script&gt;");
+    expect(detailHtml).toContain("a &amp; b");
+  });
+
+  it("skips zero-width-only entries and summaries", () => {
+    const { sandbox } = loadViewerSandbox();
+    const text = sandbox.sessionSummaryText({
+      summary: {
+        title: "Zero-width guard",
+        narrative: "Real body.",
+        keyDecisions: ["\u200b", "\u200b\u200c", "Real decision"] as unknown as string[],
+      },
+    });
+    expect(text).toContain("Key decisions: Real decision");
+    expect(text).not.toContain("\u200b\u200b");
+    expect(
+      sandbox.sessionSummaryText({ summary: "\u200b\u200b " }),
+    ).toBe("");
+  });
+
+  it("falls through a non-string firstPrompt to the serialized summary", () => {
+    const { sandbox, getElement } = loadViewerSandbox();
+    sandbox.state.sessions.items = [
+      baseSession({
+        firstPrompt: { malicious: "object" } as unknown as string,
+        summary: sessionSummaryObject,
+      }),
+    ];
+
+    sandbox.renderSessions();
+
+    const html = getElement("view-sessions").innerHTML;
+    expect(html).not.toContain("[object Object]");
+    expect(html).toContain("Todoist skill fixes");
+  });
+
+  it("does not throw when a hostile summary getter fires through the render paths", async () => {
+    const { sandbox, getElement } = loadViewerSandbox();
+    const hostileSession: Record<string, unknown> = baseSession();
+    Object.defineProperty(hostileSession, "summary", {
+      get() {
+        throw new Error("boom");
+      },
+    });
+    sandbox.state.sessions.items = [hostileSession];
+    sandbox.state.sessions.selectedId = "20260811_113447_ba4a38";
+
+    expect(() => sandbox.renderSessions()).not.toThrow();
+    const listHtml = getElement("view-sessions").innerHTML;
+    expect(listHtml).not.toContain("[object Object]");
+
+    await sandbox.renderSessionDetail();
+    const detailHtml = getElement("session-detail").innerHTML;
+    expect(detailHtml).not.toContain("[object Object]");
+  });
+
+  it("trims a padded non-empty legacy string summary", () => {
+    const { sandbox, getElement } = loadViewerSandbox();
+    sandbox.state.sessions.items = [
+      baseSession({ summary: "  Padded legacy summary  " }),
+    ];
+
+    expect(sandbox.sessionSummaryText({ summary: "  Padded legacy  " })).toBe(
+      "Padded legacy",
+    );
+
+    sandbox.renderSessions();
+
+    const html = getElement("view-sessions").innerHTML;
+    expect(html).toContain("Padded legacy summary");
+    expect(html).not.toContain("  Padded");
   });
 });

--- a/test/viewer-session-summary.test.ts
+++ b/test/viewer-session-summary.test.ts
@@ -235,9 +235,16 @@ describe("viewer session summary rendering", () => {
     // The list preview truncates at 140 chars, so assert the labeled lists
     // through the full serialization the detail panel renders (600 chars).
     const text = sandbox.sessionSummaryText({ summary: sessionSummaryObject });
-    expect(text).toContain("Key decisions: Ship API v1 behind a flag, Keep v0 fallback for a release");
-    expect(text).toContain("Files: integrations/todoist.ts, skills/todoist.md");
-    expect(text).toContain("Concepts: api-migration, skills");
+    // Exact pin: the full serialization, including labeled-section order.
+    expect(text).toBe(
+      "Todoist skill fixes — " +
+        "Migrated the Todoist integration to API v1 and fixed the skill handlers. — " +
+        "Key decisions: Ship API v1 behind a flag, Keep v0 fallback for a release — " +
+        "Files: integrations/todoist.ts, skills/todoist.md — " +
+        "Concepts: api-migration, skills",
+    );
+    expect(text.indexOf("Key decisions:")).toBeLessThan(text.indexOf("Files:"));
+    expect(text.indexOf("Files:")).toBeLessThan(text.indexOf("Concepts:"));
 
     return sandbox.renderSessionDetail().then(() => {
       const html = getElement("session-detail").innerHTML;
@@ -253,6 +260,14 @@ describe("viewer session summary rendering", () => {
     const { sandbox, getElement } = loadViewerSandbox();
     sandbox.state.sessions.items = [baseSession({ summary: sessionSummaryObject })];
     sandbox.state.sessions.selectedId = "20260811_113447_ba4a38";
+    // Observations with a recovered prompt must NOT outrank the serialized
+    // summary: the detail chain is firstPrompt || summary || firstPromptFromObs.
+    sandbox.fetch = async () => ({
+      ok: true,
+      json: async () => ({
+        observations: [{ type: "conversation", userPrompt: "Observed prompt" }],
+      }),
+    });
 
     await sandbox.renderSessionDetail();
 
@@ -260,6 +275,7 @@ describe("viewer session summary rendering", () => {
     expect(html).not.toContain("[object Object]");
     expect(html).toContain("Migrated the Todoist integration to API v1");
     expect(html).toContain("Ship API v1 behind a flag");
+    expect(html).not.toContain("Observed prompt");
   });
 
   it("keeps rendering plain string summaries unchanged", () => {
@@ -317,7 +333,15 @@ describe("viewer session summary rendering", () => {
     expect(() => sandbox.renderSessions()).not.toThrow();
     const html = getElement("view-sessions").innerHTML;
     expect(html).not.toContain("[object Object]");
-    expect(html).toContain("still/works.ts");
+    // Title is numeric: it must be dropped, not stringified into the preview.
+    // The exact preview pins this: only the surviving Files entry renders.
+    expect(html).toContain('>Files: still/works.ts</div>');
+    // A numeric narrative must likewise never leak into the text.
+    expect(
+      sandbox.sessionSummaryText({
+        summary: { title: "T", narrative: 99, keyDecisions: ["K"] } as unknown as object,
+      }),
+    ).toBe("T — Key decisions: K");
   });
 
   it("skips non-string and empty entries inside summary list fields", () => {
@@ -325,7 +349,7 @@ describe("viewer session summary rendering", () => {
     const summary = {
       title: "Mixed entry types",
       narrative: "Narrative body.",
-      keyDecisions: ["Real decision", {}, null, "", 42] as unknown as string[],
+      keyDecisions: ["Real decision", "  ", "", {}, null, 42] as unknown as string[],
       filesModified: ["kept.ts", {}, "also.ts"] as unknown as string[],
       concepts: [{ nested: true }, "concept"] as unknown as string[],
     };
@@ -333,9 +357,13 @@ describe("viewer session summary rendering", () => {
     expect(text).not.toContain("[object Object]");
     expect(text).not.toContain("null");
     expect(text).not.toContain("42");
-    expect(text).toContain("Key decisions: Real decision");
-    expect(text).toContain("Files: kept.ts, also.ts");
-    expect(text).toContain("Concepts: concept");
+    // Whitespace-only entries must be skipped, not joined as stray ", ," gaps.
+    expect(text).not.toContain(", ,");
+    // Exact pin: filter + join order for every list field.
+    expect(text).toBe(
+      "Mixed entry types — Narrative body. — Key decisions: Real decision — " +
+        "Files: kept.ts, also.ts — Concepts: concept",
+    );
   });
 
   it("renders firstPrompt over a serialized summary in both render paths", async () => {

--- a/test/viewer-session-summary.test.ts
+++ b/test/viewer-session-summary.test.ts
@@ -161,14 +161,27 @@ function loadViewerSandbox() {
   };
 
   const scriptWithoutAutoStart = scriptMatch[1]
-    .replace(/\n\s*switchTab\(tabFromRoute\(\)[^;]*;\n/, "\n")
-    .replace(/\n\s*\(async function initWs\(\)[\s\S]*?\}\)\(\);\n/, "\n")
+    // The startup call at the script tail is textually identical to the
+    // body of syncTabFromRoute() (src/viewer/index.html), so anchor the
+    // strip to the startup occurrence with the comment that follows it;
+    // an unanchored regex strips the wrong one and leaves startup code
+    // running inside every test.
+    .replace(/\n\s*switchTab\(tabFromRoute\(\), \{ replaceRoute: true \}\);\n(?=\s*\/\/ Resolve the stream)/, "\n")
+    .replace(/\n\s*\(async function initWs\(\)[\s\S]*?\}\)\(\);\n(?=\s*startDashboardAutoRefresh\(\);)/, "\n")
     .replace(/\n\s*startDashboardAutoRefresh\(\);\n/, "\n");
 
-  // The strip must actually fire. If the viewer script's startup tail
-  // changes shape, fail loudly here instead of silently running startup
-  // code (WebSocket/fetch chains) inside every rendering test.
+  // The strip must actually fire AND hit the startup tail, not the
+  // identically-texted call inside syncTabFromRoute() (which must remain).
+  // If the viewer script's startup shape changes, fail loudly here instead
+  // of silently running startup code (WebSocket/fetch chains) in every test.
   expect(scriptWithoutAutoStart).not.toBe(scriptMatch[1]);
+  const startupCall = 'switchTab(tabFromRoute(), { replaceRoute: true });';
+  const callsBefore = scriptMatch[1].split(startupCall).length - 1;
+  const callsAfter = scriptWithoutAutoStart.split(startupCall).length - 1;
+  expect(callsBefore).toBe(2);
+  expect(callsAfter).toBe(callsBefore - 1);
+  expect(scriptWithoutAutoStart).not.toContain('startDashboardAutoRefresh();');
+  expect(scriptWithoutAutoStart).not.toContain('(async function initWs()');
 
   vm.createContext(sandbox);
   vm.runInContext(scriptWithoutAutoStart, sandbox);
@@ -359,6 +372,12 @@ describe("viewer session summary rendering", () => {
     expect(
       sandbox.sessionSummaryText({
         summary: { title: "Same text", narrative: "Same text" },
+      }),
+    ).toBe("Same text");
+    // Whitespace-variant duplicates are also deduplicated.
+    expect(
+      sandbox.sessionSummaryText({
+        summary: { title: "Same text", narrative: "  Same text  " },
       }),
     ).toBe("Same text");
     expect(

--- a/test/viewer-session-summary.test.ts
+++ b/test/viewer-session-summary.test.ts
@@ -403,4 +403,39 @@ describe("viewer session summary rendering", () => {
     expect(html).not.toContain("[object Object]");
     expect(html).not.toContain("session-preview");
   });
+
+  it("renders no preview for a whitespace-only string summary and keeps the detail fallback", async () => {
+    const { sandbox, getElement } = loadViewerSandbox();
+    sandbox.state.sessions.items = [
+      baseSession({ summary: "  \n\t " }),
+    ];
+    sandbox.state.sessions.selectedId = "20260811_113447_ba4a38";
+    sandbox.fetch = async () => ({
+      ok: true,
+      json: async () => ({
+        observations: [{ type: "conversation", userPrompt: "Recovered from observations" }],
+      }),
+    });
+
+    sandbox.renderSessions();
+    const listHtml = getElement("view-sessions").innerHTML;
+    expect(listHtml).not.toContain("session-preview");
+
+    await sandbox.renderSessionDetail();
+    const detailHtml = getElement("session-detail").innerHTML;
+    expect(detailHtml).not.toContain("[object Object]");
+    expect(detailHtml).toContain("Recovered from observations");
+  });
+
+  it("returns empty text when a summary property getter throws", () => {
+    const { sandbox } = loadViewerSandbox();
+    const hostile: Record<string, unknown> = {};
+    Object.defineProperty(hostile, "title", {
+      get() {
+        throw new Error("boom");
+      },
+    });
+
+    expect(sandbox.sessionSummaryText({ summary: hostile })).toBe("");
+  });
 });

--- a/test/viewer-session-summary.test.ts
+++ b/test/viewer-session-summary.test.ts
@@ -228,7 +228,7 @@ describe("viewer session summary rendering", () => {
     expect(html).toContain("Ship API v1 behind a flag");
   });
 
-  it("labels and joins the other list fields of an object summary", () => {
+  it("labels and joins the other list fields of an object summary", async () => {
     const { sandbox, getElement } = loadViewerSandbox();
     sandbox.state.sessions.items = [baseSession({ summary: sessionSummaryObject })];
     sandbox.state.sessions.selectedId = "20260811_113447_ba4a38";
@@ -244,17 +244,15 @@ describe("viewer session summary rendering", () => {
         "Files: integrations/todoist.ts, skills/todoist.md — " +
         "Concepts: api-migration, skills",
     );
-    expect(text.indexOf("Key decisions:")).toBeLessThan(text.indexOf("Files:"));
-    expect(text.indexOf("Files:")).toBeLessThan(text.indexOf("Concepts:"));
 
-    return sandbox.renderSessionDetail().then(() => {
-      const html = getElement("session-detail").innerHTML;
-      expect(html).not.toContain("[object Object]");
-      expect(html).toContain("Files:");
-      expect(html).toContain("integrations/todoist.ts");
-      expect(html).toContain("Concepts:");
-      expect(html).toContain("api-migration");
-    });
+    await sandbox.renderSessionDetail();
+
+    const html = getElement("session-detail").innerHTML;
+    expect(html).not.toContain("[object Object]");
+    expect(html).toContain("Files:");
+    expect(html).toContain("integrations/todoist.ts");
+    expect(html).toContain("Concepts:");
+    expect(html).toContain("api-migration");
   });
 
   it("renders the detail panel preview from an object summary", async () => {

--- a/test/viewer-session-summary.test.ts
+++ b/test/viewer-session-summary.test.ts
@@ -6,6 +6,13 @@ import { renderViewerDocument } from "../src/viewer/document.js";
 // string (legacy title slice) or the full SessionSummary object merged by
 // api::sessions. The Sessions tab must render readable text in both shapes
 // and never the literal "[object Object]" (issue #1229).
+function htmlEscape(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
 function loadViewerSandbox() {
   const rendered = renderViewerDocument();
   expect(rendered.found).toBe(true);
@@ -93,7 +100,10 @@ function loadViewerSandbox() {
           text = String(value ?? "");
         },
         get innerHTML() {
-          return text;
+          // Matches the sibling loader in test/viewer-session-id.test.ts —
+          // the esc() helper in the viewer script round-trips through
+          // createElement/textContent/innerHTML escaping.
+          return htmlEscape(text);
         },
       };
     },
@@ -150,10 +160,15 @@ function loadViewerSandbox() {
     encodeURIComponent,
   };
 
-  const scriptWithoutAutoStart = scriptMatch[1].replace(
-    /\n\s*loadTab\('dashboard'\);\n\s*connectWs\(\);\n\s*startDashboardAutoRefresh\(\);\s*$/,
-    "\n",
-  );
+  const scriptWithoutAutoStart = scriptMatch[1]
+    .replace(/\n\s*switchTab\(tabFromRoute\(\)[^;]*;\n/, "\n")
+    .replace(/\n\s*\(async function initWs\(\)[\s\S]*?\}\)\(\);\n/, "\n")
+    .replace(/\n\s*startDashboardAutoRefresh\(\);\n/, "\n");
+
+  // The strip must actually fire. If the viewer script's startup tail
+  // changes shape, fail loudly here instead of silently running startup
+  // code (WebSocket/fetch chains) inside every rendering test.
+  expect(scriptWithoutAutoStart).not.toBe(scriptMatch[1]);
 
   vm.createContext(sandbox);
   vm.runInContext(scriptWithoutAutoStart, sandbox);
@@ -203,15 +218,10 @@ describe("viewer session summary rendering", () => {
 
     // The list preview truncates at 140 chars, so assert the labeled lists
     // through the full serialization the detail panel renders (600 chars).
-    expect(sandbox.sessionSummaryText({ summary: sessionSummaryObject })).toContain(
-      "Key decisions: Ship API v1 behind a flag, Keep v0 fallback for a release",
-    );
-    expect(sandbox.sessionSummaryText({ summary: sessionSummaryObject })).toContain(
-      "Files: integrations/todoist.ts, skills/todoist.md",
-    );
-    expect(sandbox.sessionSummaryText({ summary: sessionSummaryObject })).toContain(
-      "Concepts: api-migration, skills",
-    );
+    const text = sandbox.sessionSummaryText({ summary: sessionSummaryObject });
+    expect(text).toContain("Key decisions: Ship API v1 behind a flag, Keep v0 fallback for a release");
+    expect(text).toContain("Files: integrations/todoist.ts, skills/todoist.md");
+    expect(text).toContain("Concepts: api-migration, skills");
 
     return sandbox.renderSessionDetail().then(() => {
       const html = getElement("session-detail").innerHTML;

--- a/test/viewer-session-summary.test.ts
+++ b/test/viewer-session-summary.test.ts
@@ -1,0 +1,296 @@
+import * as vm from "node:vm";
+import { describe, expect, it } from "vitest";
+import { renderViewerDocument } from "../src/viewer/document.js";
+
+// Session summaries arrive on GET /agentmemory/sessions as either a plain
+// string (legacy title slice) or the full SessionSummary object merged by
+// api::sessions. The Sessions tab must render readable text in both shapes
+// and never the literal "[object Object]" (issue #1229).
+function loadViewerSandbox() {
+  const rendered = renderViewerDocument();
+  expect(rendered.found).toBe(true);
+  if (!rendered.found) throw new Error("viewer document not found");
+
+  const scriptMatch = rendered.html.match(/<script nonce="[^"]+">([\s\S]*?)<\/script>/);
+  expect(scriptMatch).not.toBeNull();
+  if (!scriptMatch) throw new Error("viewer script not found");
+
+  const elements = new Map<string, any>();
+  const createMockElement = (id = "") => {
+    const attributes = new Map<string, string>();
+    const classes = new Set<string>();
+    const listeners = new Map<string, Array<(event?: unknown) => void>>();
+    return {
+      id,
+      innerHTML: "",
+      textContent: "",
+      value: "",
+      checked: false,
+      dataset: {},
+      style: {},
+      listeners,
+      classList: {
+        add: (name: string) => classes.add(name),
+        remove: (name: string) => classes.delete(name),
+        contains: (name: string) => classes.has(name),
+        toggle: (name: string, force?: boolean) => {
+          const enabled = force ?? !classes.has(name);
+          if (enabled) classes.add(name);
+          else classes.delete(name);
+          return enabled;
+        },
+      },
+      addEventListener: (type: string, handler: (event?: unknown) => void) => {
+        const current = listeners.get(type) || [];
+        current.push(handler);
+        listeners.set(type, current);
+      },
+      getAttribute: (name: string) => attributes.get(name) ?? null,
+      setAttribute: (name: string, value: unknown) => {
+        attributes.set(name, String(value));
+      },
+      removeAttribute: (name: string) => {
+        attributes.delete(name);
+      },
+      querySelectorAll: () => [],
+    };
+  };
+  const getElement = (id: string) => {
+    if (!elements.has(id)) elements.set(id, createMockElement(id));
+    return elements.get(id);
+  };
+
+  const tabs = [
+    "dashboard",
+    "graph",
+    "memories",
+    "timeline",
+    "sessions",
+    "lessons",
+    "actions",
+    "crystals",
+    "audit",
+    "activity",
+    "profile",
+    "replay",
+  ];
+  const tabButtons = tabs.map((tab) => ({ ...createMockElement(), dataset: { tab } }));
+  const views = tabs.map((tab) => ({ ...createMockElement(`view-${tab}`), id: `view-${tab}` }));
+  const checkboxes = [createMockElement(), createMockElement()].map((el) => ({ ...el, checked: false }));
+  const querySelectorAll = (selector: string) => {
+    if (selector === ".tab-bar button") return tabButtons;
+    if (selector === ".view") return views;
+    if (selector === 'input[type="checkbox"]') return checkboxes;
+    return [];
+  };
+
+  const document = {
+    documentElement: { dataset: {} },
+    createElement: () => {
+      let text = "";
+      return {
+        set textContent(value: unknown) {
+          text = String(value ?? "");
+        },
+        get innerHTML() {
+          return text;
+        },
+      };
+    },
+    getElementById: getElement,
+    querySelectorAll,
+    addEventListener: () => {},
+  };
+
+  const sandbox: Record<string, any> = {
+    console: { log: () => {}, warn: () => {}, error: () => {} },
+    document,
+    window: {
+      location: {
+        search: "",
+        port: "3113",
+        protocol: "http:",
+        hostname: "localhost",
+        host: "localhost:3113",
+        origin: "http://localhost:3113",
+      },
+      matchMedia: () => ({ matches: false }),
+      addEventListener: () => {},
+    },
+    history: { replaceState: () => {}, pushState: () => {} },
+    location: { hash: "", pathname: "/", search: "" },
+    localStorage: { getItem: () => null, setItem: () => {} },
+    sessionStorage: (() => {
+      const values = new Map<string, string>();
+      return {
+        getItem: (key: string) => values.get(key) ?? null,
+        setItem: (key: string, value: string) => values.set(key, value),
+        removeItem: (key: string) => values.delete(key),
+      };
+    })(),
+    fetch: async () => ({ ok: true, json: async () => ({}) }),
+    WebSocket: function WebSocket() {},
+    navigator: { userAgent: "vitest" },
+    Element: function Element() {},
+    alert: () => {},
+    setInterval: () => 0,
+    clearInterval: () => {},
+    setTimeout: () => 0,
+    clearTimeout: () => {},
+    URLSearchParams,
+    Date,
+    Math,
+    Promise,
+    JSON,
+    Array,
+    Object,
+    String,
+    Number,
+    parseInt,
+    encodeURIComponent,
+  };
+
+  const scriptWithoutAutoStart = scriptMatch[1].replace(
+    /\n\s*loadTab\('dashboard'\);\n\s*connectWs\(\);\n\s*startDashboardAutoRefresh\(\);\s*$/,
+    "\n",
+  );
+
+  vm.createContext(sandbox);
+  vm.runInContext(scriptWithoutAutoStart, sandbox);
+
+  return { sandbox, getElement };
+}
+
+const sessionSummaryObject = {
+  title: "Todoist skill fixes",
+  narrative: "Migrated the Todoist integration to API v1 and fixed the skill handlers.",
+  concepts: ["api-migration", "skills"],
+  filesModified: ["integrations/todoist.ts", "skills/todoist.md"],
+  keyDecisions: ["Ship API v1 behind a flag", "Keep v0 fallback for a release"],
+};
+
+function baseSession(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "20260811_113447_ba4a38",
+    project: "Cross-project memory",
+    cwd: "/tmp/work",
+    startedAt: "2026-08-11T11:34:47.000Z",
+    status: "completed",
+    observationCount: 4,
+    ...overrides,
+  };
+}
+
+describe("viewer session summary rendering", () => {
+  it("renders an object summary as readable text in the sessions list", () => {
+    const { sandbox, getElement } = loadViewerSandbox();
+    sandbox.state.sessions.items = [baseSession({ summary: sessionSummaryObject })];
+
+    sandbox.renderSessions();
+
+    const html = getElement("view-sessions").innerHTML;
+    expect(html).not.toContain("[object Object]");
+    expect(html).toContain("Todoist skill fixes");
+    expect(html).toContain("Migrated the Todoist integration to API v1");
+    expect(html).toContain("Key decisions:");
+    expect(html).toContain("Ship API v1 behind a flag");
+  });
+
+  it("labels and joins the other list fields of an object summary", () => {
+    const { sandbox, getElement } = loadViewerSandbox();
+    sandbox.state.sessions.items = [baseSession({ summary: sessionSummaryObject })];
+    sandbox.state.sessions.selectedId = "20260811_113447_ba4a38";
+
+    // The list preview truncates at 140 chars, so assert the labeled lists
+    // through the full serialization the detail panel renders (600 chars).
+    expect(sandbox.sessionSummaryText({ summary: sessionSummaryObject })).toContain(
+      "Key decisions: Ship API v1 behind a flag, Keep v0 fallback for a release",
+    );
+    expect(sandbox.sessionSummaryText({ summary: sessionSummaryObject })).toContain(
+      "Files: integrations/todoist.ts, skills/todoist.md",
+    );
+    expect(sandbox.sessionSummaryText({ summary: sessionSummaryObject })).toContain(
+      "Concepts: api-migration, skills",
+    );
+
+    return sandbox.renderSessionDetail().then(() => {
+      const html = getElement("session-detail").innerHTML;
+      expect(html).not.toContain("[object Object]");
+      expect(html).toContain("Files:");
+      expect(html).toContain("integrations/todoist.ts");
+      expect(html).toContain("Concepts:");
+      expect(html).toContain("api-migration");
+    });
+  });
+
+  it("renders the detail panel preview from an object summary", async () => {
+    const { sandbox, getElement } = loadViewerSandbox();
+    sandbox.state.sessions.items = [baseSession({ summary: sessionSummaryObject })];
+    sandbox.state.sessions.selectedId = "20260811_113447_ba4a38";
+
+    await sandbox.renderSessionDetail();
+
+    const html = getElement("session-detail").innerHTML;
+    expect(html).not.toContain("[object Object]");
+    expect(html).toContain("Migrated the Todoist integration to API v1");
+    expect(html).toContain("Ship API v1 behind a flag");
+  });
+
+  it("keeps rendering plain string summaries unchanged", () => {
+    const { sandbox, getElement } = loadViewerSandbox();
+    sandbox.state.sessions.items = [baseSession({ summary: "Legacy plain-text summary" })];
+
+    sandbox.renderSessions();
+
+    const html = getElement("view-sessions").innerHTML;
+    expect(html).not.toContain("[object Object]");
+    expect(html).toContain("Legacy plain-text summary");
+  });
+
+  it("falls back to firstPromptFromObs in the detail panel when summary is missing", async () => {
+    const { sandbox, getElement } = loadViewerSandbox();
+    sandbox.state.sessions.items = [baseSession()];
+    sandbox.state.sessions.selectedId = "20260811_113447_ba4a38";
+    sandbox.fetch = async () => ({
+      ok: true,
+      json: async () => ({
+        observations: [{ type: "conversation", userPrompt: "Fix the parser fallback" }],
+      }),
+    });
+
+    await sandbox.renderSessionDetail();
+
+    const html = getElement("session-detail").innerHTML;
+    expect(html).not.toContain("[object Object]");
+    expect(html).toContain("Fix the parser fallback");
+  });
+
+  it("renders no preview line when summary is missing in the sessions list", () => {
+    const { sandbox, getElement } = loadViewerSandbox();
+    sandbox.state.sessions.items = [baseSession()];
+
+    sandbox.renderSessions();
+
+    const html = getElement("view-sessions").innerHTML;
+    expect(html).not.toContain("[object Object]");
+    expect(html).not.toContain("session-preview");
+  });
+
+  it("does not throw on a malformed object summary", () => {
+    const { sandbox, getElement } = loadViewerSandbox();
+    sandbox.state.sessions.items = [
+      baseSession({
+        summary: {
+          title: 42,
+          keyDecisions: "not-an-array",
+          filesModified: ["still/works.ts"],
+        } as unknown as object,
+      }),
+    ];
+
+    expect(() => sandbox.renderSessions()).not.toThrow();
+    const html = getElement("view-sessions").innerHTML;
+    expect(html).not.toContain("[object Object]");
+    expect(html).toContain("still/works.ts");
+  });
+});

--- a/test/viewer-session-summary.test.ts
+++ b/test/viewer-session-summary.test.ts
@@ -303,4 +303,82 @@ describe("viewer session summary rendering", () => {
     expect(html).not.toContain("[object Object]");
     expect(html).toContain("still/works.ts");
   });
+
+  it("skips non-string and empty entries inside summary list fields", () => {
+    const { sandbox } = loadViewerSandbox();
+    const summary = {
+      title: "Mixed entry types",
+      narrative: "Narrative body.",
+      keyDecisions: ["Real decision", {}, null, "", 42] as unknown as string[],
+      filesModified: ["kept.ts", {}, "also.ts"] as unknown as string[],
+      concepts: [{ nested: true }, "concept"] as unknown as string[],
+    };
+    const text = sandbox.sessionSummaryText({ summary });
+    expect(text).not.toContain("[object Object]");
+    expect(text).not.toContain("null");
+    expect(text).not.toContain("42");
+    expect(text).toContain("Key decisions: Real decision");
+    expect(text).toContain("Files: kept.ts, also.ts");
+    expect(text).toContain("Concepts: concept");
+  });
+
+  it("renders firstPrompt over a serialized summary in both render paths", async () => {
+    const { sandbox, getElement } = loadViewerSandbox();
+    sandbox.state.sessions.items = [
+      baseSession({ firstPrompt: "User prompt text", summary: sessionSummaryObject }),
+    ];
+    sandbox.state.sessions.selectedId = "20260811_113447_ba4a38";
+
+    sandbox.renderSessions();
+    const listHtml = getElement("view-sessions").innerHTML;
+    expect(listHtml).not.toContain("[object Object]");
+    expect(listHtml).toContain("User prompt text");
+    expect(listHtml).not.toContain("Todoist skill fixes");
+
+    await sandbox.renderSessionDetail();
+    const detailHtml = getElement("session-detail").innerHTML;
+    expect(detailHtml).not.toContain("[object Object]");
+    expect(detailHtml).toContain("User prompt text");
+  });
+
+  it("renders the serialized summary when firstPrompt is absent", () => {
+    const { sandbox, getElement } = loadViewerSandbox();
+    sandbox.state.sessions.items = [
+      baseSession({ firstPrompt: "", summary: sessionSummaryObject }),
+    ];
+
+    sandbox.renderSessions();
+
+    const html = getElement("view-sessions").innerHTML;
+    expect(html).toContain("Todoist skill fixes");
+    expect(html).toContain("Migrated the Todoist integration to API v1");
+  });
+
+  it("deduplicates a narrative identical to the title", () => {
+    const { sandbox } = loadViewerSandbox();
+    expect(
+      sandbox.sessionSummaryText({
+        summary: { title: "Same text", narrative: "Same text" },
+      }),
+    ).toBe("Same text");
+    expect(
+      sandbox.sessionSummaryText({
+        summary: { title: "Same text", narrative: "Same text." },
+      }),
+    ).toBe("Same text — Same text.");
+  });
+
+  it("returns empty text for numeric and empty-object summaries", () => {
+    const { sandbox, getElement } = loadViewerSandbox();
+    sandbox.state.sessions.items = [
+      baseSession({ summary: 42 as unknown as object }),
+      baseSession({ id: "20260904_empty_obj", summary: {} }),
+    ];
+
+    sandbox.renderSessions();
+
+    const html = getElement("view-sessions").innerHTML;
+    expect(html).not.toContain("[object Object]");
+    expect(html).not.toContain("session-preview");
+  });
 });

--- a/test/viewer-session-summary.test.ts
+++ b/test/viewer-session-summary.test.ts
@@ -7,11 +7,14 @@ import { renderViewerDocument } from "../src/viewer/document.js";
 // api::sessions. The Sessions tab must render readable text in both shapes
 // and never the literal "[object Object]" (issue #1229).
 function htmlEscape(value: string): string {
+  // Matches real text-node innerHTML serialization (&, <, >, nbsp only).
+  // Double quotes are intentionally NOT escaped — a browser does not
+  // escape them in text context, and over-escaping would mask quote
+  // breakouts the real viewer could produce.
   return value
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
+    .replace(/>/g, "&gt;");
 }
 function loadViewerSandbox() {
   const rendered = renderViewerDocument();


### PR DESCRIPTION
## Summary

On the Sessions tab, sessions with an LLM-generated summary displayed the literal string `[object Object]` instead of the summary text. `GET /agentmemory/sessions` merges each session's `SessionSummary` object into `session.summary`, and the viewer interpolated that field directly as a string. The Sessions list preview and the session detail panel now run the field through a small `sessionSummaryText()` serializer, rendering the title, narrative, and labeled `keyDecisions` / `filesModified` / `concepts` lists as readable text. Plain-string summaries, missing summaries, and the `firstPrompt` / `firstPromptFromObs` fallback order render exactly as before. The serializer is defensive over malformed stored payloads (non-string fields, non-array lists), so no shape can reintroduce `[object Object]`.

Fixes #1229.

## How to verify

- New regression test: `npx vitest run test/viewer-session-summary.test.ts` — 19 tests covering object, plain-string, whitespace-only, zero-width, missing, malformed, and mixed-entry summaries across both render paths, plus precedence, dedup, escaping, and hostile-input pins.
- `npm test` passes: 160 test files, 1730 tests (1 env-gated skip).
- Manually verified against a live daemon (zero-LLM): seeded sessions with object, plain-string, and missing summaries; the Sessions tab renders readable text in all three shapes and the detail panel shows the full labeled serialization, with zero console errors. The diff then survived a 5-pass layered audit (logic, escaping, edge cases, test fidelity, full sweep) plus a final independent code-review round whose findings — non-string `firstPrompt`/`userPrompt` chain terms, zero-width characters, untrimmed list joins, an unguarded `summary` read, escaping pins, and `any` justification — were all fixed and independently validated.

## Unapplied review findings

- [x] P2 — test/viewer-session-summary.test.ts — firstPrompt-over-summary precedence in the fallback chain is never tested. (Closed: precedence pinned in both render paths by commit 01ce0c6 and the pass-4 audit commits.) Suggested fix: add a test with `baseSession({ firstPrompt: 'User prompt text', summary: sessionSummaryObject })` asserting both `renderSessions()` and `renderSessionDetail()` render 'User prompt text' (not the serialized summary), plus a mirror case where firstPrompt is empty.

Review run context: run_id 20260904-201709-a9c565cf.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session summaries now display as readable text in session lists and details.
  * Fixed object-based summaries appearing as “[object Object]”.
  * Improved handling of legacy, missing, malformed, whitespace-only, and invisible summaries.
  * Prevented unusual summary data from interrupting page rendering.
  * Cleaned up summary text, filtered invalid entries, and safely escaped rendered content.
  * Improved fallback behavior for prompts derived from session summaries.

* **Tests**
  * Added comprehensive coverage for summary parsing, filtering, fallbacks, rendering, and hostile or malformed data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

