### PR TITLE
fix(hooks): back-fill prompts from Claude Code transcripts too

### DIFF
--- a/plugin/scripts/session-end.mjs
+++ b/plugin/scripts/session-end.mjs
@@ -45,6 +45,17 @@ function authHeaders() {
 	if (SECRET) h["Authorization"] = `Bearer ${SECRET}`;
 	return h;
 }
+function isUserTurn(msg) {
+	if (msg.isSidechain) return false;
+	return msg.role === "user" || msg.type === "user" || msg.message?.role === "user";
+}
+function turnTexts(content) {
+	if (typeof content === "string") return [content];
+	if (!Array.isArray(content)) return [];
+	const texts = [];
+	for (const block of content) if (block?.type === "text" && typeof block.text === "string") texts.push(block.text);
+	return texts;
+}
 function extractTranscriptPrompts(data) {
 	const path = data.transcript_path;
 	if (typeof path !== "string" || !path.endsWith(".jsonl")) return [];
@@ -63,12 +74,11 @@ function extractTranscriptPrompts(data) {
 		} catch {
 			continue;
 		}
-		if (msg.role !== "user") continue;
-		for (const block of msg.message?.content ?? []) {
+		if (!isUserTurn(msg)) continue;
+		for (const raw of turnTexts(msg.message?.content)) {
 			if (prompts.length >= 50) return prompts;
-			if (block.type !== "text" || typeof block.text !== "string") continue;
-			const m = block.text.match(/<user_query>\n?([\s\S]*?)\n?<\/user_query>/);
-			const text = (m ? m[1] : block.text).trim();
+			const m = raw.match(/<user_query>\n?([\s\S]*?)\n?<\/user_query>/);
+			const text = (m ? m[1] : raw).trim();
 			if (text) prompts.push(text.slice(0, 8e3));
 		}
 	}

--- a/src/hooks/session-end.ts
+++ b/src/hooks/session-end.ts
@@ -25,11 +25,6 @@ type TranscriptLine = {
   message?: { role?: string; content?: string | TranscriptBlock[] };
 };
 
-// Two transcript dialects reach this hook. Cursor writes the role at the top
-// level and always wraps content in typed blocks; Claude Code writes
-// `type: "user"` with the role nested under `message`, and a plain user turn
-// carries `content` as a bare string. Matching only the first shape silently
-// backfilled nothing from a Claude Code session.
 function isUserTurn(msg: TranscriptLine): boolean {
   if (msg.isSidechain) return false;
   return (
@@ -37,8 +32,6 @@ function isUserTurn(msg: TranscriptLine): boolean {
   );
 }
 
-// A Claude Code user turn is either the bare prompt string or a block array
-// that is mostly tool_result records; only text blocks are prompts.
 function turnTexts(content: string | TranscriptBlock[] | undefined): string[] {
   if (typeof content === "string") return [content];
   if (!Array.isArray(content)) return [];

--- a/src/hooks/session-end.ts
+++ b/src/hooks/session-end.ts
@@ -17,6 +17,40 @@ function authHeaders(): Record<string, string> {
   return h;
 }
 
+type TranscriptBlock = { type?: string; text?: string };
+type TranscriptLine = {
+  role?: string;
+  type?: string;
+  isSidechain?: boolean;
+  message?: { role?: string; content?: string | TranscriptBlock[] };
+};
+
+// Two transcript dialects reach this hook. Cursor writes the role at the top
+// level and always wraps content in typed blocks; Claude Code writes
+// `type: "user"` with the role nested under `message`, and a plain user turn
+// carries `content` as a bare string. Matching only the first shape silently
+// backfilled nothing from a Claude Code session.
+function isUserTurn(msg: TranscriptLine): boolean {
+  if (msg.isSidechain) return false;
+  return (
+    msg.role === "user" || msg.type === "user" || msg.message?.role === "user"
+  );
+}
+
+// A Claude Code user turn is either the bare prompt string or a block array
+// that is mostly tool_result records; only text blocks are prompts.
+function turnTexts(content: string | TranscriptBlock[] | undefined): string[] {
+  if (typeof content === "string") return [content];
+  if (!Array.isArray(content)) return [];
+  const texts: string[] = [];
+  for (const block of content) {
+    if (block?.type === "text" && typeof block.text === "string") {
+      texts.push(block.text);
+    }
+  }
+  return texts;
+}
+
 function extractTranscriptPrompts(data: Record<string, unknown>): string[] {
   const path = data.transcript_path;
   if (typeof path !== "string" || !path.endsWith(".jsonl")) return [];
@@ -29,21 +63,17 @@ function extractTranscriptPrompts(data: Record<string, unknown>): string[] {
   const prompts: string[] = [];
   for (const line of raw.split("\n")) {
     if (!line.trim()) continue;
-    let msg: {
-      role?: string;
-      message?: { content?: Array<{ type?: string; text?: string }> };
-    };
+    let msg: TranscriptLine;
     try {
       msg = JSON.parse(line);
     } catch {
       continue;
     }
-    if (msg.role !== "user") continue;
-    for (const block of msg.message?.content ?? []) {
+    if (!isUserTurn(msg)) continue;
+    for (const raw of turnTexts(msg.message?.content)) {
       if (prompts.length >= 50) return prompts;
-      if (block.type !== "text" || typeof block.text !== "string") continue;
-      const m = block.text.match(/<user_query>\n?([\s\S]*?)\n?<\/user_query>/);
-      const text = (m ? m[1] : block.text).trim();
+      const m = raw.match(/<user_query>\n?([\s\S]*?)\n?<\/user_query>/);
+      const text = (m ? m[1] : raw).trim();
       if (text) prompts.push(text.slice(0, 8000));
     }
   }

--- a/test/session-end-transcript.test.ts
+++ b/test/session-end-transcript.test.ts
@@ -103,6 +103,57 @@ describe("session-end transcript prompt backfill", () => {
     }
   });
 
+  it("posts prompts from a Claude Code transcript, skipping tool results", async () => {
+    posts.length = 0;
+    const transcript = join(dir, "t-cc.jsonl");
+    writeFileSync(
+      transcript,
+      [
+        // Claude Code: role is nested, a plain turn is a bare string.
+        JSON.stringify({
+          type: "user",
+          message: { role: "user", content: "bare claude code prompt" },
+        }),
+        JSON.stringify({
+          type: "assistant",
+          message: { role: "assistant", content: [{ type: "text", text: "answer" }] },
+        }),
+        // Tool results arrive as user turns too and must not become prompts.
+        JSON.stringify({
+          type: "user",
+          message: {
+            role: "user",
+            content: [
+              { type: "tool_result", content: "exit 0" },
+              { type: "text", text: "follow-up after the tool" },
+            ],
+          },
+        }),
+        // Subagent turns are not the user speaking.
+        JSON.stringify({
+          type: "user",
+          isSidechain: true,
+          message: { role: "user", content: "subagent instruction" },
+        }),
+        "",
+      ].join("\n"),
+    );
+
+    const code = await runHook({
+      session_id: "ses_cc",
+      hook_event_name: "sessionEnd",
+      reason: "completed",
+      transcript_path: transcript,
+    });
+    expect(code).toBe(0);
+
+    const observes = posts.filter((p) => p.path.includes("/observe"));
+    expect(observes.map((p) => (p.body.data as { prompt: string }).prompt)).toEqual([
+      "bare claude code prompt",
+      "follow-up after the tool",
+    ]);
+  });
+
   it("caps backfill at 50 prompts even within a single transcript record", async () => {
     posts.length = 0;
     const transcript = join(dir, "t-cap.jsonl");


### PR DESCRIPTION
Makes the SessionEnd prompt back-fill recognise Claude Code transcripts. Fixes #1365.

`extractTranscriptPrompts` matched only the Cursor dialect — `role` at the top level, `content`
always an array of typed blocks — so on a Claude Code transcript, where the role is nested under
`message` and a plain user turn carries `content` as a bare string, every line was skipped and
the back-fill posted nothing. Sessions then arrive as bare `{endedAt, status}` records and
`mem::summarize` reports `No observations to summarize` for them forever, while
`Consolidation pipeline complete` keeps reporting success against the frozen corpus.

The extractor now accepts `type: "user"` and `message.role === "user"` alongside the original
top-level `role`, and reads a string `content` as a single text. Only text blocks are collected,
so the `tool_result` records that make up most Claude Code user lines stay out, and `isSidechain`
turns are skipped because a subagent is not the user speaking. The Cursor path, the
`<user_query>` unwrap and the 50-prompt / 8000-character caps are untouched.

Measured on a real 1187-line Claude Code transcript with 109 user records: 0 prompts extracted
before, 5 after — the session's actual user turns, with the remaining 107 `tool_result` records
correctly excluded. Verified end-to-end against a live daemon: five observations captured, the
session record gained `observationCount` and `project`, and `Session summarized` fired for a
session that had produced nothing before.

The new case in `test/session-end-transcript.test.ts` covers the bare-string turn, `tool_result`
exclusion and the sidechain skip.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session transcript processing across supported transcript formats, including Claude Code sessions.
  - User prompts are now detected more reliably from nested role metadata and alternate content formats.
  - Text prompts are extracted correctly when tool results or other non-text blocks are present.
  - Sidechain and subagent turns are excluded from prompt submissions.

- **Tests**
  - Added coverage for Claude Code transcripts, tool-result blocks, and sidechain turns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->