### PR TITLE
fix(providers): clear the circuit breaker failure count on success

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -395,6 +395,14 @@ const CIRCUIT_BREAKER_FAILURE_THRESHOLD = 10;
 const CIRCUIT_BREAKER_FAILURE_WINDOW_MS = 60_000;
 const CIRCUIT_BREAKER_RECOVERY_TIMEOUT_MS = 15_000;
 
+function positiveEnvInt(value: string | undefined, fallback: number): number {
+  const parsed = safeParseInt(value, fallback);
+  // safeParseInt returns 0 or a negative number verbatim; CircuitBreaker
+  // rejects those and substitutes its own legacy fallbacks, so an override of
+  // "0" would silently select 3 / 60s / 30s rather than the values below.
+  return parsed > 0 ? parsed : fallback;
+}
+
 export function getCircuitBreakerOptions(): {
   failureThreshold: number;
   failureWindowMs: number;
@@ -402,15 +410,15 @@ export function getCircuitBreakerOptions(): {
 } {
   const env = getMergedEnv();
   return {
-    failureThreshold: safeParseInt(
+    failureThreshold: positiveEnvInt(
       env["AGENTMEMORY_CIRCUIT_FAILURE_THRESHOLD"],
       CIRCUIT_BREAKER_FAILURE_THRESHOLD,
     ),
-    failureWindowMs: safeParseInt(
+    failureWindowMs: positiveEnvInt(
       env["AGENTMEMORY_CIRCUIT_FAILURE_WINDOW_MS"],
       CIRCUIT_BREAKER_FAILURE_WINDOW_MS,
     ),
-    recoveryTimeoutMs: safeParseInt(
+    recoveryTimeoutMs: positiveEnvInt(
       env["AGENTMEMORY_CIRCUIT_RECOVERY_TIMEOUT_MS"],
       CIRCUIT_BREAKER_RECOVERY_TIMEOUT_MS,
     ),

--- a/src/config.ts
+++ b/src/config.ts
@@ -385,6 +385,38 @@ export function getGraphBatchSize(): number {
   return safeParseInt(getMergedEnv()["GRAPH_EXTRACTION_BATCH_SIZE"], 10);
 }
 
+// Provider circuit breaker. The old hardcoded 3-failure trip was far
+// too tight for a hosted LLM proxy that returns the occasional 502 or
+// slow response: three scattered failures took the provider offline for
+// every caller. Ten failures since the last success is still a decisive
+// signal that the upstream is down, and a 15s recovery probe gets the
+// provider back quickly when it is not.
+const CIRCUIT_BREAKER_FAILURE_THRESHOLD = 10;
+const CIRCUIT_BREAKER_FAILURE_WINDOW_MS = 60_000;
+const CIRCUIT_BREAKER_RECOVERY_TIMEOUT_MS = 15_000;
+
+export function getCircuitBreakerOptions(): {
+  failureThreshold: number;
+  failureWindowMs: number;
+  recoveryTimeoutMs: number;
+} {
+  const env = getMergedEnv();
+  return {
+    failureThreshold: safeParseInt(
+      env["AGENTMEMORY_CIRCUIT_FAILURE_THRESHOLD"],
+      CIRCUIT_BREAKER_FAILURE_THRESHOLD,
+    ),
+    failureWindowMs: safeParseInt(
+      env["AGENTMEMORY_CIRCUIT_FAILURE_WINDOW_MS"],
+      CIRCUIT_BREAKER_FAILURE_WINDOW_MS,
+    ),
+    recoveryTimeoutMs: safeParseInt(
+      env["AGENTMEMORY_CIRCUIT_RECOVERY_TIMEOUT_MS"],
+      CIRCUIT_BREAKER_RECOVERY_TIMEOUT_MS,
+    ),
+  };
+}
+
 // window for the smart-search followup-rate diagnostic. A second
 // search arriving within this many seconds (with disjoint results)
 // counts as a "follow-up" — a directional signal that the first result

--- a/src/providers/circuit-breaker.ts
+++ b/src/providers/circuit-breaker.ts
@@ -45,6 +45,10 @@ export class CircuitBreaker {
   }
 
   recordSuccess(): void {
+    // A request already in flight when another request opened the breaker
+    // still lands here. Clearing openedAt in that state would strip the
+    // recovery deadline and leave the breaker open permanently.
+    if (this.state === "open") return;
     if (this.state === "half-open") {
       this.state = "closed";
     }

--- a/src/providers/circuit-breaker.ts
+++ b/src/providers/circuit-breaker.ts
@@ -1,6 +1,6 @@
 import type { CircuitBreakerState } from "../types.js";
 
-interface CircuitBreakerOptions {
+export interface CircuitBreakerOptions {
   failureThreshold?: number;
   failureWindowMs?: number;
   recoveryTimeoutMs?: number;
@@ -47,10 +47,19 @@ export class CircuitBreaker {
   recordSuccess(): void {
     if (this.state === "half-open") {
       this.state = "closed";
-      this.failures = 0;
-      this.lastFailureAt = null;
-      this.openedAt = null;
     }
+    // A success in the CLOSED state used to leave `failures` untouched,
+    // so the counter only ever reset when two consecutive failures were
+    // more than failureWindowMs apart. Under steady load — where
+    // failures are frequent enough to keep landing inside the window
+    // but rare in proportion to successes — the count crept to the
+    // threshold and opened the breaker on a provider that was mostly
+    // healthy. One flaky upstream then produced a thousand consecutive
+    // circuit_breaker_open fast-fails. Treat the window as "failures
+    // since the last success" and clear it here.
+    this.failures = 0;
+    this.lastFailureAt = null;
+    this.openedAt = null;
   }
 
   recordFailure(): void {

--- a/src/providers/resilient.ts
+++ b/src/providers/resilient.ts
@@ -1,8 +1,11 @@
 import type { MemoryProvider, CircuitBreakerState } from "../types.js";
 import { CircuitBreaker } from "./circuit-breaker.js";
+import { getCircuitBreakerOptions } from "../config.js";
 
 export class ResilientProvider implements MemoryProvider {
-  private breaker = new CircuitBreaker();
+  // Thresholds come from config so a deployment sitting behind a flaky
+  // proxy can widen them without a rebuild.
+  private breaker = new CircuitBreaker(getCircuitBreakerOptions());
   name: string;
 
   constructor(private inner: MemoryProvider) {

--- a/test/circuit-breaker.test.ts
+++ b/test/circuit-breaker.test.ts
@@ -104,4 +104,55 @@ describe("CircuitBreaker", () => {
     expect(cb.getState().state).toBe("closed");
     expect(cb.getState().failures).toBe(0);
   });
+
+  it("a success in closed state clears the accumulated failure count", () => {
+    const cb = new CircuitBreaker();
+    cb.recordFailure();
+    cb.recordFailure();
+    expect(cb.getState().failures).toBe(2);
+    cb.recordSuccess();
+    expect(cb.getState().failures).toBe(0);
+    expect(cb.getState().lastFailureAt).toBeNull();
+  });
+
+  // Regression: the breaker counted failures since the last window
+  // expiry rather than since the last success, so a provider
+  // succeeding 95% of the time still tripped — each failure landed
+  // inside the 60s window opened by the previous one. In production
+  // that turned a handful of real upstream errors into ~1100
+  // consecutive circuit_breaker_open fast-fails.
+  it("stays closed across 100 calls at a 5% failure rate", () => {
+    const cb = new CircuitBreaker();
+    for (let i = 0; i < 100; i++) {
+      if (i % 20 === 0) cb.recordFailure();
+      else cb.recordSuccess();
+      vi.advanceTimersByTime(1_000);
+      expect(cb.getState().state).toBe("closed");
+    }
+    expect(cb.isAllowed).toBe(true);
+  });
+
+  it("still opens on a genuinely failing provider", () => {
+    const cb = new CircuitBreaker({ failureThreshold: 10 });
+    for (let i = 0; i < 10; i++) {
+      cb.recordFailure();
+      vi.advanceTimersByTime(1_000);
+    }
+    expect(cb.getState().state).toBe("open");
+    expect(cb.isAllowed).toBe(false);
+  });
+
+  it("honors configured thresholds and recovery timeout", () => {
+    const cb = new CircuitBreaker({
+      failureThreshold: 10,
+      recoveryTimeoutMs: 15_000,
+    });
+    for (let i = 0; i < 9; i++) cb.recordFailure();
+    expect(cb.getState().state).toBe("closed");
+    cb.recordFailure();
+    expect(cb.getState().state).toBe("open");
+    vi.advanceTimersByTime(15_000);
+    expect(cb.isAllowed).toBe(true);
+    expect(cb.getState().state).toBe("half-open");
+  });
 });

--- a/test/circuit-breaker.test.ts
+++ b/test/circuit-breaker.test.ts
@@ -132,6 +132,27 @@ describe("CircuitBreaker", () => {
     expect(cb.isAllowed).toBe(true);
   });
 
+  // An in-flight request can succeed after a different request has already
+  // opened the breaker. That success must not strip the recovery deadline.
+  it("keeps openedAt when a success arrives while open", () => {
+    const cb = new CircuitBreaker();
+    cb.recordFailure();
+    cb.recordFailure();
+    cb.recordFailure();
+    expect(cb.getState().state).toBe("open");
+    const openedAt = cb.getState().openedAt;
+
+    cb.recordSuccess();
+
+    expect(cb.getState().state).toBe("open");
+    expect(cb.getState().openedAt).toBe(openedAt);
+    expect(cb.isAllowed).toBe(false);
+
+    vi.advanceTimersByTime(30_000);
+    expect(cb.isAllowed).toBe(true);
+    expect(cb.getState().state).toBe("half-open");
+  });
+
   it("still opens on a genuinely failing provider", () => {
     const cb = new CircuitBreaker({ failureThreshold: 10 });
     for (let i = 0; i < 10; i++) {


### PR DESCRIPTION
## Problem

`recordSuccess()` only resets the failure counter when leaving `half-open`. In the `closed` state a success leaves it untouched, and `recordFailure()` clears it only when two failures are more than `failureWindowMs` apart:

```ts
recordSuccess(): void {
  if (this.state === "half-open") {
    this.state = "closed";
    this.failures = 0;
    ...
```

Under steady load that means the counter is not "failures in the last minute", it is "failures since the last minute-long gap in failures". A provider succeeding ~95% of the time still trips, because each scattered failure lands inside the window opened by the previous one, and the successes in between never clear it.

Observed against a hosted proxy that returns the occasional 502: a handful of real upstream errors produced a stretch of **1,119 consecutive `circuit_breaker_open` fast-fails**, and `mem::compress` reached 22,400 calls against 15,086 failures. Almost none of those failures were the provider being unavailable — the breaker was the thing failing them.

The blast radius is wide because `ResilientProvider` wraps compress and summarize for every caller, so one flaky upstream silently disables compression, summarization and graph extraction together.

## What this changes

- `recordSuccess()` clears `failures` / `lastFailureAt` in the closed state too, so the window means "since the last success".
- Thresholds move into config (`AGENTMEMORY_CIRCUIT_FAILURE_THRESHOLD`, `_FAILURE_WINDOW_MS`, `_RECOVERY_TIMEOUT_MS`) so a deployment behind a flaky upstream can widen them without a rebuild.
- Defaults go from 3 failures / 30s recovery to 10 / 15s. Three scattered failures is not evidence that a hosted LLM proxy is down, and a shorter recovery probe gets the provider back sooner when it was never down.

## Relationship to the PRs already open

Both #1259 and #1277 change **which errors count** as failures, in `src/providers/resilient.ts` — 429s and content-filter rejections respectively. This changes **the counter never being reset by success**, in `src/providers/circuit-breaker.ts`. Different files, different mechanism; all three compose, and none of them alone fixes the others.

## Result

Same install, after the change: 8 genuine upstream timeouts, **0 fast-fails**. Breaker state stayed `closed` with `failures: 0` throughout.

## Verification

```
npm run build     # clean
npm test          # 1,715 passed, 1 skipped
```

Added to `test/circuit-breaker.test.ts`:

- 100 calls at a 5% failure rate keep the breaker closed (this is the regression — it fails on `main`)
- a success in the closed state clears an accumulated count
- a genuinely failing provider still opens the breaker
- configured thresholds and recovery timeout are honoured

The existing cases are unchanged and still pass, including the default-threshold ones.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable provider circuit-breaker settings for failure thresholds, monitoring windows, and recovery timeouts.
  - Settings can be customized through environment variables, with safe defaults used when values are missing or invalid.

- **Bug Fixes**
  - Successful provider requests now consistently reset circuit-breaker failure tracking.
  - Improved circuit-breaker behavior prevents intermittent failures from unnecessarily opening the circuit and preserves configured recovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->