### PR TITLE
fix(graph): bound sourceObservationIds in graph-extract and project it out of graph-query

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -385,6 +385,26 @@ export function getGraphBatchSize(): number {
   return safeParseInt(getMergedEnv()["GRAPH_EXTRACTION_BATCH_SIZE"], 10);
 }
 
+// Upstream #1168 / #1171: `sourceObservationIds` on graph nodes (and the
+// same field on edges) was capped at creation but re-unioned without a
+// cap on every merge. Because extraction re-observes the same entities
+// continuously, the array grew monotonically for the life of the graph
+// and ended up as ~97-99% of all bytes in the collection — measured here
+// at 9.55 MB of 9.4 MB across 500 nodes, with one `package.json` node
+// holding 4,707 ids in 133 KB. Provenance past the most recent handful
+// carries almost no signal, so bound it and keep the newest.
+const GRAPH_MAX_SOURCE_IDS_DEFAULT = 10;
+
+export function getGraphMaxSourceIds(): number {
+  return Math.max(
+    1,
+    safeParseInt(
+      getMergedEnv()["GRAPH_MAX_SOURCE_IDS"],
+      GRAPH_MAX_SOURCE_IDS_DEFAULT,
+    ),
+  );
+}
+
 // window for the smart-search followup-rate diagnostic. A second
 // search arriving within this many seconds (with disjoint results)
 // counts as a "follow-up" — a directional signal that the first result

--- a/src/functions/graph.ts
+++ b/src/functions/graph.ts
@@ -13,7 +13,10 @@ import {
   GRAPH_EXTRACTION_SYSTEM,
   buildGraphExtractionPrompt,
 } from "../prompts/graph-extraction.js";
-import { isGraphExtractionEnabled } from "../config.js";
+import {
+  isGraphExtractionEnabled,
+  getGraphMaxSourceIds,
+} from "../config.js";
 import { recordAudit } from "./audit.js";
 import { logger } from "../logger.js";
 
@@ -22,6 +25,37 @@ import { logger } from "../logger.js";
 // reported 11k-node / 28k-edge corpus, and 5,000 is the upper bound a
 // caller can request explicitly. Tuned conservatively because edges
 // fan out faster than nodes.
+// How many provenance ids a projected graph-query response keeps as a
+// sample. The full array is available with `includeSources: true`.
+const GRAPH_QUERY_SOURCE_SAMPLE = 3;
+
+/** Bound a provenance array, keeping the most recent ids. */
+function capSourceIds(ids: string[]): string[] {
+  const max = getGraphMaxSourceIds();
+  return ids.length <= max ? ids : ids.slice(-max);
+}
+
+/**
+ * Strip the provenance array down to a count plus a small sample.
+ * graph-query used to return node objects verbatim, so every consumer
+ * paid for accumulated provenance on every call — for an agent that
+ * cost is context window (upstream #1171).
+ */
+function projectSources<T extends { sourceObservationIds?: string[] }>(
+  row: T,
+  includeSources: boolean,
+): T & { sourceObservationCount?: number } {
+  const ids = row.sourceObservationIds ?? [];
+  if (includeSources || ids.length <= GRAPH_QUERY_SOURCE_SAMPLE) {
+    return { ...row, sourceObservationCount: ids.length };
+  }
+  return {
+    ...row,
+    sourceObservationIds: ids.slice(-GRAPH_QUERY_SOURCE_SAMPLE),
+    sourceObservationCount: ids.length,
+  };
+}
+
 const DEFAULT_GRAPH_QUERY_LIMIT = 500;
 const MAX_GRAPH_QUERY_LIMIT = 5000;
 
@@ -146,6 +180,7 @@ function paginateFromSnapshot(
   filterType: string | undefined,
   limit: number,
   offset: number,
+  includeSources = false,
 ): GraphQueryResult {
   const filteredNodes = filterType
     ? snap.topNodes.filter((n) => n.type === filterType)
@@ -159,8 +194,8 @@ function paginateFromSnapshot(
     (e) => pageIds.has(e.sourceNodeId) && pageIds.has(e.targetNodeId),
   );
   return {
-    nodes: pageNodes,
-    edges: pageEdges,
+    nodes: pageNodes.map((n) => projectSources(n, includeSources)),
+    edges: pageEdges.map((e) => projectSources(e, includeSources)),
     depth: 0,
     totalNodes: total,
     totalEdges: snap.stats.totalEdges,
@@ -280,13 +315,15 @@ function mergeNode(
 ): GraphNode {
   return {
     ...existing,
-    sourceObservationIds: [
+    // Newest ids sort last through the Set, so the cap keeps the most
+    // recent provenance and drops the oldest (upstream #1171).
+    sourceObservationIds: capSourceIds([
       ...new Set([
         ...existing.sourceObservationIds,
         ...incoming.sourceObservationIds,
         ...obsIds,
       ]),
-    ],
+    ]),
     properties: { ...existing.properties, ...incoming.properties },
     updatedAt: capturedAt,
   };
@@ -298,9 +335,9 @@ function mergeEdge(
 ): GraphEdge {
   return {
     ...existing,
-    sourceObservationIds: [
+    sourceObservationIds: capSourceIds([
       ...new Set([...existing.sourceObservationIds, ...obsIds]),
-    ],
+    ]),
   };
 }
 
@@ -327,6 +364,7 @@ function paginate(
   depth: number,
   limit: number,
   offset: number,
+  includeSources = false,
 ): GraphQueryResult {
   const totalNodes = nodes.length;
   const pageNodes = nodes.slice(offset, offset + limit);
@@ -349,8 +387,8 @@ function paginate(
     0,
   );
   return {
-    nodes: pageNodes,
-    edges: pageEdges,
+    nodes: pageNodes.map((n) => projectSources(n, includeSources)),
+    edges: pageEdges.map((e) => projectSources(e, includeSources)),
     depth,
     totalNodes,
     totalEdges,
@@ -411,7 +449,7 @@ function parseGraphXml(
       type,
       name,
       properties,
-      sourceObservationIds: observationIds,
+      sourceObservationIds: capSourceIds(observationIds),
       createdAt: now,
     });
   };
@@ -443,7 +481,7 @@ function parseGraphXml(
       sourceNodeId: sourceNode.id,
       targetNodeId: targetNode.id,
       weight: Math.max(0, Math.min(1, weight)),
-      sourceObservationIds: observationIds,
+      sourceObservationIds: capSourceIds(observationIds),
       createdAt: now,
     });
   }
@@ -484,7 +522,10 @@ export function extractGraphHeuristics(
       nodeByKey.set(key, node);
       nodes.push(node);
     } else if (!node.sourceObservationIds.includes(obsId)) {
-      node.sourceObservationIds.push(obsId);
+      node.sourceObservationIds = capSourceIds([
+        ...node.sourceObservationIds,
+        obsId,
+      ]);
     }
     return node;
   };
@@ -497,7 +538,10 @@ export function extractGraphHeuristics(
       const existing = edgeByPair.get(pair);
       if (existing) {
         if (!existing.sourceObservationIds.includes(obs.id)) {
-          existing.sourceObservationIds.push(obs.id);
+          existing.sourceObservationIds = capSourceIds([
+            ...existing.sourceObservationIds,
+            obs.id,
+          ]);
         }
         return;
       }
@@ -784,9 +828,13 @@ export function registerGraphFunction(
       query?: string;
       limit?: number;
       offset?: number;
+      includeSources?: boolean;
     }): Promise<GraphQueryResult> => {
       const maxDepth = Math.min(data.maxDepth || 3, 5);
       const { limit, offset } = resolvePagination(data.limit, data.offset);
+      // Off by default: the full provenance array is ~99% of the bytes
+      // and almost never what the caller wanted (upstream #1171).
+      const includeSources = data.includeSources === true;
 
       // #814 v2: the empty-body / nodeType-only path NEVER enumerates.
       // It reads the snapshot exclusively. The snapshot is updated
@@ -799,7 +847,7 @@ export function registerGraphFunction(
       if (noWalk) {
         const snap = await readSnapshot(kv);
         if (snap && snap.stats.totalNodes > 0) {
-          return paginateFromSnapshot(snap, data.nodeType, limit, offset);
+          return paginateFromSnapshot(snap, data.nodeType, limit, offset, includeSources);
         }
         return {
           nodes: [],
@@ -875,7 +923,7 @@ export function registerGraphFunction(
               (v) => typeof v === "string" && v.toLowerCase().includes(lower),
             ),
         );
-        return paginate(matchingNodes, allEdges, 0, limit, offset);
+        return paginate(matchingNodes, allEdges, 0, limit, offset, includeSources);
       }
 
       if (data.startNodeId) {
@@ -917,11 +965,11 @@ export function registerGraphFunction(
           }
         }
 
-        return paginate(resultNodes, resultEdges, maxDepth, limit, offset);
+        return paginate(resultNodes, resultEdges, maxDepth, limit, offset, includeSources);
       }
 
       // Unreachable — noWalk branch handles the rest.
-      return paginate([], [], 0, limit, offset);
+      return paginate([], [], 0, limit, offset, includeSources);
     },
   );
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -409,6 +409,10 @@ export interface GraphNode {
   updatedAt?: string;
   aliases?: string[];
   stale?: boolean;
+  /** Present on graph-query responses: true length of sourceObservationIds
+   *  before projection. The array itself is a recent sample unless the
+   *  caller passed includeSources (upstream #1171). */
+  sourceObservationCount?: number;
 }
 
 export type GraphEdgeType =
@@ -445,6 +449,10 @@ export interface GraphEdge {
   supersededBy?: string;
   isLatest?: boolean;
   stale?: boolean;
+  /** Present on graph-query responses: true length of sourceObservationIds
+   *  before projection. The array itself is a recent sample unless the
+   *  caller passed includeSources (upstream #1171). */
+  sourceObservationCount?: number;
 }
 
 export interface EdgeContext {

--- a/test/graph-provenance-cap.test.ts
+++ b/test/graph-provenance-cap.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("../src/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { registerGraphFunction } from "../src/functions/graph.js";
+import type {
+  CompressedObservation,
+  GraphNode,
+  GraphQueryResult,
+} from "../src/types.js";
+
+function mockKV() {
+  const store = new Map<string, Map<string, unknown>>();
+  return {
+    get: async <T>(scope: string, key: string): Promise<T | null> => {
+      return (store.get(scope)?.get(key) as T) ?? null;
+    },
+    set: async <T>(scope: string, key: string, data: T): Promise<T> => {
+      if (!store.has(scope)) store.set(scope, new Map());
+      store.get(scope)!.set(key, data);
+      return data;
+    },
+    delete: async (scope: string, key: string): Promise<void> => {
+      store.get(scope)?.delete(key);
+    },
+    list: async <T>(scope: string): Promise<T[]> => {
+      const entries = store.get(scope);
+      return entries ? (Array.from(entries.values()) as T[]) : [];
+    },
+  };
+}
+
+function mockSdk() {
+  const functions = new Map<string, Function>();
+  return {
+    registerFunction: (idOrOpts: string | { id: string }, handler: Function) => {
+      const id = typeof idOrOpts === "string" ? idOrOpts : idOrOpts.id;
+      functions.set(id, handler);
+    },
+    registerTrigger: () => {},
+    trigger: async (
+      idOrInput: string | { function_id: string; payload: unknown },
+      data?: unknown,
+    ) => {
+      const id =
+        typeof idOrInput === "string" ? idOrInput : idOrInput.function_id;
+      const payload = typeof idOrInput === "string" ? data : idOrInput.payload;
+      const fn = functions.get(id);
+      if (!fn) throw new Error(`No function: ${id}`);
+      return fn(payload);
+    },
+  };
+}
+
+// One entity, no relationships: every extract re-observes the same node,
+// which is the shape that made the provenance array grow without bound.
+const mockProvider = {
+  name: "test",
+  compress: vi.fn().mockResolvedValue(`<entities>
+<entity type="file" name="src/hot-path.ts"><property key="path">src/hot-path.ts</property></entity>
+</entities>
+<relationships>
+</relationships>`),
+  summarize: vi.fn(),
+};
+
+function obs(n: number): CompressedObservation {
+  return {
+    id: `obs_${n}`,
+    sessionId: "ses_1",
+    timestamp: `2026-02-01T10:00:${String(n % 60).padStart(2, "0")}Z`,
+    type: "file_edit",
+    title: `Edit ${n}`,
+    facts: [`change ${n}`],
+    narrative: `Edited the hot path, revision ${n}`,
+    concepts: [],
+    files: [],
+    importance: 5,
+  };
+}
+
+describe("graph provenance bounds (#1168 / #1171)", () => {
+  let sdk: ReturnType<typeof mockSdk>;
+  let kv: ReturnType<typeof mockKV>;
+  const ORIG_FLAG = process.env["GRAPH_EXTRACTION_ENABLED"];
+  const ORIG_MAX = process.env["GRAPH_MAX_SOURCE_IDS"];
+
+  beforeEach(() => {
+    sdk = mockSdk();
+    kv = mockKV();
+    vi.clearAllMocks();
+    process.env["GRAPH_EXTRACTION_ENABLED"] = "true";
+    process.env["GRAPH_MAX_SOURCE_IDS"] = "5";
+    registerGraphFunction(sdk as never, kv as never, mockProvider as never);
+  });
+
+  afterEach(() => {
+    if (ORIG_FLAG === undefined) delete process.env["GRAPH_EXTRACTION_ENABLED"];
+    else process.env["GRAPH_EXTRACTION_ENABLED"] = ORIG_FLAG;
+    if (ORIG_MAX === undefined) delete process.env["GRAPH_MAX_SOURCE_IDS"];
+    else process.env["GRAPH_MAX_SOURCE_IDS"] = ORIG_MAX;
+  });
+
+  // The regression: creation capped at ten ids, mergeNode re-unioned with
+  // no cap, so re-observing an entity grew the array for the life of the
+  // graph.
+  it("keeps sourceObservationIds bounded across repeated merges", async () => {
+    for (let i = 1; i <= 20; i++) {
+      await sdk.trigger("mem::graph-extract", { observations: [obs(i)] });
+    }
+
+    const nodes = await kv.list<GraphNode>("mem:graph:nodes");
+    const hot = nodes.find((n) => n.name === "src/hot-path.ts")!;
+    expect(hot).toBeDefined();
+    expect(hot.sourceObservationIds.length).toBeLessThanOrEqual(5);
+    // Newest kept, oldest dropped.
+    expect(hot.sourceObservationIds).toContain("obs_20");
+    expect(hot.sourceObservationIds).not.toContain("obs_1");
+  });
+
+  it("caps provenance at creation too", async () => {
+    await sdk.trigger("mem::graph-extract", {
+      observations: [obs(1), obs(2), obs(3), obs(4), obs(5), obs(6), obs(7)],
+    });
+
+    const nodes = await kv.list<GraphNode>("mem:graph:nodes");
+    for (const node of nodes) {
+      expect(node.sourceObservationIds.length).toBeLessThanOrEqual(5);
+    }
+  });
+
+  it("graph-query projects provenance to a count plus a sample", async () => {
+    for (let i = 1; i <= 20; i++) {
+      await sdk.trigger("mem::graph-extract", { observations: [obs(i)] });
+    }
+
+    const result = (await sdk.trigger("mem::graph-query", {
+      query: "hot-path",
+    })) as GraphQueryResult;
+
+    const node = result.nodes.find((n) => n.name === "src/hot-path.ts")!;
+    expect(node).toBeDefined();
+    expect(node.sourceObservationCount).toBeGreaterThan(0);
+    expect(node.sourceObservationIds.length).toBeLessThanOrEqual(3);
+  });
+
+  it("graph-query returns the full array when includeSources is set", async () => {
+    for (let i = 1; i <= 20; i++) {
+      await sdk.trigger("mem::graph-extract", { observations: [obs(i)] });
+    }
+
+    const projected = (await sdk.trigger("mem::graph-query", {
+      query: "hot-path",
+    })) as GraphQueryResult;
+    const full = (await sdk.trigger("mem::graph-query", {
+      query: "hot-path",
+      includeSources: true,
+    })) as GraphQueryResult;
+
+    const projectedNode = projected.nodes.find(
+      (n) => n.name === "src/hot-path.ts",
+    )!;
+    const fullNode = full.nodes.find((n) => n.name === "src/hot-path.ts")!;
+
+    expect(fullNode.sourceObservationIds.length).toBe(
+      fullNode.sourceObservationCount,
+    );
+    expect(fullNode.sourceObservationIds.length).toBeGreaterThanOrEqual(
+      projectedNode.sourceObservationIds.length,
+    );
+  });
+});


### PR DESCRIPTION
Refs #1171
Refs #1168

## Problem

Node creation caps provenance, but `mergeNode()` and `mergeEdge()` re-union `sourceObservationIds` with no cap. Extraction re-observes the same entities continuously, so the array grows monotonically for the life of the graph. `graph-query` then returns node objects verbatim and accepts no field projection, so every consumer pays for the whole accumulation on every call.

#1171 measured ~95% waste on a 3-day-old graph. Numbers from a larger install (0.9.29, iii 0.11.2, 33.8K observations, 71.5K nodes / 191K edges):

| | |
|---|---|
| `POST /agentmemory/graph/query` at the default limit | **10.7 MB** |
| 500 nodes | 9.4 MB, avg **19.3 KB/node** |
| of which `sourceObservationIds` | **9.55 MB — 98.9%** |
| worst single node (`package.json`) | 4,707 ids, **133 KB** |
| ids past a cap of 10, whole graph | **2,628,533** across 26,686 nodes and 28,884 edges |

That lands close enough to #1168's independent measurement (97.3% of bytes, 2,623,559 ids) to look like the same mechanism rather than one install's accident.

For an LLM consumer the cost is context window, which is the one budget the caller cannot expand.

## Relationship to the PRs already open

- **#1294** bounds the same field on the temporal-graph path, in `src/functions/temporal-graph.ts`. This PR covers `mem::graph-extract` in `src/functions/graph.ts`, which is a different code path and still unbounded on `main`.
- **#1295** bounds `sourceMemoryIds` on reflect insights, the other collection named in #1168.
- Neither touches the read side, which is the second fix #1171 asks for.

They compose; none of the three overlaps.

## What this changes

Both fixes suggested in #1171, since they solve different halves.

**1. Bound the write path.** `GRAPH_MAX_SOURCE_IDS`, default 10 to match the existing create-time cap, keeping the newest ids.

While adding this I found creation was not actually bounded either: a single extract batch carrying more observations than the cap wrote every id, and the heuristic extraction path pushed into the array in place. The cap is therefore applied on all four write paths, not only on merge. The tests below are what surfaced those two — the first version of this fix left them in.

**2. Project it out of the read path.** `graph-query` returns a three-id sample plus `sourceObservationCount`. Callers that genuinely want the full array pass `includeSources: true`. Nothing becomes unavailable; it stops being the default cost.

Keeping both means storage growth and payload size stay independent knobs, as the issue suggests.

## Result

Same corpus, no other change:

| | before | after |
|---|---|---|
| `POST /agentmemory/graph/query` (default limit) | 10.7 MB | **940 KB** |
| the same data through the MCP tool | 14.8 MB | **31 KB** |

## Verification

```
npm run build     # clean
npm test          # 1,715 passed, 1 skipped
```

New `test/graph-provenance-cap.test.ts`, four cases: the bound holding across repeated merges, newest ids surviving while oldest are dropped, creation staying bounded when a batch exceeds the cap, and `includeSources` round-tripping the full array.

Manually against a live server:

```bash
curl -s -X POST localhost:3111/agentmemory/graph/query \
  -H 'content-type: application/json' -d '{}' | wc -c
# add {"includeSources":true} for the previous shape
```

## Not in this PR

Existing rows are untouched — this bounds new writes and shapes reads. #1171 also notes there is no per-node update endpoint, so a corpus that already accumulated millions of ids stays large until something compacts it in place. That needs a new endpoint, so it is a separate PR rather than riding along with a bug fix.

`GRAPH_MAX_SOURCE_IDS` defaults to 10 to match the existing create-time cap. Happy to change the default if you'd prefer it aligned with the 20 used in #1294.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable limits for graph provenance data, with a minimum of one source ID retained.
  * Graph query results now include the total provenance count and a bounded sample of source IDs.
  * Added an `includeSources` option to request the full available provenance list when needed.

* **Bug Fixes**
  * Prevented graph provenance arrays from growing without limit during node and edge creation or merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->