### PR TITLE
perf(search): reuse one graph view per store and bound traversal

### DIFF
--- a/src/functions/graph-retrieval.ts
+++ b/src/functions/graph-retrieval.ts
@@ -2,8 +2,23 @@ import type {
   GraphNode,
   GraphEdge,
 } from "../types.js";
-import { KV } from "../state/schema.js";
 import type { StateKV } from "../state/kv.js";
+import { getGraphView, type GraphView } from "../state/graph-cache.js";
+import { getEnvVar } from "../config.js";
+
+// Traversal bounds. Both are here because this corpus grew to 69K
+// nodes / 185K edges: an unbounded start-node set means one Dijkstra
+// per matching node, and an unbounded expansion lets a single hub node
+// walk most of the graph on maxDepth=2.
+const DEFAULT_MAX_START_NODES = 25;
+const DEFAULT_MAX_VISITED = 2000;
+
+function envInt(key: string, fallback: number): number {
+  const raw = getEnvVar(key);
+  if (!raw) return fallback;
+  const parsed = parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
 
 export interface GraphRetrievalResult {
   obsId: string;
@@ -46,30 +61,46 @@ export class GraphRetrieval {
     maxDepth = 2,
     maxResults = 20,
   ): Promise<GraphRetrievalResult[]> {
-    const allNodes = (await this.kv.list<GraphNode>(KV.graphNodes)).filter((n) => !n.stale);
-    const allEdges = (await this.kv.list<GraphEdge>(KV.graphEdges)).filter((e) => !e.stale);
+    const view = await getGraphView(this.kv);
 
-    const matchingNodes = allNodes.filter((n) => {
-      const nameLower = n.name.toLowerCase();
-      return entityNames.some(
-        (e) =>
-          nameLower.includes(e.toLowerCase()) ||
-          e.toLowerCase().includes(nameLower),
-      );
-    });
+    const lowered = entityNames.map((e) => e.toLowerCase());
+    const matchingNodes: Array<{ node: GraphNode; exact: boolean }> = [];
+    for (const node of view.nodes.values()) {
+      const nameLower = node.name.toLowerCase();
+      let matched = false;
+      let exact = false;
+      for (const entity of lowered) {
+        if (nameLower === entity) {
+          matched = true;
+          exact = true;
+          break;
+        }
+        if (nameLower.includes(entity) || entity.includes(nameLower)) {
+          matched = true;
+        }
+      }
+      if (matched) matchingNodes.push({ node, exact });
+    }
 
     if (matchingNodes.length === 0) return [];
+
+    // One Dijkstra per start node, so the start set has to be bounded.
+    // Rank exact name matches first, then the shortest names — a short
+    // node name that contains the query term is the more specific
+    // entity, a long one is usually an incidental substring hit.
+    matchingNodes.sort((a, b) => {
+      if (a.exact !== b.exact) return a.exact ? -1 : 1;
+      return a.node.name.length - b.node.name.length;
+    });
+    const startNodes = matchingNodes
+      .slice(0, envInt("AGENTMEMORY_GRAPH_MAX_START_NODES", DEFAULT_MAX_START_NODES))
+      .map((m) => m.node);
 
     const results: GraphRetrievalResult[] = [];
     const visitedObs = new Set<string>();
 
-    for (const startNode of matchingNodes) {
-      const paths = this.dijkstraTraversal(
-        startNode,
-        allNodes,
-        allEdges,
-        maxDepth,
-      );
+    for (const startNode of startNodes) {
+      const paths = this.dijkstraTraversal(startNode, view, maxDepth);
 
       for (const path of paths) {
         const lastNode = path[path.length - 1].node;
@@ -119,18 +150,26 @@ export class GraphRetrieval {
     maxDepth = 1,
     maxResults = 10,
   ): Promise<GraphRetrievalResult[]> {
-    const allNodes = (await this.kv.list<GraphNode>(KV.graphNodes)).filter((n) => !n.stale);
-    const allEdges = (await this.kv.list<GraphEdge>(KV.graphEdges)).filter((e) => !e.stale);
+    const view = await getGraphView(this.kv);
 
-    const linkedNodes = allNodes.filter((n) =>
-      n.sourceObservationIds.some((id) => obsIds.includes(id)),
-    );
+    // obsId -> node ids is maintained by the view, so this no longer
+    // scans every node to find the handful that cite these chunks.
+    const linkedNodes: GraphNode[] = [];
+    const seenNodes = new Set<string>();
+    for (const obsId of obsIds) {
+      for (const nodeId of view.nodesByObservation.get(obsId) ?? []) {
+        if (seenNodes.has(nodeId)) continue;
+        seenNodes.add(nodeId);
+        const node = view.nodes.get(nodeId);
+        if (node) linkedNodes.push(node);
+      }
+    }
 
     const results: GraphRetrievalResult[] = [];
     const visitedObs = new Set<string>(obsIds);
 
     for (const node of linkedNodes) {
-      const paths = this.dijkstraTraversal(node, allNodes, allEdges, maxDepth);
+      const paths = this.dijkstraTraversal(node, view, maxDepth);
       for (const path of paths) {
         const lastNode = path[path.length - 1].node;
         for (const obsId of lastNode.sourceObservationIds) {
@@ -163,17 +202,25 @@ export class GraphRetrieval {
     currentState: GraphEdge[];
     history: GraphEdge[];
   }> {
-    const allNodes = (await this.kv.list<GraphNode>(KV.graphNodes)).filter((n) => !n.stale);
-    const allEdges = (await this.kv.list<GraphEdge>(KV.graphEdges)).filter((e) => !e.stale);
+    const view = await getGraphView(this.kv);
 
-    const entity = allNodes.find(
-      (n) => n.name.toLowerCase() === entityName.toLowerCase(),
-    );
+    const wanted = entityName.toLowerCase();
+    let entity: GraphNode | null = null;
+    for (const node of view.nodes.values()) {
+      if (node.name.toLowerCase() === wanted) {
+        entity = node;
+        break;
+      }
+    }
     if (!entity) return { entity: null, currentState: [], history: [] };
 
-    const relatedEdges = allEdges.filter(
-      (e) => e.sourceNodeId === entity.id || e.targetNodeId === entity.id,
-    );
+    // Incident edges come straight off the adjacency index instead of
+    // filtering the whole edge scope.
+    const relatedEdges: GraphEdge[] = [];
+    for (const { edgeId } of view.adjacency.get(entity.id) ?? []) {
+      const edge = view.edges.get(edgeId);
+      if (edge) relatedEdges.push(edge);
+    }
 
     if (!asOf) {
       const latestEdges = this.getLatestEdges(relatedEdges);
@@ -231,31 +278,18 @@ export class GraphRetrieval {
   // which fell back to edge-count order and ignored the 0.1-1.0 weight
   // attached to every graph edge. Dijkstra over `cost = 1/weight`
   // (cheaper edges = stronger relationships) returns the
-  // highest-weighted path to each reachable node within maxDepth. Also
-  // tightens the perf profile:
-  //   - Adjacency built once in O(V+E) (previous BFS re-filtered
-  //     allEdges per visited node, O(V·E) overall).
-  //   - Min-heap dequeue is O(log V) per pop (previous queue.shift()
-  //     was O(n) — the dominant cost on graphs above ~200 nodes per
-  //     the contributor's benchmark in #328).
+  // highest-weighted path to each reachable node within maxDepth.
+  //
+  // The node index and adjacency map now come from the shared graph
+  // view, so they are built once per process rather than once per
+  // start node (the previous code rebuilt both from the full node and
+  // edge arrays on every call).
   private dijkstraTraversal(
     startNode: GraphNode,
-    allNodes: GraphNode[],
-    allEdges: GraphEdge[],
+    view: GraphView,
     maxDepth: number,
   ): Array<Array<{ node: GraphNode; edge?: GraphEdge }>> {
-    const nodeIndex = new Map<string, GraphNode>();
-    for (const n of allNodes) nodeIndex.set(n.id, n);
-
-    const adjacency = new Map<string, Array<{ neighborId: string; edge: GraphEdge }>>();
-    for (const edge of allEdges) {
-      const a = edge.sourceNodeId;
-      const b = edge.targetNodeId;
-      if (!adjacency.has(a)) adjacency.set(a, []);
-      if (!adjacency.has(b)) adjacency.set(b, []);
-      adjacency.get(a)!.push({ neighborId: b, edge });
-      adjacency.get(b)!.push({ neighborId: a, edge });
-    }
+    const maxVisited = envInt("AGENTMEMORY_GRAPH_MAX_VISITED", DEFAULT_MAX_VISITED);
 
     const dist = new Map<string, number>();
     const pathTo = new Map<string, Array<{ node: GraphNode; edge?: GraphEdge }>>();
@@ -267,16 +301,23 @@ export class GraphRetrieval {
     );
     heap.push({ nodeId: startNode.id, depth: 0, cost: 0 });
 
+    let visited = 0;
     while (heap.size() > 0) {
       const { nodeId, depth, cost } = heap.pop()!;
       // Skip stale heap entries (cost beaten by a later push).
       if (cost > (dist.get(nodeId) ?? Infinity)) continue;
       if (depth >= maxDepth) continue;
+      // A hub node on a 69K-node graph can reach a large fraction of
+      // the corpus even at depth 2. Cap the walk: results past this
+      // point are weak paths that the caller would drop anyway.
+      if (++visited > maxVisited) break;
 
-      const neighbors = adjacency.get(nodeId) ?? [];
-      for (const { neighborId, edge } of neighbors) {
-        const nextNode = nodeIndex.get(neighborId);
+      const neighbors = view.adjacency.get(nodeId) ?? [];
+      for (const { neighborId, edgeId } of neighbors) {
+        const nextNode = view.nodes.get(neighborId);
         if (!nextNode) continue;
+        const edge = view.edges.get(edgeId);
+        if (!edge) continue;
         // Clamp weight to avoid division-by-zero on malformed edges;
         // 0.01 is below the documented 0.1 floor.
         const edgeCost = 1 / Math.max(edge.weight, 0.01);

--- a/src/functions/graph-retrieval.ts
+++ b/src/functions/graph-retrieval.ts
@@ -307,9 +307,8 @@ export class GraphRetrieval {
       // Skip stale heap entries (cost beaten by a later push).
       if (cost > (dist.get(nodeId) ?? Infinity)) continue;
       if (depth >= maxDepth) continue;
-      // A hub node on a 69K-node graph can reach a large fraction of
-      // the corpus even at depth 2. Cap the walk: results past this
-      // point are weak paths that the caller would drop anyway.
+      // A hub node on a large graph can reach much of the corpus even at
+      // depth 2. Results past this point are weak paths the caller drops.
       if (++visited > maxVisited) break;
 
       const neighbors = view.adjacency.get(nodeId) ?? [];
@@ -318,6 +317,11 @@ export class GraphRetrieval {
         if (!nextNode) continue;
         const edge = view.edges.get(edgeId);
         if (!edge) continue;
+        // Bound discovery, not just expansion. A single hub node can add
+        // tens of thousands of neighbours in one iteration, all of which
+        // would be returned and scored even though the loop stops
+        // expanding them.
+        if (!dist.has(neighborId) && pathTo.size >= maxVisited) continue;
         // Clamp weight to avoid division-by-zero on malformed edges;
         // 0.01 is below the documented 0.1 floor.
         const edgeCost = 1 / Math.max(edge.weight, 0.01);

--- a/src/state/graph-cache.ts
+++ b/src/state/graph-cache.ts
@@ -1,0 +1,261 @@
+import type { GraphEdge, GraphNode } from "../types.js";
+import { KV } from "./schema.js";
+import type { StateKV } from "./kv.js";
+import { getEnvVar } from "../config.js";
+import { logger } from "../logger.js";
+
+// GraphRetrieval used to run `kv.list(graphNodes)` + `kv.list(graphEdges)`
+// inside BOTH searchByEntities and expandFromChunks, so every hybrid
+// search paid four full-scope enumerations. At 69K nodes / 185K edges
+// that measured 24s per node+edge pair — 48s per search, growing with
+// the graph, past the 60s MCP tool timeout. The same 37MB-WS-frame
+// hazard documented on KV.graphNameIndex applies here: a full list
+// blocks the worker event loop long enough to miss heartbeats.
+//
+// This module holds one in-process view of the graph per StateKV and
+// keeps it warm through write-through patching, so the expensive
+// enumeration happens once per process instead of four times per
+// query. Every graph write routes through StateKV.set/update/delete,
+// which is where the patch hooks live — no caller has to remember to
+// invalidate.
+//
+// Keyed per StateKV rather than globally: a process can hold more than
+// one store (tests do), and a view built from one must never answer
+// for another.
+//
+// The view is released after an idle period so a search-quiet daemon
+// does not hold the whole graph resident (RSS on this corpus is
+// already flagged at 95%).
+
+export interface GraphView {
+  nodes: Map<string, GraphNode>;
+  edges: Map<string, GraphEdge>;
+  /** nodeId -> incident edges, both directions (traversal treats the graph as undirected). */
+  adjacency: Map<string, Array<{ neighborId: string; edgeId: string }>>;
+  /** observationId -> ids of nodes that cite it. */
+  nodesByObservation: Map<string, Set<string>>;
+}
+
+interface CacheEntry {
+  view: GraphView | null;
+  builtAt: number;
+  building: Promise<GraphView> | null;
+  idleTimer: ReturnType<typeof setTimeout> | null;
+}
+
+const DEFAULT_TTL_MS = 300_000;
+const DEFAULT_IDLE_MS = 600_000;
+
+const GRAPH_SCOPES = new Set<string>([KV.graphNodes, KV.graphEdges]);
+
+const caches = new WeakMap<object, CacheEntry>();
+
+function entryFor(kv: object): CacheEntry {
+  let entry = caches.get(kv);
+  if (!entry) {
+    entry = { view: null, builtAt: 0, building: null, idleTimer: null };
+    caches.set(kv, entry);
+  }
+  return entry;
+}
+
+function envMs(key: string, fallback: number): number {
+  const raw = getEnvVar(key);
+  if (!raw) return fallback;
+  const parsed = parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function emptyView(): GraphView {
+  return {
+    nodes: new Map(),
+    edges: new Map(),
+    adjacency: new Map(),
+    nodesByObservation: new Map(),
+  };
+}
+
+function indexNode(v: GraphView, node: GraphNode): void {
+  v.nodes.set(node.id, node);
+  for (const obsId of node.sourceObservationIds ?? []) {
+    let ids = v.nodesByObservation.get(obsId);
+    if (!ids) {
+      ids = new Set();
+      v.nodesByObservation.set(obsId, ids);
+    }
+    ids.add(node.id);
+  }
+}
+
+function deindexNode(v: GraphView, nodeId: string): void {
+  const existing = v.nodes.get(nodeId);
+  if (!existing) return;
+  for (const obsId of existing.sourceObservationIds ?? []) {
+    const ids = v.nodesByObservation.get(obsId);
+    if (!ids) continue;
+    ids.delete(nodeId);
+    if (ids.size === 0) v.nodesByObservation.delete(obsId);
+  }
+  v.nodes.delete(nodeId);
+}
+
+function linkEdge(v: GraphView, edge: GraphEdge): void {
+  v.edges.set(edge.id, edge);
+  const pairs: Array<[string, string]> = [
+    [edge.sourceNodeId, edge.targetNodeId],
+    [edge.targetNodeId, edge.sourceNodeId],
+  ];
+  for (const [from, to] of pairs) {
+    let list = v.adjacency.get(from);
+    if (!list) {
+      list = [];
+      v.adjacency.set(from, list);
+    }
+    if (!list.some((entry) => entry.edgeId === edge.id)) {
+      list.push({ neighborId: to, edgeId: edge.id });
+    }
+  }
+}
+
+function unlinkEdge(v: GraphView, edgeId: string): void {
+  const existing = v.edges.get(edgeId);
+  if (!existing) return;
+  for (const nodeId of [existing.sourceNodeId, existing.targetNodeId]) {
+    const list = v.adjacency.get(nodeId);
+    if (!list) continue;
+    const next = list.filter((entry) => entry.edgeId !== edgeId);
+    if (next.length === 0) v.adjacency.delete(nodeId);
+    else v.adjacency.set(nodeId, next);
+  }
+  v.edges.delete(edgeId);
+}
+
+function armIdleRelease(entry: CacheEntry): void {
+  if (entry.idleTimer) clearTimeout(entry.idleTimer);
+  entry.idleTimer = setTimeout(() => {
+    if (!entry.view) return;
+    logger.info("Graph view released (idle)", {
+      nodes: entry.view.nodes.size,
+      edges: entry.view.edges.size,
+    });
+    entry.view = null;
+    entry.builtAt = 0;
+  }, envMs("AGENTMEMORY_GRAPH_CACHE_IDLE_MS", DEFAULT_IDLE_MS));
+  // Never keep the process alive for cache bookkeeping.
+  entry.idleTimer.unref?.();
+}
+
+async function buildView(kv: StateKV): Promise<GraphView> {
+  const startedAt = Date.now();
+  // Sequential, not Promise.all: two multi-megabyte WS frames in flight
+  // at once doubles the peak parse cost on the worker event loop.
+  const rawNodes = await kv.list<GraphNode>(KV.graphNodes);
+  const rawEdges = await kv.list<GraphEdge>(KV.graphEdges);
+
+  const next = emptyView();
+  for (const node of rawNodes ?? []) {
+    if (!node || node.stale) continue;
+    indexNode(next, node);
+  }
+  for (const edge of rawEdges ?? []) {
+    if (!edge || edge.stale) continue;
+    linkEdge(next, edge);
+  }
+
+  logger.info("Graph view built", {
+    nodes: next.nodes.size,
+    edges: next.edges.size,
+    ms: Date.now() - startedAt,
+  });
+  return next;
+}
+
+/**
+ * Returns the shared graph view for this store, building it if absent
+ * or older than the TTL. Concurrent callers share one build so a burst
+ * of queries cannot trigger parallel full enumerations.
+ */
+export async function getGraphView(kv: StateKV): Promise<GraphView> {
+  const entry = entryFor(kv as unknown as object);
+  const ttlMs = envMs("AGENTMEMORY_GRAPH_CACHE_TTL_MS", DEFAULT_TTL_MS);
+  if (entry.view && Date.now() - entry.builtAt < ttlMs) {
+    armIdleRelease(entry);
+    return entry.view;
+  }
+  if (!entry.building) {
+    entry.building = buildView(kv)
+      .then((built) => {
+        entry.view = built;
+        entry.builtAt = Date.now();
+        armIdleRelease(entry);
+        return built;
+      })
+      .catch((err) => {
+        logger.warn("Graph view build failed", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        // Serve whatever we have rather than failing the search: graph
+        // results are a best-effort third stream behind BM25 + vector.
+        return entry.view ?? emptyView();
+      })
+      .finally(() => {
+        entry.building = null;
+      });
+  }
+  return entry.building;
+}
+
+/** Drops this store's view so the next read rebuilds from KV. */
+export function invalidateGraphCache(kv: object): void {
+  const entry = caches.get(kv);
+  if (!entry) return;
+  entry.view = null;
+  entry.builtAt = 0;
+}
+
+/**
+ * Write-through patch for a single graph row. Called from StateKV so
+ * every writer (graph-extract, mesh, import, cascade, snapshot restore)
+ * keeps the view warm instead of forcing a full rebuild on the next
+ * search. Rows for other scopes are ignored.
+ */
+export function onGraphWrite(
+  kv: object,
+  scope: string,
+  key: string,
+  value: unknown,
+): void {
+  if (!GRAPH_SCOPES.has(scope)) return;
+  const view = caches.get(kv)?.view;
+  if (!view) return;
+  if (!value || typeof value !== "object") {
+    invalidateGraphCache(kv);
+    return;
+  }
+  if (scope === KV.graphNodes) {
+    const node = value as GraphNode;
+    deindexNode(view, key);
+    if (!node.stale) indexNode(view, { ...node, id: node.id ?? key });
+    return;
+  }
+  const edge = value as GraphEdge;
+  unlinkEdge(view, key);
+  if (!edge.stale) linkEdge(view, { ...edge, id: edge.id ?? key });
+}
+
+/** Write-through removal for a single graph row. */
+export function onGraphDelete(kv: object, scope: string, key: string): void {
+  if (!GRAPH_SCOPES.has(scope)) return;
+  const view = caches.get(kv)?.view;
+  if (!view) return;
+  if (scope === KV.graphNodes) deindexNode(view, key);
+  else unlinkEdge(view, key);
+}
+
+/**
+ * `state::update` applies opaque ops server-side, so the patched row
+ * cannot be reconstructed locally. Drop the view instead of guessing.
+ */
+export function onGraphUpdate(kv: object, scope: string): void {
+  if (GRAPH_SCOPES.has(scope)) invalidateGraphCache(kv);
+}

--- a/src/state/graph-cache.ts
+++ b/src/state/graph-cache.ts
@@ -36,11 +36,21 @@ export interface GraphView {
   nodesByObservation: Map<string, Set<string>>;
 }
 
+// A mutation that lands while buildView is awaiting the two kv.list calls
+// has nothing to patch, and the build would then publish a snapshot taken
+// before it. Queue those mutations and replay them onto the finished view;
+// an invalidation arriving mid-build discards the result instead.
+type PendingOp =
+  | { kind: "write"; scope: string; key: string; value: unknown }
+  | { kind: "delete"; scope: string; key: string };
+
 interface CacheEntry {
   view: GraphView | null;
   builtAt: number;
   building: Promise<GraphView> | null;
   idleTimer: ReturnType<typeof setTimeout> | null;
+  pending: PendingOp[];
+  invalidatedDuringBuild: boolean;
 }
 
 const DEFAULT_TTL_MS = 300_000;
@@ -53,7 +63,14 @@ const caches = new WeakMap<object, CacheEntry>();
 function entryFor(kv: object): CacheEntry {
   let entry = caches.get(kv);
   if (!entry) {
-    entry = { view: null, builtAt: 0, building: null, idleTimer: null };
+    entry = {
+      view: null,
+      builtAt: 0,
+      building: null,
+      idleTimer: null,
+      pending: [],
+      invalidatedDuringBuild: false,
+    };
     caches.set(kv, entry);
   }
   return entry;
@@ -183,10 +200,27 @@ export async function getGraphView(kv: StateKV): Promise<GraphView> {
     return entry.view;
   }
   if (!entry.building) {
+    entry.invalidatedDuringBuild = false;
+    entry.pending = [];
     entry.building = buildView(kv)
       .then((built) => {
+        if (entry.invalidatedDuringBuild) {
+          // Something invalidated the graph while this build was reading.
+          // Serve the result once, but do not cache a snapshot we already
+          // know is behind.
+          entry.invalidatedDuringBuild = false;
+          entry.pending = [];
+          entry.view = null;
+          entry.builtAt = 0;
+          return built;
+        }
         entry.view = built;
         entry.builtAt = Date.now();
+        for (const op of entry.pending) {
+          if (op.kind === "write") applyWrite(built, op.scope, op.key, op.value);
+          else applyDelete(built, op.scope, op.key);
+        }
+        entry.pending = [];
         armIdleRelease(entry);
         return built;
       })
@@ -205,12 +239,36 @@ export async function getGraphView(kv: StateKV): Promise<GraphView> {
   return entry.building;
 }
 
+function applyWrite(
+  view: GraphView,
+  scope: string,
+  key: string,
+  value: unknown,
+): void {
+  if (scope === KV.graphNodes) {
+    const node = value as GraphNode;
+    deindexNode(view, key);
+    if (!node.stale) indexNode(view, { ...node, id: node.id ?? key });
+    return;
+  }
+  const edge = value as GraphEdge;
+  unlinkEdge(view, key);
+  if (!edge.stale) linkEdge(view, { ...edge, id: edge.id ?? key });
+}
+
+function applyDelete(view: GraphView, scope: string, key: string): void {
+  if (scope === KV.graphNodes) deindexNode(view, key);
+  else unlinkEdge(view, key);
+}
+
 /** Drops this store's view so the next read rebuilds from KV. */
 export function invalidateGraphCache(kv: object): void {
   const entry = caches.get(kv);
   if (!entry) return;
   entry.view = null;
   entry.builtAt = 0;
+  entry.pending = [];
+  if (entry.building) entry.invalidatedDuringBuild = true;
 }
 
 /**
@@ -226,30 +284,29 @@ export function onGraphWrite(
   value: unknown,
 ): void {
   if (!GRAPH_SCOPES.has(scope)) return;
-  const view = caches.get(kv)?.view;
-  if (!view) return;
+  const entry = caches.get(kv);
+  if (!entry) return;
   if (!value || typeof value !== "object") {
     invalidateGraphCache(kv);
     return;
   }
-  if (scope === KV.graphNodes) {
-    const node = value as GraphNode;
-    deindexNode(view, key);
-    if (!node.stale) indexNode(view, { ...node, id: node.id ?? key });
+  if (!entry.view) {
+    if (entry.building) entry.pending.push({ kind: "write", scope, key, value });
     return;
   }
-  const edge = value as GraphEdge;
-  unlinkEdge(view, key);
-  if (!edge.stale) linkEdge(view, { ...edge, id: edge.id ?? key });
+  applyWrite(entry.view, scope, key, value);
 }
 
 /** Write-through removal for a single graph row. */
 export function onGraphDelete(kv: object, scope: string, key: string): void {
   if (!GRAPH_SCOPES.has(scope)) return;
-  const view = caches.get(kv)?.view;
-  if (!view) return;
-  if (scope === KV.graphNodes) deindexNode(view, key);
-  else unlinkEdge(view, key);
+  const entry = caches.get(kv);
+  if (!entry) return;
+  if (!entry.view) {
+    if (entry.building) entry.pending.push({ kind: "delete", scope, key });
+    return;
+  }
+  applyDelete(entry.view, scope, key);
 }
 
 /**

--- a/src/state/hybrid-search.ts
+++ b/src/state/hybrid-search.ts
@@ -101,12 +101,18 @@ export class HybridSearch {
       }
     }
 
+    // AGENTMEMORY_GRAPH_WEIGHT=0 used to zero only the graph term in the
+    // score while both traversals still ran at full cost. Treat zero as
+    // "skip the stream" so the knob is a real kill switch when graph
+    // retrieval has to come out of the hot path.
+    const graphEnabled = this.graphWeight > 0;
+
     const entities =
       entityHints && entityHints.length > 0
         ? entityHints
         : extractEntitiesFromQuery(query);
     let graphResults: GraphRetrievalResult[] = [];
-    if (entities.length > 0) {
+    if (graphEnabled && entities.length > 0) {
       try {
         graphResults = await this.graphRetrieval.searchByEntities(
           entities,
@@ -119,7 +125,7 @@ export class HybridSearch {
     }
 
     const topVectorObs = vectorResults.slice(0, 5).map((r) => r.obsId);
-    if (topVectorObs.length > 0) {
+    if (graphEnabled && topVectorObs.length > 0) {
       try {
         const expansionResults =
           await this.graphRetrieval.expandFromChunks(topVectorObs, 1, 5);

--- a/src/state/kv.ts
+++ b/src/state/kv.ts
@@ -1,4 +1,5 @@
 import type { ISdk } from 'iii-sdk'
+import { onGraphDelete, onGraphUpdate, onGraphWrite } from './graph-cache.js'
 
 export class StateKV {
   constructor(private sdk: ISdk) {}
@@ -11,10 +12,16 @@ export class StateKV {
   }
 
   async set<T = unknown>(scope: string, key: string, value: T): Promise<T> {
-    return this.sdk.trigger<{ scope: string; key: string; value: T }, T>({
+    const result = await this.sdk.trigger<{ scope: string; key: string; value: T }, T>({
       function_id: 'state::set',
       payload: { scope, key, value },
     })
+    // Graph writes arrive from graph-extract, mesh sync, import, cascade
+    // and snapshot restore. Patching the cached graph view here — the one
+    // path they all route through — keeps it warm instead of forcing the
+    // next search to re-enumerate the whole graph scope.
+    onGraphWrite(this, scope, key, value)
+    return result
   }
 
   async update<T = unknown>(
@@ -22,20 +29,23 @@ export class StateKV {
     key: string,
     ops: Array<{ type: string; path: string; value?: unknown }>,
   ): Promise<T> {
-    return this.sdk.trigger<
+    const result = await this.sdk.trigger<
       { scope: string; key: string; ops: Array<{ type: string; path: string; value?: unknown }> },
       T
     >({
       function_id: 'state::update',
       payload: { scope, key, ops },
     })
+    onGraphUpdate(this, scope)
+    return result
   }
 
   async delete(scope: string, key: string): Promise<void> {
-    return this.sdk.trigger<{ scope: string; key: string }, void>({
+    await this.sdk.trigger<{ scope: string; key: string }, void>({
       function_id: 'state::delete',
       payload: { scope, key },
     })
+    onGraphDelete(this, scope, key)
   }
 
   async list<T = unknown>(scope: string): Promise<T[]> {

--- a/test/graph-view-reuse.test.ts
+++ b/test/graph-view-reuse.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../src/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { GraphRetrieval } from "../src/functions/graph-retrieval.js";
+import { onGraphWrite, invalidateGraphCache } from "../src/state/graph-cache.js";
+import type { GraphNode, GraphEdge } from "../src/types.js";
+
+function makeNode(
+  id: string,
+  name: string,
+  obsIds: string[] = ["obs_1"],
+): GraphNode {
+  return {
+    id,
+    type: "concept",
+    name,
+    properties: {},
+    sourceObservationIds: obsIds,
+    createdAt: "2026-02-01T10:00:00Z",
+  };
+}
+
+function makeEdge(id: string, source: string, target: string): GraphEdge {
+  return {
+    id,
+    type: "related_to",
+    sourceNodeId: source,
+    targetNodeId: target,
+    weight: 0.8,
+    sourceObservationIds: ["obs_1"],
+    createdAt: "2026-02-01T10:00:00Z",
+  };
+}
+
+/** Counting KV so the test can assert how often the graph is enumerated. */
+function countingKV(nodes: GraphNode[], edges: GraphEdge[]) {
+  const store = new Map<string, Map<string, unknown>>();
+  store.set("mem:graph:nodes", new Map(nodes.map((n) => [n.id, n])));
+  store.set("mem:graph:edges", new Map(edges.map((e) => [e.id, e])));
+  const listCalls: string[] = [];
+  return {
+    listCalls,
+    get: async <T>(scope: string, key: string): Promise<T | null> =>
+      (store.get(scope)?.get(key) as T) ?? null,
+    set: async <T>(scope: string, key: string, data: T): Promise<T> => {
+      if (!store.has(scope)) store.set(scope, new Map());
+      store.get(scope)!.set(key, data);
+      return data;
+    },
+    delete: async (scope: string, key: string): Promise<void> => {
+      store.get(scope)?.delete(key);
+    },
+    list: async <T>(scope: string): Promise<T[]> => {
+      listCalls.push(scope);
+      const entries = store.get(scope);
+      return entries ? (Array.from(entries.values()) as T[]) : [];
+    },
+  };
+}
+
+describe("graph view reuse (#1300)", () => {
+  let kv: ReturnType<typeof countingKV>;
+  let retrieval: GraphRetrieval;
+
+  beforeEach(() => {
+    kv = countingKV(
+      [
+        makeNode("gn_1", "docker", ["obs_1"]),
+        makeNode("gn_2", "compose", ["obs_2"]),
+        makeNode("gn_3", "registry", ["obs_3"]),
+      ],
+      [makeEdge("ge_1", "gn_1", "gn_2"), makeEdge("ge_2", "gn_2", "gn_3")],
+    );
+    retrieval = new GraphRetrieval(kv as never);
+    invalidateGraphCache(kv as never);
+  });
+
+  // The regression: searchByEntities and expandFromChunks each ran
+  // kv.list on both graph scopes, so a single hybrid query paid four
+  // full enumerations and every query after it paid four more.
+  it("enumerates the graph once across many queries", async () => {
+    await retrieval.searchByEntities(["docker"], 2, 10);
+    await retrieval.searchByEntities(["compose"], 2, 10);
+    await retrieval.expandFromChunks(["obs_1"], 1, 5);
+    await retrieval.searchByEntities(["registry"], 2, 10);
+
+    // One nodes list + one edges list, for all four calls.
+    expect(kv.listCalls).toEqual(["mem:graph:nodes", "mem:graph:edges"]);
+  });
+
+  it("still returns results for each query", async () => {
+    const docker = await retrieval.searchByEntities(["docker"], 2, 10);
+    const registry = await retrieval.searchByEntities(["registry"], 2, 10);
+    expect(docker.length).toBeGreaterThan(0);
+    expect(registry.length).toBeGreaterThan(0);
+  });
+
+  // Writes go through StateKV, which patches the view in place. A node
+  // added after the view was built must be reachable without paying for
+  // another enumeration.
+  it("sees nodes written after the view was built, without re-enumerating", async () => {
+    await retrieval.searchByEntities(["docker"], 2, 10);
+    const before = kv.listCalls.length;
+
+    const fresh = makeNode("gn_4", "kubernetes", ["obs_9"]);
+    await kv.set("mem:graph:nodes", fresh.id, fresh);
+    onGraphWrite(kv as never, "mem:graph:nodes", fresh.id, fresh);
+
+    const hits = await retrieval.searchByEntities(["kubernetes"], 2, 10);
+    expect(hits.some((r) => r.obsId === "obs_9")).toBe(true);
+    expect(kv.listCalls.length).toBe(before);
+  });
+
+  it("drops a node from the view when it is marked stale", async () => {
+    await retrieval.searchByEntities(["docker"], 2, 10);
+
+    const stale = { ...makeNode("gn_1", "docker", ["obs_1"]), stale: true };
+    onGraphWrite(kv as never, "mem:graph:nodes", stale.id, stale);
+
+    const hits = await retrieval.searchByEntities(["docker"], 2, 10);
+    expect(hits.some((r) => r.obsId === "obs_1")).toBe(false);
+  });
+
+  it("rebuilds after an explicit invalidation", async () => {
+    await retrieval.searchByEntities(["docker"], 2, 10);
+    const before = kv.listCalls.length;
+    invalidateGraphCache(kv as never);
+    await retrieval.searchByEntities(["docker"], 2, 10);
+    expect(kv.listCalls.length).toBe(before + 2);
+  });
+});

--- a/test/graph-view-reuse.test.ts
+++ b/test/graph-view-reuse.test.ts
@@ -124,6 +124,68 @@ describe("graph view reuse (#1300)", () => {
     expect(hits.some((r) => r.obsId === "obs_1")).toBe(false);
   });
 
+  // The visited cap used to bound only nodes popped off the heap. One hub
+  // node adds every neighbour to pathTo in a single iteration, so all of
+  // them were still returned and scored.
+  it("bounds discovered nodes on a star graph, not just expanded ones", async () => {
+    const ORIG = process.env["AGENTMEMORY_GRAPH_MAX_VISITED"];
+    process.env["AGENTMEMORY_GRAPH_MAX_VISITED"] = "5";
+    try {
+      const hub = makeNode("gn_hub", "hub", ["obs_hub"]);
+      const spokes: GraphNode[] = [];
+      const spokeEdges: GraphEdge[] = [];
+      for (let i = 0; i < 100; i++) {
+        spokes.push(makeNode(`gn_s${i}`, `spoke${i}`, [`obs_s${i}`]));
+        spokeEdges.push(makeEdge(`ge_s${i}`, "gn_hub", `gn_s${i}`));
+      }
+      const starKv = countingKV([hub, ...spokes], spokeEdges);
+      const star = new GraphRetrieval(starKv as never);
+      invalidateGraphCache(starKv as never);
+
+      const results = await star.searchByEntities(["hub"], 2, 1000);
+
+      // Start node plus at most the configured number of discovered nodes.
+      expect(results.length).toBeLessThanOrEqual(6);
+    } finally {
+      if (ORIG === undefined) delete process.env["AGENTMEMORY_GRAPH_MAX_VISITED"];
+      else process.env["AGENTMEMORY_GRAPH_MAX_VISITED"] = ORIG;
+    }
+  });
+
+  // A write landing while buildView is awaiting its two kv.list calls has no
+  // view to patch. The build must not then publish a snapshot that predates
+  // it.
+  it("does not lose a write that lands mid-build", async () => {
+    let releaseList: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      releaseList = resolve;
+    });
+    const base = countingKV([makeNode("gn_1", "docker", ["obs_1"])], []);
+    let gated = true;
+    const slowKv = {
+      ...base,
+      list: async <T>(scope: string): Promise<T[]> => {
+        if (gated) await gate;
+        return base.list<T>(scope);
+      },
+    };
+    const slow = new GraphRetrieval(slowKv as never);
+    invalidateGraphCache(slowKv as never);
+
+    const query = slow.searchByEntities(["docker"], 2, 10);
+
+    const fresh = makeNode("gn_2", "kubernetes", ["obs_late"]);
+    await base.set("mem:graph:nodes", fresh.id, fresh);
+    onGraphWrite(slowKv as never, "mem:graph:nodes", fresh.id, fresh);
+
+    gated = false;
+    releaseList();
+    await query;
+
+    const hits = await slow.searchByEntities(["kubernetes"], 2, 10);
+    expect(hits.some((r) => r.obsId === "obs_late")).toBe(true);
+  });
+
   it("rebuilds after an explicit invalidation", async () => {
     await retrieval.searchByEntities(["docker"], 2, 10);
     const before = kv.listCalls.length;


### PR DESCRIPTION
Refs #1300
Refs #309

## Why this is open again

#1300 is closed as completed, but `main` still carries the reported code. On `e04ba88`:

```
src/functions/graph-retrieval.ts:49   kv.list(KV.graphNodes)   # searchByEntities
src/functions/graph-retrieval.ts:50   kv.list(KV.graphEdges)
src/functions/graph-retrieval.ts:122  kv.list(KV.graphNodes)   # expandFromChunks
src/functions/graph-retrieval.ts:123  kv.list(KV.graphEdges)
src/functions/graph-retrieval.ts:166  kv.list(KV.graphNodes)   # temporalQuery
src/functions/graph-retrieval.ts:167  kv.list(KV.graphEdges)
```

and `hybrid-search.ts` still uses `graphWeight` only in the RRF fusion, with no short-circuit. So the behaviour described there is still present.

## What the measurement adds

I hit this on a 71.5K-node / 191K-edge corpus, where search took 48.2s and rose to 63.7s over an hour as the graph grew — past the 60s MCP tool timeout, so it presented as a broken client rather than a slow one.

The enumeration is not the dominant cost, which is worth correcting because it changes the fix:

| query | graph streams run | time |
|---|---|---|
| no entity match (expand only) | 1 | **24.5s** |
| ordinary query | 2 | **48.6s** |
| both full `kv.list` calls, measured alone | — | **3.0s** |

An exact 2:1 on stream count, with enumeration accounting for only 3s of it. The rest is `dijkstraTraversal` rebuilding `nodeIndex` and `adjacency` from the full arrays **on every call** — that is once per start node, not once per query — and `searchByEntities` accepting every bidirectional substring match as a start node with no cap. #1300's second "additional finding" names the hub problem; this is the same thing dominating the profile.

## What this changes

- **A per-`StateKV` graph view** holding nodes, edges, adjacency and an observation index. Built once and patched write-through from `StateKV.set/update/delete`, so every writer — graph-extract, mesh sync, import, cascade, snapshot restore — keeps it warm without having to know it exists. Keyed per store rather than globally so a process holding more than one store cannot cross-answer. Released after an idle period so a search-quiet daemon does not hold the graph resident.
- **Traversal reads that view** instead of rebuilding per start node.
- **Bounded expansion**: start nodes capped and ranked exact-match first then most specific (`AGENTMEMORY_GRAPH_MAX_START_NODES`, default 25), and visited nodes capped per traversal (`AGENTMEMORY_GRAPH_MAX_VISITED`, default 2000), so a hub node cannot walk the corpus.
- **`AGENTMEMORY_GRAPH_WEIGHT=0` now skips the stream** instead of only zeroing its score contribution. That is the sanctioned latency escape hatch #1300 asked for; today setting it to 0 leaves both traversals running at full cost, which means an operator who set it believes the subsystem is off while it is still on the hot path.

## Result

| | before | after |
|---|---|---|
| `/agentmemory/search`, warm | 48.2s → 63.7s and climbing | **0.89s** |
| graph view build | per start node, per query | **2.4s once**, then reused |
| daemon RSS | 1636 MB | **922 MB** |

The RSS drop is the same provenance the traversal used to re-materialise on every call no longer being re-read.

## Verification

```
npm run build     # clean
npm test          # 1,716 passed, 1 skipped
```

New `test/graph-view-reuse.test.ts` asserts the enumeration count directly rather than timing anything: four retrieval calls produce exactly one nodes list and one edges list. It also covers a node written after the view was built being visible without re-enumerating, a node marked stale dropping out, and explicit invalidation forcing a rebuild.

The existing 14 `graph-retrieval` cases pass unchanged, which is the useful signal that the traversal refactor preserved behaviour.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved graph-powered search responsiveness by reusing indexed graph data across related searches.
  * Reduced repeated graph loading during entity, chunk, and time-based queries.

* **Search Improvements**
  * Entity searches now normalize queries, prioritize exact matches, and apply configurable traversal limits.
  * Graph retrieval can now be fully disabled when its weighting is set to zero.

* **Reliability**
  * Search results stay current as graph data is added, updated, deleted, or marked stale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->