### PR TITLE
feat: separate compression models and add OpenRouter reranking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,7 @@
 # OPENAI_API_KEY=sk-...                          # Activates both the OpenAI-compatible LLM provider (DeepSeek, SiliconFlow, vLLM, LM Studio, Ollama via `/v1`) and OpenAI embeddings. Set OPENAI_API_KEY_FOR_LLM=false to scope it to embeddings only.
 # OPENAI_BASE_URL=https://api.openai.com         # Override for OpenAI-compatible providers
 # OPENAI_MODEL=gpt-5.6-luna                      # Default OpenAI-compatible chat model
+# AGENTMEMORY_COMPRESSION_MODEL=gpt-5.6-luna     # Optional model for observation compression
 # OPENAI_API_KEY_FOR_LLM=false                   # Skip OpenAI auto-detection for LLM; key stays active for embeddings
 
 # ANTHROPIC_API_KEY=sk-ant-...
@@ -86,6 +87,7 @@
 # OPENAI_EMBEDDING_DIMENSIONS=1536               # Required when the model is not in the known-models table
 
 # OPENROUTER_EMBEDDING_MODEL=openai/text-embedding-3-small  # When EMBEDDING_PROVIDER=openrouter
+# EMBEDDING_PROVIDER=openrouter                  # Use OPENROUTER_API_KEY for embeddings
 
 # -----------------------------------------------------------------------------
 # 3. Auth & security
@@ -100,6 +102,10 @@
 # -----------------------------------------------------------------------------
 # 4. Search tuning
 # -----------------------------------------------------------------------------
+
+# RERANK_ENABLED=false                            # Enable reranking in hybrid search
+# RERANK_PROVIDER=local                            # local or openrouter
+# OPENROUTER_RERANK_MODEL=cohere/rerank-v3.5       # OpenRouter rerank model
 
 # BM25_WEIGHT=0.4                                # Hybrid search weight for BM25 leg
 # VECTOR_WEIGHT=0.6                              # Hybrid search weight for vector leg

--- a/src/config.ts
+++ b/src/config.ts
@@ -215,7 +215,8 @@ export function loadConfig(): AgentMemoryConfig {
     provider,
     tokenBudget: safeParseInt(env["TOKEN_BUDGET"], 2000),
     maxObservationsPerSession: safeParseInt(env["MAX_OBS_PER_SESSION"], 500),
-    compressionModel: provider.model,
+    compressionModel:
+      env["AGENTMEMORY_COMPRESSION_MODEL"] || provider.model,
     dataDir: DATA_DIR,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -167,6 +167,13 @@ async function main() {
     fallbackConfig.providers.length > 0
       ? createFallbackProvider(config.provider, fallbackConfig)
       : createProvider(config.provider);
+  const compressionProvider =
+    config.compressionModel === config.provider.model
+      ? provider
+      : createFallbackProvider(
+          { ...config.provider, model: config.compressionModel },
+          fallbackConfig,
+        );
 
   const embeddingProvider = createEmbeddingProvider();
   const imageEmbeddingProvider = createImageEmbeddingProvider();
@@ -241,7 +248,7 @@ async function main() {
     registerSlotsFunctions(sdk, kv);
   }
   registerDiskSizeManager(sdk, kv);
-  registerCompressFunction(sdk, kv, provider, metricsStore);
+  registerCompressFunction(sdk, kv, compressionProvider, metricsStore);
   registerSearchFunction(sdk, kv);
   registerContextFunction(sdk, kv, config.tokenBudget);
   registerSummarizeFunction(sdk, kv, provider, metricsStore);
@@ -328,11 +335,11 @@ async function main() {
   registerSkillExtractFunctions(sdk, kv, provider);
   registerCascadeFunction(sdk, kv);
 
-  registerSlidingWindowFunction(sdk, kv, provider);
+  registerSlidingWindowFunction(sdk, kv, compressionProvider);
   registerQueryExpansionFunction(sdk, provider);
   registerTemporalGraphFunctions(sdk, kv, provider);
   registerRetentionFunctions(sdk, kv);
-  registerCompressFileFunction(sdk, kv, provider);
+  registerCompressFileFunction(sdk, kv, compressionProvider);
   registerReplayFunctions(sdk, kv);
   bootLog(
     `v0.6 advanced retrieval: sliding-window, query-expansion, temporal-graph, retention-scoring`,

--- a/src/state/reranker.ts
+++ b/src/state/reranker.ts
@@ -1,4 +1,6 @@
 import type { HybridSearchResult } from "../types.js";
+import { getEnvVar } from "../config.js";
+import { fetchWithTimeout } from "../providers/_fetch.js";
 
 let pipeline: any = null;
 let pipelineLoading: Promise<any> | null = null;
@@ -38,10 +40,14 @@ export async function rerank(
 ): Promise<HybridSearchResult[]> {
   if (results.length <= 1) return results;
 
+  const candidates = results.slice(0, Math.min(results.length, topK));
+
+  if (getEnvVar("RERANK_PROVIDER") === "openrouter") {
+    return rerankWithOpenRouter(query, candidates);
+  }
+
   const reranker = await loadPipeline();
   if (!reranker) return results;
-
-  const candidates = results.slice(0, Math.min(results.length, topK));
 
   const pairs = candidates.map((r) => ({
     text: `${query} [SEP] ${r.observation.title || ""} ${r.observation.narrative || ""}`.slice(0, 512),
@@ -66,6 +72,67 @@ export async function rerank(
     ...s.result,
     combinedScore: s.rerankScore,
     rerankPosition: i + 1,
+  }));
+}
+
+async function rerankWithOpenRouter(
+  query: string,
+  candidates: HybridSearchResult[],
+): Promise<HybridSearchResult[]> {
+  const apiKey = getEnvVar("OPENROUTER_API_KEY");
+  if (!apiKey) throw new Error("OPENROUTER_API_KEY is required for reranking");
+
+  const response = await fetchWithTimeout("https://openrouter.ai/api/v1/rerank", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: getEnvVar("OPENROUTER_RERANK_MODEL") || "cohere/rerank-v3.5",
+      query,
+      documents: candidates.map(
+        (candidate) =>
+          `${candidate.observation.title || ""} ${candidate.observation.narrative || ""}`.trim(),
+      ),
+      top_n: candidates.length,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`OpenRouter rerank failed (${response.status})`);
+  }
+
+  const data = (await response.json()) as {
+    results?: Array<{ index?: unknown; relevance_score?: unknown }>;
+  };
+  const ranked = data.results;
+  if (!Array.isArray(ranked) || ranked.length !== candidates.length) {
+    throw new Error("Invalid OpenRouter rerank response");
+  }
+
+  const seen = new Set<number>();
+  const scores = ranked.map((item) => {
+    const index = item.index;
+    const score = item.relevance_score;
+    if (
+      !Number.isInteger(index) ||
+      (index as number) < 0 ||
+      (index as number) >= candidates.length ||
+      seen.has(index as number) ||
+      typeof score !== "number" ||
+      !Number.isFinite(score)
+    ) {
+      throw new Error("Invalid OpenRouter rerank response");
+    }
+    seen.add(index as number);
+    return { index: index as number, score };
+  });
+
+  return scores.map(({ index, score }, position) => ({
+    ...candidates[index],
+    combinedScore: score,
+    rerankPosition: position + 1,
   }));
 }
 

--- a/test/llm-provider-independence.test.ts
+++ b/test/llm-provider-independence.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { loadConfig } from "../src/config.js";
+import { createProvider } from "../src/providers/index.js";
+import { createEmbeddingProvider } from "../src/providers/embedding/index.js";
+
+const savedEnv = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...savedEnv };
+  vi.restoreAllMocks();
+});
+
+describe("independent LLM and embedding configuration", () => {
+  it("loads the compression override and defaults it to the primary model", () => {
+    process.env.OPENAI_API_KEY = "primary-key";
+    process.env.OPENAI_MODEL = "gpt-5.6-terra";
+    process.env.AGENTMEMORY_COMPRESSION_MODEL = "gpt-5.6-luna";
+    expect(loadConfig().compressionModel).toBe("gpt-5.6-luna");
+
+    delete process.env.AGENTMEMORY_COMPRESSION_MODEL;
+    expect(loadConfig().compressionModel).toBe("gpt-5.6-terra");
+  });
+
+  it("sends Terra and Luna through the custom OpenAI endpoint with medium reasoning", async () => {
+    process.env.OPENAI_API_KEY = "custom-openai-key";
+    process.env.OPENAI_REASONING_EFFORT = "medium";
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      new Response(
+        JSON.stringify({ choices: [{ message: { content: "ok" } }] }),
+        { status: 200 },
+      ),
+    );
+
+    const primary = createProvider({
+      provider: "openai",
+      model: "gpt-5.6-terra",
+      maxTokens: 256,
+      baseURL: "https://llm.example/v1",
+    });
+    const compression = createProvider({
+      provider: "openai",
+      model: "gpt-5.6-luna",
+      maxTokens: 256,
+      baseURL: "https://llm.example/v1",
+    });
+    await primary.compress("system", "analysis");
+    await compression.compress("system", "observation");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const requests = fetchMock.mock.calls.map((call) => ({
+      url: call[0],
+      init: call[1] as RequestInit,
+    }));
+    expect(requests[0].url).toBe("https://llm.example/v1/chat/completions");
+    expect(requests[1].url).toBe("https://llm.example/v1/chat/completions");
+    for (const request of requests) {
+      expect((request.init.headers as Record<string, string>).Authorization).toBe(
+        "Bearer custom-openai-key",
+      );
+      const body = JSON.parse(request.init.body as string);
+      expect(body.reasoning_effort).toBe("medium");
+    }
+    expect(JSON.parse(requests[0].init.body as string).model).toBe("gpt-5.6-terra");
+    expect(JSON.parse(requests[1].init.body as string).model).toBe("gpt-5.6-luna");
+  });
+
+  it("forces OpenRouter embeddings with its separate key and endpoint", async () => {
+    process.env.OPENAI_API_KEY = "primary-key";
+    process.env.OPENROUTER_API_KEY = "embedding-key";
+    process.env.EMBEDDING_PROVIDER = "openrouter";
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ data: [{ embedding: Array(1536).fill(0.1) }] }), {
+        status: 200,
+      }),
+    );
+
+    const provider = createEmbeddingProvider();
+    expect(provider?.name).toBe("openrouter");
+    await provider!.embed("hello");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://openrouter.ai/api/v1/embeddings",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer embedding-key" }),
+        body: expect.stringContaining('"model":"openai/text-embedding-3-small"'),
+      }),
+    );
+  });
+});

--- a/test/reranker.test.ts
+++ b/test/reranker.test.ts
@@ -89,3 +89,65 @@ describe("reranker with loaded pipeline", () => {
     expect(reranked[0].observation.id).toBe("o1");
   });
 });
+
+describe("reranker with OpenRouter", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  const results = [
+    { observation: { id: "o1", title: "First", narrative: "one" }, combinedScore: 0.5 },
+    { observation: { id: "o2", title: "Second", narrative: "two" }, combinedScore: 0.4 },
+  ] as any;
+
+  it("uses the configured model and key and reorders by response indexes", async () => {
+    vi.stubEnv("RERANK_PROVIDER", "openrouter");
+    vi.stubEnv("OPENROUTER_API_KEY", "rerank-key");
+    vi.stubEnv("OPENAI_API_KEY", "different-openai-key");
+    vi.stubEnv("OPENROUTER_RERANK_MODEL", "custom/rerank");
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        results: [
+          { index: 1, relevance_score: 0.9 },
+          { index: 0, relevance_score: 0.2 },
+        ],
+      }),
+    } as Response);
+
+    const reranked = await rerank("query", results);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://openrouter.ai/api/v1/rerank",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer rerank-key" }),
+        body: expect.stringContaining('"model":"custom/rerank"'),
+      }),
+    );
+    const body = JSON.parse(fetchMock.mock.calls[0][1]?.body as string);
+    expect(body.query).toBe("query");
+    expect(body.documents).toEqual(["First one", "Second two"]);
+    expect(body.top_n).toBe(2);
+    expect(isRerankerAvailable()).toBe(false);
+    expect(reranked.map((item) => item.observation.id)).toEqual(["o2", "o1"]);
+    expect(reranked[0].combinedScore).toBe(0.9);
+  });
+
+  it("throws for invalid response and HTTP errors", async () => {
+    vi.stubEnv("RERANK_PROVIDER", "openrouter");
+    vi.stubEnv("OPENROUTER_API_KEY", "rerank-key");
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ results: [{ index: 0, relevance_score: 0.9 }, { index: 0, relevance_score: 0.1 }] }),
+    } as Response);
+    await expect(rerank("query", results)).rejects.toThrow("Invalid OpenRouter rerank response");
+
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 502,
+      text: async () => "bad gateway",
+    } as Response);
+    await expect(rerank("query", results)).rejects.toThrow("OpenRouter rerank failed (502)");
+  });
+});


### PR DESCRIPTION
Allow observation compression to use AGENTMEMORY_COMPRESSION_MODEL while other LLM functions retain the primary model. For example, a custom OpenAI-compatible endpoint can serve Luna for compression and Terra for analysis, with medium reasoning for both.

Add opt-in cloud reranking through OpenRouter using RERANK_PROVIDER=openrouter and OPENROUTER_RERANK_MODEL. Together with the existing EMBEDDING_PROVIDER=openrouter setting, embeddings and reranking use OPENROUTER_API_KEY independently of the custom LLM endpoint and key. The existing local reranker remains the default. Configuration examples and mocked provider-separation tests are included.

Validation: npm run build passed; npm test passed (1716 passed, 1 skipped). Live provider calls were intentionally not run; credentials and endpoints are supplied by the operator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for selecting a dedicated model for observation compression.
  - Added OpenRouter as an embedding provider option.
  - Added configurable reranking for hybrid search, including OpenRouter support.
  - Reranking results now provide updated ordering and relevance scores.
  - Added configuration options for custom model and provider selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->