### PR TITLE
feat(reflect): project-level namespace isolation for reflection and consolidation

### DIFF
--- a/src/functions/consolidation-pipeline.ts
+++ b/src/functions/consolidation-pipeline.ts
@@ -57,7 +57,8 @@ export function registerConsolidationPipelineFunction(
       const results: Record<string, unknown> = {};
 
       if (tier === "all" || tier === "semantic") {
-        const summaries = await kv.list<SessionSummary>(KV.summaries);
+        let summaries = await kv.list<SessionSummary>(KV.summaries);
+        if (data?.project) summaries = summaries.filter((s) => s.project === data.project);
         const existingSemantic = await kv.list<SemanticMemory>(KV.semantic);
 
         if (summaries.length >= 5) {

--- a/src/functions/reflect.ts
+++ b/src/functions/reflect.ts
@@ -8,6 +8,7 @@ import type {
   SemanticMemory,
   Lesson,
   Crystal,
+  Session,
   MemoryProvider,
 } from "../types.js";
 import { recordAudit } from "./audit.js";
@@ -185,8 +186,51 @@ export function registerReflectFunctions(
         activeLessons = activeLessons.filter((l) => l.project === data.project);
       }
 
+      let activeCrystals = crystals;
+      if (data?.project) {
+        activeCrystals = crystals.filter((c) => c.project === data.project);
+      }
+      activeCrystals.sort((a, b) =>
+        (b.createdAt || "").localeCompare(a.createdAt || ""),
+      );
+
+      let activeSemantic = semanticMemories;
+      if (data?.project) {
+        const sessions = await kv.list<Session>(KV.sessions).catch(() => []);
+        const projectSessionIds = new Set(
+          sessions.filter((s) => s.project === data.project).map((s) => s.id),
+        );
+        activeSemantic = semanticMemories.filter((s) =>
+          (s.sourceSessionIds || []).some((id) => projectSessionIds.has(id)),
+        );
+      }
+
+      let relevantGraphNodes = graphNodes;
+      if (data?.project) {
+        const projectTerms = new Set<string>();
+        for (const l of activeLessons) {
+          for (const t of l.tags) projectTerms.add(t.toLowerCase());
+        }
+        for (const c of activeCrystals) {
+          for (const l of c.lessons || []) projectTerms.add(l.toLowerCase());
+          for (const o of c.keyOutcomes || []) {
+            for (const term of o.toLowerCase().split(/\s+/)) {
+              if (term.length > 3) projectTerms.add(term);
+            }
+          }
+        }
+        for (const s of activeSemantic) {
+          for (const term of s.fact.toLowerCase().split(/\s+/)) {
+            if (term.length > 3) projectTerms.add(term);
+          }
+        }
+        relevantGraphNodes = graphNodes.filter(
+          (n) => n.type !== "concept" || projectTerms.has(n.name.toLowerCase()),
+        );
+      }
+
       let conceptClusters = buildGraphClusters(
-        graphNodes,
+        relevantGraphNodes,
         graphEdges,
         maxClusters,
       );
@@ -194,7 +238,7 @@ export function registerReflectFunctions(
       const usedFallback = conceptClusters.length === 0;
       if (usedFallback) {
         conceptClusters = buildJaccardClusters(
-          semanticMemories,
+          activeSemantic,
           activeLessons,
           maxClusters,
         );
@@ -210,7 +254,7 @@ export function registerReflectFunctions(
 
         const conceptSet = new Set(conceptNames.map((c) => c.toLowerCase()));
 
-        const clusterFacts = semanticMemories.filter((s) => {
+        const clusterFacts = activeSemantic.filter((s) => {
           const factTerms = s.fact.toLowerCase().split(/\s+/);
           return factTerms.some((t) => conceptSet.has(t));
         });
@@ -222,7 +266,7 @@ export function registerReflectFunctions(
           ),
         );
 
-        const clusterCrystals = crystals.filter((c) =>
+        const clusterCrystals = activeCrystals.filter((c) =>
           (c.lessons || []).some((l) =>
             conceptNames.some((cn) =>
               l.toLowerCase().includes(cn.toLowerCase()),

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -483,9 +483,10 @@ export function registerMcpEndpoints(
 
           case "memory_consolidate": {
             try {
-              const result = await sdk.trigger({ function_id: "mem::consolidate-pipeline", payload: {
-                tier: args.tier as string,
-              } });
+              const payload: Record<string, unknown> = {};
+              if (typeof args.tier === "string") payload.tier = args.tier;
+              if (typeof args.project === "string") payload.project = args.project;
+              const result = await sdk.trigger({ function_id: "mem::consolidate-pipeline", payload });
               return {
                 status_code: 200,
                 body: {

--- a/src/mcp/tools-registry.ts
+++ b/src/mcp/tools-registry.ts
@@ -294,6 +294,11 @@ export const V040_TOOLS: McpToolDef[] = [
           type: "string",
           description: "Target tier: episodic, semantic, or procedural",
         },
+        project: {
+          type: "string",
+          description:
+            "Optional project to scope consolidation and reflection to",
+        },
       },
     },
   },

--- a/test/consolidation-pipeline.test.ts
+++ b/test/consolidation-pipeline.test.ts
@@ -249,4 +249,40 @@ describe("Consolidation Pipeline", () => {
     expect(result.results).toBeDefined();
     vi.mocked(isConsolidationEnabled).mockReturnValue(true);
   });
+
+  it("filters session summaries by project when specified", async () => {
+    const provider = {
+      name: "test",
+      compress: vi.fn(),
+      summarize: vi.fn().mockResolvedValue(
+        `<facts><fact confidence="0.9">Alpha pipeline is ready</fact></facts>`,
+      ),
+    };
+    registerConsolidationPipelineFunction(sdk as never, kv as never, provider as never);
+
+    // Project alpha: 5 summaries
+    for (let i = 0; i < 5; i++) {
+      await kv.set("mem:summaries", `ses_alpha_${i}`, {
+        ...makeSummary(i),
+        project: "proj-alpha",
+      });
+    }
+    // Project beta: 5 summaries
+    for (let i = 0; i < 5; i++) {
+      await kv.set("mem:summaries", `ses_beta_${i}`, {
+        ...makeSummary(10 + i),
+        project: "proj-beta",
+      });
+    }
+
+    const result = (await sdk.trigger("mem::consolidate-pipeline", {
+      tier: "semantic",
+      project: "proj-alpha",
+    })) as { success: boolean; results: Record<string, unknown> };
+
+    expect(result.success).toBe(true);
+    const semantic = result.results.semantic as { newFacts: number; totalSummaries: number };
+    expect(semantic.totalSummaries).toBe(5);
+    expect(provider.summarize).toHaveBeenCalledTimes(1);
+  });
 });

--- a/test/reflect.test.ts
+++ b/test/reflect.test.ts
@@ -251,6 +251,94 @@ describe("Reflect", () => {
       expect(result.success).toBe(true);
       expect(result.newInsights).toBe(0);
     });
+
+    it("isolates facts, lessons, crystals, and concept clusters by project", async () => {
+      // Setup project A
+      await kv.set("mem:sessions", "ses_a1", {
+        id: "ses_a1",
+        project: "proj-alpha",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        observationCount: 5,
+        status: "active",
+      });
+      await kv.set("mem:semantic", "sem_a1", {
+        ...makeSemantic("alpha architecture pipeline design"),
+        sourceSessionIds: ["ses_a1"],
+      });
+      await kv.set("mem:lessons", "lsn_a1", {
+        ...makeLesson("Alpha pipeline lesson", ["alpha", "pipeline"]),
+        project: "proj-alpha",
+      });
+      await kv.set("mem:crystals", "cry_a1", {
+        id: "cry_a1",
+        narrative: "Alpha deployment completed",
+        keyOutcomes: ["alpha pipeline works"],
+        filesAffected: ["alpha.go"],
+        lessons: ["alpha"],
+        sourceActionIds: [],
+        project: "proj-alpha",
+        createdAt: new Date().toISOString(),
+      });
+
+      // Setup project B (unrelated)
+      await kv.set("mem:sessions", "ses_b1", {
+        id: "ses_b1",
+        project: "proj-beta",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        observationCount: 5,
+        status: "active",
+      });
+      await kv.set("mem:semantic", "sem_b1", {
+        ...makeSemantic("beta database migration indexing"),
+        sourceSessionIds: ["ses_b1"],
+      });
+      await kv.set("mem:lessons", "lsn_b1", {
+        ...makeLesson("Beta indexing lesson", ["beta", "database"]),
+        project: "proj-beta",
+      });
+      await kv.set("mem:crystals", "cry_b1", {
+        id: "cry_b1",
+        narrative: "Beta migration completed",
+        keyOutcomes: ["beta migration works"],
+        filesAffected: ["beta.go"],
+        lessons: ["beta"],
+        sourceActionIds: [],
+        project: "proj-beta",
+        createdAt: new Date().toISOString(),
+      });
+
+      // Concept graph nodes
+      await kv.set("mem:graph:nodes", "node_alpha", makeConceptNode("alpha"));
+      await kv.set("mem:graph:nodes", "node_pipeline", makeConceptNode("pipeline"));
+      await kv.set("mem:graph:nodes", "node_beta", makeConceptNode("beta"));
+      await kv.set("mem:graph:nodes", "node_database", makeConceptNode("database"));
+      await kv.set("mem:graph:edges", "edge_ap", makeEdge("alpha", "pipeline"));
+      await kv.set("mem:graph:edges", "edge_bd", makeEdge("beta", "database"));
+
+      const result = (await sdk.trigger("mem::reflect", {
+        project: "proj-alpha",
+      })) as {
+        success: boolean;
+        clustersProcessed: number;
+        newInsights: number;
+      };
+
+      expect(result.success).toBe(true);
+      expect(result.clustersProcessed).toBe(1);
+      expect(result.newInsights).toBe(2);
+
+      const insights = await kv.list<Insight>("mem:insights");
+      const alphaInsights = insights.filter((i) => i.project === "proj-alpha");
+      expect(alphaInsights.length).toBe(2);
+      expect(alphaInsights[0].sourceConceptCluster).toEqual(expect.arrayContaining(["alpha", "pipeline"]));
+      expect(alphaInsights[0].sourceConceptCluster).not.toContain("beta");
+      expect(alphaInsights[0].sourceConceptCluster).not.toContain("database");
+
+      const betaInsights = insights.filter((i) => i.project === "proj-beta");
+      expect(betaInsights.length).toBe(0);
+    });
   });
 
   describe("mem::insight-list", () => {


### PR DESCRIPTION
## Summary

Adds repository-level project isolation across reflection and the consolidation pipeline so multi-project agent environments do not cross-contaminate concept clusters or synthesized insights:

1. **Project-scoped reflection**:
   - Filter `activeLessons` and `activeCrystals` strictly by `data.project` (with crystals sorted by recency descending).
   - Filter `activeSemantic` memories through their `sourceSessionIds` matching sessions tagged with `data.project` in `KV.sessions`.
   - Gate graph concept seeds via `projectTerms` derived from project-scoped lessons, crystals, and semantic memories so foreign concepts cannot bridge or seed clusters.
   - Stamp `project: data.project` on newly generated `Insight` entities.
2. **Consolidation pipeline scoping**:
   - Scope session summaries by `data?.project` in the semantic consolidation tier of `mem::consolidate-pipeline`.
   - Forward `project: data?.project` to `mem::reflect`.
3. **MCP Tool plumbing**:
   - Add optional `project` string parameter to `memory_consolidate` tool schema and forward it in `src/mcp/server.ts`.

## Testing

- Unit tests in `test/reflect.test.ts` verifying that reflection with `project: 'proj-alpha'` completely isolates facts, lessons, crystals, and insights from unrelated projects.
- Unit tests in `test/consolidation-pipeline.test.ts` verifying that semantic consolidation filters session summaries by `data?.project`.
- `npm test test/reflect.test.ts test/consolidation-pipeline.test.ts test/mcp-standalone.test.ts` passed cleanly (51 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional project scoping to memory consolidation.
  - Added project-scoped reflection across lessons, crystals, semantic memories, and concept clusters.
  - Updated the memory consolidation tool to accept a project parameter.

- **Bug Fixes**
  - Prevented consolidation and reflection from incorporating data belonging to other projects when a project is specified.

- **Tests**
  - Added coverage confirming project isolation and correctly tagged generated insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->